### PR TITLE
rename column class names

### DIFF
--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -12,7 +12,7 @@ do_data <- function(funcname) {
       output <- df  %>%  dplyr::do(.model= do.call(funcname, list(data = ., ...)))
     }
     # Add a class for Exploratyry to recognize the type of .model
-    class(output$.model) <- c("list", paste0(".model.", funcname))
+    class(output$.model) <- c("list", ".model", paste0(".model.", funcname))
     output
   }
   ret
@@ -51,6 +51,6 @@ do_kmeans <- function(df, ..., centers=3, keep.source = TRUE, seed=0){
     )
   }
   # Add a class for Exploratyry to recognize the type of .model
-  class(output$.model) <- c("list",".model.kmeans")
+  class(output$.model) <- c("list", ".model", ".model.kmeans")
   output
 }

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -6,12 +6,13 @@ do_data <- function(funcname) {
     loadNamespace("dplyr")
     if (keep.source) {
       output <- df  %>%  dplyr::do(.model = do.call(funcname, list(data = ., ...)), .source.data = (.))
+      # Add a class for Exploratyry to recognize the type of .source.data
+      class(output$.source.data) <- c("list", ".source.data")
     } else {
       output <- df  %>%  dplyr::do(.model= do.call(funcname, list(data = ., ...)))
     }
-
-    class(output$.model) <- c("list", paste0("model-", funcname))
-    class(output$.source.data) <- c("list", ".source.data")
+    # Add a class for Exploratyry to recognize the type of .model
+    class(output$.model) <- c("list", paste0(".model.", funcname))
     output
   }
   ret
@@ -41,12 +42,15 @@ do_kmeans <- function(df, ..., centers=3, keep.source = TRUE, seed=0){
       df
       %>%  dplyr::do(.model= kmeans(.[,selected_cnames], centers), .source.data=(.))
     )
+    # Add a class for Exploratyry to recognize the type of .source.data
+    class(output$.source.data) <- c("list", ".source.data")
   } else {
     output <- (
       df
       %>%  dplyr::do(.model= kmeans(.[,selected_cnames], centers))
     )
   }
-  class(output$.model) <- "model-kmeans"
+  # Add a class for Exploratyry to recognize the type of .model
+  class(output$.model) <- ".model.kmeans"
   output
 }

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -51,6 +51,6 @@ do_kmeans <- function(df, ..., centers=3, keep.source = TRUE, seed=0){
     )
   }
   # Add a class for Exploratyry to recognize the type of .model
-  class(output$.model) <- ".model.kmeans"
+  class(output$.model) <- c("list",".model.kmeans")
   output
 }


### PR DESCRIPTION
Add class names for UI to recognise columns

# test
* devtools::test()

---
* put functions in customize.r
* import 123.flight
* `filter(!is.na(ARR_DELAY) & !is.na(DEP_DELAY))`
* `sample_n(700)`
* `group_by(CARRIER)`
* `do_glm(ARR_DELAY~DEP_DELAY, keep.source=TRUE)`
* go to table view
* cells in .source.data should be <source data>
* ` augment(.model, .source.data)`
* number of rows should be 270 and the first column should be YEAR
* go back to do_glm
* change it to `do_kmeans(ARR_DELAY,DEP_DELAY,centers=2, keep.source=TRUE)`
* go to table view
* cells in .source.data should be <source data>
* `augment(.model, .source.data)`
* number of rows should be 700 and the first column and the last column should be YEAR and .cluster