### PR TITLE
mat_to_df sort issue fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Import: dplyr,
     reshape2,
     lazyeval,
     pdftools,
-    qlcMatrix
+    qlcMatrix,
     purrr,
     httr,
     text2vec,

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -122,6 +122,8 @@ do_dist.cols <- function(df, ..., label=NULL, fill=0, fun.aggregate=mean, distin
   # this is executed on each group
   calc_dist_each <- function(df){
     mat <- df %>%  dplyr::select_(.dots=select_dots) %>%  as.matrix()
+
+    # sort the column name so that the output of pair.name will be sorted
     sortedNames <- sort(colnames(mat))
     mat <- t(mat)
     mat <- mat[sortedNames, ]

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -123,7 +123,8 @@ do_dist.cols <- function(df, ..., label=NULL, fill=0, fun.aggregate=mean, distin
   calc_dist_each <- function(df){
     mat <- df %>%  dplyr::select_(.dots=select_dots) %>%  as.matrix()
 
-    # sort the column name so that the output of pair.name will be sorted
+    # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
+    # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
     sortedNames <- sort(colnames(mat))
     mat <- t(mat)
     mat <- mat[sortedNames, ]

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -122,9 +122,12 @@ do_dist.cols <- function(df, ..., label=NULL, fill=0, fun.aggregate=mean, distin
   # this is executed on each group
   calc_dist_each <- function(df){
     mat <- df %>%  dplyr::select_(.dots=select_dots) %>%  as.matrix()
+    sortedNames <- sort(colnames(mat))
+    mat <- t(mat)
+    mat <- mat[sortedNames, ]
 
     # Dist is actually an atomic vector of upper half so upper and diag arguments don't matter
-    dist <- stats::dist(t(mat), method=method, diag=FALSE, p=p)
+    dist <- stats::dist(mat, method=method, diag=FALSE, p=p)
     if(distinct){
       if(diag){
         diag <- 0

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -67,6 +67,7 @@ do_cor.cols <- function(df, ..., use="pairwise.complete.obs", method="pearson", 
   # check if the df's grouped
   do_cor_each <- function(df){
     mat <- dplyr::select_(df, .dots = select_dots) %>%  as.matrix()
+    # sort the column name so that the output of pair.name will be sorted
     mat <- mat[,sort(colnames(mat))]
 
     cor_mat <- cor(mat, use = use, method = method)

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -67,6 +67,8 @@ do_cor.cols <- function(df, ..., use="pairwise.complete.obs", method="pearson", 
   # check if the df's grouped
   do_cor_each <- function(df){
     mat <- dplyr::select_(df, .dots = select_dots) %>%  as.matrix()
+    mat <- mat[,sort(colnames(mat))]
+
     cor_mat <- cor(mat, use = use, method = method)
     if(distinct){
       ret <- upper_gather(cor_mat, diag=diag, cnames=output_cols)

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -67,7 +67,8 @@ do_cor.cols <- function(df, ..., use="pairwise.complete.obs", method="pearson", 
   # check if the df's grouped
   do_cor_each <- function(df){
     mat <- dplyr::select_(df, .dots = select_dots) %>%  as.matrix()
-    # sort the column name so that the output of pair.name will be sorted
+    # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
+    # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
     mat <- mat[,sort(colnames(mat))]
 
     cor_mat <- cor(mat, use = use, method = method)

--- a/R/util.R
+++ b/R/util.R
@@ -73,14 +73,11 @@ upper_gather <- function(mat, names=NULL, diag=NULL, cnames = c("Var1", "Var2", 
     r_names <- rownames(tmat)
     if(is.null(c_names)){
       c_names <- seq(ncol(tmat))
-    } else {
-      c_names <- sort(c_names)
     }
     if(is.null(r_names)){
       r_names <- seq(nrow(tmat))
-    } else {
-      r_names <- sort(r_names)
     }
+
     # this creates pairs of row and column indices
     ind <- which( lower_tri , arr.ind = TRUE )
     # make a vector of upper half of matrix

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -70,6 +70,17 @@ test_that("test grouped_by", {
   expect_equal(ret, c("col1", "col2"))
 })
 
+test_that("test simple_cast colnames are sorted", {
+  test_df <- data.frame(
+    rowname = rep(c("row1", "row02", "row3", "row004"), each=3),
+    colname = rep(c("col1", "col2", "col03"), 4),
+    val = seq(12),
+    stringsAsFactors = FALSE
+  )
+  mat <- simple_cast(test_df, "rowname", "colname", "val")
+  expect_equal(test_df[test_df$rowname=="row3" & test_df$colname=="col03",3][[1]], mat["row3", "col03"])
+})
+
 test_that("test mat_to_df", {
   nc <- 4
   nr <- 5

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -2,12 +2,13 @@ context("check util functions")
 
 test_that("test upper_gather", {
   mat <- matrix(seq(20),nrow=5, ncol=4)
-  colnames(mat) <- paste("col", seq(4))
+  # use col03 to break sorted state
+  colnames(mat) <- c("col1","col2","col03", "col4")
   result <- upper_gather(mat)
   expect_equal( typeof(result[[2]]), "character")
   expect_equal(result[[1]], sort(result[[1]]))
-  expect_equal(result[result[[1]]==3 & result[[2]]=="col 4", 3][[1]], 18)
-  expect_equal(result[result[[1]]==2 & result[[2]]=="col 3", 3][[1]], 12)
+  expect_equal(result[result[[1]]==3 & result[[2]]=="col4", 3][[1]], 18)
+  expect_equal(result[result[[1]]==2 & result[[2]]=="col03", 3][[1]], 12)
   expect_equal(nrow(result), 6)
 })
 


### PR DESCRIPTION
If mat_to_df took a matrix with unsorted names, the result was wrong.

* fix mat_to_df not to sort the names inside
* fix do_cor.cols and do_dist.cols so that it sort the name beforehand
* add a test to check if simple_cast makes a matrix with sorted names for .kv functions

And there was a missing , in DESCRIPTION, so fixed it too

Test
* devtools::test()