### PR TITLE
[Google BigQuery]Switched to use Exploratory App ID and secret instead of default bigrquery one.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.3.6.6
+Version: 0.3.6.7
 Date: 2016-05-13
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -364,8 +364,8 @@ getGoogleTokenForBigQuery <- function(tokenFileId, useCache=TRUE){
   if(!requireNamespace("bigrquery")){stop("package bigrquery must be installed.")}
   loadNamespace("stringr")
   loadNamespace("httr")
-  clientId <- "465736758727.apps.googleusercontent.com"
-  secret <- "fJbIIyoIag0oA6p114lwsV2r"
+  clientId <- "1066595427418-aeppbdhi7bj7g0osn8jpj4p6r9vus7ci.apps.googleusercontent.com"
+  secret <-  "wGVbD4fttv_shYreB3PXcjDY"
   cacheOption = getOption("tam.oauth_token_cache")
   # tam.oauth_token_cache is RDS file path (~/.exploratory/projects/<projectid>/rdata/placeholder.rds)
   # for each data frame, create token cache as


### PR DESCRIPTION
As for Google BigQuery OAuth token, Switched to use Exploratory App id and secret.