### PR TITLE
error handling in apriori

### DIFF
--- a/R/arules.R
+++ b/R/arules.R
@@ -88,7 +88,12 @@ do_apriori <- function(df, subject, key, minlen=1, maxlen=10, min_support=0.1, m
     ret
   }
 
-  ret <- (df %>%  dplyr::do_(.dots = setNames(~do_apriori_each(.), cnames[[5]])) %>%  tidyr::unnest_(cnames[[5]]))
+  ret <- (df %>%  dplyr::do_(.dots = setNames(~do_apriori_each(.), cnames[[5]])))
+  if(nrow(ret) == 0){
+    stop("No matching rule was found.")
+  }
+
+  ret <- (ret %>%  tidyr::unnest_(cnames[[5]]))
   if(all(is.na(ret[[1]])) & nrow(ret)==1){
     stop("No rule was found. Adjusting arguments might work.")
   }

--- a/tests/testthat/test_arules.R
+++ b/tests/testthat/test_arules.R
@@ -28,7 +28,7 @@ test_that("test do_apriori with lhs", {
   expect_true(all(ret[, "lhs"] == "name1"))
 })
 
-test_that("test do_apriori with lhs", {
+test_that("test do_apriori with lhs and rhs", {
   test_df <- data.frame(
     name = rep(paste("name",seq(20), sep=""), each=3),
     product = rep(paste("product",seq(5), sep=""), 12),
@@ -36,6 +36,6 @@ test_that("test do_apriori with lhs", {
   )
 
   expect_error({
-    do_apriori(test_df, name, product, min_support=0.9)
-  })
+    do_apriori(test_df, name, product, min_support=0.9, lhs="name1", rhs="name2")
+  }, "No matching rule was found")
 })


### PR DESCRIPTION
Modify error message when no matching rule was found in do_apriori

![image](https://cloud.githubusercontent.com/assets/6638312/18499807/37e2c32e-7a7d-11e6-9c02-47b09899336e.png)

This error message should be
"No matching rule was found."

Test:
* devtools::test()