### PR TITLE
simple cast colnames error

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -16,6 +16,15 @@ simple_cast <- function(data, row, col, val = NULL, fun.aggregate=mean, fill=0){
   loadNamespace("reshape2")
   loadNamespace("tidyr")
 
+
+  if(!row %in% colnames(data)){
+    stop(paste0(row, " is not in column names"))
+  }
+
+  if(!col %in% colnames(data)){
+    stop(paste0(col, " is not in column names"))
+  }
+
   # noraml na causes error in reshape2::acast so it has to be NA_real_
   if(is.na(fill)){
     fill <- NA_real_
@@ -42,6 +51,9 @@ simple_cast <- function(data, row, col, val = NULL, fun.aggregate=mean, fill=0){
     mat[mat == 0] <- fill
     mat
   }else{
+    if(!val %in% colnames(data)){
+      stop(paste0(val, " is not in column names"))
+    }
     data %>%  reshape2::acast(fml, value.var=val, fun.aggregate=fun.aggregate, fill=fill)
   }
 }

--- a/R/util.R
+++ b/R/util.R
@@ -65,6 +65,14 @@ sparse_cast <- function(data, row, col, val=NULL, fun.aggregate=sum, count = FAL
   loadNamespace("tidyr")
   loadNamespace("Matrix")
 
+  if(!row %in% colnames(data)){
+    stop(paste0(row, " is not in column names"))
+  }
+
+  if(!col %in% colnames(data)){
+    stop(paste0(col, " is not in column names"))
+  }
+
   # remove NA from row and col
   data <- tidyr::drop_na_(data, c(row, col))
 
@@ -83,6 +91,9 @@ sparse_cast <- function(data, row, col, val=NULL, fun.aggregate=sum, count = FAL
         )
     }
   }else{
+    if(!val %in% colnames(data)){
+      stop(paste0(val, " is not in column names"))
+    }
     # Basic behaviour of Matrix::sparseMatrix is sum.
     # If fun.aggregate is different, it should be aggregated by it.
     if(!identical(fun.aggregate, sum)){

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -317,3 +317,10 @@ test_that("test do_cmdscale", {
   result_half <- do_cmdscale(half_df, Var1, Var2, value)
 
 })
+
+test_that("do_cmdscale undefined column name error", {
+  data <- data.frame(var1 = c(1, 3, 2, NA), var2 = c(1, 3, 2, 10))
+  expect_error({
+    do_cmdscale(data, var1, var2, var3)
+  }, "var3 is not in column names")
+})

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -146,6 +146,42 @@ test_that("test sparse_cast with na label", {
   expect_equal(dim(mat), c(2, 3))
 })
 
+test_that("test simple_cast with undefined column names", {
+  test_df <- data.frame(
+    rowname = rep(c("row1", "row02", NA), each=3),
+    colname = c("col1", "col02", NA, "col02", "col3", "col1", "col02", "col4", "col5"),
+    val = seq(9),
+    stringsAsFactors = FALSE
+  )
+  expect_error({
+    simple_cast(test_df, "row", "colname", "val")
+  }, "row is not in column names")
+  expect_error({
+    simple_cast(test_df, "rowname", "col", "val")
+  }, "col is not in column names")
+  expect_error({
+    simple_cast(test_df, "rowname", "colname", "valname")
+  }, "valname is not in column names")
+})
+
+test_that("test sparse_cast with undefined column names", {
+  test_df <- data.frame(
+    rowname = rep(c("row1", "row02", NA), each=3),
+    colname = c("col1", "col02", NA, "col02", "col3", "col1", "col02", "col4", "col5"),
+    val = seq(9),
+    stringsAsFactors = FALSE
+  )
+  expect_error({
+    sparse_cast(test_df, "row", "colname", "val")
+  }, "row is not in column names")
+  expect_error({
+    sparse_cast(test_df, "rowname", "col", "val")
+  }, "col is not in column names")
+  expect_error({
+    sparse_cast(test_df, "rowname", "colname", "valname")
+  }, "valname is not in column names")
+})
+
 test_that("test sparse_cast without val", {
   test_df <- data.frame(
     rowname = rep(c("row1", "row02", "row3"), each=3),


### PR DESCRIPTION
Add column name validations for simple_cast and sparse_cast 

Test
- [x] devtools::test()