### PR TITLE
modify list_concat so that it can take more than 2 lists

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -347,7 +347,6 @@ list_to_text <- function(column, sep = ", "){
 #' concatinate vectors in a list
 #' @export
 list_concat <- function(..., collapse = TRUE){
-  browser()
   lists <- list(...)
 
   # size of each list

--- a/R/util.R
+++ b/R/util.R
@@ -346,8 +346,28 @@ list_to_text <- function(column, sep = ", "){
 
 #' concatinate vectors in a list
 #' @export
-list_concat <- function(list){
-  list(unlist(list))
+list_concat <- function(..., collapse = TRUE){
+  browser()
+  lists <- list(...)
+
+  # size of each list
+  lengths <- lapply(lists, function(arg){
+    length(arg)
+  })
+
+  max_index <- which.max(lengths)
+
+  ret <- lapply(seq(lengths[[max_index]]), function(index){
+    val <- unlist(lapply(lists, function(arg){
+      arg[[index]]
+    }))
+  })
+
+  if(collapse){
+    ret <- list(unlist(ret))
+  }
+
+  ret
 }
 
 #' replace sequence of spaces or periods with

--- a/R/util.R
+++ b/R/util.R
@@ -346,7 +346,7 @@ list_to_text <- function(column, sep = ", "){
 
 #' concatinate vectors in a list
 #' @export
-list_concat <- function(..., collapse = TRUE){
+list_concat <- function(..., collapse = FALSE){
   lists <- list(...)
 
   # size of each list

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -342,7 +342,7 @@ test_that("list_concat", {
     c(3, 5)
   )
 
-  ret <- list_concat(list1)
+  ret <- list_concat(list1, collapse = TRUE)
   expect_equal(length(ret), 1)
   expect_equal(ret[[1]], c(NA, NA, "3", "5"))
 })

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -381,10 +381,3 @@ test_that("list_concat with multiple list", {
   expect_equal(ret1_collapse[[1]], c(NA, NA, NA, NA, "a", "c", "1", "3", "a", "c", "3", "5", "6", "6"))
 
 })
-
-test_that("list_concat real test", {
-  df <- readRDS("~/Downloads/list_concat_test.rds")
-  library(dplyr)
-  df %>%
-    mutate(test = list_concat(categories, neighborhoods))
-})

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -333,3 +333,58 @@ test_that("list_to_text should return NA", {
 
   expect_equal(ret[["text"]], c(rep(NA, 3), rep("b, b, b, b, b", 7)))
 })
+
+test_that("list_concat", {
+  list1 <- list(
+    NA,
+    NA,
+    character(0),
+    c(3, 5)
+  )
+
+  ret <- list_concat(list1)
+  expect_equal(length(ret), 1)
+  expect_equal(ret[[1]], c(NA, NA, "3", "5"))
+})
+
+test_that("list_concat with multiple list", {
+  list1 <- list(
+    NA,
+    NA,
+    character(0),
+    c(3, 5)
+  )
+
+  list2 <- list(
+    NA,
+    c("a", "c"),
+    character(0),
+    c(6)
+  )
+
+  list3 <- list(
+    NA,
+    c(1, 3),
+    c("a", "c"),
+    c(6)
+  )
+
+  ret1 <- list_concat(list1, list2, list3, collapse = FALSE)
+  expect_equal(ret1[[1]], c(NA, NA, NA))
+  expect_equal(ret1[[2]], c(NA, "a", "c", "1", "3"))
+  expect_equal(ret1[[3]], c("a", "c"))
+  expect_equal(ret1[[4]], c(3, 5, 6, 6))
+
+  ret1_collapse <- list_concat(list1, list2, list3, collapse = TRUE)
+
+  expect_equal(length(ret1_collapse), 1)
+  expect_equal(ret1_collapse[[1]], c(NA, NA, NA, NA, "a", "c", "1", "3", "a", "c", "3", "5", "6", "6"))
+
+})
+
+test_that("list_concat real test", {
+  df <- readRDS("~/Downloads/list_concat_test.rds")
+  library(dplyr)
+  df %>%
+    mutate(test = list_concat(categories, neighborhoods))
+})


### PR DESCRIPTION
### Description

modify list_concat so that it can take columns

ref: https://github.com/exploratory-io/tam/issues/3157

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test() 
- [x] Tested with Exploratory 

