### PR TITLE
[Google BigQuery] support #standardSQL keyword

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.3.9.25
+Version: 0.3.9.26
 Date: 2016-05-13
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -726,7 +726,10 @@ executeGoogleBigQuery <- function(project, sqlquery, destination_table, page_siz
   } else {
     # direct import case (for refresh data frame case)
     bigrquery::set_access_cred(token)
-    df <- bigrquery::query_exec(GetoptLong::qq(sqlquery), project = project, destination_table = destination_table, page_size = page_size, max_page = max_page, write_disposition = write_disposition)
+    # check if the quer contains special key word for standardSQL
+    isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
+    df <- bigrquery::query_exec(GetoptLong::qq(sqlquery), project = project, destination_table = destination_table,
+                                page_size = page_size, max_page = max_page, write_disposition = write_disposition, useLegacySql = isStandardSQL == FALSE)
   }
   df
 }

--- a/R/system.R
+++ b/R/system.R
@@ -587,7 +587,7 @@ submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_
   token <- getGoogleTokenForBigQuery(tokenFieldId)
   bigrquery::set_access_cred(token)
   # pass desitiona_table to support large data
-  # check if the quer contains special key word for standardSQL
+  # check if the query contains special key word for standardSQL
   # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
   isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
   job <- bigrquery::insert_query_job(GetoptLong::qq(sqlquery), project, destination_table = destination_table, write_disposition = write_disposition, useLegacySql = isStandardSQL == FALSE)
@@ -727,7 +727,7 @@ executeGoogleBigQuery <- function(project, sqlquery, destination_table, page_siz
   } else {
     # direct import case (for refresh data frame case)
     bigrquery::set_access_cred(token)
-    # check if the quer contains special key word for standardSQL
+    # check if the query contains special key word for standardSQL
     # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
     isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
     df <- bigrquery::query_exec(GetoptLong::qq(sqlquery), project = project, destination_table = destination_table,

--- a/R/system.R
+++ b/R/system.R
@@ -579,13 +579,17 @@ refreshGoogleTokenForBigQuery <- function(tokenFileId){
 submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_disposition = "WRITE_TRUNCATE", tokenFieldId){
   if(!requireNamespace("bigrquery")){stop("package bigrquery must be installed.")}
   if(!requireNamespace("GetoptLong")){stop("package GetoptLong must be installed.")}
+  if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
+
   #GetoptLong uses stringr and str_c is called without stringr:: so need to use "require" instead of "requireNamespace"
   if(!require("stringr")){stop("package stringr must be installed.")}
 
   token <- getGoogleTokenForBigQuery(tokenFieldId)
   bigrquery::set_access_cred(token)
   # pass desitiona_table to support large data
-  job <- bigrquery::insert_query_job(GetoptLong::qq(sqlquery), project, destination_table = destination_table, write_disposition = write_disposition)
+  # check if the quer contains special key word for standardSQL
+  isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
+  job <- bigrquery::insert_query_job(GetoptLong::qq(sqlquery), project, destination_table = destination_table, write_disposition = write_disposition, useLegacySql = isStandardSQL == FALSE)
   job <- bigrquery::wait_for(job)
   isCacheHit <- job$statistics$query$cacheHit
   # if cache hit case, totalBytesProcessed info is not available. So set it as -1

--- a/R/system.R
+++ b/R/system.R
@@ -588,6 +588,7 @@ submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_
   bigrquery::set_access_cred(token)
   # pass desitiona_table to support large data
   # check if the quer contains special key word for standardSQL
+  # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
   isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
   job <- bigrquery::insert_query_job(GetoptLong::qq(sqlquery), project, destination_table = destination_table, write_disposition = write_disposition, useLegacySql = isStandardSQL == FALSE)
   job <- bigrquery::wait_for(job)
@@ -727,6 +728,7 @@ executeGoogleBigQuery <- function(project, sqlquery, destination_table, page_siz
     # direct import case (for refresh data frame case)
     bigrquery::set_access_cred(token)
     # check if the quer contains special key word for standardSQL
+    # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
     isStandardSQL <- stringr::str_detect(sqlquery, "#standardSQL")
     df <- bigrquery::query_exec(GetoptLong::qq(sqlquery), project = project, destination_table = destination_table,
                                 page_size = page_size, max_page = max_page, write_disposition = write_disposition, useLegacySql = isStandardSQL == FALSE)


### PR DESCRIPTION
### Description

This PR addresses the issue that #standardSQL keyword in SQL query is not honored .

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test() 
- [ ] Tested with Exploratory 
