### PR TITLE
modify gtrends for package update

### DIFF
--- a/R/google_trends.R
+++ b/R/google_trends.R
@@ -106,7 +106,6 @@ getGoogleTrends <- function(user,
     tidyr::gather_(bind_data, "keyword", "trend", colnames(bind_data)[2:ncol(bind_data)], na.rm = TRUE)
   } else if (type == "trend"){
     trend <- ret[[type]]
-    colnames(trend)[colnames(trend) == "hits"] <- "trend"
     trend
   } else {
     stop("Currently, type must be top_regions, top_cities or trends")

--- a/R/google_trends.R
+++ b/R/google_trends.R
@@ -6,7 +6,12 @@
 #' @param last - From when the data should be retreived. Currently supported parameters are "1h", "4h", "1d", "7d", "5y", "30d", "90d", "1y" and "all" (from 2004)
 #' @param geo - Region codes. It's listed in countries data set in gtrendsR.
 #' @export
-getGoogleTrends <- function(user, password, query = "", type = "trend", last = "5y", geo = ""){
+getGoogleTrends <- function(user,
+                            password,
+                            query = "",
+                            type = "trend",
+                            last = "5y",
+                            geo = ""){
   loadNamespace("gtrendsR")
   loadNamespace("tidyr")
 
@@ -77,15 +82,9 @@ getGoogleTrends <- function(user, password, query = "", type = "trend", last = "
     key <- keys[startsWith(keys, "Top.regions") | startsWith(keys, "Top.subregions")][[1]]
     # gather columns except for the first column (names of region) to make it easy to visualise
 
-    # If query consists of only one word,
-    # gtrendsR uses regions (e.g. Japan)
-    # for output column name instead of the query word.
-    # So we are replacing it with the query word
-    # so that we can use the query word in subsequent steps.
-    if(length(query) == 1){
-      # The query is lowered and spaces are changed into . by gtrendsR, so doing the same
-      colnames(ret[[key]])[[2]] <- stringr::str_to_lower(stringr::str_replace(stringr::str_trim(query), " +", "."))
-    }
+    # Column names should be the same with queries because Japanese character is strangely returned by gtrends package
+    # The query is lowered and spaces are changed into . by gtrendsR, so doing the same
+    colnames(ret[[key]])[-1] <- stringr::str_to_lower(stringr::str_replace(stringr::str_trim(query), " +", "."))
 
     tidyr::gather_(ret[[key]], "keyword", "trend", colnames(ret[[key]])[2:ncol(ret[[key]])], na.rm = TRUE)
   } else if (type == "top_cities"){
@@ -106,24 +105,8 @@ getGoogleTrends <- function(user, password, query = "", type = "trend", last = "
     tidyr::gather_(bind_data, "keyword", "trend", colnames(bind_data)[2:ncol(bind_data)], na.rm = TRUE)
   } else if (type == "trend"){
     trend <- ret[[type]]
-    # use query and geo arguments as column names to prevent garbled characters
-    # The query is lowered and spaces are changed into . by gtrendsR, so doing the same
-    queries <- stringr::str_to_lower(stringr::str_replace(stringr::str_trim(query), " +", "."))
-    cols <- if(!is.null(geo)){
-      # put geo into column names and separate it later
-      # spaces in queries are converted to . by gtrends, so space can be used safely
-      paste(queries, geo, sep = " ")
-    } else {
-      queries
-    }
-    colnames(trend)[(ncol(trend)-length(cols)+1):ncol(trend)] <- cols
-    # gather columns except for time columns to make it easy to visualise
-    ret <- tidyr::gather_(trend, "keyword", "trend", cols, na.rm = TRUE)
-    if(!is.null(geo)){
-      # separates geo and keywords that were column names
-      ret <- tidyr::separate_(ret, "keyword", c("keyword", "geo"), sep = " ")
-    }
-    ret
+    colnames(trend)[colnames(trend) == "hits"] <- "trend"
+    trend
   } else {
     stop("Currently, type must be top_regions, top_cities or trends")
   }

--- a/R/google_trends.R
+++ b/R/google_trends.R
@@ -84,6 +84,7 @@ getGoogleTrends <- function(user,
 
     # Column names should be the same with queries because Japanese character is strangely returned by gtrends package
     # The query is lowered and spaces are changed into . by gtrendsR, so doing the same
+    # This -1 means except the first element because the first element is the name of region and don't have to be changed
     colnames(ret[[key]])[-1] <- stringr::str_to_lower(stringr::str_replace(stringr::str_trim(query), " +", "."))
 
     tidyr::gather_(ret[[key]], "keyword", "trend", colnames(ret[[key]])[2:ncol(ret[[key]])], na.rm = TRUE)


### PR DESCRIPTION
### Description
The output is changed by gtrendR upgrade, so modified the function accordingly

When type is "trend", keywords were in column names but now gtrends put them in keyword column

The amount of access to the keyword is in "hits"column by gtrendsR  but "trend" was used as the column name in exploratory package, so "trend" is still used here

Even though query is more than one, the column names need to be replaced when type is "trend" because Japanese character becomes strange if it's in the column

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement - No test because this needs account information
- [x] Pass devtools::check()
- [x] Pass devtools::test() 
- [x] Tested with Exploratory 

