### PR TITLE
prediction for models using categorical columns support

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -215,7 +215,7 @@ prediction <- function(df, source_data, test = TRUE){
         safe_slice(df, index)
       })) %>%
       dplyr::mutate(data = purrr::map2(data, model, function(df, model){
-        # remove rows that has categories that aren't in training data
+        # remove rows that have categories that aren't in training data
         # otherwise, broom::augment causes an error
         filtered_data <- df
         for (cname in colnames(model$model)) {

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -214,6 +214,15 @@ prediction <- function(df, source_data, test = TRUE){
         # keep data only in test_index
         safe_slice(df, index)
       })) %>%
+      dplyr::mutate(data = purrr::map2(data, model, function(df, model){
+        # remove rows that has categories that aren't in training data
+        # otherwise, broom::augment causes an error
+        filtered_data <- df
+        for (cname in colnames(model$model)) {
+          filtered_data <- filtered_data[filtered_data[[cname]] %in% model$model[[cname]], ]
+        }
+        filtered_data
+      })) %>%
       dplyr::select(-.test_index) %>%
       dplyr::rowwise() %>%
       dplyr::mutate(data = list(broom::augment(model, newdata = data))) %>%

--- a/tests/testthat/test_build_glm.R
+++ b/tests/testthat/test_build_glm.R
@@ -101,3 +101,24 @@ test_that("predict glm with new data", {
   expect_equal(colnames(confint_ret), c("group", "Term", "Prob 0.5", "Prob 99.5"))
 })
 
+
+test_that("prediction with categorical columns", {
+  test_data <- structure(
+    list(
+      CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
+
+  # duplicate rows to make some predictable data
+  # otherwise, the number of rows of the result of prediction becomes 0
+  test_data <- bind_rows(test_data, test_data)
+
+  model_data <- build_glm(test_data, CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
+
+  ret <- prediction(model_data, test_data)
+  expect_true(nrow(ret) > 0)
+  expect_equal(colnames(ret), c("CANCELLED", "Carrier.Name", "CARRIER", "DISTANCE", "Fitted", "Standard Error"))
+})
+

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -101,3 +101,23 @@ test_that("build_lm with evaluation", {
                                       ))
 
 })
+
+test_that("prediction with categorical columns", {
+  test_data <- structure(
+    list(
+      CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
+
+  # duplicate rows to make some predictable data
+  # otherwise, the number of rows of the result of prediction becomes 0
+  test_data <- bind_rows(test_data, test_data)
+
+  model_data <- build_lm(test_data, CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
+
+  ret <- prediction(model_data, test_data)
+  expect_true(nrow(ret) > 0)
+  expect_equal(colnames(ret), c("CANCELLED", "Carrier.Name", "CARRIER", "DISTANCE", "Fitted", "Standard Error"))
+})


### PR DESCRIPTION
### Description
Fix an issue that prediction causes an error for test data that have categorical data that is not in training data

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
