### PR TITLE
modify prediction functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.4.4.4
+Version: 0.4.4.5
 Date: 2016-05-13
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -103,10 +103,10 @@ add_prediction <- function(df, model_df, ...){
     broom::augment(model_df, model, newdata = df, ...)
   }, error = function(e){
     if (grepl("arguments imply differing number of rows: ", e$message)) {
-      # in this case, df has categories that aren't in model
+      # In this case, df has categories that aren't in model.
+      # For example, a model that was created by "category" column which has "a", "b"
+      # causes an error if df has "category" columnm which has "c".
 
-      # for example, a model that was created by "category" column which has "a", "b"
-      # causes an error if df has "category" columnm which has "c"
       filtered_data <- df
 
       for(model in model_df[["model"]]){
@@ -265,7 +265,8 @@ prediction <- function(df, source_data, test = TRUE, ...){
     augmented <- tryCatch({
       data_to_augment %>%
         dplyr::rowwise() %>%
-        dplyr::mutate_(.dots = list( data = aug_fml))
+        # evaluate the formula of augment and "data" column will have it
+        dplyr::mutate_(.dots = list(data = aug_fml))
     }, error = function(e){
       if (grepl("arguments imply differing number of rows: ", e$message)) {
         data_to_augment %>%
@@ -279,7 +280,8 @@ prediction <- function(df, source_data, test = TRUE, ...){
             filtered_data
           })) %>%
           dplyr::rowwise() %>%
-          dplyr::mutate_(.dots = list( data = aug_fml))
+          # evaluate the formula of augment and "data" column will have it
+          dplyr::mutate_(.dots = list(data = aug_fml))
       } else {
         stop(e$message)
       }
@@ -305,7 +307,8 @@ prediction <- function(df, source_data, test = TRUE, ...){
       })) %>%
       dplyr::select(-.test_index) %>%
       dplyr::rowwise() %>%
-      dplyr::mutate_(.dots = list( data = aug_fml)) %>%
+      # evaluate the formula of augment and "data" column will have it
+      dplyr::mutate_(.dots = list(data = aug_fml)) %>%
       dplyr::select(-model) %>%
       tidyr::unnest(data)
   }

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -93,6 +93,9 @@ predict <- function(df, model, ...){
 }
 
 #' apply data frame with model to a data frame
+#' @param df Data frame to predict
+#' @param model_df Data frame that has model
+#' @param ... Additional argument to be passed to broom::augment
 #' @export
 add_prediction <- function(df, model_df, ...){
 
@@ -214,6 +217,7 @@ kmeans_info <- function(df){
 #' @param df Data frame that has model and .test_index
 #' @param source_data Data frame used to create the model data
 #' @param test Test data or training data should be used as data
+#' @param ... Additional argument to be passed to broom::augment
 #' @export
 prediction <- function(df, source_data, test = TRUE, ...){
   df_cnames <- colnames(df)

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -294,6 +294,7 @@ prediction <- function(df, source_data, test = TRUE, ...){
   } else {
     # augment by trainig data
     # use formula to support expanded aug_args (especially for type.predict for logistic regression)
+    # because ... can't be passed to a function inside mutate directly
     aug_fml <- if(aug_args == ""){
       as.formula("~list(broom::augment(model, data = data))")
     } else {

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -246,8 +246,10 @@ prediction <- function(df, source_data, test = TRUE, ...){
 
   ret <- if(test){
     # augment by test data
-    # use formula to support expanded aug_args (especially for type.predict for logistic regression)
-    # because ... can't be passed to a function inside mutate directly
+
+    # Use formula to support expanded aug_args (especially for type.predict for logistic regression)
+    # because ... can't be passed to a function inside mutate directly.
+    # If test is TRUE, this uses newdata as an argument and if not, uses data as an argument.
     aug_fml <- if(aug_args == ""){
       as.formula("~list(broom::augment(model, newdata = data))")
     } else {
@@ -293,8 +295,10 @@ prediction <- function(df, source_data, test = TRUE, ...){
 
   } else {
     # augment by trainig data
-    # use formula to support expanded aug_args (especially for type.predict for logistic regression)
-    # because ... can't be passed to a function inside mutate directly
+
+    # Use formula to support expanded aug_args (especially for type.predict for logistic regression)
+    # because ... can't be passed to a function inside mutate directly.
+    # If test is FALSE, this uses data as an argument and if not, uses newdata as an argument.
     aug_fml <- if(aug_args == ""){
       as.formula("~list(broom::augment(model, data = data))")
     } else {

--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -145,4 +145,5 @@ test_that("cluster_data", {
 
   assigned_ret <- kmeans_ret %>% assign_cluster(test_df)
   expect_equal(colnames(assigned_ret), c("g", "with_na_group1", "with_na_group2", "cluster"))
+
 })

--- a/tests/testthat/test_build_glm.R
+++ b/tests/testthat/test_build_glm.R
@@ -117,8 +117,9 @@ test_that("prediction with categorical columns", {
 
   model_data <- build_glm(test_data, CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
 
-  ret <- prediction(model_data, test_data)
+  ret <- prediction(model_data, test_data, type.predict = "response")
   expect_true(nrow(ret) > 0)
+  expect_true(all(ret["Fitted"] >= 0 & ret["Fitted"] <= 1))
   expect_equal(colnames(ret), c("CANCELLED", "Carrier.Name", "CARRIER", "DISTANCE", "Fitted", "Standard Error"))
 })
 

--- a/tests/testthat/test_build_glm.R
+++ b/tests/testthat/test_build_glm.R
@@ -115,7 +115,7 @@ test_that("prediction with categorical columns", {
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
 
-  model_data <- build_glm(test_data, CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
+  model_data <- build_glm(test_data, family = "binomial", CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
 
   ret <- prediction(model_data, test_data, type.predict = "response")
   expect_true(nrow(ret) > 0)

--- a/tests/testthat/test_build_glm.R
+++ b/tests/testthat/test_build_glm.R
@@ -121,5 +121,9 @@ test_that("prediction with categorical columns", {
   expect_true(nrow(ret) > 0)
   expect_true(all(ret["Fitted"] >= 0 & ret["Fitted"] <= 1))
   expect_equal(colnames(ret), c("CANCELLED", "Carrier.Name", "CARRIER", "DISTANCE", "Fitted", "Standard Error"))
+
+  add_prediction_ret <- test_data %>% add_prediction(model_data, type.predict = "response")
+  expect_true(all(add_prediction_ret[".fitted"] >= 0 & add_prediction_ret[".fitted"] <= 1))
+
 })
 


### PR DESCRIPTION
### Description
* resolve https://github.com/exploratory-io/tam/issues/4143

* add_prediction for unknown categories support

* filter data only when prediction causes error because it can work if there is only one categorical variable



### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [x] Test installing from github
- [x] Tested with Exploratory
