### PR TITLE
Work around for returning 0 row with Actual Technology's Oracle ODBC driver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.4.5
+Version: 0.4.5.1
 Date: 2016-05-13
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -483,6 +483,14 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
     connstr <- stringr::str_c(connstr, ",", additionalParams, ")")
   }
   conn <- eval(parse(text=connstr))
+
+  # For some reason, following line works around Actual Oracle Driver for Mac issue
+  # that it always returns 0 rows.
+  # Since it does not have performance impact because it does not return any row
+  # because of the dummy catalog/schema specification, we are just calling it
+  # unconditionally rather than first checking which ODBC driver is used for the connection.
+  RODBC::sqlTables(conn, catalog = "dummy", schema = "dummy")
+
   df <- RODBC::sqlQuery(conn, GetoptLong::qq(query), max = numOfRows)
   RODBC::odbcClose(conn)
   df


### PR DESCRIPTION
### Description
Work around for returning 0 row with Actual Technology's Oracle ODBC driver for Mac.
Without this 0 row is returned from RODBC::sqlQuery().

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
