### PR TITLE
use conf_int for model_coef

### DIFF
--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -213,10 +213,6 @@ test_that("test prediction binary", {
 
   model_data <- build_lr(test_data, CANCELLED ~ DISTANCE, test_rate = 0.2)
 
-  ret <- prediction_binary(model_data, threshold = 0.5, pretty.name = FALSE)
-  expect_true("predicted_label" %in% colnames(ret))
-
-  opt_ret <- prediction_binary(model_data, threshold = "f_score", pretty.name = FALSE)
-  expect_true(any(ret[["predicted_label"]] != opt_ret[["predicted_label"]]))
+  model_coef(model_data, conf.int = "default")
 
 })


### PR DESCRIPTION
### Description
Add an option for model_coef to use confint.default for performance

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
