### PR TITLE
Changed to pass encoding argument to make it work with Japanese environment.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.5.4
+Version: 0.5.4.1
 Date: 2016-05-13
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -486,7 +486,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
 
   # For some reason, calling RODBC::sqlTables() works around Actual Oracle Driver for Mac issue
   # that it always returns 0 rows.
-  # Since we want this to be done without sacrificing performance, 
+  # Since we want this to be done without sacrificing performance,
   # we are adding dummy catalog/schema condition to make it return nothing.
   # Since it does not have performance impact, we are just calling it
   # unconditionally rather than first checking which ODBC driver is used for the connection.
@@ -1057,7 +1057,7 @@ checkSourceConflict <- function(files){
   for (file in files){
     ret[[file]] <- tryCatch({
       env <- new.env()
-      source(file, local=env)
+      source(file, local=env, encoding = "UTF-8")
       attached_objects <- ls(env)
       list(names = attached_objects)
     }, error = function(e){


### PR DESCRIPTION
### Description

This PR addresses the issue that exploratory::checkSourceConflict does not work with Japanese file.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
