### PR TITLE
modify output column names for pairwise functions

### DIFF
--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -266,7 +266,7 @@ do_dist.cols <- function(df,
 
   select_dots <- lazyeval::lazy_dots(...)
 
-  cnames <- avoid_conflict(grouped_column, c("pair.name.1", "pair.name.2", "value"))
+  cnames <- avoid_conflict(grouped_column, c("pair.name.x", "pair.name.y", "value"))
 
   # this is executed on each group
   calc_dist_each <- function(df){

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -124,7 +124,7 @@ do_cor.cols <- function(df, ..., use="pairwise.complete.obs", method="pearson", 
   # select columns using dplyr::select logic
   select_dots <- lazyeval::lazy_dots(...)
   grouped_col <- grouped_by(df)
-  output_cols <- avoid_conflict(grouped_col, c("pair.name.1", "pair.name.2", "value"))
+  output_cols <- avoid_conflict(grouped_col, c("pair.name.x", "pair.name.y", "value"))
   # check if the df's grouped
   do_cor_each <- function(df){
     mat <- dplyr::select_(df, .dots = select_dots) %>%  as.matrix()


### PR DESCRIPTION
### Description
* modify pairwise functions so that they will generate always ~.x, ~.y and value columns

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
