### PR TITLE
Avoid name conflict in prediction_survfit

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -844,7 +844,7 @@ prediction_survfit <- function(df, newdata = NULL, ...){
       united_colnames = c(united_colnames, united_colname)
     }
     # gather the united values into key column (cohort) and value column (val)
-    gathered <- ret %>% gather_("cohort", "val", united_colnames)
+    gathered <- ret %>% gather_(".cohort.temp", "val", united_colnames)
     # separte the value column to reverse the effect of unite() we did before.
     ret <- gathered %>% separate_("val",c("estimate", "std_error", "conf_high", "conf_low"),sep="_")
     # convert characterized data back to numeric.
@@ -852,10 +852,10 @@ prediction_survfit <- function(df, newdata = NULL, ...){
     # replace the cohort name with a string that is a concatenation of values that represents the cohort.
     cohorts_labels <- newdata %>% unite(label, everything())
     for (i in 1:nrow(newdata)){
-      ret <- ret %>% mutate(cohort = if_else(paste0("est", i) == cohort, cohorts_labels$label[[i]], cohort))
+      ret <- ret %>% mutate(.cohort.temp = if_else(paste0("est", i) == .cohort.temp, cohorts_labels$label[[i]], .cohort.temp))
     }
-    # replace the "cohort" column name with name like "age_sex".
-    colnames(ret)[colnames(ret) == "cohort"] <- paste0(colnames(newdata), collapse = "_")
+    # replace the .cohort.temp column name with name like "age_sex".
+    colnames(ret)[colnames(ret) == ".cohort.temp"] <- paste0(colnames(newdata), collapse = "_")
   }
 
   colnames(ret)[colnames(ret) == "n.risk"] <- "n_risk"

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -843,10 +843,10 @@ prediction_survfit <- function(df, newdata = NULL, ...){
       ret <- ret %>% unite_(united_colname, c(paste0("estimate.",i), paste0("std.error.",i), paste0("conf.high.",i),paste0("conf.low.",i)), sep="_", remove=TRUE)
       united_colnames = c(united_colnames, united_colname)
     }
-    # gather the united values into key column (cohort) and value column (val)
-    gathered <- ret %>% gather_(".cohort.temp", "val", united_colnames)
+    # gather the united values into key column (.cohort.temp) and value column (.val.temp)
+    gathered <- ret %>% gather_(".cohort.temp", ".val.temp", united_colnames)
     # separte the value column to reverse the effect of unite() we did before.
-    ret <- gathered %>% separate_("val",c("estimate", "std_error", "conf_high", "conf_low"),sep="_")
+    ret <- gathered %>% separate_(".val.temp",c("estimate", "std_error", "conf_high", "conf_low"),sep="_")
     # convert characterized data back to numeric.
     ret <- ret %>% mutate(estimate = as.numeric(estimate), std_error = as.numeric(std_error), conf_high = as.numeric(conf_high), conf_low = as.numeric(conf_low))
     # replace the cohort name with a string that is a concatenation of values that represents the cohort.


### PR DESCRIPTION
### Description
Avoid name conflict in prediction_survfit
### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
