### PR TITLE
Make cohort names shorter by omitting columns with only 1 unique value

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -879,12 +879,14 @@ prediction_survfit <- function(df, newdata = NULL, ...){
     # convert characterized data back to numeric.
     ret <- ret %>% mutate(estimate = as.numeric(estimate), std_error = as.numeric(std_error), conf_high = as.numeric(conf_high), conf_low = as.numeric(conf_low))
     # replace the cohort name with a string that is a concatenation of values that represents the cohort.
-    cohorts_labels <- newdata %>% unite(label, everything())
-    for (i in 1:nrow(newdata)){
+    # but, omit newdata column that has only 1 unique value from the cohort names we create here.
+    selected_newdata <- newdata %>% dplyr::select_if(function(x) length(unique(x)) > 1)
+    cohorts_labels <- selected_newdata %>% unite(label, everything())
+    for (i in 1:nrow(selected_newdata)){
       ret <- ret %>% mutate(.cohort.temp = if_else(paste0("est", i) == .cohort.temp, cohorts_labels$label[[i]], .cohort.temp))
     }
     # replace the .cohort.temp column name with name like "age_sex".
-    colnames(ret)[colnames(ret) == ".cohort.temp"] <- paste0(colnames(newdata), collapse = "_")
+    colnames(ret)[colnames(ret) == ".cohort.temp"] <- paste0(colnames(selected_newdata), collapse = "_")
   }
 
   colnames(ret)[colnames(ret) == "n.risk"] <- "n_risk"


### PR DESCRIPTION
### Description
Make cohort names shorter by omitting columns with only 1 unique value
As a column to distinguish cohort, we create column like age_sex_ph.ecog,
but for example, if there is only 1 type of sex in newdata, it will be age_ph.ecog.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
