### PR TITLE
add error message for empty data

### DIFF
--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -26,6 +26,10 @@ data_xgboost <- function(data, x_names, y_name, weight = NULL, nrounds= 10, ...)
     x <- matrix(as.double(x), ncol = ncol(x))
   }
 
+  if (nrow(x) == 0) {
+    stop("No valid data to create xgboost model.")
+  }
+
   y <- as.numeric(data[[y_name]])
 
   ret <- xgboost::xgboost(data = x, label = y, weight = weight, nrounds = nrounds, ...)


### PR DESCRIPTION
### Description
add error message for xgboost when there is no valid data (containing NA in all rows)

![image](https://cloud.githubusercontent.com/assets/6638312/23733376/ec343a9c-04bb-11e7-9f54-bea1ec935af4.png)

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
