### PR TITLE
make client key and secret nullable

### DIFF
--- a/R/oauth.R
+++ b/R/oauth.R
@@ -76,8 +76,6 @@ getGoogleTokenForAnalytics <- function(tokenFileId = "", useCache=TRUE){
       validate = "https://www.googleapis.com/oauth2/v1/tokeninfo",
       revoke = "https://accounts.google.com/o/oauth2/revoke",
       appname = appName,
-      key = clientId,
-      secret = secret,
       credentials = list(
         access_token = token_info$access_token,
         refresh_token = token_info$refresh_token,

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -122,8 +122,6 @@ getGoogleTokenForSheet <- function(tokenFileId="", useCache=TRUE){
       validate = "https://www.googleapis.com/oauth2/v1/tokeninfo",
       revoke = "https://accounts.google.com/o/oauth2/revoke",
       appname = appName,
-      key = clientId,
-      secret = secret,
       credentials = list(
         access_token = token_info$access_token,
         refresh_token = token_info$refresh_token,

--- a/R/oauth_wrapper.R
+++ b/R/oauth_wrapper.R
@@ -3,13 +3,21 @@ HttrOAuthToken2.0 <- R6::R6Class("HttrOAuthToken2.0", inherit = httr::Token2.0, 
   initialize = function(
     ...,
     appname,
-    key,
-    secret,
+    key = NULL,
+    secret = NULL,
     credentials = list()
   ){
     self$endpoint <- httr::oauth_endpoint(
       ...
     )
+    # token is created directly from access token,
+    # so these parameters are created by dummy parameters
+    if(is.null(key)){
+      key <- "dummy"
+    }
+    if(is.null(secret)){
+      secret <- "dummy"
+    }
     self$app <- httr::oauth_app(
       appname = appname,
       key = key,
@@ -26,13 +34,21 @@ HttrOAuthToken1.0 <- R6::R6Class("HttrOAuthToken1.0", inherit = httr::Token1.0, 
   initialize = function(
     ...,
     appname,
-    key,
-    secret,
+    key = NULL,
+    secret = NULL,
     credentials = list()
   ){
     self$endpoint <- httr::oauth_endpoint(
       ...
     )
+    # token is created directly from access token,
+    # so these parameters are created by dummy parameters
+    if(is.null(key)){
+      key <- "dummy"
+    }
+    if(is.null(secret)){
+      secret <- "dummy"
+    }
     self$app <- httr::oauth_app(
       appname = appname,
       key = key,


### PR DESCRIPTION
### Description
oauth token works if key and secret is invalid, so made them dummy string

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
