### PR TITLE
Use wrong but compatible id googlesheet

### DIFF
--- a/R/oauth.R
+++ b/R/oauth.R
@@ -112,7 +112,7 @@ getGoogleTokenForSheet <- function(tokenFileId="", useCache=TRUE){
   endpointType = "google"
   # retrieve token info from environment
   # main purpose is to enable server refresh
-  token_info <- getTokenInfo("googlesheets")
+  token_info <- getTokenInfo("googlesheet") # this should be googlesheets but our plunin is already named googlesheet
   if(!is.null(token_info)){
     HttrOAuthToken2.0$new(
       authorize = "https://accounts.google.com/o/oauth2/auth",


### PR DESCRIPTION
### Description
Use wrong but compatible id "googlesheet" rather than "googlesheets"

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
