### PR TITLE
set better prophet seasonality default values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.5.9.3
+Version: 0.5.9.5
 Date: 2017-04-26
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -38,7 +38,7 @@ do_prophet <- function(df, time, value = NULL, ...){
 #' @param uncertainty.samples - Number of simulations made for calculating uncertainty intervals. Default is 1000.
 #' @export
 do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "day", include_history = TRUE,
-                        fun.aggregate = sum, cap = NULL, weekly.seasonality = "auto", yearly.seasonality = "auto", ...){
+                        fun.aggregate = sum, cap = NULL, weekly.seasonality = TRUE, yearly.seasonality = TRUE, ...){ # make default for weekly/yearly.seasonality TRUE since 'auto' does not behave well.
 
   loadNamespace("dplyr")
   # For some reason this needs to be library() instead of loadNamespace() to avoid error.
@@ -106,9 +106,10 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
     if (time_unit != "day") { # if time_unit is larger than day (the next level is week), having weekly.seasonality does not make sense.
       weekly.seasonality = FALSE
     }
-    if (time_unit == "year") { # if time_unit is year (the largest unit), having yearly.seasonality does not make sense.
-      yearly.seasonality = FALSE
-    }
+    # disabling this logic for now, since setting yearly.seasonality FALSE disables weekly.seasonality too.
+    # if (time_unit == "year") { # if time_unit is year (the largest unit), having yearly.seasonality does not make sense.
+    #   yearly.seasonality = FALSE
+    # }
     if (!is.null(cap) && is.data.frame(cap)) {
       # in this case, cap is the future data frame with cap, specified by user.
       # this is a back door to allow user to specify cap column.

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -38,7 +38,13 @@ do_prophet <- function(df, time, value = NULL, ...){
 #' @param uncertainty.samples - Number of simulations made for calculating uncertainty intervals. Default is 1000.
 #' @export
 do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "day", include_history = TRUE,
-                        fun.aggregate = sum, cap = NULL, weekly.seasonality = TRUE, yearly.seasonality = TRUE, ...){ # make default for weekly/yearly.seasonality TRUE since 'auto' does not behave well.
+                        fun.aggregate = sum, cap = NULL, weekly.seasonality = TRUE, yearly.seasonality = TRUE, ...){
+  # we are making default for weekly/yearly.seasonality TRUE since 'auto' does not behave well.
+  # it seems that there are cases that weekly.seasonality is turned off as a side-effect of yearly.seasonality turned off.
+  # if that happens, since no seasonality is on, prophet forecast result becomes just a linear trend line,
+  # which does not look convincing.
+  # since there seems to be cases where 'auto' on yearly.seasonality triggers this situation, we are using TRUE as default.
+  # we have not seen any issue on 'auto' on weekly.seasonality, but are not using it for now just to be careful.
 
   loadNamespace("dplyr")
   # For some reason this needs to be library() instead of loadNamespace() to avoid error.


### PR DESCRIPTION
### Description
Set better prophet seasonality default values, to avoid the situation where forecast result degrades to only linear trend line.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
