### PR TITLE
build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 man
+.Rbuildignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .Rhistory
 .RData
 man
-.Rbuildignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     broom,
     tibble,
     jsonlite,
-    rgeolocate,
     countrycode,
     reshape2,
     lazyeval,
@@ -67,5 +66,6 @@ Suggests:
     AnomalyDetection,
     prophet,
     randomForest,
-    lexicon
+    lexicon,
+    rgeolocate
 RoxygenNote: 6.0.1

--- a/R/geolocation.R
+++ b/R/geolocation.R
@@ -5,8 +5,8 @@
 #'@param type Returning data type from maxmind. This can be "continent_name", "country_name", "country_code", "region_name", "city_name", "city_geoname_id", "timezone", "longitude", "latitude" and "connection"
 #'@return Vector output from maxmind
 maxmind_closure <- function(type){
-  loadNamespace("rgeolocate")
   function(ip){
+    loadNamespace("rgeolocate")
     rgeolocatefile <- system.file("extdata","GeoLite2-Country.mmdb", package = "rgeolocate")
     df <- rgeolocate::maxmind(ip, rgeolocatefile, type)
     df[[type]]


### PR DESCRIPTION
### Description
There is no rgeolocate in cran but it was in dependancy, so the build was failing.
So moved it to Suggest and moved loadNamespace("rgeolocate"), so that it won't be needed for build

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [x] Test installing from github
- [ ] Tested with Exploratory
