### PR TITLE
update do_svd parameters

### DIFF
--- a/R/do_svd.R
+++ b/R/do_svd.R
@@ -224,16 +224,16 @@ do_svd.kv_ <- function(df,
 #' @param output "long" or "wide".
 #' "long" is a format with 3 columns which represents rows, columns and values
 #' "wide" is a format which spreads the long information into matrix
+#' @param keep_cols If TRUE, selected columns are kept in the result.
 #' @return Tidy format of svd result in a data frame.
 #' @export
 do_svd.cols <- function(df,
-                         ...,
+                        ...,
                         type="group",
-                        fill=0,
-                        fun.aggregate=mean,
-                        n_component=3,
+                        n_component=2,
                         centering=TRUE,
-                        output ="long"){
+                        output ="wide",
+                        keep_cols = FALSE){
   validate_empty_data(df)
 
   loadNamespace("dplyr")
@@ -252,14 +252,15 @@ do_svd.cols <- function(df,
   # this is executed on each group
   do_svd_each <- function(df){
     # create matrix by selected columns
-    matrix <- df %>%
-      dplyr::select_(.dots=select_dots) %>%
+    selected_df <- df %>%
+      dplyr::select_(.dots=select_dots)
+    matrix <- selected_df %>%
       as.matrix() %>%
       na.omit() # this removes rows which have any NA
 
     # n_component must be smaller than
     # or equal to ncol(matrix).
-    # Otherwise, svd takes to much memory and R session
+    # Otherwise, svd takes too much memory and R session
     # crushes
     n_component <- min(c(ncol(matrix), n_component))
 
@@ -300,8 +301,17 @@ do_svd.cols <- function(df,
         ret <- as.data.frame(mat)
         colnames(ret) <- avoid_conflict(c(colnames(df), grouped_col), paste0("axis", seq(ncol(ret))))
 
+        # remove selected columns
+        not_selected_df <- df[,!colnames(df) %in% colnames(selected_df)]
+
         # append u matrix to the original data frame
-        ret <- cbind(df, ret)
+        ret <- if(keep_cols){
+          # keep selected columns in the end
+          # if keep_cols is TRUE
+          cbind(not_selected_df, ret, selected_df)
+        } else {
+          cbind(not_selected_df, ret)
+        }
       } else if (output=="long") {
         # this returns molten format data frame of matrix
         # with subjects, new dimentions and values

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -201,6 +201,7 @@ do_cmdscale_ <- function(df,
     }
     points <- cmdscale(as.dist(t(mat)), eig=FALSE, k=k)
     result_df <- as.data.frame(points)
+    colnames(result_df) <- paste("axis", seq(ncol(result_df)), sep = "")
 
     df <- setNames(data.frame(rownames(points), stringsAsFactors=FALSE), name_col)
     ret <- cbind(df, result_df)

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -201,6 +201,8 @@ do_cmdscale_ <- function(df,
     }
     points <- cmdscale(as.dist(t(mat)), eig=FALSE, k=k)
     result_df <- as.data.frame(points)
+
+    # these column names should be consistent with the result of do_svd
     colnames(result_df) <- paste("axis", seq(ncol(result_df)), sep = "")
 
     df <- setNames(data.frame(rownames(points), stringsAsFactors=FALSE), name_col)

--- a/tests/testthat/test_do_svd.R
+++ b/tests/testthat/test_do_svd.R
@@ -28,7 +28,7 @@ test_that("test do_svd cols with NA long", {
 
   ret <- do_svd(test_df, dplyr::starts_with("col"), output = "long")
 
-  expect_equal(nrow(ret), 9)
+  expect_equal(nrow(ret), 6)
   expect_true(all(ret$row %in% seq(3)))
 })
 
@@ -46,7 +46,7 @@ test_that("test do_svd cols with NA", {
   ret <- do_svd(test_df, dplyr::starts_with("col"), output = "wide")
 
   expect_equal(nrow(ret), 4)
-  expect_equal(colnames(ret), c(colnames(test_df), "axis1.new", "axis2", "axis3"))
+  expect_equal(colnames(ret), c("axis1", "axis1.new", "axis2"))
 })
 
 test_that("test do_svd cols dimension with NA long", {
@@ -62,7 +62,7 @@ test_that("test do_svd cols dimension with NA long", {
 
   ret <- do_svd(test_df, dplyr::starts_with("col"), output = "long", type = "dimension")
 
-  expect_equal(nrow(ret), 9)
+  expect_equal(nrow(ret), 6)
   expect_true(all(ret$colname %in% colnames(test_df)))
 })
 
@@ -96,7 +96,7 @@ test_that("test do_svd cols variance with NA long", {
 
   ret <- do_svd(test_df, dplyr::starts_with("col"), output = "long", type = "variance")
 
-  expect_equal(nrow(ret), 3)
+  expect_equal(nrow(ret), 2)
   expect_equal(colnames(ret), c("new.dimension", "value"))
 })
 
@@ -114,5 +114,5 @@ test_that("test do_svd cols variance with NA wide", {
   ret <- do_svd(test_df, dplyr::starts_with("col"), output = "wide", type = "variance")
 
   expect_equal(nrow(ret), 1)
-  expect_equal(colnames(ret), c("axis1", "axis2", "axis3"))
+  expect_equal(colnames(ret), c("axis1", "axis2"))
 })


### PR DESCRIPTION
### Description
Modify default parameters for do_svd.cols

Modify column names of do_cmdscale to match the result of do_svd (axis1, axis2)
![image](https://cloud.githubusercontent.com/assets/6638312/26664657/28425920-46ce-11e7-844a-9fd05995913a.png)


### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
