### PR TITLE
Fix bug that happens when do_cor returns one row result 

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -202,6 +202,9 @@ upper_gather <- function(mat, names=NULL, diag=NULL, cnames = c("Var1", "Var2", 
       ind[ind[,2] < ind[,1], ]
     }
 
+    if(is.vector(filtered)){
+      filtered <- as.data.frame(as.list(filtered))
+    }
     # this creates pairs of row and column indices
     # make a vector of upper half of matrix
     row <- r_names[filtered[,1]]

--- a/R/util.R
+++ b/R/util.R
@@ -202,8 +202,8 @@ upper_gather <- function(mat, names=NULL, diag=NULL, cnames = c("Var1", "Var2", 
       ind[ind[,2] < ind[,1], ]
     }
 
-    # when there is only one index peirs,
-    # filtered becomes vector, not matrix
+    # when there is only one index pairs,
+    # filtered becomes a vector, not matrix
     # but matrix is expected later
     # so should be converted to matrix with
     # one row

--- a/R/util.R
+++ b/R/util.R
@@ -202,9 +202,15 @@ upper_gather <- function(mat, names=NULL, diag=NULL, cnames = c("Var1", "Var2", 
       ind[ind[,2] < ind[,1], ]
     }
 
+    # when there is only one index peirs,
+    # filtered becomes vector, not matrix
+    # but matrix is expected later
+    # so should be converted to matrix with
+    # one row
     if(is.vector(filtered)){
-      filtered <- as.data.frame(as.list(filtered))
+      filtered <- t(as.matrix(filtered))
     }
+
     # this creates pairs of row and column indices
     # make a vector of upper half of matrix
     row <- r_names[filtered[,1]]

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -51,24 +51,6 @@ test_that("do_cor with NA values", {
   }
 })
 
-test_that("do_cor with 2 columns and distinct TRUE", {
-  loadNamespace("reshape2")
-  nrow <- 10
-  ncol <- 2
-  vec <- rnorm(nrow * ncol)
-  vec[[3]] <- NA
-  vec[[30]] <- NA
-  vec[[55]] <- NA
-  mat <- matrix(vec, nrow = nrow)
-  melt_mat <- reshape2::melt(mat)
-  colnames(melt_mat)[[2]] <- "Var 2"
-
-  ret <- do_cor(melt_mat, Var1, `Var 2`, distinct = TRUE)
-
-  cor_ret <- cor(melt_mat[["Var1"]], melt_mat[["Var 2"]], use = "pairwise.complete.obs")
-
-})
-
 tidy_test_df <- data.frame(
   cat=rep(c("cat1", "cat2"), 20),
   dim = sort(rep(paste0("dim", seq(4)), 5)),

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -51,6 +51,26 @@ test_that("do_cor with NA values", {
   }
 })
 
+test_that("do_cor with 2 columns and distinct TRUE", {
+  loadNamespace("reshape2")
+  nrow <- 10
+  ncol <- 2
+  vec <- rnorm(nrow * ncol)
+  vec[[3]] <- NA
+  vec[[30]] <- NA
+  vec[[55]] <- NA
+  mat <- matrix(vec, nrow = nrow)
+  melt_mat <- reshape2::melt(mat)
+  colnames(melt_mat)[[2]] <- "Var 2"
+
+  ret <- do_cor(melt_mat, Var1, `Var 2`, distinct = TRUE)
+
+  cor_ret <- cor(melt_mat[["Var1"]], melt_mat[["Var 2"]], use = "pairwise.complete.obs")
+
+  browser()
+
+})
+
 tidy_test_df <- data.frame(
   cat=rep(c("cat1", "cat2"), 20),
   dim = sort(rep(paste0("dim", seq(4)), 5)),

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -67,8 +67,6 @@ test_that("do_cor with 2 columns and distinct TRUE", {
 
   cor_ret <- cor(melt_mat[["Var1"]], melt_mat[["Var 2"]], use = "pairwise.complete.obs")
 
-  browser()
-
 })
 
 tidy_test_df <- data.frame(

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -19,6 +19,17 @@ test_that("test upper_gather", {
   expect_equal(nrow(result), 6)
 })
 
+test_that("upper_gather with 2 by 2 matrix", {
+  upper_gather(
+    structure(
+      c(1, 0.952601667396786, 0.952601667396786, 1),
+      .Dim = c(2L,2L),
+      .Dimnames = list(
+        c("ARR_DELAY", "DEP_DELAY"),
+        c("ARR_DELAY", "DEP_DELAY"))))
+  browser()
+})
+
 test_that("test upper_gather with vector", {
   mat <- seq(6)
   names <- paste("entity", seq(4))

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -20,14 +20,21 @@ test_that("test upper_gather", {
 })
 
 test_that("upper_gather with 2 by 2 matrix", {
-  upper_gather(
+  ret <- upper_gather(
     structure(
       c(1, 0.952601667396786, 0.952601667396786, 1),
       .Dim = c(2L,2L),
       .Dimnames = list(
         c("ARR_DELAY", "DEP_DELAY"),
         c("ARR_DELAY", "DEP_DELAY"))))
-  browser()
+  expect_equal(ret,
+               structure(
+                 list(
+                   Var1 = "ARR_DELAY", Var2 = "DEP_DELAY", value = 0.952601667396786),
+                 .Names = c("Var1", "Var2", "value"),
+                 row.names = c(NA, -1L),
+                 class = "data.frame")
+               )
 })
 
 test_that("test upper_gather with vector", {


### PR DESCRIPTION
### Description

An error occurred when one pair of cor is selected and distinct is TRUE

![image](https://user-images.githubusercontent.com/6638312/26999624-55a8c554-4dd9-11e7-93a7-4ccc412652ef.png)


It was because a vector is returned although matrix is expected because the pair is only one and one row is selected from a matrix

Confirmed the fix by Exploratory

![image](https://user-images.githubusercontent.com/6638312/26999619-1f9eeef2-4dd9-11e7-8ef8-5adaf2a0b211.png)


### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
