### PR TITLE
Adjust bsts stats output column names

### DIFF
--- a/R/causal_impact.R
+++ b/R/causal_impact.R
@@ -8,13 +8,15 @@ glance.bsts <- function(x) {
   data.frame(residual_sd = ret$residual.sd,
              prediction_sd = ret$prediction.sd,
              r_square = ret$rsquare,
-             relative_gof = ret$relative.gof,
-             coef_min = ret$size[[1]],
-             coef_1st_quartile = ret$size[[2]],
-             coef_median = ret$size[[3]],
-             coef_mean = ret$size[[4]],
-             coef_3rd_quartile = ret$size[[5]],
-             coef_max = ret$size[[6]])
+             # relative.gof always gives NA.
+             # bsts does not seem to handle NAs in the data in post-event period from CausalImpact. seems to be a bsts bug.
+             # relative_gof = ret$relative.gof,
+             n_coef_min = ret$size[[1]],
+             n_coef_1st_quartile = ret$size[[2]],
+             n_coef_median = ret$size[[3]],
+             n_coef_mean = ret$size[[4]],
+             n_coef_3rd_quartile = ret$size[[5]],
+             n_coef_max = ret$size[[6]])
 }
 
 #' broom::tidy() implementation for bsts model
@@ -22,9 +24,9 @@ glance.bsts <- function(x) {
 tidy.bsts <- function(x) {
   df <- as.data.frame(summary(x)$coefficients)
   df <- tibble::rownames_to_column(df, var="market") # not really generic, but in our usage, it is market.
-  colnames(df)[colnames(df) == "mean.inc"] <- "mean_inc"
-  colnames(df)[colnames(df) == "sd.inc"] <- "sd_inc"
-  colnames(df)[colnames(df) == "inc.prob"] <- "inc_prob"
+  colnames(df)[colnames(df) == "mean.inc"] <- "mean_when_included"
+  colnames(df)[colnames(df) == "sd.inc"] <- "sd_when_included"
+  colnames(df)[colnames(df) == "inc.prob"] <- "include_prob"
   df
 }
 


### PR DESCRIPTION
### Description
Renamed bsts stats output column name so that they represent their meanings better.
Also, removed relative.gof since it always returns NULL due to CausalImpact bug.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
