### PR TITLE
[MongoDB] Support @ character in password

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.6.3.5
+Version: 0.6.3.6
 Date: 2017-04-26
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -170,6 +170,10 @@ getMongoURL <- function(host, port, database, username, pass, isSSL=FALSE, authS
   loadNamespace("stringr")
 
   if (stringr::str_length(username) > 0) {
+    if(!is.null(pass) && pass != ''){
+      # mongodb connection URL uses @ as a separator so need to escape it if used inside password.
+      pass = stringr::str_replace_all(pass, "@", "%40")
+    }
     url = stringr::str_c("mongodb://", username, ":", pass, "@", host, ":", as.character(port), "/", database)
   }
   else {

--- a/R/system.R
+++ b/R/system.R
@@ -168,11 +168,12 @@ getGithubIssues <- function(username, password, owner, repository){
 
 getMongoURL <- function(host, port, database, username, pass, isSSL=FALSE, authSource=NULL) {
   loadNamespace("stringr")
+  loadNamespace("urltools")
 
   if (stringr::str_length(username) > 0) {
     if(!is.null(pass) && pass != ''){
-      # mongodb connection URL uses @ as a separator so need to escape it if used inside password.
-      pass = stringr::str_replace_all(pass, "@", "%40")
+      # mongodb connection URL uses @ as a separator so need to encode password for those special characters.
+      pass = urltools::url_encode(pass)
     }
     url = stringr::str_c("mongodb://", username, ":", pass, "@", host, ":", as.character(port), "/", database)
   }


### PR DESCRIPTION
### Description

Currently, MongoDB connection fails if it contains @ in it.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
