### PR TITLE
modify bayes output labels

### DIFF
--- a/R/do_bayes_ab.R
+++ b/R/do_bayes_ab.R
@@ -237,14 +237,14 @@ tidy.bayesTest <- function(x, percentLift = 0, credInt = 0.9, type = "summary", 
     indice_b <- beta_b$x > 0 & beta_b$x < 1
 
     a_data <- data.frame(
-      ab_identifier = rep("A", length(indice_a)),
+      ab_identifier = "A",
       conversion_rate_pct = beta_a$x[indice_a] * 100,
       probability_density = beta_a$y[indice_a],
       stringsAsFactors = FALSE
     )
 
     b_data <- data.frame(
-      ab_identifier = rep("B", length(indice_a)),
+      ab_identifier = "B",
       conversion_rate_pct = beta_b$x[indice_b] * 100,
       probability_density = beta_b$y[indice_b],
       stringsAsFactors = FALSE

--- a/R/do_bayes_ab.R
+++ b/R/do_bayes_ab.R
@@ -250,7 +250,8 @@ tidy.bayesTest <- function(x, percentLift = 0, credInt = 0.9, type = "summary", 
       stringsAsFactors = FALSE
     )
     # set factor levels so that better group
-    # will come to the first level of output
+    # will come to the first level of output.
+    # This is needed for showing better chart
     s <- summary(x)
     level <- if(s$probability[[1]] > 0.5) {
       c("A", "B")

--- a/R/do_bayes_ab.R
+++ b/R/do_bayes_ab.R
@@ -225,12 +225,6 @@ tidy.bayesTest <- function(x, percentLift = 0, credInt = 0.9, type = "summary", 
     ret
 
   } else if (type == "posteriors") {
-    s <- summary(x)
-    level <- if(s$probability[[1]] > 0.5) {
-      c("A", "B")
-    } else {
-      c("B", "A")
-    }
     probability_a = x$posteriors$Probability$A_probs
     probability_b = x$posteriors$Probability$B_probs
 
@@ -241,12 +235,6 @@ tidy.bayesTest <- function(x, percentLift = 0, credInt = 0.9, type = "summary", 
 
     beta_b <- density(probability_b, n = 2048)
     indice_b <- beta_b$x > 0 & beta_b$x < 1
-
-    ab_identifier <- if(!is.null(x$ab_identifier) && length(x$ab_identifier) == 2){
-      x$ab_identifier
-    } else {
-      c("A", "B")
-    }
 
     a_data <- data.frame(
       ab_identifier = rep("A", length(indice_a)),
@@ -261,6 +249,14 @@ tidy.bayesTest <- function(x, percentLift = 0, credInt = 0.9, type = "summary", 
       probability_density = beta_b$y[indice_b],
       stringsAsFactors = FALSE
     )
+    # set factor levels so that better group
+    # will come to the first level of output
+    s <- summary(x)
+    level <- if(s$probability[[1]] > 0.5) {
+      c("A", "B")
+    } else {
+      c("B", "A")
+    }
     dplyr::bind_rows(a_data, b_data) %>%
       mutate(ab_identifier = factor(ab_identifier, levels = level))
   } else if (type == "improvement") {


### PR DESCRIPTION
### Description
* modify output labels for do_bayes_ab to show blue line right hand side

![image](https://user-images.githubusercontent.com/6638312/28871156-4f938938-77be-11e7-85e4-1b6cde433c7a.png)

* modify column values for this legend

![image](https://user-images.githubusercontent.com/6638312/28871184-72ad6baa-77be-11e7-919f-ce9f697154db.png)


### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
