### PR TITLE
Rename columns by creating new df since rename_ throws error when column name has space

### DIFF
--- a/R/do_retention_cohort.R
+++ b/R/do_retention_cohort.R
@@ -28,7 +28,11 @@ do_cohort <- function(df, time, value, cohort, time_unit = "month", fun.aggregat
   # this will be executed for each group
   each_func <- function(df, ...){
     # rename columns to temporary ones first and use familiar NSE dplyr functions.
-    ret <- df %>% rename_(.dots = list(.time = time_col, .value = value_col, .cohort = cohort_col))
+    # since rename_ throws error with column name with space, we use regular R approach with colnames().
+    ret <- df
+    colnames(ret)[colnames(ret) == time_col] <- ".time"
+    colnames(ret)[colnames(ret) == value_col] <- ".value"
+    colnames(ret)[colnames(ret) == cohort_col] <- ".cohort"
     if (class(df[[cohort_col]]) %in% c("Date", "POSIXct")) { # floor cohort if it is time.
       ret <- ret %>% dplyr::mutate(.cohort =lubridate::floor_date(.cohort, unit = time_unit))
     }

--- a/R/do_retention_cohort.R
+++ b/R/do_retention_cohort.R
@@ -29,10 +29,7 @@ do_cohort <- function(df, time, value, cohort, time_unit = "month", fun.aggregat
   each_func <- function(df, ...){
     # rename columns to temporary ones first and use familiar NSE dplyr functions.
     # since rename_ throws error with column name with space, we use regular R approach with colnames().
-    ret <- df
-    colnames(ret)[colnames(ret) == time_col] <- ".time"
-    colnames(ret)[colnames(ret) == value_col] <- ".value"
-    colnames(ret)[colnames(ret) == cohort_col] <- ".cohort"
+    ret <- data.frame(.time = df[[time_col]], .value = df[[value_col]], .cohort = df[[cohort_col]])
     if (class(df[[cohort_col]]) %in% c("Date", "POSIXct")) { # floor cohort if it is time.
       ret <- ret %>% dplyr::mutate(.cohort =lubridate::floor_date(.cohort, unit = time_unit))
     }

--- a/R/do_retention_cohort.R
+++ b/R/do_retention_cohort.R
@@ -28,7 +28,7 @@ do_cohort <- function(df, time, value, cohort, time_unit = "month", fun.aggregat
   # this will be executed for each group
   each_func <- function(df, ...){
     # rename columns to temporary ones first and use familiar NSE dplyr functions.
-    # since rename_ throws error with column name with space, we use regular R approach with colnames().
+    # since rename_ throws error with column name with space, we just create new data.frame.
     ret <- data.frame(.time = df[[time_col]], .value = df[[value_col]], .cohort = df[[cohort_col]])
     if (class(df[[cohort_col]]) %in% c("Date", "POSIXct")) { # floor cohort if it is time.
       ret <- ret %>% dplyr::mutate(.cohort =lubridate::floor_date(.cohort, unit = time_unit))


### PR DESCRIPTION
Rename columns by creating new data.frame since rename_ throws error when column name has space

### Description
Describe your fix here

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
