### PR TITLE
prevent replacing entire term string

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -707,6 +707,9 @@ model_coef <- function(df, pretty.name = FALSE, conf_int = NULL, ...){
         paste0(
           "^",
           all.vars(df$model[[1]]$term),
+          # this prevents replacing entire character
+          # http://www.regular-expressions.info/lookaround.html
+          "(?!$)",
           collapse = "|"
         ), "")
     )


### PR DESCRIPTION
### Description
Fix an issue that model_coef for coxph replaces entire term

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
