### PR TITLE
fix bayes ab for prior output

### DIFF
--- a/R/do_bayes_ab.R
+++ b/R/do_bayes_ab.R
@@ -19,6 +19,8 @@ do_bayes_ab <- function(df, a_b_identifier, total_count, conversion_rate, prior_
   set.seed(seed)
 
   # when type is prior, no need to evaluate other parameters
+  # but when prior_mean or prior_sd is NULL, it will be guessed by
+  # conversion_rate_col, so this should be run
   if (type != "prior" || (is.null(prior_mean) || is.null(prior_sd))) {
     # this seems to be the new way of NSE column selection evaluation
     # ref: https://github.com/tidyverse/tidyr/blob/3b0f946d507f53afb86ea625149bbee3a00c83f6/R/spread.R


### PR DESCRIPTION
### Description
fix bayes ab for prior output

fix this error when output type is prior
![image](https://user-images.githubusercontent.com/6638312/28954124-c9af60c0-7917-11e7-93b1-424bc1627900.png)

the cause was a needed variable was not created if type is "prior" although it was used to estimate for NULL prior parameters

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
