### PR TITLE
add na.rm argument to simple cast

### DIFF
--- a/R/do_svd.R
+++ b/R/do_svd.R
@@ -87,7 +87,15 @@ do_svd.kv_ <- function(df,
       df <- df[!is.na(df[[value_col]]), ]
     }
 
-    matrix <- simple_cast(df, subject_col, dimension_col, value_col, fun.aggregate = fun.aggregate, fill=fill)
+    matrix <- simple_cast(
+      df,
+      subject_col,
+      dimension_col,
+      value_col,
+      fun.aggregate = fun.aggregate,
+      fill=fill,
+      na.rm = TRUE
+    )
 
     # n_component must be smaller than
     # or equal to ncol(matrix).

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -77,7 +77,15 @@ build_kmeans.kv_ <- function(df,
     # to avoid it appears as duplicated column
     # after unnesting the result
     df <- df[, !colnames(df) %in% grouped_column]
-    mat <- simple_cast(df, row_col, col_col, value_col, fun.aggregate = fun.aggregate, fill=fill)
+    mat <- simple_cast(
+      df,
+      row_col,
+      col_col,
+      value_col,
+      fun.aggregate = fun.aggregate,
+      fill=fill,
+      na.rm = TRUE
+    )
     rownames(mat) <- NULL # this prevents warning about discarding row names of the matrix
     kmeans_ret <- tryCatch({
       kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)},

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -149,7 +149,15 @@ do_dist.kv_ <- function(df,
     # but simple_cast is designed for subject to columns,
     # so the matrix is transposed
     mat <- df %>%
-      simple_cast(key_col, subject_col, value_col, fill=fill, fun.aggregate=fun.aggregate, time_unit = time_unit) %>%
+      simple_cast(
+        key_col,
+        subject_col,
+        value_col,
+        fill=fill,
+        fun.aggregate=fun.aggregate,
+        time_unit = time_unit,
+        na.rm = TRUE
+      ) %>%
       t()
 
     # Dist is actually an atomic vector of upper half so upper and diag arguments don't matter

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -242,7 +242,14 @@ do_kl_dist.kv_ <- function(df,
 
   # this is executed on each group
   calc_dist_each <- function(df){
-    mat <- df %>%  simple_cast(subject_col, key_col, value_col, fill=fill, fun.aggregate=fun.aggregate)
+    mat <- df %>%  simple_cast(
+      subject_col,
+      key_col,
+      value_col,
+      fill=fill,
+      fun.aggregate=fun.aggregate,
+      na.rm = TRUE
+    )
     # Dist is actually an atomic vector of upper half so upper and diag arguments don't matter
     jensenShannon <- function(x, y) {
       m <- 0.5*(x + y)

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -95,7 +95,16 @@ do_cor.kv_ <- function(df,
 
 
   do_cor_each <- function(df){
-    mat <- simple_cast(df, row, col, val, fun.aggregate=fun.aggregate, fill=fill, time_unit = time_unit)
+    mat <- simple_cast(
+      df,
+      row,
+      col,
+      val,
+      fun.aggregate=fun.aggregate,
+      fill=fill,
+      time_unit = time_unit,
+      na.rm = TRUE
+    )
     cor_mat <- cor(mat, use = use, method = method)
     if(distinct){
       ret <- upper_gather(

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -226,7 +226,15 @@ do_cmdscale_ <- function(df,
 
   # this is executed on each group
   do_cmdscale_each <- function(df){
-    mat <- simple_cast(df, pair1_col, pair2_col, value_col, fun.aggregate = fun.aggregate, fill=fill)
+    mat <- simple_cast(
+      df,
+      pair1_col,
+      pair2_col,
+      value_col,
+      fun.aggregate = fun.aggregate,
+      fill=fill,
+      na.rm = TRUE
+    )
     cnames <- colnames(mat)
     rnames <- rownames(mat)
     if(any(cnames != rnames)){

--- a/R/util.R
+++ b/R/util.R
@@ -158,7 +158,15 @@ to_matrix <- function(df, select_dots, by_col=NULL, key_col=NULL, value_col=NULL
     if(is.null(by_col) | is.null(key_col) | is.null(value_col)){
       stop("all by, key and value should be defined")
     }
-    simple_cast(df, by_col, key_col, value_col, fun.aggregate = fun.aggregate, fill=fill)
+    simple_cast(
+      df,
+      by_col,
+      key_col,
+      value_col,
+      fun.aggregate = fun.aggregate,
+      fill=fill,
+      na.rm = TRUE
+    )
   } else {
     loadNamespace("dplyr")
     dplyr::select_(df, .dots=select_dots) %>%  as.matrix()

--- a/R/util.R
+++ b/R/util.R
@@ -21,8 +21,9 @@ col_name <- function(x, default = stop("Please supply column name", call. = FALS
 #' @param fun.aggregate Aggregate function for duplicated row and col
 #' @param fill Values to fill NA.
 #' @param time_unit Unit of time to aggregate key_col if key_col is Date or POSIXct#' @param time_unit Unit of time to aggregate key_col if key_col is Date or POSIXct. NULL doesn't aggregate.
+#' @param na.rm If NA in val should be removed
 #' @export
-simple_cast <- function(data, row, col, val=NULL, fun.aggregate=mean, fill=0, time_unit=NULL){
+simple_cast <- function(data, row, col, val=NULL, fun.aggregate=mean, fill=0, time_unit=NULL, na.rm = FALSE){
   loadNamespace("reshape2")
   loadNamespace("tidyr")
 
@@ -38,6 +39,11 @@ simple_cast <- function(data, row, col, val=NULL, fun.aggregate=mean, fill=0, ti
   # noraml na causes error in reshape2::acast so it has to be NA_real_
   if(is.na(fill)){
     fill <- NA_real_
+  }
+
+  if(!is.null(val) && na.rm){
+    data <- data %>%
+      dplyr::filter(!is.na(!!as.symbol(val)))
   }
 
   # remove NA from row and column

--- a/tests/testthat/test_pairwise.R
+++ b/tests/testthat/test_pairwise.R
@@ -231,9 +231,6 @@ test_that("do_dist with NA values", {
   nrow <- 10
   ncol <- 20
   vec <- rnorm(nrow * ncol)
-  vec[[3]] <- NA
-  vec[[30]] <- NA
-  vec[[55]] <- NA
   mat <- matrix(vec, nrow = nrow)
   melt_mat <- reshape2::melt(mat)
   # test column name with space

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -406,5 +406,5 @@ test_that("do_cmdscale undefined column name error", {
   data <- data.frame(var1 = c(1, 3, 2, NA), var2 = c(1, 3, 2, 10))
   expect_error({
     do_cmdscale(data, var1, var2, var3)
-  }, "var3 is not in column names")
+  }, "Evaluation error: object 'var3' not found.")
 })

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -91,9 +91,6 @@ test_that("do_cor with NA values", {
   nrow <- 10
   ncol <- 20
   vec <- rnorm(nrow * ncol)
-  vec[[3]] <- NA
-  vec[[30]] <- NA
-  vec[[55]] <- NA
   mat <- matrix(vec, nrow = nrow)
   melt_mat <- reshape2::melt(mat)
   colnames(melt_mat)[[2]] <- "Var 2"


### PR DESCRIPTION
### Description
Related to https://github.com/exploratory-io/tam/issues/6588

If there are na in values, simple cast removes it if na.rm is TRUE
With it, do_dist and do_cor doesn't return NA even if some values are NA
Add na.rm TRUE to other places where simple_cast is used

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
  * run do_dist skv analysis
  * run do_cor skv analysis
