### PR TITLE
add substitute for do_survfit time

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -995,6 +995,9 @@ prediction_survfit <- function(df, newdata = NULL, ...){
 do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, time_unit = "day", ...){
   validate_empty_data(df)
 
+  # substitute is needed because time can be
+  # NSE column name and it throws an evaluation error
+  # without it
   if (is.null(substitute(time))) {
     # as.numeric() does not support all units.
     # also support of units are different between Date and POSIXct.

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -995,7 +995,7 @@ prediction_survfit <- function(df, newdata = NULL, ...){
 do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, time_unit = "day", ...){
   validate_empty_data(df)
 
-  if (is.null(time)) {
+  if (is.null(substitute(time))) {
     # as.numeric() does not support all units.
     # also support of units are different between Date and POSIXct.
     # let's do it ourselves.

--- a/tests/testthat/test_do_survfit.R
+++ b/tests/testthat/test_do_survfit.R
@@ -1,0 +1,32 @@
+context("test do_survfit")
+
+test_that("test do_survfit", {
+  # log simulation data
+  data <- structure(list(weeks_on_service = c(18, 13, 0, 7, 0, 0, 1, 0,
+                                              0, 0), is_churned = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
+                                                                    TRUE, FALSE, TRUE), os = structure(c(1L, 2L, 1L, 1L, 2L, 2L,
+                                                                                                         2L, 2L, 2L, 1L), .Label = c("Windows", "Mac"), class = "factor"),
+                         country = structure(c(13L, 82L, 27L, 82L, 82L, 27L, 13L,
+                                               29L, 1L, 82L), .Label = c("Japan", "Afghanistan", "Argentina",
+                                                                         "Australia", "Austria", "Belgium", "Benin", "Bermuda", "Bolivia",
+                                                                         "Bosnia and Herzegovina", "Brazil", "Bulgaria", "Canada",
+                                                                         "Chile", "China", "Colombia", "Costa Rica", "Croatia", "Czech Republic",
+                                                                         "Denmark", "Dominican Republic", "Ecuador", "Egypt", "El Salvador",
+                                                                         "Ethiopia", "Finland", "France", "Georgia", "Germany", "Greece",
+                                                                         "Hashemite Kingdom of Jordan", "Hong Kong", "Hungary", "Iceland",
+                                                                         "India", "Indonesia", "Ireland", "Israel", "Italy", "Kenya",
+                                                                         "Kosovo", "Latvia", "Malaysia", "Mali", "Malta", "Mexico",
+                                                                         "Mongolia", "Nepal", "Netherlands", "New Zealand", "Nigeria",
+                                                                         "Norway", "Oman", "Panama", "Peru", "Philippines", "Poland",
+                                                                         "Portugal", "Republic of Korea", "Republic of Lithuania",
+                                                                         "Russia", "Saudi Arabia", "Senegal", "Serbia", "Singapore",
+                                                                         "Slovak Republic", "Slovenia", "Somalia", "South Africa",
+                                                                         "Spain", "Sri Lanka", "Sweden", "Switzerland", "Taiwan",
+                                                                         "Tajikistan", "Thailand", "Trinidad and Tobago", "Turkey",
+                                                                         "Ukraine", "United Arab Emirates", "United Kingdom", "United States",
+                                                                         "Uruguay", "Venezuela", "Vietnam", "Zambia"), class = "factor")),
+                    row.names = c(NA,-10L), class = c("tbl_df", "tbl", "data.frame"), .Names = c("weeks_on_service","is_churned", "os", "country"))
+  ret <- data %>% do_survfit(weeks_on_service, is_churned)
+
+
+})


### PR DESCRIPTION
### Description
add test case to do_survfit and substitute to time argument in case of time is a NSE column name

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
