### PR TITLE
Make survival time integer when time_unit is specified

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1010,6 +1010,7 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
                                 year = "365.25",
                                 "1")
     # we are flooring survival time to make it integer in the specified time unit.
+    # this is to make resulting survival curve to have integer data point in the specified time unit.
     fml <- as.formula(paste0("survival::Surv(as.numeric(`", substitute(end_time), "`-`", substitute(start_time), "`, units = \"days\")%/%", time_unit_days_str, ", `", substitute(status), "`) ~ 1"))
   }
   else {

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1009,7 +1009,8 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
                                 quarter = "(365.25/4)",
                                 year = "365.25",
                                 "1")
-    fml <- as.formula(paste0("survival::Surv(as.numeric(`", substitute(end_time), "`-`", substitute(start_time), "`, units = \"days\")/", time_unit_days_str, ", `", substitute(status), "`) ~ 1"))
+    # we are flooring survival time to make it integer in the specified time unit.
+    fml <- as.formula(paste0("survival::Surv(as.numeric(`", substitute(end_time), "`-`", substitute(start_time), "`, units = \"days\")%/%", time_unit_days_str, ", `", substitute(status), "`) ~ 1"))
   }
   else {
     # need to compose formula with non-standard evaluation.


### PR DESCRIPTION
### Description
Make survival time integer when time_unit is specified.
Replaced / with %/%.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
