### PR TITLE
do_survfit(): Use default of today() for end_time

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1000,13 +1000,13 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
   # without it
   if (is.null(substitute(time))) {
     start_time_col <- col_name(substitute(start_time))
-    df[[start_time_col]] <- as.Date(df[[start_time_col]])
-    if (!is.null(substitute(end_time))) {
+    df[[start_time_col]] <- as.Date(df[[start_time_col]]) # convert to Date in case it is POSIXct.
+    if (!is.null(substitute(end_time))) { # if end_time exists, fill NA with today()
       end_time_col <- col_name(substitute(end_time))
-      df[[end_time_col]] <- as.Date(df[[end_time_col]])
+      df[[end_time_col]] <- as.Date(df[[end_time_col]]) # convert to Date in case it is POSIXct.
       df[[end_time_col]] <- impute_na(df[[end_time_col]] ,type = "value", val=lubridate::today())
     }
-    else {
+    else { # if end_time does not exist, create .end_time column with value of today()
       end_time_col <- ".end_time"
       df[[".end_time"]] <- lubridate::today()
     }

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -999,8 +999,17 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
   # NSE column name and it throws an evaluation error
   # without it
   if (is.null(substitute(time))) {
-    end_time_col <- col_name(substitute(end_time))
-    df[[end_time_col]] <- impute_na(df[[end_time_col]] ,type = "value", val=lubridate::today())
+    start_time_col <- col_name(substitute(start_time))
+    df[[start_time_col]] <- as.Date(df[[start_time_col]])
+    if (!is.null(substitute(end_time))) {
+      end_time_col <- col_name(substitute(end_time))
+      df[[end_time_col]] <- as.Date(df[[end_time_col]])
+      df[[end_time_col]] <- impute_na(df[[end_time_col]] ,type = "value", val=lubridate::today())
+    }
+    else {
+      end_time_col <- ".end_time"
+      df[[".end_time"]] <- lubridate::today()
+    }
 
     # as.numeric() does not support all units.
     # also support of units are different between Date and POSIXct.
@@ -1014,7 +1023,7 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
                                 "1")
     # we are flooring survival time to make it integer in the specified time unit.
     # this is to make resulting survival curve to have integer data point in the specified time unit.
-    fml <- as.formula(paste0("survival::Surv(as.numeric(`", substitute(end_time), "`-`", substitute(start_time), "`, units = \"days\")%/%", time_unit_days_str, ", `", substitute(status), "`) ~ 1"))
+    fml <- as.formula(paste0("survival::Surv(as.numeric(`", end_time_col, "`-`", start_time_col, "`, units = \"days\")%/%", time_unit_days_str, ", `", substitute(status), "`) ~ 1"))
   }
   else {
     # need to compose formula with non-standard evaluation.

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -999,6 +999,9 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
   # NSE column name and it throws an evaluation error
   # without it
   if (is.null(substitute(time))) {
+    end_time_col <- col_name(substitute(end_time))
+    df[[end_time_col]] <- impute_na(df[[end_time_col]] ,type = "value", val=lubridate::today())
+
     # as.numeric() does not support all units.
     # also support of units are different between Date and POSIXct.
     # let's do it ourselves.

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1007,8 +1007,8 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
       df[[end_time_col]] <- impute_na(df[[end_time_col]] ,type = "value", val=lubridate::today())
     }
     else { # if end_time does not exist, create .end_time column with value of today()
-      end_time_col <- ".end_time"
-      df[[".end_time"]] <- lubridate::today()
+      end_time_col <- avoid_conflict(colnames(df), ".end_time")
+      df[[end_time_col]] <- lubridate::today()
     }
 
     # as.numeric() does not support all units.


### PR DESCRIPTION
### Description
do_survfit(): Use default of today() for end_time

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
