### PR TITLE
Use ceiling for survival

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -999,9 +999,6 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
   # NSE column name and it throws an evaluation error
   # without it
   if (is.null(substitute(time))) {
-    # for each group_by group, create row for time 0 with 100% survival rate
-    time_zero_rows <- df %>% summarize(time = 0, n_risk = n(), n_event = 0, n_censor = 0, estimate = 1, std_error = 0, conf_high = 1, conf_low = 1)
-
     start_time_col <- col_name(substitute(start_time))
     df[[start_time_col]] <- as.Date(df[[start_time_col]]) # convert to Date in case it is POSIXct.
     if (!is.null(substitute(end_time))) { # if end_time exists, fill NA with today()
@@ -1024,10 +1021,9 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
                                 quarter = "(365.25/4)",
                                 year = "365.25",
                                 "1")
-    # we are flooring survival time, then plus 1 to make it integer in the specified time unit.
+    # we are ceiling survival time to make it integer in the specified time unit.
     # this is to make resulting survival curve to have integer data point in the specified time unit.
-    # with plus 1, even an observation with time 0 is moved to time 1, but this is necessary to make things consistent with our addition of time 0 point.
-    fml <- as.formula(paste0("survival::Surv(as.numeric(`", end_time_col, "`-`", start_time_col, "`, units = \"days\")%/%", time_unit_days_str, "+1, `", substitute(status), "`) ~ 1"))
+    fml <- as.formula(paste0("survival::Surv(ceiling(as.numeric(`", end_time_col, "`-`", start_time_col, "`, units = \"days\")/", time_unit_days_str, "), `", substitute(status), "`) ~ 1"))
   }
   else {
     # need to compose formula with non-standard evaluation.
@@ -1043,11 +1039,6 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
   colnames(ret)[colnames(ret) == "std.error"] <- "std_error"
   colnames(ret)[colnames(ret) == "conf.low"] <- "conf_low"
   colnames(ret)[colnames(ret) == "conf.high"] <- "conf_high"
-
-  # bind with time 0 rows for analytics view. sort it by time.
-  if (is.null(substitute(time))) {
-    ret <- ret %>% bind_rows(time_zero_rows) %>% arrange(time)
-  }
   ret
 }
 


### PR DESCRIPTION
### Description
Use ceiling for survival instead of floor.
This makes start of the survival curve consistent regardless of period.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
