### PR TITLE
Dremio : Direct access support on windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.6.6
+Version: 0.6.6.1
 Date: 2017-10-10
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -415,7 +415,7 @@ getDBConnection <- function(type, host, port, databaseName, username = "", passw
         conn <- eval(parse(text=connstr))
       } else if (host != "") { # for dremio direct access
         if(.Platform$OS.type == "windows"){ # Dremio Connector is only available for Win for now..
-          connstr <-"DRIVER=Dremio Connector"
+          connstr <- "DRIVER=Dremio Connector"
         } else {
           connstr <- "DRIVER=Dremio ODBC Driver"
         }

--- a/R/system.R
+++ b/R/system.R
@@ -414,7 +414,13 @@ getDBConnection <- function(type, host, port, databaseName, username = "", passw
         }
         conn <- eval(parse(text=connstr))
       } else if (host != "") { # for dremio direct access
-        conn <- RODBC::odbcDriverConnect(stringr::str_c("DRIVER=Dremio ODBC Driver;HOST=", host, ";ConnectionType=Direct;AuthenticationType=Plain;Catalog=DREMIO;PORT=", port, ";UID=", username, ";PWD=", password))
+        if(.Platform$OS.type == "windows"){ # Dremio Connector is only available for Win for now..
+          connstr <-"DRIVER=Dremio Connector"
+        } else {
+          connstr <- "DRIVER=Dremio ODBC Driver"
+        }
+        connstr <- stringr::str_c(connstr, ";HOST=", host, ";ConnectionType=Direct;AuthenticationType=Plain;Catalog=DREMIO;PORT=", port, ";UID=", username, ";PWD=", password)
+        conn <- RODBC::odbcDriverConnect(connstr)
       }
       if (conn == -1) {
         # capture warning and throw error with the message.


### PR DESCRIPTION
### Description

On Windows, Dremio driver name is "Dremio Connector", so use the name instead.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
