### PR TITLE
Random forest fixes on na handling and factorization on newdata

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -101,6 +101,12 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
     if(!is.null(types)){
       validate_data(types, df)
     }
+    # turn character predictor columns into factors
+    # with the same levels as training data.
+    flevels <- model_meta[[1]]$flevels
+    if(!is.null(types)){
+      df <- factorize_data(flevels, df)
+    }
   }
 
   get_result <- function(model_df, df, aug_args, with_respose){

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -574,7 +574,7 @@ augment.randomForest.classification <- function(x, data = NULL, newdata = NULL, 
       # append predicted probability
       predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
       predicted_prob <- predicted_prob[, 2]
-      data[[predicted_value_col]] <- predicted_prob
+      data[[predicted_value_col]][!na_at] <- predicted_prob
     } else if (x$classification_type == "multi"){
       # append predicted probability for each class, max and labels at max values
       ret <- get_multi_predicted_values(predicted_prob, cleaned_data[[y_name]])

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -525,7 +525,9 @@ augment.randomForest.classification <- function(x, data = NULL, newdata = NULL, 
     oob_col <- avoid_conflict(colnames(data), "out_of_bag_times")
 
     # These are from https://github.com/mdlincoln/broom/blob/e3cdf5f3363ab9514e5b61a56c6277cb0d9899fd/R/rf_tidiers.R
-    # TODO: This seems to be taking care of NA cases. Should review this part later
+    # create index of eliminated rows (na_at) by na.action from model.
+    # since prediction output may have fewer rows than original data because of na.action, 
+    # we cannot augment the data just by binding columns.
     n_data <- nrow(data)
     if (is.null(x[["na.action"]])) {
       na_at <- rep(FALSE, times = n_data)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -580,7 +580,10 @@ augment.randomForest.classification <- function(x, data = NULL, newdata = NULL, 
     } else if (x$classification_type == "multi"){
       # append predicted probability for each class, max and labels at max values
       ret <- get_multi_predicted_values(predicted_prob, cleaned_data[[y_name]])
-      data <- dplyr::bind_cols(data, ret)
+      for (i in 1:length(ret)) { # for each column
+        # this is basically bind_cols with na_at taken into account.
+        data[[colnames(ret)[[i]]]][!na_at] <- ret[[i]]
+      }
     }
 
     data

--- a/R/util.R
+++ b/R/util.R
@@ -1044,9 +1044,11 @@ validate_data <- function(types, data){
 #' @param data new data to predict on.
 factorize_data <- function(flevels, data) {
   fcol_names <- names(flevels)
-  for (i in 1:length(flevels)) {
-    if (class(data[[fcol_names[[i]]]]) == "character") {
-      data[[fcol_names[[i]]]] <- factor(data[[fcol_names[[i]]]], levels = flevels[[i]])
+  if (length(flevels) > 0) {
+    for (i in 1:length(flevels)) {
+      if (class(data[[fcol_names[[i]]]]) == "character") {
+        data[[fcol_names[[i]]]] <- factor(data[[fcol_names[[i]]]], levels = flevels[[i]])
+      }
     }
   }
   data

--- a/R/util.R
+++ b/R/util.R
@@ -1038,6 +1038,10 @@ validate_data <- function(types, data){
   TRUE
 }
 
+#' turn character predictor columns into factors,
+#' with the same levels as training data.
+#' @param flevels list. Names are column names, and values are factor levels for the columns.
+#' @param data new data to predict on.
 factorize_data <- function(flevels, data) {
   fcol_names <- names(flevels)
   for (i in 1:length(flevels)) {

--- a/R/util.R
+++ b/R/util.R
@@ -1054,11 +1054,23 @@ create_model_meta <- function(df, formula){
     md_frame <- model.frame(formula, data = df)
     ret$terms <- terms(md_frame, formula)
     pred_cnames <- all.vars(ret$terms)[-1]
+
+    # capture column data types info
     types <- vapply(pred_cnames, function(cname) {
       get_data_type(df[[cname]])
     }, FUN.VALUE = "")
     names(types) <- pred_cnames
     ret$types <- types
+
+    # capture factor levels info so that we can use same levels
+    # when we preprocess newdata.
+    flevels <- list()
+    for (cname in pred_cnames) {
+      if (is.factor(df[[cname]])) {
+        flevels[[cname]] <- levels(df[[cname]])
+      }
+    }
+    ret$flevels <- flevels
   }, error = function(e){
     NULL
   })

--- a/R/util.R
+++ b/R/util.R
@@ -1039,6 +1039,12 @@ validate_data <- function(types, data){
 }
 
 factorize_data <- function(flevels, data) {
+  fcol_names <- names(flevels)
+  for (i in 1:length(flevels)) {
+    if (class(data[[fcol_names[[i]]]]) == "character") {
+      data[[fcol_names[[i]]]] <- factor(data[[fcol_names[[i]]]], levels = flevels[[i]])
+    }
+  }
   data
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -1038,6 +1038,10 @@ validate_data <- function(types, data){
   TRUE
 }
 
+factorize_data <- function(flevels, data) {
+  data
+}
+
 # This is used in model building functions
 # to create meta data.
 # It contains terms to create model and

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -123,7 +123,7 @@ test_that("test randomForest with regression", {
   pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
-test_that("test randomForest with unsupervied", {
+test_that("test randomForest with unsupervised", {
   test_data <- structure(
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
@@ -160,7 +160,7 @@ test_that("test randomForest with unsupervied by 3 classes", {
   prediction_ret <- prediction(model_ret)
 })
 
-test_that("test randomForest with classification", {
+test_that("test randomForest with multinomial classification", {
   test_data <- structure(
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
@@ -182,7 +182,7 @@ test_that("test randomForest with classification", {
   pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
-test_that("test randomForest with classification", {
+test_that("test randomForest with multinomial classification", {
   test_data <- structure(
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -55,6 +55,7 @@ test_that("test randomForest with multinomial classification", {
   model_stats <- model_stats(model_ret, pretty.name = TRUE)
   pred_train_ret <- prediction(model_ret, data = "training")
   pred_test_ret <- prediction(model_ret, data = "test")
+  pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
 test_that("test randomForest with binary classification", {
@@ -75,6 +76,7 @@ test_that("test randomForest with binary classification", {
   model_stats <- model_stats(model_ret, pretty.name = TRUE)
   pred_train_ret <- prediction_binary(model_ret, data = "training")
   pred_test_ret <- prediction_binary(model_ret, data = "test")
+  pred_test_ret <- prediction_binary(model_ret, data = "newdata", data_frame = test_data)
 })
 
 test_that("test randomForest with regression without localImp", {
@@ -96,6 +98,7 @@ test_that("test randomForest with regression without localImp", {
   stats_ret <- model_stats(model_ret)
   pred_train_ret <- prediction(model_ret, data = "training")
   pred_test_ret <- prediction(model_ret, data = "test")
+  pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
 test_that("test randomForest with regression", {
@@ -117,6 +120,7 @@ test_that("test randomForest with regression", {
   stats_ret <- model_stats(model_ret)
   pred_train_ret <- prediction(model_ret, data = "training")
   pred_test_ret <- prediction(model_ret, data = "test")
+  pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
 test_that("test randomForest with unsupervied", {
@@ -175,6 +179,7 @@ test_that("test randomForest with classification", {
   model_stats <- model_stats(model_ret, pretty.name = TRUE)
   pred_train_ret <- prediction(model_ret, data = "training")
   pred_test_ret <- prediction(model_ret, data = "test")
+  pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })
 
 test_that("test randomForest with classification", {
@@ -196,4 +201,5 @@ test_that("test randomForest with classification", {
   model_stats <- model_stats(model_ret, pretty.name = TRUE)
   pred_train_ret <- prediction(model_ret, data = "training")
   pred_test_ret <- prediction(model_ret, data = "test")
+  pred_test_ret <- prediction(model_ret, data = "newdata", data_frame = test_data)
 })

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -1,6 +1,6 @@
 context("test tidiers for randomForest")
 
-test_that("test when the number of rows of classes is one", {
+test_that("test calc_feature_imp when the number of rows of classes is one", {
   sample_data <- data.frame(
     y = c("a", "b", "b", "b", "b", "c"),
     num = runif(6)
@@ -13,7 +13,7 @@ test_that("test when the number of rows of classes is one", {
   expect_equal(nrow(ret), 0)
 })
 
-test_that("test randomForest with binary classification", {
+test_that("test calc_feature_imp", {
   set.seed(0)
   nrow <- 100
   test_data <- data.frame(
@@ -37,12 +37,12 @@ test_that("test randomForest with binary classification", {
 
 })
 
-test_that("test randomForest with binary classification", {
+test_that("test randomForest with multinomial classification", {
   test_data <- structure(
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
@@ -62,7 +62,7 @@ test_that("test randomForest with binary classification", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
@@ -82,7 +82,7 @@ test_that("test randomForest with regression without localImp", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
@@ -103,7 +103,7 @@ test_that("test randomForest with regression", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
@@ -124,7 +124,7 @@ test_that("test randomForest with unsupervied", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
   test_data[["IS_AA"]] <- test_data$CARRIER == "AA"
@@ -142,7 +142,7 @@ test_that("test randomForest with unsupervied by 3 classes", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
   test_data[["IS_AA"]] <- test_data$CARRIER == "AA"
@@ -161,7 +161,7 @@ test_that("test randomForest with classification", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
@@ -182,7 +182,7 @@ test_that("test randomForest with classification", {
     list(
       CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", NA), # test NA handling
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 


### PR DESCRIPTION
### Description
- make prediction on training data with NA work with RandomForest binary classification: handle row number difference caused by NA in data
- make prediction on new data work with RandomForest (and other models which use build_model function): factorize character columns with same levels as training data.
- add tests on NA handling
- add tests on newdata prediction
- make prediction on training data with NA work with RandomForest multinomial classification: handle row number difference caused by NA in data

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
