### PR TITLE
Fix: logical factor level order is reversed on confusion matrix from calc_feature_imp 

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -759,10 +759,17 @@ calc_feature_imp <- function(df,
   # if target is numeric, it is regression but
   # if not, it is classification
   if (!is.numeric(clean_df[[clean_target_col]])) {
-    # limit the number of levels in factor by fct_lump
-    clean_df[[clean_target_col]] <- forcats::fct_lump(
-      as.factor(clean_df[[clean_target_col]]), n = target_n
-    )
+    if (!is.logical(clean_df[[clean_target_col]])) {
+      # limit the number of levels in factor by fct_lump
+      clean_df[[clean_target_col]] <- forcats::fct_lump(
+        as.factor(clean_df[[clean_target_col]]), n = target_n
+      )
+    }
+    else {
+      # we need to convert logical to factor since na.roughfix only works for numeric or factor.
+      # for logical set TRUE, FALSE level order for better visualization.
+      clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]], levels = c("TRUE", "FALSE"))
+    }
   }
 
   each_func <- function(df) {
@@ -832,8 +839,9 @@ calc_feature_imp <- function(df,
             df[[hour_col]] <- factor(lubridate::hour(df[[col]])) # treat hour as category
           }
         } else if(!is.numeric(df[[col]])) {
-          # convert data to factor if predictors are not numeric or logical
-          # and limit the number of levels in factor by fct_lump
+          # convert data to factor if predictors are not numeric.
+          # and limit the number of levels in factor by fct_lump.
+          # we need to convert logical to factor too since na.roughfix only works for numeric or factor.
           df[[col]] <- forcats::fct_lump(as.factor(df[[col]]), n=predictor_n)
         }
       }

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -37,6 +37,33 @@ test_that("test calc_feature_imp", {
 
 })
 
+test_that("test calc_feature_imp predicting logical", {
+  set.seed(0)
+  nrow <- 100
+  test_data <- data.frame(
+    target = c(NA, sample(c(TRUE,FALSE), nrow-2, replace = TRUE), NA),
+    cat_10 = sample(c(letters[1:10], NA_character_), nrow, replace = TRUE),
+    cat_25 = sample(letters[1:25], nrow, replace = TRUE),
+    num_1 = runif(nrow),
+    num_2 = runif(nrow),
+    Group = rbinom(nrow, 2, 0.5)
+  ) %>%
+    rename(`Tar get` = "target") # check if colname with space works
+
+  ret <- test_data %>%
+    dplyr::group_by(Group) %>%
+    calc_feature_imp(`Tar get`,
+                      dplyr::starts_with("cat_"),
+                      num_1,
+                      num_2)
+
+  conf_mat <- tidy(ret, model, type = "conf_mat", pretty.name = TRUE)
+  # factor order should be TRUE then FALSE.
+  expect_equal(levels(conf_mat$actual_value)[1], "TRUE")
+  expect_equal(levels(conf_mat$predicted_value)[1], "TRUE")
+
+})
+
 test_that("test randomForest with multinomial classification", {
   test_data <- structure(
     list(


### PR DESCRIPTION
### Description
Set logical factor ordered as "TRUE" then "FALSE" in calc_feature_imp.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
