### PR TITLE
Fix test failure from ab test and kmeans

### DIFF
--- a/tests/testthat/test_model_builder.R
+++ b/tests/testthat/test_model_builder.R
@@ -259,7 +259,7 @@ test_that("test build_kmeans skv with wrong column name", {
     test_df %>%
       build_kmeans(skv = c("vec1", "vec"), centers=2) %>%
       augment_kmeans(model, data = source.data)
-  }, "undefined columns selected")
+  }, "Unknown column `vec` ")
 })
 
 test_that("test build_kmeans cols with wrong column name", {


### PR DESCRIPTION
### Description
Fix test failure from ab test and kmeans
- adjust input/output to bayesAB functions that are updated with the new version of bayesAB package.
- adjust for new error message from kmeans function to pass test.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
