### PR TITLE
edarf error fix

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -844,6 +844,8 @@ calc_feature_imp <- function(df,
       # for logical set TRUE, FALSE level order for better visualization. but only do it when
       # the target column actually has both TRUE and FALSE, since edarf::partial_dependence errors out if target
       # factor column has more levels than actual data. TODO: Can this issue be caused by group_by??
+      # error from edarf::partial_dependence looks like following.
+      #   Error in factor(x, seq_len(length(unique(data[[target]]))), levels(data[[target]])) : invalid 'labels'; length 2 should be 1 or 1
       if (length(unique(clean_df[[clean_target_col]])) >= 2) {
         clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]], levels=c("TRUE","FALSE"))
       }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -843,6 +843,7 @@ calc_feature_imp <- function(df,
 
   each_func <- function(df) {
     tryCatch({
+      browser()
       # sample the data because randomForest takes long time
       # if data size is too large
       if (nrow(df) > max_nrow) {
@@ -856,24 +857,24 @@ calc_feature_imp <- function(df,
       # in such case.
       # The group with NULL is removed when
       # unnesting the result
-      for (level in levels(df[[target_col]])) {
-        if(sum(df[[target_col]] == level, na.rm = TRUE) == 1) {
+      for (level in levels(df[[clean_target_col]])) {
+        if(sum(df[[clean_target_col]] == level, na.rm = TRUE) == 1) {
           return(NULL)
         }
       }
 
-      if (is.logical(df[[target_col]])) {
+      if (is.logical(df[[clean_target_col]])) {
         # we need to convert logical to factor since na.roughfix only works for numeric or factor.
         # for logical set TRUE, FALSE level order for better visualization. but only do it when
         # the target column actually has both TRUE and FALSE, since edarf::partial_dependence errors out if target
         # factor column has more levels than actual data.
         # error from edarf::partial_dependence looks like following.
         #   Error in factor(x, seq_len(length(unique(data[[target]]))), levels(data[[target]])) : invalid 'labels'; length 2 should be 1 or 1
-        if (length(unique(df[[target_col]])) >= 2) {
-          df[[target_col]] <- factor(df[[target_col]], levels=c("TRUE","FALSE"))
+        if (length(unique(df[[clean_target_col]])) >= 2) {
+          df[[clean_target_col]] <- factor(df[[clean_target_col]], levels=c("TRUE","FALSE"))
         }
         else {
-          df[[target_col]] <- factor(df[[target_col]])
+          df[[clean_target_col]] <- factor(df[[clean_target_col]])
         }
       }
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -839,20 +839,6 @@ calc_feature_imp <- function(df,
         as.factor(clean_df[[clean_target_col]]), n = target_n, ties.method="first"
       ))
     }
-    else {
-      # we need to convert logical to factor since na.roughfix only works for numeric or factor.
-      # for logical set TRUE, FALSE level order for better visualization. but only do it when
-      # the target column actually has both TRUE and FALSE, since edarf::partial_dependence errors out if target
-      # factor column has more levels than actual data. TODO: Can this issue be caused by group_by??
-      # error from edarf::partial_dependence looks like following.
-      #   Error in factor(x, seq_len(length(unique(data[[target]]))), levels(data[[target]])) : invalid 'labels'; length 2 should be 1 or 1
-      if (length(unique(clean_df[[clean_target_col]])) >= 2) {
-        clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]], levels=c("TRUE","FALSE"))
-      }
-      else {
-        clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]])
-      }
-    }
   }
 
   each_func <- function(df) {
@@ -873,6 +859,21 @@ calc_feature_imp <- function(df,
       for (level in levels(df[[target_col]])) {
         if(sum(df[[target_col]] == level, na.rm = TRUE) == 1) {
           return(NULL)
+        }
+      }
+
+      if (is.logical(df[[target_col]])) {
+        # we need to convert logical to factor since na.roughfix only works for numeric or factor.
+        # for logical set TRUE, FALSE level order for better visualization. but only do it when
+        # the target column actually has both TRUE and FALSE, since edarf::partial_dependence errors out if target
+        # factor column has more levels than actual data.
+        # error from edarf::partial_dependence looks like following.
+        #   Error in factor(x, seq_len(length(unique(data[[target]]))), levels(data[[target]])) : invalid 'labels'; length 2 should be 1 or 1
+        if (length(unique(df[[target_col]])) >= 2) {
+          df[[target_col]] <- factor(df[[target_col]], levels=c("TRUE","FALSE"))
+        }
+        else {
+          df[[target_col]] <- factor(df[[target_col]])
         }
       }
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -843,7 +843,6 @@ calc_feature_imp <- function(df,
 
   each_func <- function(df) {
     tryCatch({
-      browser()
       # sample the data because randomForest takes long time
       # if data size is too large
       if (nrow(df) > max_nrow) {
@@ -1136,8 +1135,10 @@ tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, n.vars = 10
           ret[[var_col]] <- signif(ret[[var_col]], digits=4) # limit digits before we turn it into a factor.
         }
       }
-      ret <- ret %>% tidyr::gather_("x_name", "x_value", var_cols, na.rm = TRUE, convert = TRUE)
-      ret <- ret %>% tidyr::gather("y_name", "y_value", -x_name, -x_value, na.rm = TRUE, convert = TRUE)
+      ret <- ret %>% tidyr::gather_("x_name", "x_value", var_cols, na.rm = TRUE, convert = FALSE)
+      # convert must be FALSE for y to make sure y_name is always character. otherwise bind_rows internally done
+      # in tidy() errors out because y_name can be, for example, mixture of logical and character.
+      ret <- ret %>% tidyr::gather("y_name", "y_value", -x_name, -x_value, na.rm = TRUE, convert = FALSE)
       ret <- ret %>% dplyr::mutate(x_name = forcats::fct_relevel(x_name, imp_vars)) # set factor level order so that charts appear in order of importance.
       # set order to ret and turn it back to character, so that the order is kept when groups are bound.
       # if it were kept as factor, when groups are bound, only the factor order from the first group would be respected.

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -841,8 +841,15 @@ calc_feature_imp <- function(df,
     }
     else {
       # we need to convert logical to factor since na.roughfix only works for numeric or factor.
-      # for logical set TRUE, FALSE level order for better visualization.
-      clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]], levels = c("TRUE", "FALSE"))
+      # for logical set TRUE, FALSE level order for better visualization. but only do it when
+      # the target column actually has both TRUE and FALSE, since edarf::partial_dependence errors out if target
+      # factor column has more levels than actual data. TODO: Can this issue be caused by group_by??
+      if (length(unique(clean_df[[clean_target_col]])) >= 2) {
+        clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]], levels=c("TRUE","FALSE"))
+      }
+      else {
+        clean_df[[clean_target_col]] <- factor(clean_df[[clean_target_col]])
+      }
     }
   }
 

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -15,9 +15,9 @@ test_that("test calc_feature_imp when the number of rows of classes is one", {
     num = runif(6)
   )
 
-  ret <- sample_data %>%
-    calc_feature_imp(y, num) %>%
-    rf_importance()
+  model_df <- sample_data %>%
+    calc_feature_imp(y, num)
+  ret <- model_df %>% rf_importance()
 
   expect_equal(nrow(ret), 0)
 })
@@ -35,15 +35,16 @@ test_that("test calc_feature_imp", {
   ) %>%
     rename(`Tar get` = "target") # check if colname with space works
 
-  ret <- test_data %>%
+  model_df <- test_data %>%
     dplyr::group_by(Group) %>%
     calc_feature_imp(`Tar get`,
                       dplyr::starts_with("cat_"),
                       num_1,
                       num_2)
 
-  conf_mat <- tidy(ret, model, type = "conf_mat", pretty.name = TRUE)
-
+  conf_mat <- tidy(model_df, model, type = "conf_mat", pretty.name = TRUE)
+  ret <- model_df %>% rf_importance()
+  # ret <- model_df %>% rf_partial_dependence() TODO: this errors out
 })
 
 test_that("test calc_feature_imp predicting logical", {
@@ -59,14 +60,16 @@ test_that("test calc_feature_imp predicting logical", {
   ) %>%
     rename(`Tar get` = "target") # check if colname with space works
 
-  ret <- test_data %>%
+  model_df <- test_data %>%
     dplyr::group_by(Group) %>%
     calc_feature_imp(`Tar get`,
                       dplyr::starts_with("cat_"),
                       num_1,
                       num_2)
 
-  conf_mat <- tidy(ret, model, type = "conf_mat", pretty.name = TRUE)
+  conf_mat <- tidy(model_df, model, type = "conf_mat", pretty.name = TRUE)
+  ret <- model_df %>% rf_importance()
+  ret <- model_df %>% rf_partial_dependence()
   # factor order should be TRUE then FALSE.
   expect_equal(levels(conf_mat$actual_value)[1], "TRUE")
   expect_equal(levels(conf_mat$predicted_value)[1], "TRUE")


### PR DESCRIPTION
### Description
Fixed the edarf error. The route cause was that edarf errors out when target column is factor, and the data does not actually have all the levels of factor. This was happening for logical target, which we cast to TRUE/FALSE factor, and group_by case where some group does not have all the factor level. I fixed it by adjusting the level of factor to what the data actually has, inside the group_by loop.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
