### PR TITLE
Add time=0 row to survival curve start point from do_survfit

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1047,7 +1047,9 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
       # drop grouping columns
       df <- df[, !colnames(df) %in% grouped_col]
     }
-    df <- rbind(data.frame(time=0, n.risk=df$n.risk[1], n.event=0, n.censor=0, estimate=1, std.error=0, conf.high=1, conf.low=1), df)
+    if (nrow(df[df$time==0,]) == 0) {
+      df <- rbind(data.frame(time=0, n.risk=df$n.risk[1], n.event=0, n.censor=0, estimate=1, std.error=0, conf.high=1, conf.low=1), df)
+    }
     df
   }
 

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1042,12 +1042,13 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
 
   ret <- df %>% build_model(model_func = survival::survfit, formula = fml, ...) %>% broom::tidy(model)
 
+  # for better viz, add time=0 row for each group when it is not already there.
   add_time_zero_row_each <- function(df) {
     if(!is.null(grouped_col)){
       # drop grouping columns
       df <- df[, !colnames(df) %in% grouped_col]
     }
-    if (nrow(df[df$time==0,]) == 0) {
+    if (nrow(df[df$time==0,]) == 0) { # do this only when time=0 row is not already there.
       df <- rbind(data.frame(time=0, n.risk=df$n.risk[1], n.event=0, n.censor=0, estimate=1, std.error=0, conf.high=1, conf.low=1), df)
     }
     df

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1047,6 +1047,7 @@ do_survfit <- function(df, time, status, start_time = NULL, end_time = NULL, tim
       # drop grouping columns
       df <- df[, !colnames(df) %in% grouped_col]
     }
+    df <- rbind(data.frame(time=0, n.risk=df$n.risk[1], n.event=0, n.censor=0, estimate=1, std.error=0, conf.high=1, conf.low=1), df)
     df
   }
 


### PR DESCRIPTION
### Description
Add time=0 row to survival curve start point from do_survfit

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
