### PR TITLE
Support Google BigQuery Server OAuth

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.6.8.6
+Version: 0.6.8.7
 Date: 2017-11-23
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func


### PR DESCRIPTION
### Description

Updated getGoogleTokenForBigQuery to accept token info so that it can create  HttrOAuthToken2.0$new with info passed from exploratory server.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
