### PR TITLE
Fix: Linear Regression: when variable is ordered factor, term names becomes strange

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -188,12 +188,12 @@ build_coxph.fast <- function(df,
 
           c_cols <- c(c_cols, absolute_time_col, wday_col, day_col, yday_col, month_col, year_col)
           df[[absolute_time_col]] <- as.numeric(df[[col]])
-          # turn it into character since if it is factor, the name of term is broken
-          df[[wday_col]] <- as.character(lubridate::wday(df[[col]], label=TRUE))
+          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          df[[wday_col]] <- factor(lubridate::wday(df[[col]], label=TRUE), ordered=FALSE)
           df[[day_col]] <- lubridate::day(df[[col]])
           df[[yday_col]] <- lubridate::yday(df[[col]])
-          # turn it into character since if it is factor, the name of term is broken
-          df[[month_col]] <- as.character(lubridate::month(df[[col]], label=TRUE))
+          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          df[[month_col]] <- factor(lubridate::month(df[[col]], label=TRUE), ordered=FALSE)
           df[[year_col]] <- lubridate::year(df[[col]])
           if(lubridate::is.POSIXct(df[[col]])) {
             hour_col <- avoid_conflict(colnames(df), paste0(col, "_hour"))

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -210,12 +210,15 @@ build_coxph.fast <- function(df,
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
         } else if(!is.numeric(df[[col]])) {
-          # convert data to factor if predictors are not numeric or logical
-          # and limit the number of levels in factor by fct_lump.
-          # we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
-          # TODO: see if ties.method would make sense for calc_feature_imp.
-          # also, turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
+          # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
+          #    coxph takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
+          #    which we do not want for this function.
+          # 2. convert data to factor if predictors are not numeric or logical
+          #    and limit the number of levels in factor by fct_lump.
+          #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
+          #    TODO: see if ties.method would make sense for calc_feature_imp.
+          # 3. turn NA into (Missing) factor level so that lm will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(factor(df[[col]], ordered=FALSE), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -209,16 +209,24 @@ build_coxph.fast <- function(df,
             df[[hour_col]] <- factor(lubridate::hour(df[[col]])) # treat hour as category
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
-        } else if(!is.numeric(df[[col]])) {
-          # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
+        } else if(is.factor(df[[col]])) {
+          # 1. if the data is factor, respect the levels and keep first 10 levels, and make others "Others" level.
+          # 2. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    coxph takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
-          # 2. convert data to factor if predictors are not numeric or logical
+          if (length(levels(df[[col]])) >= 12) {
+            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:10])
+          }
+          else {
+            df[[col]] <- factor(df[[col]], ordered=FALSE)
+          }
+        } else if(!is.numeric(df[[col]])) {
+          # 1. convert data to factor if predictors are not numeric or logical
           #    and limit the number of levels in factor by fct_lump.
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
           #    TODO: see if ties.method would make sense for calc_feature_imp.
-          # 3. turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(factor(df[[col]], ordered=FALSE), n=predictor_n, ties.method="first"))
+          # 2. turn NA into (Missing) factor level so that coxph will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -279,7 +279,8 @@ build_lm.fast <- function(df,
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
         } else if(is.factor(df[[col]])) {
-          # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
+          # 1. if the data is factor, respect the levels and keep first 10 levels, and make others "Others" level.
+          # 2. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
           if (length(levels(df[[col]])) >= 12) {
@@ -289,12 +290,12 @@ build_lm.fast <- function(df,
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
         } else if(!is.numeric(df[[col]])) {
-          # 2. convert data to factor if predictors are not numeric or logical
+          # 1. convert data to factor if predictors are not numeric or logical
           #    and limit the number of levels in factor by fct_lump.
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
           #    TODO: see if ties.method would make sense for calc_feature_imp.
-          # 3. turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(factor(df[[col]], ordered=FALSE), n=predictor_n, ties.method="first"))
+          # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -257,11 +257,13 @@ build_lm.fast <- function(df,
 
           c_cols <- c(c_cols, absolute_time_col, wday_col, day_col, yday_col, month_col, year_col)
           df[[absolute_time_col]] <- as.numeric(df[[col]])
-          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          # turn it into unordered factor since if it is ordered factor,
+          # lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
+          # which we do not want for this function.
           df[[wday_col]] <- factor(lubridate::wday(df[[col]], label=TRUE), ordered=FALSE)
           df[[day_col]] <- lubridate::day(df[[col]])
           df[[yday_col]] <- lubridate::yday(df[[col]])
-          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          # turn it into unordered factor for the same reason as wday.
           df[[month_col]] <- factor(lubridate::month(df[[col]], label=TRUE), ordered=FALSE)
           df[[year_col]] <- lubridate::year(df[[col]])
           if(lubridate::is.POSIXct(df[[col]])) {

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -282,7 +282,7 @@ build_lm.fast <- function(df,
           # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
-          if (length(levels(df[[col]]) >= 12) {
+          if (length(levels(df[[col]])) >= 12) {
             df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:10])
           }
           else {

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -260,6 +260,7 @@ build_lm.fast <- function(df,
           # turn it into unordered factor since if it is ordered factor,
           # lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           # which we do not want for this function.
+          # Reference: https://hlplab.wordpress.com/2008/01/28/the-mysterious-l-q-and-c/
           df[[wday_col]] <- factor(lubridate::wday(df[[col]], label=TRUE), ordered=FALSE)
           df[[day_col]] <- lubridate::day(df[[col]])
           df[[yday_col]] <- lubridate::yday(df[[col]])

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -257,12 +257,12 @@ build_lm.fast <- function(df,
 
           c_cols <- c(c_cols, absolute_time_col, wday_col, day_col, yday_col, month_col, year_col)
           df[[absolute_time_col]] <- as.numeric(df[[col]])
-          # turn it into character since if it is factor, the name of term is broken
-          df[[wday_col]] <- as.character(lubridate::wday(df[[col]], label=TRUE))
+          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          df[[wday_col]] <- factor(lubridate::wday(df[[col]], label=TRUE), ordered=FALSE)
           df[[day_col]] <- lubridate::day(df[[col]])
           df[[yday_col]] <- lubridate::yday(df[[col]])
-          # turn it into character since if it is factor, the name of term is broken
-          df[[month_col]] <- as.character(lubridate::month(df[[col]], label=TRUE))
+          # turn it into unordered factor since if it is ordered factor, the name of term is broken
+          df[[month_col]] <- factor(lubridate::month(df[[col]], label=TRUE), ordered=FALSE)
           df[[year_col]] <- lubridate::year(df[[col]])
           if(lubridate::is.POSIXct(df[[col]])) {
             hour_col <- avoid_conflict(colnames(df), paste0(col, "_hour"))

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -278,10 +278,17 @@ build_lm.fast <- function(df,
             df[[hour_col]] <- factor(lubridate::hour(df[[col]])) # treat hour as category
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
-        } else if(!is.numeric(df[[col]])) {
+        } else if(is.factor(df[[col]])) {
           # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
+          if (length(levels(df[[col]]) >= 12) {
+            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:10])
+          }
+          else {
+            df[[col]] <- factor(df[[col]], ordered=FALSE)
+          }
+        } else if(!is.numeric(df[[col]])) {
           # 2. convert data to factor if predictors are not numeric or logical
           #    and limit the number of levels in factor by fct_lump.
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -279,12 +279,15 @@ build_lm.fast <- function(df,
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
         } else if(!is.numeric(df[[col]])) {
-          # convert data to factor if predictors are not numeric or logical
-          # and limit the number of levels in factor by fct_lump.
-          # we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
-          # TODO: see if ties.method would make sense for calc_feature_imp.
-          # also, turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
+          # 1. if the data is ordered factor, turn it into unordered. For ordered factor,
+          #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
+          #    which we do not want for this function.
+          # 2. convert data to factor if predictors are not numeric or logical
+          #    and limit the number of levels in factor by fct_lump.
+          #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
+          #    TODO: see if ties.method would make sense for calc_feature_imp.
+          # 3. turn NA into (Missing) factor level so that lm will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(factor(df[[col]], ordered=FALSE), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -3,6 +3,7 @@ context("test build_coxph")
 test_that("test build_coxph.fast", {
   df <- survival::lung
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age)
+  df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, sex, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
   ret <- model_df %>% broom::tidy(model)

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -145,6 +145,8 @@ test_that("prediction with target column name with space by build_lm.fast", {
 
   model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE)
   ret <- model_data %>% broom::glance(model)
+  # TODO: the returned coefficients does not show all input variables. 
+  # most likely due to too few rows. look into it and add check for the values in the returned df. 
   ret <- model_data %>% broom::tidy(model)
   ret <- model_data %>% broom::augment(model)
 

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -141,6 +141,7 @@ test_that("prediction with target column name with space by build_lm.fast", {
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
+  test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
   model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE)
   ret <- model_data %>% broom::glance(model)
@@ -164,6 +165,7 @@ test_that("prediction with glm model with SMOTE by build_lm.fast", {
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
+  test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
   model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE, model_type = "glm", smote=FALSE)
   ret <- model_data %>% broom::glance(model, pretty.name=TRUE)


### PR DESCRIPTION
### Description
Fixes 3 factor related issues in build_lm.fast and build_coxph.fast below.
- Linear Regression: when variable is ordered factor, term names becomes strange
- Linear Regression: Base level of factored order variable is not respected by lm
- Analytics: We should pick the first 10 levels for Factor Columns

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
