### PR TITLE
fix stem_word function throws error #8301

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.6.9.7
+Version: 0.6.9.8
 Date: 2017-11-23
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -297,7 +297,7 @@ do_tfidf <- function(df, group, term, idf_log_scale = log, tf_weight="raw", norm
 #' @export
 stem_word <- function(...){
   loadNamespace("quanteda")
-  quanteda::wordstem(...)
+  quanteda::char_wordstem(...)
 }
 
 #' Generate ngram in groups.


### PR DESCRIPTION
### Description

Underlying quanteda::wordstem function does not exist anymore, so switched to use quanteda::char_wordstem() instead.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
