### PR TITLE
better factor handling in regressions

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -91,6 +91,10 @@ build_coxph.fast <- function(df,
     stop("grouping column is used as variable columns")
   }
 
+  if (predictor_n < 2) {
+    stop("Max # of categories for explanatory vars must be at least 2.")
+  }
+
   if(!is.null(seed)){
     set.seed(seed)
   }

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -214,8 +214,8 @@ build_coxph.fast <- function(df,
           # 2. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    coxph takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
-          if (length(levels(df[[col]])) >= 12) {
-            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:10])
+          if (length(levels(df[[col]])) >= predictor_n + 2) {
+            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:predictor_n])
           }
           else {
             df[[col]] <- factor(df[[col]], ordered=FALSE)

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -226,7 +226,7 @@ build_coxph.fast <- function(df,
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
           #    TODO: see if ties.method would make sense for calc_feature_imp.
           # 2. turn NA into (Missing) factor level so that coxph will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -221,11 +221,11 @@ build_coxph.fast <- function(df,
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
         } else if(!is.numeric(df[[col]])) {
-          # 1. convert data to factor if predictors are not numeric or logical
-          #    and limit the number of levels in factor by fct_lump.
+          # 1. convert data to factor if predictors are not numeric or logical.
+          # 2. sort levels by frequency so that base level is the most frequent category.
+          # 3. limit the number of levels in factor by fct_lump.
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
-          #    TODO: see if ties.method would make sense for calc_feature_imp.
-          # 2. turn NA into (Missing) factor level so that coxph will not drop all the rows.
+          # 4. turn NA into (Missing) factor level so that lm will not drop all the rows.
           df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -70,7 +70,7 @@ build_coxph.fast <- function(df,
                     ...,
                     max_nrow = 50000, # With 50000 rows, taking 6 to 7 seconds on late-2016 Macbook Pro.
                     predictor_n = 12, # so that at least months can fit in it.
-                    seed = 0
+                    seed = NULL
                     ){
   # TODO: cleanup code only aplicable to randomForest. this func was started from copy of calc_feature_imp, and still adjusting for lm. 
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -164,6 +164,10 @@ build_lm.fast <- function(df,
     stop("grouping column is used as variable columns")
   }
 
+  if (predictor_n < 2) {
+    stop("Max # of categories for explanatory vars must be at least 2.")
+  }
+
   if(!is.null(seed)){
     set.seed(seed)
   }

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -140,7 +140,7 @@ build_lm.fast <- function(df,
                     max_nrow = 50000,
                     predictor_n = 12, # so that at least months can fit in it.
                     smote = FALSE,
-                    seed = 0
+                    seed = NULL
                     ){
   # TODO: add test
   # TODO: cleanup code only aplicable to randomForest. this func was started from copy of calc_feature_imp, and still adjusting for lm. 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -372,7 +372,7 @@ glance.lm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
     }
   }
   if(pretty.name) {
-    ret <- ret %>% dplyr::rename(`R Squared`=r.squared, `Adj R Squared`=adj.r.squared, `Root Mean Square Error`=sigma, `F Ratio`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Log Likelihood`=logLik, Deviance=deviance, `Residual DF`=df.residual)
+    ret <- ret %>% dplyr::rename(`R Squared`=r.squared, `Adj R Squared`=adj.r.squared, `RMSE`=sigma, `F Ratio`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Log Likelihood`=logLik, Deviance=deviance, `Residual DF`=df.residual)
   }
   ret
 }

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -298,7 +298,7 @@ build_lm.fast <- function(df,
           #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
           #    TODO: see if ties.method would make sense for calc_feature_imp.
           # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(as.factor(df[[col]]), n=predictor_n, ties.method="first"))
+          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first"))
         } else {
           # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -286,8 +286,8 @@ build_lm.fast <- function(df,
           # 2. if the data is ordered factor, turn it into unordered. For ordered factor,
           #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
           #    which we do not want for this function.
-          if (length(levels(df[[col]])) >= 12) {
-            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:10])
+          if (length(levels(df[[col]])) >= predictor_n + 2) {
+            df[[col]] <- fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:predictor_n])
           }
           else {
             df[[col]] <- factor(df[[col]], ordered=FALSE)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -875,7 +875,7 @@ calc_feature_imp <- function(df,
     if (!is.logical(clean_df[[clean_target_col]])) {
       # limit the number of levels in factor by fct_lump
       clean_df[[clean_target_col]] <- forcats::fct_explicit_na(forcats::fct_lump(
-        fct_infreq(as.factor(clean_df[[clean_target_col]])), n = target_n, ties.method="first"
+        as.factor(clean_df[[clean_target_col]]), n = target_n, ties.method="first"
       ))
 
       if (length(unique(clean_df[[clean_target_col]])) == 2) {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -960,6 +960,11 @@ calc_feature_imp <- function(df,
             df[[hour_col]] <- factor(lubridate::hour(df[[col]])) # treat hour as category
           }
           df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
+        } else if(is.factor(df[[col]])) {
+          # if the data is factor, respect the levels and keep first 10 levels, and make others "Others" level.
+          if (length(levels(df[[col]])) >= predictor_n + 2) {
+            df[[col]] <- fct_other(df[[col]], keep=levels(df[[col]])[1:predictor_n])
+          }
         } else if(!is.numeric(df[[col]])) {
           # convert data to factor if predictors are not numeric.
           # and limit the number of levels in factor by fct_lump.

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -875,7 +875,7 @@ calc_feature_imp <- function(df,
     if (!is.logical(clean_df[[clean_target_col]])) {
       # limit the number of levels in factor by fct_lump
       clean_df[[clean_target_col]] <- forcats::fct_explicit_na(forcats::fct_lump(
-        as.factor(clean_df[[clean_target_col]]), n = target_n, ties.method="first"
+        fct_infreq(as.factor(clean_df[[clean_target_col]])), n = target_n, ties.method="first"
       ))
 
       if (length(unique(clean_df[[clean_target_col]])) == 2) {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -839,6 +839,14 @@ calc_feature_imp <- function(df,
     stop("grouping column is used as variable columns")
   }
 
+  if (target_n < 2) {
+    stop("Max # of categories for target var must be at least 2.")
+  }
+
+  if (predictor_n < 2) {
+    stop("Max # of categories for explanatory vars must be at least 2.")
+  }
+
   # remove NA because it's not permitted for randomForest
   df <- df %>%
     dplyr::filter(!is.na(!!target_col))

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -814,8 +814,12 @@ calc_feature_imp <- function(df,
                              nodesize = 12,
                              target_n = 20,
                              predictor_n = 12, # so that at least months can fit in it.
-                             smote = FALSE
+                             smote = FALSE,
+                             seed = NULL
                              ){
+  if(!is.null(seed)){
+    set.seed(seed)
+  }
   # this seems to be the new way of NSE column selection evaluation
   # ref: https://github.com/tidyverse/tidyr/blob/3b0f946d507f53afb86ea625149bbee3a00c83f6/R/spread.R
   target_col <- dplyr::select_var(names(df), !! rlang::enquo(target))

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -277,7 +277,13 @@ tidy.chisq_exploratory <- function(x, type = "observed") {
 
     ret <- obs_df %>% left_join(resid_df, by=c(x$var1, x$var2)) # join residual column 
     ret <- ret %>% left_join(raw_resid_df, by=c(x$var1, x$var2)) # join raw_residual column
-    ret <- ret %>% mutate(contrib = 100*residual^2/x$statistic) # add percent contribution too.
+    browser()
+    if (is.nan(x$statistic) || x$statistic <= 0) {
+      ret <- ret %>% mutate(contrib = 0) # avoid division by 0
+    }
+    else {
+      ret <- ret %>% mutate(contrib = 100*residual^2/x$statistic) # add percent contribution too.
+    }
 
     if (!is.null(x$var1_levels)) {
       ret[[x$var1]] <- factor(ret[[x$var1]], levels=x$var1_levels)

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -4,7 +4,7 @@ test_that("test build_coxph.fast", {
   df <- survival::lung
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
-  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, sex, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss)
+  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, sex, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_n = 2)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
   ret <- model_df %>% broom::tidy(model)
   ret <- model_df %>% broom::glance(model, pretty.name=TRUE)

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -143,7 +143,7 @@ test_that("prediction with target column name with space by build_lm.fast", {
   test_data <- dplyr::bind_rows(test_data, test_data)
   test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
-  model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE)
+  model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3)
   ret <- model_data %>% broom::glance(model)
   # TODO: the returned coefficients does not show all input variables. 
   # most likely due to too few rows. look into it and add check for the values in the returned df. 

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -95,7 +95,7 @@ test_that("test calc_feature_imp predicting logical", {
     calc_feature_imp(`Tar get`,
                       dplyr::starts_with("cat_"),
                       num_1,
-                      num_2)
+                      num_2, predictor_n = 6)
 
   conf_mat <- tidy(model_df, model, type = "conf_mat", pretty.name = TRUE)
 


### PR DESCRIPTION
### Description
- respect original factor levels in calc_feature_imp
- respect predictor_n (limit for fct_lump) when column type is factor
- sort levels by frequency before fct_lump so that base levels for regression is the most frequent category.
- add seed parameter to calc_feature_imp

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
