### PR TITLE
Make t-test/ANOVA more robust in case of group_by

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -339,11 +339,12 @@ exp_ttest <- function(df, var1, var2, func2 = NULL, ...) {
       model
     }, error = function(e){
       if(length(grouped_cols) > 0) {
-        # ignore the error if
+        # Ignore the error if
         # it is caused by subset of
         # grouped data frame
         # to show result of
-        # data frames that succeed
+        # data frames that succeed.
+        # For example, error can happen if one of the groups does not have both values (e.g. both TRUE and FALSE) of var2.
         NULL
       } else {
         stop(e)
@@ -438,11 +439,12 @@ exp_anova <- function(df, var1, var2, func2 = NULL, ...) {
       model
     }, error = function(e){
       if(length(grouped_cols) > 0) {
-        # ignore the error if
+        # Ignore the error if
         # it is caused by subset of
         # grouped data frame
         # to show result of
-        # data frames that succeed
+        # data frames that succeed.
+        # For example, error can happen if one of the groups has only one unique value in its set of var2.
         NULL
       } else {
         stop(e)

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -416,7 +416,7 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
 exp_anova <- function(df, var1, var2, func2 = NULL, ...) {
   var1_col <- col_name(substitute(var1))
   var2_col <- col_name(substitute(var2))
-  grouped_col <- grouped_by(df)
+  grouped_cols <- grouped_by(df)
 
   if (!is.null(func2) && (is.Date(df[[var2_col]]) || is.POSIXct(df[[var2_col]]))) {
     df <- df %>% mutate(!!rlang::sym(var2_col) := extract_from_date(!!rlang::sym(var2_col), type=func2))
@@ -429,12 +429,25 @@ exp_anova <- function(df, var1, var2, func2 = NULL, ...) {
   formula = as.formula(paste0('`', var1_col, '`~`', var2_col, '`'))
 
   anova_each <- function(df) {
-    model <- aov(formula, data = df, ...)
-    class(model) <- c("anova_exploratory", class(model))
-    model$var1 <- var1_col
-    model$var2 <- var2_col
-    model$data <- df
-    model
+    tryCatch({
+      model <- aov(formula, data = df, ...)
+      class(model) <- c("anova_exploratory", class(model))
+      model$var1 <- var1_col
+      model$var2 <- var2_col
+      model$data <- df
+      model
+    }, error = function(e){
+      if(length(grouped_cols) > 0) {
+        # ignore the error if
+        # it is caused by subset of
+        # grouped data frame
+        # to show result of
+        # data frames that succeed
+        NULL
+      } else {
+        stop(e)
+      }
+    })
   }
 
   # Calculation is executed in each group.

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -212,10 +212,24 @@ test_that("test exp_ttest", {
   ret
 })
 
+test_that("test exp_ttest with group_by", {
+  ret <- mtcars %>% group_by(vs) %>% exp_ttest(mpg, am)
+  ret %>% tidy(model, type="data_summary")
+  ret
+})
+
 test_that("test exp_anova", {
   ret <- exp_anova(mtcars, mpg, am)
   ret %>% tidy(model, type="data_summary")
   ret <- exp_anova(mtcars, mpg, gear)
+  ret %>% tidy(model, type="data_summary")
+  ret
+})
+
+test_that("test exp_anova with group_by", {
+  ret <- mtcars %>% group_by(vs) %>% exp_anova(mpg, am)
+  ret %>% tidy(model, type="data_summary")
+  ret <- mtcars %>% group_by(vs) %>% exp_anova(mpg, gear)
   ret %>% tidy(model, type="data_summary")
   ret
 })


### PR DESCRIPTION
### Description
In exp_ttext and exp_anova, we will keep going even if one of the group_by group has error, so that we can show the result from other groups.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
