### PR TITLE
Skip normality test for a column with always same value

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -548,7 +548,7 @@ exp_normality<- function(df, ..., n_sample = 50) {
     df.model <- data.frame()
 　  for (col in selected_cols) {
       if (n_distinct(df[[col]], na.rm=TRUE) <= 1) {
-        # skip if the column has only 1 unique value, to avoid error.
+        # skip if the column has only 1 unique value or only NAs, to avoid error.
         # TODO: show what happened in the summary table.
       }
       else {

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -547,34 +547,40 @@ exp_normality<- function(df, ..., n_sample = 50) {
     df.qqline <- data.frame()
     df.model <- data.frame()
 　  for (col in selected_cols) {
-　    # set plot.it to FALSE to disable plotting (avoid launching another window)
-　    res <- stats::qqnorm(df[[col]], plot.it=FALSE)
-　    df.qq <- dplyr::bind_rows(df.qq, data.frame(x=res$x, y=res$y, col=col))
-
-      # bind reference line data too.
-      ref_res <- qqline_data(df[[col]])
-      min_x <- min(res$x, na.rm=TRUE)
-      max_x <- max(res$x, na.rm=TRUE)
-      ref_min_y <- ref_res[[1]] + ref_res[[2]] * min_x
-      ref_max_y <- ref_res[[1]] + ref_res[[2]] * max_x
-　    df.qqline <- dplyr::bind_rows(df.qqline, data.frame(x=c(min_x, max_x), refline_y=c(ref_min_y,ref_max_y), col=col))
-
-      if (n_sample > 5000) {
-        n_sample <- 5000 # shapiro.test takes only up to max of 5000 samples. 
-      }
-
-      if (length(df[[col]]) > n_sample) {
-        col_to_test <- sample(df[[col]], n_sample)
-        sample_size <- n_sample
+      if (n_distinct(df[[col]]) <= 1) {
+        # skip if the column has only 1 unique value, to avoid error.
+        # TODO: show what happened in the summary table.
       }
       else {
-        col_to_test <- df[[col]]
-        sample_size <- length(col_to_test)
+　      # set plot.it to FALSE to disable plotting (avoid launching another window)
+　      res <- stats::qqnorm(df[[col]], plot.it=FALSE)
+　      df.qq <- dplyr::bind_rows(df.qq, data.frame(x=res$x, y=res$y, col=col))
+
+        # bind reference line data too.
+        ref_res <- qqline_data(df[[col]])
+        min_x <- min(res$x, na.rm=TRUE)
+        max_x <- max(res$x, na.rm=TRUE)
+        ref_min_y <- ref_res[[1]] + ref_res[[2]] * min_x
+        ref_max_y <- ref_res[[1]] + ref_res[[2]] * max_x
+　      df.qqline <- dplyr::bind_rows(df.qqline, data.frame(x=c(min_x, max_x), refline_y=c(ref_min_y,ref_max_y), col=col))
+
+        if (n_sample > 5000) {
+          n_sample <- 5000 # shapiro.test takes only up to max of 5000 samples. 
+        }
+
+        if (length(df[[col]]) > n_sample) {
+          col_to_test <- sample(df[[col]], n_sample)
+          sample_size <- n_sample
+        }
+        else {
+          col_to_test <- df[[col]]
+          sample_size <- length(col_to_test)
+        }
+        res <- shapiro.test(col_to_test) %>% tidy() %>%
+          dplyr::mutate(col=col, sample_size=sample_size) %>%
+          dplyr::select(col, everything())
+　      df.model <- dplyr::bind_rows(df.model, res)
       }
-      res <- shapiro.test(col_to_test) %>% tidy() %>%
-        dplyr::mutate(col=col, sample_size=sample_size) %>%
-        dplyr::select(col, everything())
-　    df.model <- dplyr::bind_rows(df.model, res)
     }
 
     model <- list()

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -547,7 +547,7 @@ exp_normality<- function(df, ..., n_sample = 50) {
     df.qqline <- data.frame()
     df.model <- data.frame()
 　  for (col in selected_cols) {
-      if (n_distinct(df[[col]]) <= 1) {
+      if (n_distinct(df[[col]], na.rm=TRUE) <= 1) {
         # skip if the column has only 1 unique value, to avoid error.
         # TODO: show what happened in the summary table.
       }

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -195,7 +195,12 @@ do_chisq.test_ <- function(df,
 
 #' Chi-Square test wrapper for Analytics View
 #' @export
-exp_chisq <- function(df, var1, var2, value = NULL, func1 = NULL, func2 = NULL, fun.aggregate = sum, ...) {
+exp_chisq <- function(df, var1, var2, value = NULL, func1 = NULL, func2 = NULL, fun.aggregate = sum, correct = FALSE, ...) {
+  # We are turning off Yates's correction by default because...
+  # 1. It seems that it is commonly discussed that it is overly conservative and not necessary.
+  #    https://en.wikipedia.org/wiki/Yates%27s_correction_for_continuity
+  #    https://aue.repo.nii.ac.jp/?action=repository_uri&item_id=785&file_id=15&file_no=1
+  # 2. With Yates's correction residuals do not add up to chi-square value, which makes contributions not adding up to 100%.
   var1_col <- col_name(substitute(var1))
   var2_col <- col_name(substitute(var2))
   value_col <- col_name(substitute(value))
@@ -234,7 +239,7 @@ exp_chisq <- function(df, var1, var2, value = NULL, func1 = NULL, func2 = NULL, 
     }
     df <- df %>% tibble::column_to_rownames(var=var1_col)
     x <- df %>% as.matrix()
-    model <- chisq.test(x = x, ...)
+    model <- chisq.test(x = x, correct = correct, ...)
     # add variable name info to the model
     model$var1 <- var1_col
     model$var2 <- var2_col

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -235,7 +235,7 @@ test_that("test exp_anova with group_by", {
 })
 
 test_that("test exp_normality", {
-  df <- mtcars %>% mutate(dummy=1) # test for column with always same value
+  df <- mtcars %>% mutate(dummy=c(NA, rep(1,n()-1))) # test for column with always same value, except for NA.
   ret <- df %>% exp_normality(mpg, gear, dummy, n_sample=20)
   qq <- ret %>% tidy(model, type="qq", n_sample=30)
   model_summary <- ret %>% tidy(model, type="model_summary", conf_level=0.9)

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -235,7 +235,8 @@ test_that("test exp_anova with group_by", {
 })
 
 test_that("test exp_normality", {
-  ret <- exp_normality(mtcars, mpg, gear, n_sample=20)
+  df <- mtcars %>% mutate(dummy=1) # test for column with always same value
+  ret <- df %>% exp_normality(mpg, gear, dummy, n_sample=20)
   qq <- ret %>% tidy(model, type="qq", n_sample=30)
   model_summary <- ret %>% tidy(model, type="model_summary", conf_level=0.9)
   ret


### PR DESCRIPTION
### Description
- Skip normality test for a column with always same value
- Turn off Yate's correction for exp_chisq by default

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
