### PR TITLE
logical factor order for regression predictors should be FALSE then TRUE

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -224,6 +224,10 @@ build_coxph.fast <- function(df,
           else {
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
+        } else if(is.logical(df[[col]])) {
+          # 1. convert data to factor if predictors are logical
+          # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
         } else if(!is.numeric(df[[col]])) {
           # 1. convert data to factor if predictors are not numeric or logical.
           # 2. sort levels by frequency so that base level is the most frequent category.

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -225,7 +225,7 @@ build_coxph.fast <- function(df,
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
         } else if(is.logical(df[[col]])) {
-          # 1. convert data to factor if predictors are logical
+          # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
           # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
           df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
         } else if(!is.numeric(df[[col]])) {

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -296,6 +296,10 @@ build_lm.fast <- function(df,
           else {
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
+        } else if(is.logical(df[[col]])) {
+          # 1. convert data to factor if predictors are logical
+          # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
+          df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
         } else if(!is.numeric(df[[col]])) {
           # 1. convert data to factor if predictors are not numeric or logical
           #    and limit the number of levels in factor by fct_lump.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -297,7 +297,7 @@ build_lm.fast <- function(df,
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
         } else if(is.logical(df[[col]])) {
-          # 1. convert data to factor if predictors are logical
+          # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
           # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
           df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
         } else if(!is.numeric(df[[col]])) {

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -4,6 +4,7 @@ test_that("test build_coxph.fast", {
   df <- survival::lung
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
+  df <- df %>% mutate(sex = sex==1) # test handling of logical
   model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, sex, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_n = 2)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
   ret <- model_df %>% broom::tidy(model)

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -132,18 +132,19 @@ test_that("prediction with target column name with space by build_lm.fast", {
   test_data <- structure(
     list(
       `CANCELLED X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `logical col` = c(TRUE, FALSE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, NA, TRUE, FALSE, NA, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
       CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
       # testing filtering of Inf, -Inf, NA here.
       DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
-    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "Carrier Name", "CARRIER", "DISTANCE"))
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "logical col", "Carrier Name", "CARRIER", "DISTANCE"))
 
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
   test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
-  model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3)
+  model_data <- build_lm.fast(test_data, `CANCELLED X`, `logical col`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3)
   ret <- model_data %>% broom::glance(model)
   # TODO: the returned coefficients does not show all input variables. 
   # most likely due to too few rows. look into it and add check for the values in the returned df. 
@@ -151,7 +152,7 @@ test_that("prediction with target column name with space by build_lm.fast", {
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED.X", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+  expect_equal(colnames(ret), c("CANCELLED.X", "logical.col", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
 })
 
 test_that("prediction with glm model with SMOTE by build_lm.fast", {


### PR DESCRIPTION
### Description
logical factor order for regression predictors should be FALSE then TRUE

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
