### PR TITLE
turn NA into (Missing) factor level even when column is already factor

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -296,6 +296,8 @@ build_lm.fast <- function(df,
           else {
             df[[col]] <- factor(df[[col]], ordered=FALSE)
           }
+          # turn NA into (Missing) factor level. Without this, lm or glm drops rows internally.
+          df[[col]] <- forcats::fct_explicit_na(df[[col]])
         } else if(is.logical(df[[col]])) {
           # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
           # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -160,7 +160,7 @@ test_that("prediction with glm model with SMOTE by build_lm.fast", {
     list(
       `CANCELLED X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
-      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      CARRIER = factor(c(NA, "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL")), # test with factor with NA
       # testing filtering of Inf, -Inf, NA here.
       DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "Carrier Name", "CARRIER", "DISTANCE"))


### PR DESCRIPTION
### Description
Turn NA into (Missing) factor level even when column is already factor.
This fixes the error from logistic regression we had in training, which happens when predictor is a factor with NAs.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
