### PR TITLE
chisq: preserve logical TRUE/FALSE order on chart

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -222,6 +222,9 @@ exp_chisq <- function(df, var1, var2, value = NULL, func1 = NULL, func2 = NULL, 
 
   var1_levels <- NULL
   var2_levels <- NULL
+  # preserve class of var1 and var2 so that we can cast them back to original class later.
+  var1_class <- class(df[[var1_col]])
+  var2_class <- class(df[[var2_col]])
   if (is.factor(df[[var1_col]])) {
     var1_levels <- levels(df[[var1_col]])
   }
@@ -243,6 +246,8 @@ exp_chisq <- function(df, var1, var2, value = NULL, func1 = NULL, func2 = NULL, 
     # add variable name info to the model
     model$var1 <- var1_col
     model$var2 <- var2_col
+    model$var1_class <- var1_class
+    model$var2_class <- var2_class
     model$var1_levels <- var1_levels
     model$var2_levels <- var2_levels
     class(model) <- c("chisq_exploratory", class(model))
@@ -304,6 +309,13 @@ tidy.chisq_exploratory <- function(x, type = "observed") {
     }
     if (!is.null(x$var2_levels)) {
       ret[[x$var2]] <- factor(ret[[x$var2]], levels=x$var2_levels)
+    }
+    # if original class of var1, var2 was logical, return them as logical.
+    if (x$var1_class == "logical") {
+      ret[[x$var1]] <- as.logical(ret[[x$var1]])
+    }
+    if (x$var2_class == "logical") {
+      ret[[x$var2]] <- as.logical(ret[[x$var2]])
     }
   }
   ret

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -199,6 +199,13 @@ test_that("test exp_chisq", {
   ret
 })
 
+test_that("test exp_chisq with logical", {
+  model_df <- exp_chisq(mtcars %>% mutate(gear=gear>3, carb=carb>3), gear, carb) # factor order should be kept in the model
+  ret <- model_df %>% tidy(model, type="residuals")
+  expect_equal(class(ret$gear), "logical")
+  expect_equal(class(ret$carb), "logical")
+})
+
 test_that("test exp_chisq with group_by", {
   ret <- mtcars %>% group_by(vs) %>% exp_chisq(gear, carb, value=cyl)
   observed <- ret %>% broom::tidy(model, type="observed")

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -572,9 +572,9 @@ test_that("test extract_from_date", {
 
 test_that("test %in_or_all%", {
   ret <- c(1,2,3) %in_or_all% c(1,2)
-  expect_equal(ret, c(TRUE, TRUE, FALSE)
+  expect_equal(ret, c(TRUE, TRUE, FALSE))
   ret <- c(1,2,3) %in_or_all% NULL
-  expect_equal(ret, c(TRUE, TRUE, TRUE)
+  expect_equal(ret, c(TRUE, TRUE, TRUE))
   ret <- c(1,2,3) %in_or_all% c()
-  expect_equal(ret, c(TRUE, TRUE, TRUE)
+  expect_equal(ret, c(TRUE, TRUE, TRUE))
 })


### PR DESCRIPTION
### Description
To preserve logical TRUE/FALSE order on chart, output should be casted back to logical when input columns were logical originally.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
