### PR TITLE
Move random sampling in normality test from tidy() to exp_normality()

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -550,8 +550,11 @@ qqline_data <- function (y, datax = FALSE, distribution = qnorm, probs = c(0.25,
 
 
 #' @param n_sample - Downsample to this size before shapiro test. Note that this is not applied for qq data. 
+#' @param n_sample_qq - Downsample qq-plot data down to this number.
+#'                   This is to make sure qq-line part of the data would not be sampled out in qq scatter plot.
+#'                   Default 4500 is to make room for qqline rows. (default sample size by scatter plot data query is 5000)
 #' @export
-exp_normality<- function(df, ..., n_sample = 50) {
+exp_normality<- function(df, ..., n_sample = 50, n_sample_qq = 4500) {
   selected_cols <- dplyr::select_vars(names(df), !!! rlang::quos(...))
   
   shapiro_each <- function(df) {
@@ -597,6 +600,12 @@ exp_normality<- function(df, ..., n_sample = 50) {
 
     model <- list()
     model$qq <- df.qq
+    if (!is.null(n_sample_qq) && nrow(df$qq) > n_sample_qq) {
+      model$sampled_qq <- dplyr::sample_n(df$qq, n_sample_qq)
+    }
+    else {
+      model$sampled_qq <- df$qq
+    }
     model$qqline <- df.qqline
     model$model_summary <- df.model
     class(model) <- c("shapiro_exploratory", class(model))

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -624,13 +624,11 @@ exp_normality<- function(df, ..., n_sample = 50, n_sample_qq = 4500) {
   ret
 }
 
-#' @param n_sample - Downsample qq-plot data down to this number.
-#'                   This is to make sure qq-line part of the data would not be sampled out in qq scatter plot.
 #' @export
-tidy.shapiro_exploratory <- function(x, type = "model", signif_level=0.05, n_sample=NULL) {
-  if (type == "qq") {
-    if (!is.null(n_sample) && nrow(x$qq) > n_sample) {
-      sampled_qq_df <- dplyr::sample_n(x$qq, n_sample)
+tidy.shapiro_exploratory <- function(x, type = "model", signif_level=0.05) {
+  if (type == "qq" || type == "histogram") {
+    if (type == "qq") {
+      sampled_qq_df <- x$sampled_qq
     }
     else {
       sampled_qq_df <- x$qq

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -600,11 +600,11 @@ exp_normality<- function(df, ..., n_sample = 50, n_sample_qq = 4500) {
 
     model <- list()
     model$qq <- df.qq
-    if (!is.null(n_sample_qq) && nrow(df$qq) > n_sample_qq) {
-      model$sampled_qq <- dplyr::sample_n(df$qq, n_sample_qq)
+    if (!is.null(n_sample_qq) && nrow(df.qq) > n_sample_qq) {
+      model$sampled_qq <- dplyr::sample_n(df.qq, n_sample_qq)
     }
     else {
-      model$sampled_qq <- df$qq
+      model$sampled_qq <- df.qq
     }
     model$qqline <- df.qqline
     model$model_summary <- df.model

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -243,8 +243,8 @@ test_that("test exp_anova with group_by", {
 
 test_that("test exp_normality", {
   df <- mtcars %>% mutate(dummy=c(NA, rep(1,n()-1))) # test for column with always same value, except for NA.
-  ret <- df %>% exp_normality(mpg, gear, dummy, n_sample=20)
-  qq <- ret %>% tidy(model, type="qq", n_sample=30)
+  ret <- df %>% exp_normality(mpg, gear, dummy, n_sample=20, n_sample_qq=30)
+  qq <- ret %>% tidy(model, type="qq")
   model_summary <- ret %>% tidy(model, type="model_summary", signif_level=0.1)
   ret
 })


### PR DESCRIPTION
### Description
To keep exported result (csv etc.) same as what is displayed, we need to eliminate randomness from analytics view preprocessor, whose result is not cached.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
