### PR TITLE
do_prophet bug fixes

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -13,7 +13,7 @@ do_prophet <- function(df, time, value = NULL, ...){
 #' @param time_col - Column that has time data
 #' @param value_col - Column that has value data
 #' @param periods - Number of time periods (e.g. days. unit is determined by time_unit) to forecast.
-#' @param time_unit - "day", "week", "month", "quarter", or "year"
+#' @param time_unit - "second", "minute", "hour", "day", "week", "month", "quarter", or "year"
 #' @param include_history - Whether to include history data in forecast or not.
 #' @param fun.aggregate - Function to aggregate values.
 #' @param ... - extra values to be passed to prophet::prophet. listed below.

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -173,7 +173,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
     # but now, filter them out again.
     # by doing so, we affect future table, and skip prediction (interpolation)
     # for all missing date/time, which could be expensive if the training data is sparse.
-    training_data <- training_data %>% dplyr::filter(!is.na(y))
+    # keep the last row even if it does not have training data, to mark the end of training period, which is the start of test period.
+    training_data <- training_data %>% dplyr::filter(!is.na(y) | row_number() == n())
 
     if (!is.null(cap) && is.data.frame(cap)) {
       # in this case, cap is the future data frame with cap, specified by user.

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -13,7 +13,7 @@ do_prophet <- function(df, time, value = NULL, ...){
 #' @param time_col - Column that has time data
 #' @param value_col - Column that has value data
 #' @param periods - Number of time periods (e.g. days. unit is determined by time_unit) to forecast.
-#' @param time_unit - "second", "minute", "hour", "day", "week", "month", "quarter", or "year"
+#' @param time_unit - "second"/"sec", "minute"/"min", "hour", "day", "week", "month", "quarter", or "year".
 #' @param include_history - Whether to include history data in forecast or not.
 #' @param fun.aggregate - Function to aggregate values.
 #' @param ... - extra values to be passed to prophet::prophet. listed below.
@@ -56,6 +56,13 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
   library("prophet")
 
   grouped_col <- grouped_by(df)
+
+  if (time_unit == "min") {
+    time_unit <- "minute"
+  }
+  else if (time_unit == "sec") {
+    time_unit <- "second"
+  }
 
   # column name validation
   if(!time_col %in% colnames(df)){

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -135,6 +135,15 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
         dplyr::group_by(ds) %>%
         dplyr::summarise(y = n())
     }
+    # fill aggregated_data$ds with missing data/time.
+    browser()
+    ts <- seq.POSIXt(as.POSIXct(min(aggregated_data$ds)), as.POSIXct(max(aggregated_data$ds)), by=time_unit)
+    if (lubridate::is.Date(aggregated_data$ds)) {
+      ts <- as.Date(ts)
+    }
+    ts_df <- data.frame(ds=ts)
+    aggregated_data <- dplyr::full_join(ts_df, aggregated_data, by = c("ds" = "ds"))
+    
 
     if (time_unit != "day") { # if time_unit is larger than day (the next level is week), having weekly.seasonality does not make sense.
       weekly.seasonality = FALSE

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -135,13 +135,25 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
         dplyr::group_by(ds) %>%
         dplyr::summarise(y = n())
     }
+
     # fill aggregated_data$ds with missing data/time.
-    browser()
-    ts <- seq.POSIXt(as.POSIXct(min(aggregated_data$ds)), as.POSIXct(max(aggregated_data$ds)), by=time_unit)
+    # this is necessary to make forecast period correspond with test period in test mode when there is missing date/time in original aggregated_data$ds.
+
+    if (time_unit == "minute") {
+      time_unit_for_seq = "min"
+    }
+    else if (time_unit == "second") {
+      time_unit_for_seq = "sec"
+    }
+    else {
+      time_unit_for_seq = time_unit
+    }
+    ts <- seq.POSIXt(as.POSIXct(min(aggregated_data$ds)), as.POSIXct(max(aggregated_data$ds)), by=time_unit_for_seq)
     if (lubridate::is.Date(aggregated_data$ds)) {
       ts <- as.Date(ts)
     }
     ts_df <- data.frame(ds=ts)
+    # ts_df has to be the left-hand side to keep the row order according to time order.
     aggregated_data <- dplyr::full_join(ts_df, aggregated_data, by = c("ds" = "ds"))
     
 

--- a/R/util.R
+++ b/R/util.R
@@ -1345,11 +1345,11 @@ computeMASE <- function(forecast, train, test, period){
   test <- as.vector(test)
 
   n <- length(train)
-  scalingFactor <- sum(abs(train[(period+1):n] - train[1:(n-period)])) / (n-period)
+  scalingFactor <- mean(abs(train[(period+1):n] - train[1:(n-period)]), na.rm=TRUE)
 
   et <- abs(test-forecast)
   qt <- et/scalingFactor
-  meanMASE <- mean(qt)
+  meanMASE <- mean(qt, na.rm=TRUE)
   return(meanMASE)
 }
 

--- a/tests/testthat/test_pairwise.R
+++ b/tests/testthat/test_pairwise.R
@@ -151,12 +151,34 @@ test_that("test do_dist with cmd_scale", {
   )
   result_kv <- test_df %>%
     do_dist(skv = c("row", "col", "val"), diag=TRUE, cmdscale_k = 3)
+  # it seems result_kv can be 3 or 2 dimensional with this data,
+  # since axis3 gets near 0.
+  #
+  # 3 dimensional result (got on Mac).
+  #
+  # # A tibble: 4 x 4
+  #   row    axis1        axis2         axis3
+  #   <chr>  <dbl>        <dbl>         <dbl>
+  # 1 row 1 -22.0   0.000000613  0           
+  # 2 row 2  -7.35 -0.000000167  0.0000000359
+  # 3 row 3   7.35  0.000000167  0.000000111 
+  # 4 row 4  22.0   0.000000501 -0.0000000250
+  #
+  # 2 dimensional result (got on Linux).
+  #
+  # # A tibble: 4 x 3
+  #   row    axis1        axis2
+  #   <chr>  <dbl>        <dbl>
+  # 1 row 1 -22.0   0.000000613
+  # 2 row 2  -7.35 -0.000000167
+  # 3 row 3   7.35  0.000000167
+  # 4 row 4  22.0   0.000000501
 
   result_cols <- test_df %>%
     tidyr::spread(col, val) %>% dplyr::select(-row) %>%
     do_dist(dplyr::everything(), diag=TRUE, cmdscale_k = 3)
 
-  expect_equal(ncol(result_kv), 4)
+  expect_true(ncol(result_kv) %in% c(4,3))
   expect_equal(ncol(result_cols), 4)
   expect_equal(result_kv[[2]], c(-22.045408, -7.348469, 7.348469, 22.045408), tolerance=0.01)
 })


### PR DESCRIPTION
### Description
- mase() to tolerate NAs
- In test mode, test period and prediction period should correspond even if test period data has missing date/time
- Take "min","sec" as aliases of "minutes","seconds" for time_unit, so that it works well with viz.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
