### PR TITLE
do_prophet: handle "month" and larger time unit in test mode

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -153,8 +153,11 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
 
 
     if (test_mode) {
-      # fill aggregated_data$ds with missing data/time.
-      # this is necessary to make forecast period correspond with test period in test mode when there is missing date/time in original aggregated_data$ds.
+      # Remove end of aggregated_data as test data to make training data.
+
+      # Fill aggregated_data$ds with missing data/time.
+      # This is necessary to make forecast period correspond with test period in test mode when there is missing date/time in original aggregated_data$ds.
+      # Note that this is only for the purpose of correctly determine where to start test period, and we remove those filled data once that purpose is met.
 
       if (time_unit == "minute") {
         time_unit_for_seq <- "min"

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -165,9 +165,18 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods, time_unit = "da
       else {
         time_unit_for_seq <- time_unit
       }
-      ts <- seq.POSIXt(as.POSIXct(min(aggregated_data$ds)), as.POSIXct(max(aggregated_data$ds)), by=time_unit_for_seq)
-      if (lubridate::is.Date(aggregated_data$ds)) {
-        ts <- as.Date(ts)
+      # Create periodical sequence of time to fill missing date/time
+      if (time_unit %in% c("hour", "minute", "second")) { # Use seq.POSIXt for unit smaller than day.
+        ts <- seq.POSIXt(as.POSIXct(min(aggregated_data$ds)), as.POSIXct(max(aggregated_data$ds)), by=time_unit_for_seq)
+        if (lubridate::is.Date(aggregated_data$ds)) {
+          ts <- as.Date(ts)
+        }
+      }
+      else { # Use seq.Date for unit of day or larger. Using seq.POSIXct for month does not always give first day of month.
+        ts <- seq.Date(as.Date(min(aggregated_data$ds)), as.Date(max(aggregated_data$ds)), by=time_unit_for_seq)
+        if (!lubridate::is.Date(aggregated_data$ds)) {
+          ts <- as.POSIXct(ts)
+        }
       }
       ts_df <- data.frame(ds=ts)
       # ts_df has to be the left-hand side to keep the row order according to time order.

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -36,6 +36,37 @@ test_that("do_prophet with aggregation", {
   expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
 })
 
+test_that("do_prophet test mode with month as time units", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2030-01-01"), by="month")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
+  raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
+  ret <- raw_data %>%
+    do_prophet(`time stamp`, `da ta`, 10, time_unit = "month", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+})
+
+test_that("do_prophet test mode with quarter as time units", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2030-01-01"), by="quarter")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
+  raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
+  ret <- raw_data %>%
+    do_prophet(`time stamp`, `da ta`, 10, time_unit = "quarter", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+})
+
+test_that("do_prophet test mode with year as time units", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2030-01-01"), by="year")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
+  raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
+  ret <- raw_data %>%
+    do_prophet(`time stamp`, `da ta`, 10, time_unit = "year", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+})
+
+
 test_that("do_prophet grouped case", {
   data("raw_data", package = "AnomalyDetection")
   raw_data$timestamp <- as.POSIXct(raw_data$timestamp)

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -8,16 +8,30 @@ test_that("do_prophet with aggregation", {
     do_prophet(`time stamp`, `cou nt`, 10, time_unit = "day")
   ret <- raw_data %>%
     do_prophet(`time stamp`, `cou nt`, 10, time_unit = "hour")
-  # comment out for now since the following takes time. TODO: modify data and make it faster.
-  # ret <- raw_data %>%
-  #   do_prophet(`time stamp`, `cou nt`, 10, time_unit = "minute")
-  # ret <- raw_data %>%
-  #   do_prophet(`time stamp`, `cou nt`, 10, time_unit = "second")
+  ret <- raw_data %>% tail(100) %>%
+    do_prophet(`time stamp`, `cou nt`, 10, time_unit = "minute")
+  ret <- raw_data %>% tail(100) %>%
+    do_prophet(`time stamp`, `cou nt`, 10, time_unit = "second")
 
   # test for test mode.
   raw_data$`cou nt`[[length(raw_data$`cou nt`) - 2]] <- NA # inject NA near the end to test #9211
   ret <- raw_data %>%
     do_prophet(`time stamp`, `cou nt`, 2, time_unit = "day", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+
+  ret <- raw_data %>%
+    do_prophet(`time stamp`, `cou nt`, 2, time_unit = "hour", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+
+  ret <- raw_data %>% tail(100) %>%
+    do_prophet(`time stamp`, `cou nt`, 2, time_unit = "minute", test_mode=TRUE)
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+
+  ret <- raw_data %>% tail(100) %>%
+    do_prophet(`time stamp`, `cou nt`, 2, time_unit = "second", test_mode=TRUE)
   # verify that the last forecasted_value is not NA to test #9211
   expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
 })


### PR DESCRIPTION
### Description
do_prophet: handle "month" and larger time unit in test mode correctly.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
