### PR TITLE
Use openxlsx package for importing .xlsx file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.7.2.5
+Version: 0.7.2.6
 Date: 2018-07-14
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -1446,9 +1446,9 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   loadNamespace('stringr')
   df <- NULL
   # for .xlsx file extension
-  if(stringr::str_detect(path, '.xlsx')) {
+  if(stringr::str_detect(path, '\\.xlsx')) {
     if(n_max != Inf) {
-      df <- openxlsx::read.xlsx(xlsxFile = path, rows=skip+1:n_max, sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
+      df <- openxlsx::read.xlsx(xlsxFile = path, rows=(skip+1):n_max, sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
     } else {
       df <- openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip+1, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names, detectDates = detectDates)
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1477,11 +1477,20 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   df
 }
 
-#'Wrapper for openxlsx::getSheetNames to support remote file
+#'Wrapper for readxl::excel_sheets to support remote file
 #'@export
 get_excel_sheets <- function(path){
-  loadNamespace("openxlsx")
-  openxlsx::getSheetNames(path)
+  loadNamespace("readxl")	+  loadNamespace("openxlsx")
+  loadNamespace("stringr")	+  openxlsx::getSheetNames(path)
+  if (stringr::str_detect(path, "^https://") ||
+      stringr::str_detect(path, "^http://") ||
+      stringr::str_detect(path, "^ftp://")) {
+    tmp <- download_data_file(path, "excel")
+    readxl::excel_sheets(tmp)
+  } else {
+    # if it's local file simply call readxl::read_excel
+    readxl::excel_sheets(path)
+  }
 }
 
 #'Wrapper for readr::read_delim to support remote file

--- a/R/system.R
+++ b/R/system.R
@@ -1440,13 +1440,13 @@ download_data_file <- function(url, type){
 #'Wrapper for openxlsx::read.xlsx (in case of .xlsx file) and readxl::read_excel (in case of old .xls file)
 #'Use openxlsx::read.xlsx since it's memory footprint is less than that of readxl::read_excel and this creates benefit for users with less memory like Windows 32 bit users.
 #'@export
-read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
+read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, useOld = FALSE, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
   loadNamespace("openxlsx")
   loadNamespace('readr')
   loadNamespace('stringr')
   df <- NULL
   # for .xlsx file extension
-  if(stringr::str_detect(path, '\\.xlsx')) {
+  if(stringr::str_detect(path, '\\.xlsx') & useOld == FALSE) {
     if(n_max != Inf) {
       df <- openxlsx::read.xlsx(xlsxFile = path, rows=(skip+1):n_max, sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
     } else {

--- a/R/system.R
+++ b/R/system.R
@@ -1452,12 +1452,13 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
     } else {
       df <- openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip+1, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names, detectDates = detectDates)
     }
-    # preserve original column name for backward comaptibility (ref: https://github.com/awalker89/openxlsx/issues/102)
-    df <- df %>% magrittr::set_colnames(openxlsx::read.xlsx(xlsxFile = path, sheet, rows = skip+1, check.names = FALSE, colNames = FALSE) %>% as.character())
+    # trim white space needs to be done first since it cleans column names
     if(trim_ws == TRUE) {
       # use trimws from base to remove ending and trailing white space for character columns
       df <- data.frame(lapply(df, function(x) if(class(x)=="character") trimws(x) else(x)), stringsAsFactors=F)
     }
+    # preserve original column name for backward comaptibility (ref: https://github.com/awalker89/openxlsx/issues/102)
+    colnames(df) <- openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, rows = (skip+1), check.names = FALSE, colNames = FALSE) %>% as.character()
     if(col_names == FALSE) {
       # For backward comatilibity, use X__1, X__2, .. for default column names
       columnNames <- paste("X", 1:ncol(df), sep = "__")

--- a/R/system.R
+++ b/R/system.R
@@ -1438,6 +1438,7 @@ download_data_file <- function(url, type){
 }
 
 #'Wrapper for openxlsx::read.xlsx (in case of .xlsx file) and readxl::read_excel (in case of old .xls file)
+#'Use openxlsx::read.xlsx since it's memory footprint is less than that of readxl::read_excel and this creates benefit for users with less memory like Windows 32 bit users.
 #'@export
 read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
   loadNamespace("openxlsx")
@@ -1447,7 +1448,7 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   # for .xlsx file extension
   if(stringr::str_detect(path, '.xlsx')) {
     if(n_max != Inf) {
-      df <- openxlsx::read.xlsx(xlsxFile = path, rows=c(skip+1:n_max), sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
+      df <- openxlsx::read.xlsx(xlsxFile = path, rows=skip+1:n_max, sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
     } else {
       df <- openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip+1, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names, detectDates = detectDates)
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1440,13 +1440,13 @@ download_data_file <- function(url, type){
 #'Wrapper for openxlsx::read.xlsx (in case of .xlsx file) and readxl::read_excel (in case of old .xls file)
 #'Use openxlsx::read.xlsx since it's memory footprint is less than that of readxl::read_excel and this creates benefit for users with less memory like Windows 32 bit users.
 #'@export
-read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, useOld = FALSE, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
+read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl  = FALSE, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
   loadNamespace("openxlsx")
   loadNamespace('readr')
   loadNamespace('stringr')
   df <- NULL
   # for .xlsx file extension
-  if(stringr::str_detect(path, '\\.xlsx') & useOld == FALSE) {
+  if(stringr::str_detect(path, '\\.xlsx') & use_readxl == FALSE) {
     if(n_max != Inf) {
       df <- openxlsx::read.xlsx(xlsxFile = path, rows=(skip+1):n_max, sheet = sheet, colNames = col_names, na.strings = na, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols , check.names = check.names, detectDates = detectDates)
     } else {

--- a/R/system.R
+++ b/R/system.R
@@ -1437,36 +1437,18 @@ download_data_file <- function(url, type){
   }
 }
 
-#'Wrapper for readxl::read_excel to support remote file
+#'Wrapper for openxlsx::read.xlsx to support remote file
 #'@export
 read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf){
-  loadNamespace("readxl")
-  loadNamespace("stringr")
-  if (stringr::str_detect(path, "^https://") ||
-      stringr::str_detect(path, "^http://") ||
-      stringr::str_detect(path, "^ftp://")) {
-    tmp <- download_data_file(path, "excel")
-    readxl::read_excel(tmp, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max)
-  } else {
-    # if it's local file simply call readxl::read_excel
-    readxl::read_excel(path, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max)
-  }
+  loadNamespace("openxlsx")
+  openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip+1, na.strings = na, skipEmptyRows = FALSE, skipEmptyCols = FALSE)
 }
 
-#'Wrapper for readxl::excel_sheets to support remote file
+#'Wrapper for openxlsx::getSheetNames to support remote file
 #'@export
 get_excel_sheets <- function(path){
-  loadNamespace("readxl")
-  loadNamespace("stringr")
-  if (stringr::str_detect(path, "^https://") ||
-      stringr::str_detect(path, "^http://") ||
-      stringr::str_detect(path, "^ftp://")) {
-    tmp <- download_data_file(path, "excel")
-    readxl::excel_sheets(tmp)
-  } else {
-    # if it's local file simply call readxl::read_excel
-    readxl::excel_sheets(path)
-  }
+  loadNamespace("openxlsx")
+  openxlsx::getSheetNames(path)
 }
 
 #'Wrapper for readr::read_delim to support remote file

--- a/R/system.R
+++ b/R/system.R
@@ -1480,8 +1480,8 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
 #'Wrapper for readxl::excel_sheets to support remote file
 #'@export
 get_excel_sheets <- function(path){
-  loadNamespace("readxl")	+  loadNamespace("openxlsx")
-  loadNamespace("stringr")	+  openxlsx::getSheetNames(path)
+  loadNamespace("readxl")
+  loadNamespace("stringr")
   if (stringr::str_detect(path, "^https://") ||
       stringr::str_detect(path, "^http://") ||
       stringr::str_detect(path, "^ftp://")) {

--- a/R/system.R
+++ b/R/system.R
@@ -1439,9 +1439,13 @@ download_data_file <- function(url, type){
 
 #'Wrapper for openxlsx::read.xlsx to support remote file
 #'@export
-read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf){
+read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, detectDates = FALSE, ...){
   loadNamespace("openxlsx")
-  openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip+1, na.strings = na, skipEmptyRows = FALSE, skipEmptyCols = FALSE)
+  if(n_max != Inf) {
+    openxlsx::read.xlsx(xlsxFile = path, rows=c(skip:n_max), sheet = sheet, colNames = col_names, startRow = skip, na.strings = na, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, detectDates = detectDates)
+  } else {
+    openxlsx::read.xlsx(xlsxFile = path, sheet = sheet, colNames = col_names, startRow = skip, na.strings = na, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, detectDates = detectDates)
+  }
 }
 
 #'Wrapper for openxlsx::getSheetNames to support remote file


### PR DESCRIPTION
### Description

For better memory usage point of view, use openxlsx package for importing/exporting .xlsx file.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
