### PR TITLE
fix wrong loadNamespace call: read_excel_file

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1442,7 +1442,7 @@ download_data_file <- function(url, type){
 #'@export
 read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl  = FALSE, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, ...){
   loadNamespace("openxlsx")
-  loadNamespace('readr')
+  loadNamespace('readxl')
   loadNamespace('stringr')
   df <- NULL
   # for .xlsx file extension


### PR DESCRIPTION
### Description

fix loadNamespace call in read_excel_file. It was loading 'readr' but it should be 'readxl'

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
