### PR TITLE
rf_evaluation error when binary prediction is one sided

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1252,7 +1252,14 @@ get_binary_predicted_value_from_probability <- function(x) {
   # x$predictions is 2-diminsional matrix with 2 columns for the 2 categories. values in the matrix is the probabilities.
   # TODO: thought x$predictions was 3 dimensinal array with tree dimension from the doc and independently running ranger,
   # but looks like it is already averaged? look into it.
-  predicted <- factor(x$forest$levels[apply(x$predictions, 1, function(x){if(x[1]>x[2]) 1 else 2})], levels=x$forest$levels)
+  predicted <- factor(x$forest$levels[apply(x$predictions, 1, function(x){
+    if(is.na(x[2])){ # take care of the case where x$predictions has only 1 column. possible when there are only one value in training data.
+      1
+    }
+    else {
+      if(x[1]>x[2]) 1 else 2
+    }
+  })], levels=x$forest$levels)
   predicted
 }
 

--- a/tests/testthat/test_exp_survival.R
+++ b/tests/testthat/test_exp_survival.R
@@ -33,11 +33,22 @@ test_that("test exp_survival", {
   ret <- data %>% exp_survival(`weeks on service`, `is churned`)
   ret1 <- ret %>% tidy(model1)
   ret2 <- ret %>% tidy(model2)
+
   data2 <- data %>% mutate(`o s` = "Windows") # test single value cohort case
-  ret <- data %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)
+  ret <- data2 %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)
   ret1 <- ret %>% tidy(model1)
   expect_true(!is.null(ret1$cohort))
   ret2 <- ret %>% tidy(model2)
 
+  data3 <- data %>% mutate(`o s` = factor(`o s`)) # test cohort as factor
+  ret <- data3 %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)
+  ret1 <- ret %>% tidy(model1)
+  expect_true(is.factor(ret1$cohort)) # factor levels should be kept
+  ret2 <- ret %>% tidy(model2)
 
+  data3 <- data %>% mutate(`o s` = `o s` == "Windows") # test cohort as logical 
+  ret <- data3 %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)
+  ret1 <- ret %>% tidy(model1)
+  expect_true(is.factor(ret1$cohort))
+  ret2 <- ret %>% tidy(model2)
 })

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -169,7 +169,10 @@ test_that("test calc_feature_imp with group_by where a group has only TRUE rows 
                       num_1,
                       num_2)
 
+  ret <- model_df %>% rf_importance()
   ret <- model_df %>% rf_partial_dependence()
+  ret <- model_df %>% rf_evaluation(pretty.name=TRUE) # TODO test that output is different from multiclass classification
+  ret <- model_df %>% rf_evaluation_by_class(pretty.name=TRUE)
 })
 
 test_that("test randomForest with multinomial classification", {


### PR DESCRIPTION
### Description
- Fix rf_evaluation error when binary prediction is one sided.
- exp_survival: Keep factor level of cohort column.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
