### PR TITLE
Error from randomForest binary prediction when target column name has space

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -493,6 +493,13 @@ prediction_binary <- function(df, threshold = 0.5, ...){
     }
   }
 
+  # if there is terms_mapping for randomForest, use the original column name
+  if ("randomForest" %in% class(first_model)) {
+    if (!is.na(first_model$terms_mapping) && !is.na(first_model$terms_mapping[[actual_col]])) {
+      actual_col <- first_model$terms_mapping[[actual_col]]
+    }
+  }
+
   actual_val <- ret[[actual_col]]
   actual_logical <- as.logical(as.numeric(actual_val))
 

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -205,14 +205,14 @@ test_that("test randomForest with binary classification", {
       DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
     class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE"))
 
-  test_data[["IS_AA"]] <- test_data$CARRIER == "AA"
+  test_data[["IS AA"]] <- test_data$CARRIER == "AA" # test target column name with space
   model_ret <- build_model(test_data,
                            model_func = randomForestBinary,
-                           formula = IS_AA ~ DISTANCE,
+                           formula = `IS AA` ~ DISTANCE,
                            test_rate = 0.3)
   coef_ret <- model_coef(model_ret)
   model_stats <- model_stats(model_ret, pretty.name = TRUE)
-  pred_train_ret <- prediction_binary(model_ret, data = "training")
+  pred_train_ret <- prediction_binary(model_ret, data = "training", threshold = "f_score") # test f_score which had issue with target column name with space once.
   pred_test_ret <- prediction_binary(model_ret, data = "test")
   pred_test_ret <- prediction_binary(model_ret, data = "newdata", data_frame = test_data)
 })


### PR DESCRIPTION
### Description
Fix error from randomForest binary prediction when target column name has space.
Use original column name to get actual data rather than cleaned up one.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
