### PR TITLE
chisq : keep numeric/integer type in the output

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -311,11 +311,24 @@ tidy.chisq_exploratory <- function(x, type = "observed") {
       ret[[x$var2]] <- factor(ret[[x$var2]], levels=x$var2_levels)
     }
     # if original class of var1, var2 was logical, return them as logical.
-    if (x$var1_class == "logical") {
+    if ("logical" %in% x$var1_class) {
       ret[[x$var1]] <- as.logical(ret[[x$var1]])
     }
-    if (x$var2_class == "logical") {
+    else if ("integer" %in% x$var1_class) {
+      ret[[x$var1]] <- as.integer(ret[[x$var1]])
+    }
+    else if ("numeric" %in% x$var1_class) {
+      ret[[x$var1]] <- as.numeric(ret[[x$var1]])
+    }
+
+    if ("logical" %in% x$var2_class) {
       ret[[x$var2]] <- as.logical(ret[[x$var2]])
+    }
+    else if ("integer" %in% x$var2_class) {
+      ret[[x$var2]] <- as.integer(ret[[x$var2]])
+    }
+    else if ("numeric" %in% x$var2_class) {
+      ret[[x$var2]] <- as.numeric(ret[[x$var2]])
     }
   }
   ret

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -131,20 +131,20 @@ test_that("prediction with categorical columns", {
 test_that("prediction with target column name with space by build_lm.fast", {
   test_data <- structure(
     list(
-      `CANCELLED X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `CANCELLED:X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `logical col` = c(TRUE, FALSE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, NA, TRUE, FALSE, NA, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE),
       `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
       CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
       # testing filtering of Inf, -Inf, NA here.
       DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
-    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "logical col", "Carrier Name", "CARRIER", "DISTANCE"))
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED:X", "logical col", "Carrier Name", "CARRIER", "DISTANCE"))
 
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
   test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
-  model_data <- build_lm.fast(test_data, `CANCELLED X`, `logical col`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3)
+  model_data <- build_lm.fast(test_data, `CANCELLED:X`, `logical col`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3)
   ret <- model_data %>% broom::glance(model)
   # TODO: the returned coefficients does not show all input variables. 
   # most likely due to too few rows. look into it and add check for the values in the returned df. 

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -200,10 +200,24 @@ test_that("test exp_chisq", {
 })
 
 test_that("test exp_chisq with logical", {
-  model_df <- exp_chisq(mtcars %>% mutate(gear=gear>3, carb=carb>3), gear, carb) # factor order should be kept in the model
+  model_df <- exp_chisq(mtcars %>% mutate(gear=gear>3, carb=carb>3), gear, carb) # logical type should be kept in the model
   ret <- model_df %>% tidy(model, type="residuals")
   expect_equal(class(ret$gear), "logical")
   expect_equal(class(ret$carb), "logical")
+})
+
+test_that("test exp_chisq with numeric", {
+  model_df <- exp_chisq(mtcars , gear, carb) # numeric type should be kept in the model
+  ret <- model_df %>% tidy(model, type="residuals")
+  expect_equal(class(ret$gear), "numeric")
+  expect_equal(class(ret$carb), "numeric")
+})
+
+test_that("test exp_chisq with integer", {
+  model_df <- exp_chisq(mtcars %>% mutate(gear=as.integer(gear), carb=as.integer(carb)), gear, carb) # integer type should be kept in the model
+  ret <- model_df %>% tidy(model, type="residuals")
+  expect_equal(class(ret$gear), "integer")
+  expect_equal(class(ret$carb), "integer")
 })
 
 test_that("test exp_chisq with group_by", {


### PR DESCRIPTION
### Description
- chi-squared : keep numeric/integer type in the output
- linear regression : additional test of column name with colon.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
