### PR TITLE
exp_survival: Fix the case where Date is passed as end_time_fill

### DIFF
--- a/R/survival.R
+++ b/R/survival.R
@@ -46,10 +46,10 @@ exp_survival <- function(df, time, status, start_time = NULL, end_time = NULL, e
       end_time_col <- col_name(substitute(end_time))
       df[[end_time_col]] <- as.Date(df[[end_time_col]]) # convert to Date in case it is POSIXct.
       # set value to fill NAs of end time
-      if (end_time_fill == "max") {
+      if (is.character(end_time_fill) && end_time_fill == "max") { # type check before comparison is necessary to avoid error.
         end_time_fill_val <- max(df[[start_time_col]], df[[end_time_col]], na.rm = TRUE)
       }
-      else if (end_time_fill == "today") {
+      else if (is.character(end_time_fill) && end_time_fill == "today") {
         end_time_fill_val <- lubridate::today()
       }
       else {

--- a/tests/testthat/test_exp_survival.R
+++ b/tests/testthat/test_exp_survival.R
@@ -67,5 +67,8 @@ test_that("test exp_survival", {
   ret <- data %>% exp_survival(NULL, `is churned`, start_time=`start date`, end_time=`end date`, end_time_fill="2020-01-01")
   ret1 <- ret %>% tidy(model1)
   ret2 <- ret %>% tidy(model2)
+  ret <- data %>% exp_survival(NULL, `is churned`, start_time=`start date`, end_time=`end date`, end_time_fill=as.Date("2020-01-01"))
+  ret1 <- ret %>% tidy(model1)
+  ret2 <- ret %>% tidy(model2)
 
 })


### PR DESCRIPTION
### Description
Fix the case where Date is passed as end_time_fill in exp_survival().

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
