### PR TITLE
Handle column name y, ds for do_prophet()

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -440,11 +440,15 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     }
 
     # revive original column names (time_col, value_col)
-    colnames(ret)[colnames(ret) == "ds"] <- avoid_conflict(colnames(ret), time_col)
+    if (time_col != "ds") { # if time_col happens to be "ds", do not do this, since it will make the column name "ds.new".
+      colnames(ret)[colnames(ret) == "ds"] <- avoid_conflict(colnames(ret), time_col)
+    }
     if (is.null(value_col)) {
       value_col <- "count"
     }
-    colnames(ret)[colnames(ret) == "y"] <- avoid_conflict(colnames(ret), value_col)
+    if (value_col != "y") { # if value_col happens to be "y", do not do this, since it will make the column name "y.new".
+      colnames(ret)[colnames(ret) == "y"] <- avoid_conflict(colnames(ret), value_col)
+    }
 
     # adjust column name style
     colnames(ret)[colnames(ret) == "yhat"] <- avoid_conflict(colnames(ret), "forecasted_value")

--- a/tests/testthat/test_prophet_2.R
+++ b/tests/testthat/test_prophet_2.R
@@ -1,0 +1,13 @@
+context("more test on prophet functions")
+
+test_that("do_prophet test mode with y, ds as column names", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2013-01-01"), by="day")
+  raw_data <- data.frame(ds=ts, y=runif(length(ts)))
+  raw_data$ds[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
+  ret <- raw_data %>%
+    do_prophet(ds, y, 10, time_unit = "day", test_mode=TRUE)
+  expect_true("y" %in% colnames(ret))
+  expect_true("ds" %in% colnames(ret))
+  # verify that the last forecasted_value is not NA to test #9211
+  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
+})


### PR DESCRIPTION
### Description

Handle the case where input column names are y, ds for do_prophet()

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
