### PR TITLE
exp_rpart: Throw appropriate error when categorical target has only 1 unique value

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1516,6 +1516,14 @@ exp_rpart <- function(df,
       if (smote && length(unique_val[!is.na(unique_val)]) == 2) {
         df <- df %>% exp_balance(clean_target_col, sample=FALSE) # since we already sampled, no further sample.
       }
+      # if target is categorical (not numeric) and only 1 unique value (or all NA), throw error.
+      if ("numeric" %nin% class(clean_target_col) &&
+          "integer" %nin% class(clean_target_col) &&
+          length(unique_val[!is.na(unique_val)]) <= 1) {
+        # We might want to skip and show the status in Summary when we support Repeat By,
+        # but for now just throw error to show.
+        stop("Categorical Target Variable must have 2 or more unique values.")
+      }
 
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
       fml <- as.formula(paste0("`", clean_target_col, "`", " ~ ", rhs))

--- a/tests/testthat/test_rpart.R
+++ b/tests/testthat/test_rpart.R
@@ -43,4 +43,10 @@ test_that("exp_rpart multiclass classification", {
   res <- model_df %>% tidy(model, type="conf_mat")
 })
 
+test_that("exp_rpart throws error with classification with only one unique value", {
+  expect_error({
+    flight2 <- flight %>% filter(`ORIGIN STATE ABR` %in% c("CA"))
+    model_df <- flight2 %>% exp_rpart(`ORIGIN STATE ABR`,`DEP DELAY`)
+  }, "Categorical Target Variable must have 2 or more unique values.")
+})
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -430,7 +430,6 @@ test_that("move_col", {
 
   right_to_left <- move_col(test_data, "f", 2)
   expect_equal(colnames(right_to_left), c("a", "f", "b", "c", "d", "e", "g"))
-
 })
 
 test_that("unixtime_to_datetime", {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -657,4 +657,3 @@ test_that("excel_numeric_to_date", {
   res <- exploratory::excel_numeric_to_date(50000L) # test integer input
   expect_equal(res, as.Date("2036-11-21"))
 })
-

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -652,3 +652,9 @@ test_that("r_squared", {
   res <- r_squared(c(1,2,3,4,5), c(3,4,2,4,7))
   expect_equal(res, -0.3, tolerance = 0.001)
 })
+
+test_that("excel_numeric_to_date", {
+  res <- exploratory::excel_numeric_to_date(50000L) # test integer input
+  expect_equal(res, as.Date("2036-11-21"))
+})
+

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -395,7 +395,6 @@ test_that("list_concat with multiple list", {
 
   expect_equal(length(ret1_collapse), 1)
   expect_equal(ret1_collapse[[1]], c(NA, NA, NA, NA, "a", "c", "1", "3", "a", "c", "3", "5", "6", "6"))
-
 })
 
 test_that("test expand_args", {


### PR DESCRIPTION
### Description
exp_rpart: Throw appropriate error when categorical target has only 1 unique value

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
