### PR TITLE
Updated exploratory::guess_csv_file_encoding so that guessing csv file encoding for non-ascii file path gets much faster

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1592,7 +1592,12 @@ guess_csv_file_encoding <- function(file,  n_max = 1e4, threshold = 0.20){
     # if it's local file simply call readr::read_delim
     # reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside guess_encoding.
-    readr::guess_encoding(readr::read_lines_raw(file(file), n_max), threshold=threshold)
+    if(stringi::stri_enc_mark(file) == "ASCII"){
+      encode <- readr::guess_encoding(file, n_max=n_max, threshold=threshold)
+    } else {
+      encode <- readr::guess_encoding(readr::read_lines_raw(file(file), n_max), threshold=threshold)
+    }
+    encode
   }
 }
 


### PR DESCRIPTION
### Description

Previously, exploratory::guess_csv_file_encoding always uses `file(file)` to workaround the non-ASCII file path issue. But if the file path is ASCII, this had performance drawback.

With this PR, now it detects if the path contains non-ASCII characters of not and decide whether we need to do `file(file)` or not. 

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
