### PR TITLE
Make sure to skip file(file) handle for exploratory::read_delim_file when file path is all ascii characters

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1573,9 +1573,9 @@ read_delim_file <- function(file, delim, quote = '"',
     # if it's local file simply call readr::read_delim
     # reading through file() is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside read_delim.
-    file_path = file
+    file_path <- file
     if(stringi::stri_enc_mark(file) != "ASCII"){
-      file_path = file(file)
+      file_path <- file(file)
     }
     readr::read_delim(file_path, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
                       locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)

--- a/R/system.R
+++ b/R/system.R
@@ -1595,7 +1595,7 @@ guess_csv_file_encoding <- function(file,  n_max = 1e4, threshold = 0.20){
     readr::guess_encoding(tmp, n_max, threshold)
   } else {
     # If it's local file simply call readr::read_delim.
-    # reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
+    # Reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside guess_encoding.
     # Since file() call has about 1 sec overhead at first read (most likely read-ahead), we do this selectively
     # only when multibyte characters are in the path.

--- a/R/system.R
+++ b/R/system.R
@@ -1573,8 +1573,13 @@ read_delim_file <- function(file, delim, quote = '"',
     # if it's local file simply call readr::read_delim
     # reading through file() is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside read_delim.
-    readr::read_delim(file(file), delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
-                      locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
+    if(stringi::stri_enc_mark(file) == "ASCII"){
+      readr::read_delim(file, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
+                        locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
+    } else {
+      readr::read_delim(file(file), delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
+                        locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
+    }
   }
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -1573,13 +1573,13 @@ read_delim_file <- function(file, delim, quote = '"',
     # if it's local file simply call readr::read_delim
     # reading through file() is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside read_delim.
-    if(stringi::stri_enc_mark(file) == "ASCII"){
-      readr::read_delim(file, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
-                        locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
-    } else {
-      readr::read_delim(file(file), delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
-                        locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
+    file_path = file
+    if(stringi::stri_enc_mark(file) != "ASCII"){
+      file_path = file(file)
     }
+    readr::read_delim(file_path, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
+                      locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)
+
   }
 }
 
@@ -1595,8 +1595,8 @@ guess_csv_file_encoding <- function(file,  n_max = 1e4, threshold = 0.20){
     readr::guess_encoding(tmp, n_max, threshold)
   } else {
     # If it's local file simply call readr::read_delim.
-    # Reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
-    # Without it, error is thrown from inside guess_encoding.
+    # reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
+    # without it, error is thrown from inside guess_encoding.
     # Since file() call has about 1 sec overhead at first read (most likely read-ahead), we do this selectively
     # only when multibyte characters are in the path.
     if(stringi::stri_enc_mark(file) == "ASCII"){

--- a/R/system.R
+++ b/R/system.R
@@ -1594,13 +1594,15 @@ guess_csv_file_encoding <- function(file,  n_max = 1e4, threshold = 0.20){
     tmp <- download_data_file(file, "csv")
     readr::guess_encoding(tmp, n_max, threshold)
   } else {
-    # if it's local file simply call readr::read_delim
-    # reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
-    # without it, error is thrown from inside guess_encoding.
+    # If it's local file simply call readr::read_delim.
+    # Reading through read_lines_raw(file()) is to be able to read files with path that includes multibyte chars.
+    # Without it, error is thrown from inside guess_encoding.
+    # Since file() call has about 1 sec overhead at first read (most likely read-ahead), we do this selectively
+    # only when multibyte characters are in the path.
     if(stringi::stri_enc_mark(file) == "ASCII"){
       encode <- readr::guess_encoding(file, n_max=n_max, threshold=threshold)
     } else {
-      encode <- readr::guess_encoding(readr::read_lines_raw(file(file), n_max), threshold=threshold)
+      encode <- readr::guess_encoding(readr::read_lines_raw(file(file), n_max=n_max), threshold=threshold)
     }
     encode
   }


### PR DESCRIPTION
### Description

Make sure to skip file(file) handle for exploratory::read_delim_file when file path is all ascii characters

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
