### PR TITLE
To avoid the issue that bind_rows fails due to column data type mismatch, first load each csv file as character then do type_convert after bind_rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 0.7.4.4
+Version: 0.7.4.5
 Date: 2018-10-09
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -928,7 +928,7 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
   });
   files <- list.files(path=download_dir, pattern = ".gz");
   # pass progress as FALSE to prevent SIGPIPE error on Exploratory Desktop.
-  # To avoid the issue that bind_rows thorws an error due to column data type mismatch,
+  # To avoid the issue that bind_rows throws an error due to column data type mismatch,
   # First, import all the csv files with column data types as character, then convert the column data types with readr::type_convert.
   df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), col_types = readr::cols(.default = "c"), progress = FALSE)}) %>% dplyr::bind_rows() %>% readr::type_convert()
 }

--- a/R/system.R
+++ b/R/system.R
@@ -928,6 +928,8 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
   });
   files <- list.files(path=download_dir, pattern = ".gz");
   # pass progress as FALSE to prevent SIGPIPE error on Exploratory Desktop.
+  # To avoid the issue that bind_rows thorws an error due to column data type mismatch,
+  # First, import all the csv files with column data types as character, then convert the column data types with readr::type_convert.
   df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), col_types = readr::cols(.default = "c"), progress = FALSE)}) %>% dplyr::bind_rows() %>% readr::type_convert()
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -928,7 +928,7 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
   });
   files <- list.files(path=download_dir, pattern = ".gz");
   # pass progress as FALSE to prevent SIGPIPE error on Exploratory Desktop.
-  df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), progress = FALSE)}) %>% dplyr::bind_rows()
+  df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), col_types = cols(.default = "c"), progress = FALSE)}) %>% dplyr::bind_rows() %>% readr::type_convert()
 }
 
 #' API to get a list of buckets from Google Cloud Storage

--- a/R/system.R
+++ b/R/system.R
@@ -928,7 +928,7 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
   });
   files <- list.files(path=download_dir, pattern = ".gz");
   # pass progress as FALSE to prevent SIGPIPE error on Exploratory Desktop.
-  df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), col_types = cols(.default = "c"), progress = FALSE)}) %>% dplyr::bind_rows() %>% readr::type_convert()
+  df <- lapply(files, function(file){readr::read_csv(stringr::str_c(download_dir, "/", file), col_types = readr::cols(.default = "c"), progress = FALSE)}) %>% dplyr::bind_rows() %>% readr::type_convert()
 }
 
 #' API to get a list of buckets from Google Cloud Storage


### PR DESCRIPTION
### Description

When downloading CSV files from cloud storage, it's possible that `readr:read_csv` guesses data type for the same column in a different way per file.  To work around this, first treat all the column as a character, then perform bind_rows and finally do type_convert for column type guessing.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
