### PR TITLE
Handle asterisk in glue expression

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -236,7 +236,7 @@ js_glue_transformer <- function(code, envir) {
   val <- ifelse(is.na(val), "null", val)
 
   # for numeric it should work as is. expression like 1e+10 works on js too.
-  glue::glue_collapse(val, sep=", ")
+  glue::collapse(val, sep=", ")
 }
 
 odbc_glue_transformer <- function(code, envir) {
@@ -256,7 +256,7 @@ odbc_glue_transformer <- function(code, envir) {
   # TODO: How should we handle logical, Date, POSIXct, POSIXlt?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
-  glue::glue_collapse(val, sep=", ")
+  glue::collapse(val, sep=", ")
 }
 
 bigquery_glue_transformer <- function(code, envir) {
@@ -278,7 +278,7 @@ bigquery_glue_transformer <- function(code, envir) {
   # TODO: How should we handle logical, Date, POSIXct, POSIXlt?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
-  glue::glue_collapse(val, sep=", ")
+  glue::collapse(val, sep=", ")
 }
 
 #' @export

--- a/R/system.R
+++ b/R/system.R
@@ -240,6 +240,12 @@ js_glue_transformer <- function(code, envir) {
 }
 
 odbc_glue_transformer <- function(code, envir) {
+  # We always collapse, but to keep syntax same as glue's default, take care of * at the end of code.
+  should_collapse <- grepl("[*]$", code)
+  if (should_collapse) {
+    code <- sub("[*]$", "", code)
+  }
+
   val <- eval(parse(text = code), envir)
   if (is.character(val) || is.factor(val)) {
     # escape for SQL
@@ -254,6 +260,12 @@ odbc_glue_transformer <- function(code, envir) {
 }
 
 bigquery_glue_transformer <- function(code, envir) {
+  # We always collapse, but to keep syntax same as glue's default, take care of * at the end of code.
+  should_collapse <- grepl("[*]$", code)
+  if (should_collapse) {
+    code <- sub("[*]$", "", code)
+  }
+
   val <- eval(parse(text = code), envir)
   if (is.character(val) || is.factor(val)) {
     # escape for Standard SQL for bigquery

--- a/R/system.R
+++ b/R/system.R
@@ -236,7 +236,7 @@ js_glue_transformer <- function(code, envir) {
   val <- ifelse(is.na(val), "null", val)
 
   # for numeric it should work as is. expression like 1e+10 works on js too.
-  glue::collapse(val, sep=", ")
+  glue::glue_collapse(val, sep=", ")
 }
 
 odbc_glue_transformer <- function(code, envir) {
@@ -256,7 +256,7 @@ odbc_glue_transformer <- function(code, envir) {
   # TODO: How should we handle logical, Date, POSIXct, POSIXlt?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
-  glue::collapse(val, sep=", ")
+  glue::glue_collapse(val, sep=", ")
 }
 
 bigquery_glue_transformer <- function(code, envir) {
@@ -278,7 +278,7 @@ bigquery_glue_transformer <- function(code, envir) {
   # TODO: How should we handle logical, Date, POSIXct, POSIXlt?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
-  glue::collapse(val, sep=", ")
+  glue::glue_collapse(val, sep=", ")
 }
 
 #' @export

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -134,3 +134,15 @@ test_that("js_glue_transformer", {
   res <- glue::glue("{v}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")
 })
+
+test_that("odbc_glue_transformer", {
+  v <- c(1,2,3)
+  res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
+  expect_equal(as.character(res), "1, 2, 3")
+})
+
+test_that("bigquery_glue_transformer", {
+  v <- c(1,2,3)
+  res <- glue::glue("{v*}", .transformer=bigquery_glue_transformer)
+  expect_equal(as.character(res), "1, 2, 3")
+})

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -139,10 +139,16 @@ test_that("odbc_glue_transformer", {
   v <- c(1,2,3)
   res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
+  v <- c("a","b","c")
+  res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
+  expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 
 test_that("bigquery_glue_transformer", {
   v <- c(1,2,3)
   res <- glue::glue("{v*}", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
+  v <- c("a","b","c")
+  res <- glue::glue("{v*}", .transformer=bigquery_glue_transformer)
+  expect_equal(as.character(res), '"a", "b", "c"')
 })


### PR DESCRIPTION
### Description
Handle asterisk in glue expression so that standard expression of glue SQL translator works.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
