### PR TITLE
Keep columns for Subject Column for parallel coordinates

### DIFF
--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -146,8 +146,11 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       }
     }
 
-    if (type == "gathered_data") { # for boxplot and paralell coordinates. this is only when with kmeans.
-      res <- res %>% dplyr::select(!!c(column_names,"cluster"))
+    if (type == "gathered_data") { # for boxplot and parallel coordinates. this is only when with kmeans.
+      # We used to drop columns other than cluster and ones used for clustering like this commented out line,
+      # to keep only the data we use, but since we are showing Subject Column value
+      # on parallel coordinates, we need to keep other columns, which would include Subject Column.
+      # res <- res %>% dplyr::select(!!c(column_names,"cluster"))
       res <- res %>% dplyr::mutate(row_id=seq(n())) # row_id for line representation.
       res <- res %>% tidyr::gather(key="key",value="value",!!column_names)
     }


### PR DESCRIPTION
### Description
Do not drop columns other than the ones used for clustering for data for k-means parallel coordinates,
so that we have column to use as Subject Column.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
