### PR TITLE
Move @{} notation translation from js to R

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -218,6 +218,16 @@ getMongoURL <- function(host = NULL, port, database, username, pass, isSSL=FALSE
 # glue transformer for mongo js query.
 # supports character, factor, logical, Date, POSIXct, POSIXlt, and numeric.
 js_glue_transformer <- function(code, envir) {
+  # Trim white spaces.
+  code <- trimws(code)
+
+  # Strip quote by ``.
+  should_strip <- grepl("^`.+`$", code)
+  if (should_strip) {
+    code <- sub("^`", "", code)
+    code <- sub("`$", "", code)
+  }
+  code <- paste0("exploratory_env$`", code, "`")
   val <- eval(parse(text = code), envir)
   if (is.character(val) || is.factor(val)) {
     # escape for js

--- a/R/system.R
+++ b/R/system.R
@@ -344,7 +344,8 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
       pipeline <- convertUserInputToUtf8(pipeline)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
       # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      pipeline <- glue::glue(pipeline, .transformer=js_glue_transformer, .open = "@{", .close = "}", .envir = parent.frame())
+      pipeline <- stringr::str_replace_all(pipeline, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
+      pipeline <- glue::glue(pipeline, .transformer=js_glue_transformer, .open = "<<<", .close = ">>>", .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       pipeline <- jsToMongoJson(pipeline)
       data <- con$aggregate(pipeline = pipeline)
@@ -354,7 +355,8 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
       sort <- convertUserInputToUtf8(sort)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
       # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      query <- glue::glue(query, .transformer=js_glue_transformer, .open = "@{", .close = "}", .envir = parent.frame())
+      pipeline <- stringr::str_replace_all(pipeline, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
+      query <- glue::glue(query, .transformer=js_glue_transformer, .open = "<<<", .close = ">>>", .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       query <- jsToMongoJson(query)
       fields <- jsToMongoJson(fields)

--- a/R/system.R
+++ b/R/system.R
@@ -344,7 +344,7 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
       pipeline <- convertUserInputToUtf8(pipeline)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
       # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      pipeline <- glue::glue(pipeline, .transformer=js_glue_transformer, .open = "<<", .close = ">>", .envir = parent.frame())
+      pipeline <- glue::glue(pipeline, .transformer=js_glue_transformer, .open = "@{", .close = "}", .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       pipeline <- jsToMongoJson(pipeline)
       data <- con$aggregate(pipeline = pipeline)
@@ -354,7 +354,7 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
       sort <- convertUserInputToUtf8(sort)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
       # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      query <- glue::glue(query, .transformer=js_glue_transformer, .open = "<<", .close = ">>", .envir = parent.frame())
+      query <- glue::glue(query, .transformer=js_glue_transformer, .open = "@{", .close = "}", .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       query <- jsToMongoJson(query)
       fields <- jsToMongoJson(fields)

--- a/R/system.R
+++ b/R/system.R
@@ -313,10 +313,9 @@ bigquery_glue_transformer <- function(code, envir) {
   if (is.character(val) || is.factor(val)) {
     # escape for Standard SQL for bigquery
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
-    # escape for js
-    val <- gsub("\\", "\\\\", val, fixed=TRUE)
-    val <- gsub("\"", "\\\"", val, fixed=TRUE)
-    val <- paste0('"', val, '"')
+    val <- gsub("\\", "\\\\", val, fixed=TRUE) # Escape literal backslash
+    val <- gsub("\'", "\\\'", val, fixed=TRUE) # Escape literal single quote
+    val <- paste0("'", val, "'")
   }
   else if (lubridate::is.Date(val)) {
     val <- as.character(val)

--- a/R/system.R
+++ b/R/system.R
@@ -262,7 +262,7 @@ js_glue_transformer <- function(code, envir) {
   glue::collapse(val, sep=", ")
 }
 
-odbc_glue_transformer <- function(code, envir) {
+sql_glue_translator <- function(code, envir) {
   # Trim white spaces.
   code <- trimws(code)
 
@@ -874,8 +874,8 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    # glue_sql does not quote Date or POSIXct. Let's use our odbc_glue_transformer here.
-    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    # glue_sql does not quote Date or POSIXct. Let's use our sql_glue_translator here.
+    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
     resultSet <- RPostgreSQL::dbSendQuery(conn, query)
     df <- DBI::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
@@ -894,7 +894,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
@@ -931,7 +931,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {

--- a/R/system.R
+++ b/R/system.R
@@ -832,7 +832,9 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    resultSet <- RPostgreSQL::dbSendQuery(conn, glue::glue_sql(query, .con = conn, .envir = parent.frame()))
+    # glue_sql does not quote Date or POSIXct. Let's use our odbc_glue_transformer here.
+    query <- glue::glue(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    resultSet <- RPostgreSQL::dbSendQuery(conn, query)
     df <- DBI::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try

--- a/R/system.R
+++ b/R/system.R
@@ -262,7 +262,7 @@ js_glue_transformer <- function(code, envir) {
   glue::collapse(val, sep=", ")
 }
 
-sql_glue_translator <- function(code, envir) {
+sql_glue_transformer <- function(code, envir) {
   # Trim white spaces.
   code <- trimws(code)
 
@@ -874,8 +874,8 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    # glue_sql does not quote Date or POSIXct. Let's use our sql_glue_translator here.
-    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
+    # glue_sql does not quote Date or POSIXct. Let's use our sql_glue_transformer here.
+    query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
     resultSet <- RPostgreSQL::dbSendQuery(conn, query)
     df <- DBI::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
@@ -894,7 +894,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
@@ -931,7 +931,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue_exploratory(query, .transformer=sql_glue_translator, .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {

--- a/R/system.R
+++ b/R/system.R
@@ -253,7 +253,16 @@ odbc_glue_transformer <- function(code, envir) {
     val <- gsub("'", "''", val, fixed=TRUE) # both Oracle and SQL Server escapes single quote by doubling them.
     val <- paste0("'", val, "'") # both Oracle and SQL Server quotes strings with single quote.
   }
-  # TODO: How should we handle logical, Date, POSIXct, POSIXlt?
+  else if (lubridate::is.Date(val)) {
+    val <- as.character(val)
+    val <- paste0("'", val, "'") # Athena and PostgreSQL quotes date with single quote. e.g. '2019-01-01'
+  }
+  else if (lubridate::is.POSIXt(val)) {
+    val <- as.character(val)
+    val <- paste0("'", val, "'") # Athena and PostgreSQL quotes timestamp with single quote. e.g. '2019-01-01 00:00:00'
+  }
+
+  # TODO: How should we handle logical?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
   glue::collapse(val, sep=", ")

--- a/R/system.R
+++ b/R/system.R
@@ -875,7 +875,7 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
     # glue_sql does not quote Date or POSIXct. Let's use our odbc_glue_transformer here.
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
     resultSet <- RPostgreSQL::dbSendQuery(conn, query)
     df <- DBI::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
@@ -894,7 +894,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
@@ -931,7 +931,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
@@ -1020,7 +1020,7 @@ submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_
     isStandardSQL = TRUE; # honor value provided by paramerer
   }
   # set envir = parent.frame() to get variables from users environment, not papckage environment
-  sqlquery <- glue::glue(sqlquery, .transformer=bigquery_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
+  sqlquery <- glue_exploratory(sqlquery, .transformer=bigquery_glue_transformer, .envir = parent.frame())
   job <- bigrquery::bq_perform_query(query = sqlquery, billing = project,  use_legacy_sql = !isStandardSQL)
   bigrquery::bq_job_wait(job)
   meta <- bigrquery::bq_job_meta(job)
@@ -1168,7 +1168,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       isStandardSQL = TRUE;
     }
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=bigquery_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
+    query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
     tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
     df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, max_connections = max_connections, quiet = TRUE)
   }

--- a/R/system.R
+++ b/R/system.R
@@ -220,7 +220,7 @@ getMongoURL <- function(host = NULL, port, database, username, pass, isSSL=FALSE
 # hard to use inside js code. Even in SQL, expression like '{d @{date_param}}'
 # which would happen in SQL Server's SQL would not work with the original
 # glue::glue() behavior.
-glue_exploratory <- function(text, transformer, envir) {
+glue_exploratory <- function(text, transformer, envir = parent.frame()) {
   # Internally, replace a{ and } with <<< and >>>.
   text <- stringr::str_replace_all(text, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
   # Then, call glue::glue().

--- a/R/system.R
+++ b/R/system.R
@@ -220,11 +220,11 @@ getMongoURL <- function(host = NULL, port, database, username, pass, isSSL=FALSE
 # hard to use inside js code. Even in SQL, expression like '{d @{date_param}}'
 # which would happen in SQL Server's SQL would not work with the original
 # glue::glue() behavior.
-glue_exploratory <- function(text, transformer, envir = parent.frame()) {
+glue_exploratory <- function(text, .transformer, .envir = parent.frame()) {
   # Internally, replace a{ and } with <<< and >>>.
   text <- stringr::str_replace_all(text, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
   # Then, call glue::glue().
-  ret <- glue::glue(text, .transformer=transformer, .open = "<<<", .close = ">>>", .envir = envir)
+  ret <- glue::glue(text, .transformer = .transformer, .open = "<<<", .close = ">>>", .envir = .envir)
   ret
 }
 
@@ -356,9 +356,7 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
     if(queryType == "aggregate"){
       pipeline <- convertUserInputToUtf8(pipeline)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
-      # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      pipeline <- stringr::str_replace_all(pipeline, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
-      pipeline <- glue::glue(pipeline, .transformer=js_glue_transformer, .open = "<<<", .close = ">>>", .envir = parent.frame())
+      pipeline <- glue_exploratory(pipeline, .transformer=js_glue_transformer, .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       pipeline <- jsToMongoJson(pipeline)
       data <- con$aggregate(pipeline = pipeline)
@@ -367,9 +365,7 @@ queryMongoDB <- function(host = NULL, port = "", database, collection, username,
       fields <- convertUserInputToUtf8(fields)
       sort <- convertUserInputToUtf8(sort)
       # set .envir = parent.frame() to get variables from users environment, not papckage environment
-      # use <<>> instead of default {} to avoid conflict with js syntax. @{} did not work because }} can appear in js.
-      pipeline <- stringr::str_replace_all(pipeline, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
-      query <- glue::glue(query, .transformer=js_glue_transformer, .open = "<<<", .close = ">>>", .envir = parent.frame())
+      query <- glue_exploratory(query, .transformer=js_glue_transformer, .envir = parent.frame())
       # convert js query into mongo JSON, which mongolite understands.
       query <- jsToMongoJson(query)
       fields <- jsToMongoJson(fields)

--- a/R/system.R
+++ b/R/system.R
@@ -791,7 +791,7 @@ executeGenericQuery <- function(type, host, port, databaseName, username, passwo
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    resultSet <- DBI::dbSendQuery(conn, glue::glue_sql(query, .con = conn, .envir = parent.frame()))
+    resultSet <- DBI::dbSendQuery(conn, glue_exploratory(query, .transformer = sql_glue_transformer, .envir = parent.frame()))
     df <- DBI::dbFetch(resultSet)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try
@@ -851,7 +851,7 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
     DBI::dbGetQuery(conn,"set names utf8")
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    resultSet <- RMySQL::dbSendQuery(conn, glue::glue_sql(query, .con = conn, .envir = parent.frame()))
+    resultSet <- RMySQL::dbSendQuery(conn, glue_exploratory(query, .transformer = sql_glue_transformer, .envir = parent.frame()))
     df <- RMySQL::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try

--- a/R/system.R
+++ b/R/system.R
@@ -240,8 +240,15 @@ js_glue_transformer <- function(code, envir) {
 }
 
 odbc_glue_transformer <- function(code, envir) {
-  # TODO: trim code etc.
+  # Trim white spaces.
+  code <- trimws(code)
 
+  # Strip quote by ``.
+  should_strip <- grepl("^`.+`$", code)
+  if (should_strip) {
+    code <- sub("^`", "", code)
+    code <- sub("`$", "", code)
+  }
   code <- paste0("exploratory_env$`", code, "`")
 
   val <- eval(parse(text = code), envir)

--- a/R/system.R
+++ b/R/system.R
@@ -240,11 +240,9 @@ js_glue_transformer <- function(code, envir) {
 }
 
 odbc_glue_transformer <- function(code, envir) {
-  # We always collapse, but to keep syntax same as glue's default, take care of * at the end of code.
-  should_collapse <- grepl("[*]$", code)
-  if (should_collapse) {
-    code <- sub("[*]$", "", code)
-  }
+  # TODO: trim code etc.
+
+  code <- paste0("exploratory_env$`", code, "`")
 
   val <- eval(parse(text = code), envir)
   if (is.character(val) || is.factor(val)) {
@@ -265,6 +263,7 @@ odbc_glue_transformer <- function(code, envir) {
   # TODO: How should we handle logical?
   #       Does expression like 1e+10 work?
   # TODO: Need to handle NA here. Find out appropriate way.
+  # We always collapse, unlike glue_sql.
   glue::collapse(val, sep=", ")
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -839,7 +839,7 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
     # glue_sql does not quote Date or POSIXct. Let's use our odbc_glue_transformer here.
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
     resultSet <- RPostgreSQL::dbSendQuery(conn, query)
     df <- DBI::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
@@ -858,7 +858,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
@@ -895,7 +895,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=odbc_glue_transformer, .envir = parent.frame())
+    query <- glue::glue(query, .transformer=odbc_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
     df <- RODBC::sqlQuery(conn, query,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {

--- a/R/system.R
+++ b/R/system.R
@@ -999,7 +999,7 @@ submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_
     isStandardSQL = TRUE; # honor value provided by paramerer
   }
   # set envir = parent.frame() to get variables from users environment, not papckage environment
-  sqlquery <- glue::glue(sqlquery, .transformer=bigquery_glue_transformer, .envir = parent.frame())
+  sqlquery <- glue::glue(sqlquery, .transformer=bigquery_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
   job <- bigrquery::bq_perform_query(query = sqlquery, billing = project,  use_legacy_sql = !isStandardSQL)
   bigrquery::bq_job_wait(job)
   meta <- bigrquery::bq_job_meta(job)
@@ -1147,7 +1147,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       isStandardSQL = TRUE;
     }
     # set envir = parent.frame() to get variables from users environment, not papckage environment
-    query <- glue::glue(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
+    query <- glue::glue(query, .transformer=bigquery_glue_transformer, .open="@{", .close="}", .envir = parent.frame())
     tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
     df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, max_connections = max_connections, quiet = TRUE)
   }

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -149,18 +149,25 @@ test_that("sql_glue_transformer", {
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 
-  exploratory_env$dept_names <- c("Sales","HR")
+  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary")
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)
-  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR') and empid > 1100")
+  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO''s secretary') and empid > 1100")
 })
 
 test_that("bigquery_glue_transformer", {
   exploratory_env <- new.env()
+
   exploratory_env$v <- c(1,2,3)
   res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
+
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+
+  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary")
+  exploratory_env$empid_above <- 1100
+  res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=bigquery_glue_transformer)
+  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO\\'s secretary') and empid > 1100")
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -135,10 +135,11 @@ test_that("js_glue_transformer", {
 })
 
 test_that("odbc_glue_transformer", {
-  v <- c(1,2,3)
-  res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
+  exploratory_env <- new.env()
+  exploratory_env$v <- c(1,2,3)
+  res <- glue::glue("@{v}", .transformer=odbc_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "1, 2, 3")
-  v <- c("a","b","c")
+  exploratory_env$v <- c("a","b","c")
   res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -140,9 +140,12 @@ test_that("odbc_glue_transformer", {
   exploratory_env$v <- c(1,2,3)
   res <- glue::glue("@{ v }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "1, 2, 3")
+  exploratory_env$v <- 1
+  res <- glue::glue("{a: {x: @{v}}} ", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  expect_equal(as.character(res), "{a: {x: 1}}")
   exploratory_env$v <- c("a","b","c")
-  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
-  expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+  res <- glue::glue("[@{ `v` }]", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  expect_equal(as.character(res), "['a', 'b', 'c']") # Not sure if this behavior works for all types of databases.
 })
 
 test_that("bigquery_glue_transformer", {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -129,8 +129,9 @@ test_that("countycode", {
 })
 
 test_that("js_glue_transformer", {
-  v <- c(T,F,NA)
-  res <- glue::glue("{v}", .transformer=js_glue_transformer)
+  exploratory_env <- new.env()
+  exploratory_env$v <- c(T,F,NA)
+  res <- glue::glue("@{v}", .transformer=js_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "true, false, null")
 })
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -131,12 +131,10 @@ test_that("countycode", {
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(T,F,NA)
-  res <- glue::glue("@{v}", .transformer=js_glue_transformer, .open="@{", .close="}")
+  res <- glue_exploratory("@{v}", transformer=js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")
   exploratory_env$v <- 1
-  query <- "{a: {x: @{v}}}" 
-  query <- stringr::str_replace_all(query, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
-  res <- glue::glue(query, .transformer=js_glue_transformer, .open="<<<", .close=">>>")
+  res <- glue_exploratory("{a: {x: @{v}}}", transformer=js_glue_transformer)
   expect_equal(as.character(res), "{a: {x: 1}}")
 })
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -138,13 +138,13 @@ test_that("js_glue_transformer", {
   expect_equal(as.character(res), "{a: {x: 1}}")
 })
 
-test_that("odbc_glue_transformer", {
+test_that("sql_glue_translator", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(1,2,3)
-  res <- glue_exploratory("@{ v }", .transformer=odbc_glue_transformer)
+  res <- glue_exploratory("@{ v }", .transformer=sql_glue_translator)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue_exploratory("@{ `v` }", .transformer=odbc_glue_transformer)
+  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_translator)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 
@@ -154,6 +154,6 @@ test_that("bigquery_glue_transformer", {
   res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue_exploratory("@{ `v` }", .transformer=odbc_glue_transformer)
+  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_translator)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -133,6 +133,11 @@ test_that("js_glue_transformer", {
   exploratory_env$v <- c(T,F,NA)
   res <- glue::glue("@{v}", .transformer=js_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "true, false, null")
+  exploratory_env$v <- 1
+  query <- "{a: {x: @{v}}}" 
+  query <- stringr::str_replace_all(query, "\\@\\{([^\\}]+)\\}", "<<<\\1>>>")
+  res <- glue::glue(query, .transformer=js_glue_transformer, .open="<<<", .close=">>>")
+  expect_equal(as.character(res), "{a: {x: 1}}")
 })
 
 test_that("odbc_glue_transformer", {
@@ -140,12 +145,9 @@ test_that("odbc_glue_transformer", {
   exploratory_env$v <- c(1,2,3)
   res <- glue::glue("@{ v }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "1, 2, 3")
-  exploratory_env$v <- 1
-  res <- glue::glue("{a: {x: @{v}}} ", .transformer=odbc_glue_transformer, .open="@{", .close="}")
-  expect_equal(as.character(res), "{a: {x: 1}}")
   exploratory_env$v <- c("a","b","c")
-  res <- glue::glue("[@{ `v` }]", .transformer=odbc_glue_transformer, .open="@{", .close="}")
-  expect_equal(as.character(res), "['a', 'b', 'c']") # Not sure if this behavior works for all types of databases.
+  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 
 test_that("bigquery_glue_transformer", {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -138,13 +138,13 @@ test_that("js_glue_transformer", {
   expect_equal(as.character(res), "{a: {x: 1}}")
 })
 
-test_that("sql_glue_translator", {
+test_that("sql_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(1,2,3)
-  res <- glue_exploratory("@{ v }", .transformer=sql_glue_translator)
+  res <- glue_exploratory("@{ v }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_translator)
+  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 
@@ -154,6 +154,6 @@ test_that("bigquery_glue_transformer", {
   res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_translator)
+  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -140,12 +140,19 @@ test_that("js_glue_transformer", {
 
 test_that("sql_glue_transformer", {
   exploratory_env <- new.env()
+
   exploratory_env$v <- c(1,2,3)
   res <- glue_exploratory("@{ v }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
+
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+
+  exploratory_env$dept_names <- c("Sales","HR")
+  exploratory_env$empid_above <- 1100
+  res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)
+  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR') and empid > 1100")
 })
 
 test_that("bigquery_glue_transformer", {
@@ -154,6 +161,6 @@ test_that("bigquery_glue_transformer", {
   res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
+  res <- glue_exploratory("@{ `v` }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -141,19 +141,19 @@ test_that("js_glue_transformer", {
 test_that("odbc_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(1,2,3)
-  res <- glue::glue("@{ v }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  res <- glue_exploratory("@{ v }", .transformer=odbc_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  res <- glue_exploratory("@{ `v` }", .transformer=odbc_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 
 test_that("bigquery_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(1,2,3)
-  res <- glue::glue("@{ v }", .transformer=bigquery_glue_transformer, .open="@{", .close="}")
+  res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  res <- glue_exploratory("@{ `v` }", .transformer=odbc_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -131,10 +131,10 @@ test_that("countycode", {
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(T,F,NA)
-  res <- glue_exploratory("@{v}", transformer=js_glue_transformer)
+  res <- glue_exploratory("@{v}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")
   exploratory_env$v <- 1
-  res <- glue_exploratory("{a: {x: @{v}}}", transformer=js_glue_transformer)
+  res <- glue_exploratory("{a: {x: @{v}}}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "{a: {x: 1}}")
 })
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -145,10 +145,11 @@ test_that("odbc_glue_transformer", {
 })
 
 test_that("bigquery_glue_transformer", {
-  v <- c(1,2,3)
-  res <- glue::glue("{v*}", .transformer=bigquery_glue_transformer)
+  exploratory_env <- new.env()
+  exploratory_env$v <- c(1,2,3)
+  res <- glue::glue("@{ v }", .transformer=bigquery_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "1, 2, 3")
-  v <- c("a","b","c")
-  res <- glue::glue("{v*}", .transformer=bigquery_glue_transformer)
-  expect_equal(as.character(res), '"a", "b", "c"')
+  exploratory_env$v <- c("a","b","c")
+  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -137,10 +137,10 @@ test_that("js_glue_transformer", {
 test_that("odbc_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$v <- c(1,2,3)
-  res <- glue::glue("@{v}", .transformer=odbc_glue_transformer, .open="@{", .close="}")
+  res <- glue::glue("@{ v }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "1, 2, 3")
   exploratory_env$v <- c("a","b","c")
-  res <- glue::glue("{v*}", .transformer=odbc_glue_transformer)
+  res <- glue::glue("@{ `v` }", .transformer=odbc_glue_transformer, .open="@{", .close="}")
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 })
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -149,10 +149,10 @@ test_that("sql_glue_transformer", {
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 
-  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary")
+  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary", "Data Science\\Statistics")
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)
-  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO''s secretary') and empid > 1100")
+  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO''s secretary', 'Data Science\\Statistics') and empid > 1100")
 })
 
 test_that("bigquery_glue_transformer", {
@@ -166,8 +166,8 @@ test_that("bigquery_glue_transformer", {
   res <- glue_exploratory("@{ `v` }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 
-  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary")
+  exploratory_env$dept_names <- c("Sales","HR","CEO's secretary", "Data Science\\Statistics")
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=bigquery_glue_transformer)
-  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO\\'s secretary') and empid > 1100")
+  expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO\\'s secretary', 'Data Science\\\\Statistics') and empid > 1100")
 })


### PR DESCRIPTION
### Description
Move @{} notation translation from js to R.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
