### PR TITLE
Add normalize_data option to kmeans commands

### DIFF
--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -89,6 +89,9 @@ build_kmeans.kv_ <- function(df,
     )
     if (normalize_data) { # Normalize data if specified so.
       mat <- scale(mat)
+      # Column with zero variance will be filled with NaN because of division by 0.
+      # Replace them with 0.
+      mat[is.nan(mat)] <- 0
     }
     rownames(mat) <- NULL # this prevents warning about discarding row names of the matrix
     kmeans_ret <- tryCatch({
@@ -192,6 +195,9 @@ build_kmeans.cols <- function(df, ...,
       mat <- as_numeric_matrix_(df, columns = selected_column)
       if (normalize_data) { # Normalize data if specified so.
         mat <- scale(mat)
+        # Column with zero variance will be filled with NaN because of division by 0.
+        # Replace them with 0.
+        mat[is.nan(mat)] <- 0
       }
       kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)
     }, error = function(e) {

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -148,6 +148,7 @@ build_kmeans.cols <- function(df, ...,
                             nstart = 1,
                             algorithm = "Hartigan-Wong",
                             trace = FALSE,
+                            normalize_data = TRUE,
                             keep.source = TRUE,
                             seed=0,
                             augment=TRUE
@@ -185,6 +186,9 @@ build_kmeans.cols <- function(df, ...,
         stop("No data after removing NA")
       }
       mat <- as_numeric_matrix_(df, columns = selected_column)
+      if (normalize_data) { # Normalize data if specified so.
+        mat <- scale(mat)
+      }
       kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)
     }, error = function(e) {
       if(e$message == "invalid first argument"){

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -45,6 +45,7 @@ build_kmeans.kv_ <- function(df,
                              nstart = 1,
                              algorithm = "Hartigan-Wong",
                              trace = FALSE,
+                             normalize_data = TRUE,
                              keep.source = TRUE,
                              seed=0,
                              augment=TRUE,
@@ -86,6 +87,9 @@ build_kmeans.kv_ <- function(df,
       fill=fill,
       na.rm = TRUE
     )
+    if (normalize_data) { # Normalize data if specified so.
+      mat <- scale(mat)
+    }
     rownames(mat) <- NULL # this prevents warning about discarding row names of the matrix
     kmeans_ret <- tryCatch({
       kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)},


### PR DESCRIPTION
### Description
Add normalize_data option to following kmeans commands.
build_kmeans, build_kmeans.cols, build_kmeans.kv

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
