### PR TITLE
fix Google BigQuery : Error: Invalid value at 'max_results.value' (TYPE_UINT32), "1e+06" [badRequest]

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1208,7 +1208,7 @@ getGoogleBigQueryTables <- function(project, dataset, tokenFileId=""){
     token <- getGoogleTokenForBigQuery(tokenFileId);
     bigrquery::set_access_cred(token)
     # if we do not pass max_results, it only returnss 50 items. so explicitly set it.
-    tables <- bigrquery::list_tables(project, dataset, page_size=1000000);
+    tables <- bigrquery::list_tables(project, dataset, page_size=10000);
   }, error = function(err){
     c("")
   })

--- a/R/system.R
+++ b/R/system.R
@@ -1207,7 +1207,11 @@ getGoogleBigQueryTables <- function(project, dataset, tokenFileId=""){
   tryCatch({
     token <- getGoogleTokenForBigQuery(tokenFileId);
     bigrquery::set_access_cred(token)
-    # if we do not pass max_results, it only returnss 50 items. so explicitly set it.
+    # if we do not pass max_results (via page_size argument), it only returnss 50 items. so explicitly set it.
+    # See https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/list for max_results
+    # If we pass large value to max_results (via page_size argument) like 1,000,000, Google BigQuery gives 
+    # Error: Invalid value at 'max_results.value' (TYPE_UINT32), "1e+06" [badRequest]
+    # so set 10,000 as the default value.
     tables <- bigrquery::list_tables(project, dataset, page_size=10000);
   }, error = function(err){
     c("")


### PR DESCRIPTION
### Description

Currently, `getGoogleBigQueryTables` passes `page_size=1000000` when it calls 

```r
    tables <- bigrquery::list_tables(project, dataset, page_size=1000000);
```

However, this started raising below error:

```r
Error: Invalid value at 'max_results.value' (TYPE_UINT32), "1e+06" [badRequest]
```
So it needs to decrease default value to `page_size=10000`

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
