### PR TITLE
Handle empty vector in glue transformers

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -279,7 +279,7 @@ sql_glue_transformer <- function(code, envir) {
 
   val <- eval(parse(text = code), envir)
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
-    val <- ""
+    val <- "NULL" # With PostgreSQL, "IN (NULL)" is valid while "IN ()" is syntax error. TODO: Test other databases.
   }
   else if (is.character(val) || is.factor(val)) {
     # escape for SQL
@@ -317,7 +317,7 @@ bigquery_glue_transformer <- function(code, envir) {
 
   val <- eval(parse(text = code), envir)
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
-    val <- ""
+    val <- "NULL" # With BigQuery, "IN (NULL)" is valid while "IN ()" is syntax error.
   }
   else if (is.character(val) || is.factor(val)) {
     # escape for Standard SQL for bigquery

--- a/R/system.R
+++ b/R/system.R
@@ -242,7 +242,10 @@ js_glue_transformer <- function(code, envir) {
   }
   code <- paste0("exploratory_env$`", code, "`")
   val <- eval(parse(text = code), envir)
-  if (is.character(val) || is.factor(val)) {
+  if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
+    val <- ""
+  }
+  else if (is.character(val) || is.factor(val)) {
     # escape for js
     val <- gsub("\\", "\\\\", val, fixed=TRUE)
     val <- gsub("\"", "\\\"", val, fixed=TRUE)

--- a/R/system.R
+++ b/R/system.R
@@ -278,7 +278,10 @@ sql_glue_transformer <- function(code, envir) {
   code <- paste0("exploratory_env$`", code, "`")
 
   val <- eval(parse(text = code), envir)
-  if (is.character(val) || is.factor(val)) {
+  if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
+    val <- ""
+  }
+  else if (is.character(val) || is.factor(val)) {
     # escape for SQL
     # TODO: check if this makes sense for Dremio and Athena
     val <- gsub("'", "''", val, fixed=TRUE) # both Oracle and SQL Server escapes single quote by doubling them.
@@ -313,7 +316,10 @@ bigquery_glue_transformer <- function(code, envir) {
   code <- paste0("exploratory_env$`", code, "`")
 
   val <- eval(parse(text = code), envir)
-  if (is.character(val) || is.factor(val)) {
+  if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
+    val <- ""
+  }
+  else if (is.character(val) || is.factor(val)) {
     # escape for Standard SQL for bigquery
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
     val <- gsub("\\", "\\\\", val, fixed=TRUE) # Escape literal backslash

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -142,6 +142,10 @@ test_that("js_glue_transformer", {
   exploratory_env$stock_symbols <- c("AAPL", "GOOG")
   res <- glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "{stock:{$in:[\"AAPL\", \"GOOG\"]}}")
+
+  exploratory_env$stock_symbols <- c()
+  res <- glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=js_glue_transformer)
+  expect_equal(as.character(res), "{stock:{$in:[]}}", "message")
 })
 
 test_that("sql_glue_transformer", {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -163,6 +163,10 @@ test_that("sql_glue_transformer", {
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO''s secretary', 'Data Science\\Statistics') and empid > 1100")
+
+  exploratory_env$dept_names <- c()
+  res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)
+  expect_equal(as.character(res), "select * from emp where deptname in () and empid > 1100")
 })
 
 test_that("bigquery_glue_transformer", {
@@ -180,4 +184,8 @@ test_that("bigquery_glue_transformer", {
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO\\'s secretary', 'Data Science\\\\Statistics') and empid > 1100")
+
+  exploratory_env$dept_names <- c()
+  res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=bigquery_glue_transformer)
+  expect_equal(as.character(res), "select * from emp where deptname in () and empid > 1100")
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -130,12 +130,18 @@ test_that("countycode", {
 
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
+
   exploratory_env$v <- c(T,F,NA)
   res <- glue_exploratory("@{v}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")
+
   exploratory_env$v <- 1
   res <- glue_exploratory("{a: {x: @{v}}}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "{a: {x: 1}}")
+
+  exploratory_env$stock_symbols <- c("AAPL", "GOOG")
+  res <- glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=js_glue_transformer)
+  expect_equal(as.character(res), "{stock:{$in:[\"AAPL\", \"GOOG\"]}}")
 })
 
 test_that("sql_glue_transformer", {


### PR DESCRIPTION
### Description
Handle empty vector case in glue transformers for SQL, Big Query SQL, and MongoDB Query.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
