### PR TITLE
Make sure to pass as.is argument to RODBC::sqlQuery to honor a data type returned by ODBC.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -896,14 +896,14 @@ queryPostgres <- function(host, port, databaseName, username, password, numOfRow
 }
 
 #' @export
-queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IAM Credentials", s3OutputLocation = "", user = "", password = "", additionalParams = "", query = "", numOfRows = 0, stringsAsFactors = FALSE, ...){
+queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IAM Credentials", s3OutputLocation = "", user = "", password = "", additionalParams = "", query = "", numOfRows = 0, stringsAsFactors = FALSE, as.is = TRUE, ...){
   if(!requireNamespace("RODBC")){stop("package RODBC must be installed.")}
   conn <- getAmazonAthenaConnection(driver = driver, region = region, authenticationType = authenticationType, s3OutputLocation = s3OutputLocation, user = user, password = password, additionalParams = additionalParams)
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
     query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
-    df <- RODBC::sqlQuery(conn, query,
+    df <- RODBC::sqlQuery(conn, query, as.is = as.is,
                           max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
       # when it is error, RODBC::sqlQuery() does not stop() (throw) with error most of the cases.
@@ -932,7 +932,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
 
 
 #' @export
-queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, query, stringsAsFactors = FALSE, host="", port="", ...){
+queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, query, stringsAsFactors = FALSE, host="", port="", as.is = TRUE, ...){
   if(!requireNamespace("RODBC")){stop("package RODBC must be installed.")}
 
   conn <- getDBConnection("odbc", host, port, NULL, username, password, dsn = dsn, additionalParams = additionalParams)
@@ -940,8 +940,7 @@ queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, q
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
     query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
-    df <- RODBC::sqlQuery(conn, query,
-                          max = numOfRows, stringsAsFactors=stringsAsFactors)
+    df <- RODBC::sqlQuery(conn, query, as.is = as.is, max = numOfRows, stringsAsFactors=stringsAsFactors)
     if (!is.data.frame(df)) {
       # when it is error, RODBC::sqlQuery() does not stop() (throw) with error most of the cases.
       # in such cases, df is a character vecter rather than a data.frame.

--- a/R/system.R
+++ b/R/system.R
@@ -931,7 +931,19 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
 }
 
 
+#' API to query ODBC database
 #' @export
+#' @param dsn - Data Source Name for the ODBC
+#' @param username - Usernaame of the database
+#' @param password - Password of the database
+#' @param additionalParams - Additional parameters
+#' @param numOfRows - Nuber of rows in result. 0 means fetch all rows
+#' @param query - SQL query
+#' @param stringsAsFactors - Flag to tell if you want to convert character data type to factor data type in result.
+#' @param host - Server where the database is running.
+#' @param port - Database port number
+#' @param as.is - Flag to tell if you honor data types from ODBC
+#'
 queryODBC <- function(dsn,username, password, additionalParams, numOfRows = 0, query, stringsAsFactors = FALSE, host="", port="", as.is = TRUE, ...){
   if(!requireNamespace("RODBC")){stop("package RODBC must be installed.")}
 


### PR DESCRIPTION
### Description

Currently, `exploratory::queryODBC` does not explicitly pass `as.is` argument to `RODBC::sqlQuery` and this prevents users from getting data type from ODBC. So need to pass this argument from `exploratory::queryODBC`.  This will prevent an issue where character column is converted to numeric column and data like "000123" is imported like "123".

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
