### PR TITLE
do_apriori with preprocessing to limit items in a basket to top n most frequents

### DIFF
--- a/R/arules.R
+++ b/R/arules.R
@@ -1,6 +1,6 @@
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
-do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
+do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=5,
                                 min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL,
                                 max_basket_items = 12) {
   validate_empty_data(df)
@@ -28,7 +28,7 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
     # If there are too many items in a busket, combinations to search tends to explode.
     # To avoid it, when called from Exploratory Analytics View, we limit items (subject_col)
     # in baskets (key_col) only to top frequent items in each basket.
-    # Default is set to 12 so that default maxlen 10 fits in it.
+    # Default is set to 10 so that default maxlen 5 (we also reduced this from 10) fits in it.
     if (!is.null(max_basket_items)) {
       df <- df %>% group_by(!!rlang::sym(key_col), !!rlang::sym(subject_col)) %>%
         summarize(.tmp_num_rows = n()) %>%
@@ -119,7 +119,7 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
+do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
   if (min_support == "auto") { # search for min_support that returns some rules.
     ret <- NULL
     curr_min_support = 0.1
@@ -152,7 +152,7 @@ do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=10, min_suppo
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori <- function(df, subject, key, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
+do_apriori <- function(df, subject, key, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
   subject_col <- col_name(substitute(subject))
   key_col <- col_name(substitute(key))
   do_apriori_(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs, max_basket_items)

--- a/R/arules.R
+++ b/R/arules.R
@@ -22,6 +22,13 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10, m
 
   # This is executed by each group
   do_apriori_each <- function(df){
+
+    # Limit to top 10 frequent items in each key_col (basket)
+    df <- df %>% group_by(!!rlang::sym(key_col), !!rlang::sym(subject_col)) %>%
+      summarize(.tmp_num_rows = n()) %>%
+      top_n(10, .tmp_num_rows) %>%
+      ungroup()
+
     mat <- sparse_cast(df, subject_col, key_col)
 
     # create appearance list

--- a/R/arules.R
+++ b/R/arules.R
@@ -2,7 +2,7 @@
 #' It calculates support, confidence and lift values from combinations of items.
 do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
                                 min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL,
-                                max_basket_items = NULL) {
+                                max_basket_items = 12) {
   validate_empty_data(df)
 
   loadNamespace("dplyr")
@@ -28,6 +28,7 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
     # If there are too many items in a busket, combinations to search tends to explode.
     # To avoid it, when called from Exploratory Analytics View, we limit items (subject_col)
     # in baskets (key_col) only to top frequent items in each basket.
+    # Default is set to 12 so that default maxlen 10 fits in it.
     if (!is.null(max_basket_items)) {
       df <- df %>% group_by(!!rlang::sym(key_col), !!rlang::sym(subject_col)) %>%
         summarize(.tmp_num_rows = n()) %>%
@@ -118,12 +119,13 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=10,
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL){
+do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
   if (min_support == "auto") { # search for min_support that returns some rules.
     ret <- NULL
     curr_min_support = 0.1
     while (curr_min_support >= 0.00001) {
-      ret <- tryCatch(do_apriori_internal(df, subject_col, key_col, minlen, maxlen, curr_min_support, max_support, min_confidence, lhs, rhs), error=function(e) {
+      ret <- tryCatch(do_apriori_internal(df, subject_col, key_col, minlen, maxlen, curr_min_support, max_support, min_confidence, lhs, rhs,
+                                          max_basket_items), error=function(e) {
         if (e$message == "No rule was found. Smaller minimum support or minimum confidence might find rules.") { #TODO: this matching is dumb.. 
           TRUE
         }
@@ -143,17 +145,17 @@ do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=10, min_suppo
     ret
   }
   else {
-    do_apriori_internal(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs)
+    do_apriori_internal(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs, max_basket_items)
   }
 }
 
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori <- function(df, subject, key, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL){
+do_apriori <- function(df, subject, key, minlen=1, maxlen=10, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
   subject_col <- col_name(substitute(subject))
   key_col <- col_name(substitute(key))
-  do_apriori_(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs)
+  do_apriori_(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs, max_basket_items)
 }
 
 # rules_metric can be "support", "confidence", or "lift".

--- a/R/arules.R
+++ b/R/arules.R
@@ -2,7 +2,7 @@
 #' It calculates support, confidence and lift values from combinations of items.
 do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=5,
                                 min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL,
-                                max_basket_items = 12) {
+                                max_basket_items = 10) {
   validate_empty_data(df)
 
   loadNamespace("dplyr")
@@ -119,7 +119,7 @@ do_apriori_internal <- function(df, subject_col, key_col, minlen=1, maxlen=5,
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
+do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=10){
   if (min_support == "auto") { # search for min_support that returns some rules.
     ret <- NULL
     curr_min_support = 0.1
@@ -152,7 +152,7 @@ do_apriori_ <- function(df, subject_col, key_col, minlen=1, maxlen=5, min_suppor
 #' Find association rules from itemsets.
 #' It calculates support, confidence and lift values from combinations of items.
 #' @export
-do_apriori <- function(df, subject, key, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=12){
+do_apriori <- function(df, subject, key, minlen=1, maxlen=5, min_support=0.1, max_support=1, min_confidence=0.5, lhs=NULL, rhs=NULL, max_basket_items=10){
   subject_col <- col_name(substitute(subject))
   key_col <- col_name(substitute(key))
   do_apriori_(df, subject_col, key_col, minlen, maxlen, min_support, max_support, min_confidence, lhs, rhs, max_basket_items)


### PR DESCRIPTION
### Description
do_apriori with preprocessing to limit items in a basket to top n most frequents,
so that it at least returns some result instead of using up memory for search.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
