### PR TITLE
do_cor returning model with original data

### DIFF
--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -188,6 +188,16 @@ do_cor.cols <- function(df, ..., use="pairwise.complete.obs", method="pearson", 
   }
 }
 
+#' @export
+tidy.cor_exploratory <- function(x, type = "cor", ...) { #TODO: add test
+  if (type == "cor") {
+    x$cor
+  }
+  else {
+    x$data
+  }
+}
+
 #' Non standard evaluation version for do_cmdscale_
 #' @return Tidy format of data frame.
 #' @export

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -70,7 +70,8 @@ do_cor.kv_ <- function(df,
                       distinct = FALSE,
                       diag = FALSE,
                       fill = 0,
-                      fun.aggregate=mean
+                      fun.aggregate = mean,
+                      return_type = "data.frame"
                       )
 {
   validate_empty_data(df)
@@ -117,6 +118,17 @@ do_cor.kv_ <- function(df,
     } else {
       ret <- mat_to_df(cor_mat, cnames=output_cols, diag=diag, na.rm = FALSE)
     }
+
+    if (return_type == "data.frame") {
+      ret # Return correlation data frame as is.
+    }
+    else {
+      # Return cor_exploratory model, which is a set of correlation data frame and the original data.
+      # We use the original data for scatter matrix on Analytics View.
+      ret <- list(cor = ret, data = df)
+      class(ret) <- c("cor_exploratory", class(ret))
+      ret
+    }
   }
   # Calculation is executed in each group.
   # Storing the result in this tmp_col and
@@ -124,11 +136,16 @@ do_cor.kv_ <- function(df,
   # If the original data frame is grouped by "tmp",
   # overwriting it should be avoided,
   # so avoid_conflict is used here.
-  tmp_col <- avoid_conflict(grouped_col, "tmp")
-  df %>%
-    dplyr::do_(.dots=setNames(list(~do_cor_each(.)), tmp_col)) %>%
-    dplyr::ungroup() %>%
-    unnest_with_drop_(tmp_col)
+  if (return_type == "data.frame") {
+    tmp_col <- avoid_conflict(grouped_col, "tmp")
+    df %>%
+      dplyr::do_(.dots=setNames(list(~do_cor_each(.)), tmp_col)) %>%
+      dplyr::ungroup() %>%
+      unnest_with_drop_(tmp_col)
+  }
+  else {
+    do_on_each_group(df, do_cor_each, name = "model", with_unnest = FALSE)
+  }
 }
 
 #'

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -152,6 +152,17 @@ test_that("test do_cor.kv for duplicated pair", {
   expect_equal(result[["value"]], replicate(2, 1))
 })
 
+test_that("test do_cor.kv with model output", {
+  result <- tidy_test_df %>%  do_cor.kv(cat, dim, val, return_type = "model")
+  result_cor <- result %>% tidy(model, type = "cor")
+  expect_equal(ncol(result_cor), 3)
+  expect_equal(result_cor[["cat.x"]], c("cat1", "cat2"))
+  expect_equal(result_cor[["cat.y"]], c("cat2", "cat1"))
+  expect_equal(result_cor[["value"]], replicate(2, 1))
+  result_data <- result %>% tidy(model, type = "data")
+  expect_equal(colnames(result_data), c("cat", "dim", "val", "dim_na"))
+})
+
 test_that("test do_cor.kv for grouped data frame as subject error", {
   data <- data.frame(group=rep(c(1,2,3), each=6),
                      row = rep(c(1, 1, 2, 2, 3,3), 3),

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -122,10 +122,13 @@ test_that("test do_cor.cols", {
 })
 
 test_that("test do_cor.cols with model output", {
-  browser()
   result <- spread_test_df %>%
     do_cor.cols(dplyr::starts_with("var"), return_type = "model")
   expect_equal(colnames(result), "model")
+  result_cor <- result %>% tidy(model, type = "cor")
+  expect_equal(result_cor[["value"]], rep(1, 2))
+  result_data <- result %>% tidy(model, type = "data")
+  expect_equal(colnames(result_data), c("var1", "var2"))
 })
 
 test_that("test do_cor.cols for grouped df", {

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -144,6 +144,23 @@ test_that("test do_cor.cols for grouped df", {
   expect_equal(dim(result), c(4, 4))
 })
 
+test_that("test do_cor.cols for grouped df with model output", {
+  loadNamespace("dplyr")
+  group1 <- cbind(spread_test_df, data.frame(group=rep("group1", 4)))
+  group2 <- cbind(spread_test_df, data.frame(group=rep("group2", 4)))
+  group2$var2 <- -group2$var2
+  test_df <- rbind(group1, group2)
+  result <- (
+    test_df
+    %>%  dplyr::group_by(group)
+    %>%  do_cor.cols(dplyr::starts_with("var"), return_type = "model"))
+
+  result_cor <- result %>% tidy(model)
+  expect_equal(dim(result_cor), c(4, 4))
+  result_data <- result %>% tidy(model, type = "data")
+  expect_equal(colnames(result_data), c("var1", "var2", "group"))
+})
+
 test_that("test do_cor.kv for duplicated pair", {
   result <- tidy_test_df %>%  do_cor.kv(cat, dim, val)
   expect_equal(ncol(result), 3)

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -121,6 +121,13 @@ test_that("test do_cor.cols", {
   expect_equal(result[["value"]], rep(1, 2))
 })
 
+test_that("test do_cor.cols with model output", {
+  browser()
+  result <- spread_test_df %>%
+    do_cor.cols(dplyr::starts_with("var"), return_type = "model")
+  expect_equal(colnames(result), "model")
+})
+
 test_that("test do_cor.cols for grouped df", {
   loadNamespace("dplyr")
   group1 <- cbind(spread_test_df, data.frame(group=rep("group1", 4)))

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -109,6 +109,30 @@ test_that("do_cor with NA values", {
   }
 })
 
+test_that("do_cor with NA values with model output", {
+  loadNamespace("reshape2")
+  nrow <- 10
+  ncol <- 20
+  vec <- rnorm(nrow * ncol)
+  mat <- matrix(vec, nrow = nrow)
+  melt_mat <- reshape2::melt(mat)
+  colnames(melt_mat)[[2]] <- "Var 2"
+
+  ret <- do_cor(melt_mat, skv = c("Var 2", "Var1", "value"), diag = TRUE, return_type = "model")
+  ret <- ret %>% tidy(model, type = "cor")
+
+  cor_ret <- cor(mat, use = "pairwise.complete.obs")
+  melt_ret <- reshape2::melt(cor_ret)
+
+  for(i in seq(ncol)){
+    for(j in seq(ncol)){
+      mat_answer <- cor_ret[i, j]
+      df_answer <- ret[ret[[1]] == i & ret[[2]] == j, 3][[1]]
+      expect_equal(mat_answer, df_answer)
+    }
+  }
+})
+
 tidy_test_df <- data.frame(
   cat=rep(c("cat1", "cat2"), 20),
   dim = sort(rep(paste0("dim", seq(4)), 5)),


### PR DESCRIPTION
### Description
do_cor returning model with original data, when argument return_type="model" is specified.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
