### PR TITLE
Add exploratory::parse_character as a wrapper function for readr::parse_character

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -126,7 +126,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
   loadNamespace("stringr")
 
   orig_input_col <- col_name(substitute(input))
-  input_col <- avoid_conflict(colnames(df), "input") 
+  input_col <- avoid_conflict(colnames(df), "input")
   # since unnest_tokens_ does not handle column with space well, rename column name temporarily.
   # the following does not work with error that says := is unknown. do it base-R way.
   # df <- dplyr::rename(!!rlang::sym(input_col) := !!rlang::sym(orig_input_col))
@@ -372,4 +372,19 @@ do_ngram <- function(df, token, sentence, document, maxn=2, sep="_"){
 get_sentiment <- function(text){
   loadNamespace("sentimentr")
   sentimentr::sentiment_by(text)$ave_sentiment
+}
+
+#' Wrapper function for readr::parse_parse_character.
+#' @param n How many tokens should be together as new tokens. This should be numeric vector.
+#' @export
+parse_character <- function(text, ...){
+  loadNamespace("readr")
+  tryCatch(
+    readr::parse_character(text = text, ...),
+    error=function(e){
+      # if readr::parse_character fails,
+      # fallbak to base as.character
+      as.character(text)
+    }
+  )
 }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -375,7 +375,7 @@ get_sentiment <- function(text){
 }
 
 #' Wrapper function for readr::parse_parse_character.
-#' @param n How many tokens should be together as new tokens. This should be numeric vector.
+#' @param text to parse
 #' @export
 parse_character <- function(text, ...){
   loadNamespace("readr")

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -379,12 +379,10 @@ get_sentiment <- function(text){
 #' @export
 parse_character <- function(text, ...){
   loadNamespace("readr")
-  tryCatch(
-    readr::parse_character(text = text, ...),
-    error=function(e){
-      # if readr::parse_character fails,
-      # fallbak to base as.character
+    # For non-character, use base as.character since readr::parse_character fails
+    if(!is.character(text)) {
       as.character(text)
+    } else {
+      readr::parse_character(text = text, ...)
     }
-  )
 }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -378,7 +378,10 @@ get_sentiment <- function(text){
 #' @param text to parse
 #' @export
 parse_character <- function(text, ...){
-  # For non-character, use base as.character since readr::parse_character fails
+  # After updating readr version from 1.1.1 to to 1.3.1,
+  # readr::parse_character now fails for non-characters.
+  # So if the input is not character (e.g. numeric, Date, etc),
+  # use base as.character to avoid the error raised from readr::parse_character.
   if(!is.character(text)) {
     as.character(text)
   } else {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -378,11 +378,10 @@ get_sentiment <- function(text){
 #' @param text to parse
 #' @export
 parse_character <- function(text, ...){
-  loadNamespace("readr")
-    # For non-character, use base as.character since readr::parse_character fails
-    if(!is.character(text)) {
-      as.character(text)
-    } else {
-      readr::parse_character(text = text, ...)
-    }
+  # For non-character, use base as.character since readr::parse_character fails
+  if(!is.character(text)) {
+    as.character(text)
+  } else {
+    readr::parse_character(text = text, ...)
+  }
 }

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -289,3 +289,9 @@ test_that("stem_word", {
   ret <- stem_word(c("impingement","feline"))
   expect_equal(ret, c("imping", "felin"))
 })
+
+test_that("parse_character", {
+  ret <- exploratory::parse_character(c(1, 2))
+  expect_equal(ret, c("1", "2"))
+})
+


### PR DESCRIPTION
### Description

Add `exploratory::parse_character` as a wrapper function for `readr::parse_character` so that transformation step created by the previous version of Exploratory Desktop does not fail.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [x] Test installing from github
- [x] Tested with Exploratory

### Test Result

There is one error but the error is not from this PR, but from exp_boruta regression (@test_boruta.R#14) 

```R
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  ══ testthat results  ═════════════════════════════════════════════════════════════════════════════════════════
  OK: 1983 SKIPPED: 20 FAILED: 21
  1. Error: exp_boruta regression (@test_boruta.R#14) 
  2. Failure: test relative importance (@test_build_lm.R#29) 
  3. Error: prediction with glm model with SMOTE by build_lm.fast (@test_build_lm.R#255) 
  4. Error: binary prediction with character target column (@test_build_lm_2.R#17) 
  5. Error: binary prediction with factor target column (@test_build_lm_2.R#41) 
  6. Error: binary prediction with variable_metric argument (@test_build_lm_2.R#71) 
  7. Error: test exp_balance with character (@test_randomForest_tidiers.R#11) 
  8. Error: test exp_balance with factor (@test_randomForest_tidiers.R#20) 
  9. Error: test exp_balance with logical (@test_randomForest_tidiers.R#31) 
  1. ...
  
  Error: testthat unit tests failed
  Execution halted
* DONE
Status: 1 ERROR, 5 WARNINGs, 5 NOTEs
 [81s/95s]
```