### PR TITLE
exp_balance fix of passing down new arguments.

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -947,7 +947,12 @@ exp_balance <- function(df,
       output <- forcats::fct_infreq(output)
       orig_levels <- levels(output)
       levels(output) <- c("0", "1")
-      df_balanced <- ubSMOTE2(input, output, ...) # defaults are, max_synth_perc=200, target_minority_perc=40, target_size=NULL, k = 5
+      df_balanced <- ubSMOTE2(input, output,
+                              target_minority_perc = target_minority_perc,
+                              target_size = target_size,
+                              max_synth_perc = max_synth_perc,
+                              k = k,
+                              ...) # defaults are, max_synth_perc=200, target_minority_perc=40, target_size=NULL, k = 5
 
       # revert the name changes made by ubSMOTE.
       colnames(df_balanced) <- c(colnames(input), target_col, "synthesized")

--- a/tests/testthat/test_smote.R
+++ b/tests/testthat/test_smote.R
@@ -65,6 +65,7 @@ test_that("test exp_balance with numeric, enough minority and majority, with tar
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_equal(50 ,nrow(res))
 })
 
 test_that("test exp_balance with numeric, not enough minority but enough with smote, and enough majority, with target size", {

--- a/tests/testthat/test_smote.R
+++ b/tests/testthat/test_smote.R
@@ -12,7 +12,7 @@ test_that("test exp_balance with numeric, already enough minority, without targe
     y = c(rep(3, 49), rep(4, 51)),
     num = runif(100)
   )
-  res <- exp_balance(sample_data, y)
+  res <- exp_balance(sample_data, y, target_size = NULL)
   expect_true("data.frame" %in% class(res))
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
@@ -24,7 +24,7 @@ test_that("test exp_balance with numeric, enough minority with SMOTE, without ta
     y = c(rep(3, 10), rep(4, 30)),
     num = runif(40)
   )
-  res <- exp_balance(sample_data, y)
+  res <- exp_balance(sample_data, y, target_size = NULL)
   expect_true("data.frame" %in% class(res))
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
@@ -36,7 +36,7 @@ test_that("test exp_balance with numeric, not enough minority even with SMOTE, w
     y = c(rep(3, 5), rep(4, 50)),
     num = runif(55)
   )
-  res <- exp_balance(sample_data, y)
+  res <- exp_balance(sample_data, y, target_size = NULL)
   expect_true("data.frame" %in% class(res))
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))

--- a/tests/testthat/test_smote.R
+++ b/tests/testthat/test_smote.R
@@ -31,6 +31,8 @@ test_that("test exp_balance with numeric, enough minority with SMOTE, without ta
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_lte(nrow(res), 50)
+  expect_gt(nrow(res[res$y==3,]), 10)
 })
 
 test_that("test exp_balance with numeric, not enough minority even with SMOTE, without target size", {
@@ -43,6 +45,8 @@ test_that("test exp_balance with numeric, not enough minority even with SMOTE, w
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_lte(nrow(res), 38) # Minority is SMOTEd and majority is sampled. Expectation with some slack.
+  expect_gt(nrow(res[res$y==3,]), 7)
 })
 
 test_that("test exp_balance with numeric, enough minority and not enough majority, with target size", {
@@ -55,6 +59,8 @@ test_that("test exp_balance with numeric, enough minority and not enough majorit
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_equal(nrow(res), 100) # res should be as is
+  expect_equal(nrow(res[res$y==3,]), 49)
 })
 
 test_that("test exp_balance with numeric, enough minority and majority, with target size", {
@@ -67,12 +73,13 @@ test_that("test exp_balance with numeric, enough minority and majority, with tar
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
-  expect_equal(50 ,nrow(res))
+  expect_equal(nrow(res), 50) # Both minority and majority should be sampled down.
+  expect_equal(nrow(res[res$y==3,]), 20)
 })
 
 test_that("test exp_balance with numeric, not enough minority but enough with smote, and enough majority, with target size", {
   sample_data <- data.frame(
-    y = c(rep(3, 8), rep(4, 92)),
+    y = c(rep(3, 12), rep(4, 88)),
     num = runif(100)
   )
   res <- exp_balance(sample_data, y, target_size=50)
@@ -80,18 +87,27 @@ test_that("test exp_balance with numeric, not enough minority but enough with sm
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_lt(nrow(res), 55) # Minority is SMOTEd and majority is sampled down.
+  expect_gt(nrow(res), 45)
+  expect_gt(nrow(res[res$y==3,]), 15)
 })
 
 test_that("test exp_balance with numeric, not enough minority even with smote, and enough majority, with target size", {
   sample_data <- data.frame(
-    y = c(rep(3, 3), rep(4, 97)),
+    y = c(rep(3, 5), rep(4, 95)),
     num = runif(100)
   )
-  res <- exp_balance(sample_data, y, target_size=50)
+  res <- exp_balance(sample_data, y, target_size=50, k=3) # Smaller k, since original minority size is small.
   expect_true("data.frame" %in% class(res))
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  # Minority is SMOTEd to the limit and majority is sampled down to make the ratio.
+  # Ideal result: minority 15, majority 22.5
+  # This one is rather unstable most likely because of too small minority.
+  expect_lte(nrow(res), 40)
+  expect_gte(nrow(res), 30)
+  expect_gt(nrow(res[res$y==3,]), 12)
 })
 
 test_that("test exp_balance with numeric, not enough minority and not enough majority, but enough minority for target ratio, with target size", {
@@ -104,6 +120,8 @@ test_that("test exp_balance with numeric, not enough minority and not enough maj
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_equal(nrow(res), 100) # res should be as is
+  expect_equal(nrow(res[res$y==3,]), 40)
 })
 
 test_that("test exp_balance with numeric, not enough minority and not enough majority, but enough minority with SMOTE for target ratio, with target size", {
@@ -116,6 +134,10 @@ test_that("test exp_balance with numeric, not enough minority and not enough maj
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  # Minority should be SMOTEd to make ratio
+  expect_lte(nrow(res), 130)
+  expect_gte(nrow(res), 1)
+  expect_gt(nrow(res[res$y==3,]), 3)
 })
 
 test_that("test exp_balance with numeric, not enough minority and not enough majority, not enough minority even with SMOTE for target ratio, with target size", {
@@ -128,6 +150,10 @@ test_that("test exp_balance with numeric, not enough minority and not enough maj
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  # Minority should be SMOTEd to the limit and majority should be sampled to make ratio.
+  expect_lte(nrow(res), 85)
+  expect_gte(nrow(res), 65)
+  expect_gt(nrow(res[res$y==3,]), 25)
 })
 
 test_that("test exp_balance with character", {

--- a/tests/testthat/test_smote.R
+++ b/tests/testthat/test_smote.R
@@ -17,6 +17,8 @@ test_that("test exp_balance with numeric, already enough minority, without targe
   expect_true("synthesized" %in% names(res))
   expect_equal("numeric" ,class(res$y))
   expect_equal(c(3,4) ,sort(unique(res$y)))
+  expect_equal(nrow(res), 100) # res should be as is.
+  expect_equal(nrow(res[res$y==3,]), 49) # res should be as is.
 })
 
 test_that("test exp_balance with numeric, enough minority with SMOTE, without target size", {


### PR DESCRIPTION
### Description
- Bug fix on exp_balance about passing down new arguments.
- Added test on expected number of rows and minority rows from exp_balance.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
