### PR TITLE
exp_ttest fails with var.equal=TRUE

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -424,8 +424,12 @@ glance.ttest_exploratory <- function(x) {
 #' @export
 tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
   if (type == "model") {
-    browser()
     ret <- broom:::tidy.htest(x)
+
+    if (is.null(ret$estimate)) { # estimate is empty when var.equal = TRUE.
+                                 # Looks like an issue from broom. Working it around.
+      ret <- ret %>% dplyr::mutate(estimate = estimate1 - estimate2)
+    }
     ret <- ret %>% dplyr::select(statistic, p.value, parameter, estimate, conf.high, conf.low) %>%
       dplyr::rename(`t Ratio`=statistic,
                     `P Value`=p.value,

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -424,6 +424,7 @@ glance.ttest_exploratory <- function(x) {
 #' @export
 tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
   if (type == "model") {
+    browser()
     ret <- broom:::tidy.htest(x)
     ret <- ret %>% dplyr::select(statistic, p.value, parameter, estimate, conf.high, conf.low) %>%
       dplyr::rename(`t Ratio`=statistic,

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -241,6 +241,16 @@ test_that("test exp_ttest", {
   ret
 })
 
+test_that("test exp_ttest with varEqual = TRUE", {
+  mtcars2 <- mtcars
+  mtcars2$am[[1]] <- NA # test NA filtering
+  ret <- exp_ttest(mtcars2, mpg, am, varEqual = TRUE)
+  ret %>% tidy(model, type="model")
+  ret %>% tidy(model, type="data_summary")
+  ret
+})
+
+
 test_that("test exp_ttest with asint grouping", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -241,10 +241,28 @@ test_that("test exp_ttest", {
   ret
 })
 
-test_that("test exp_ttest with varEqual = TRUE", {
+test_that("test exp_ttest with var.equal = TRUE", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering
-  ret <- exp_ttest(mtcars2, mpg, am, varEqual = TRUE)
+  ret <- exp_ttest(mtcars2, mpg, am, var.equal = TRUE)
+  ret %>% tidy(model, type="model")
+  ret %>% tidy(model, type="data_summary")
+  ret
+})
+
+test_that("test exp_ttest with alternative = greater", {
+  mtcars2 <- mtcars
+  mtcars2$am[[1]] <- NA # test NA filtering
+  ret <- exp_ttest(mtcars2, mpg, am, alternative = "greater")
+  ret %>% tidy(model, type="model")
+  ret %>% tidy(model, type="data_summary")
+  ret
+})
+
+test_that("test exp_ttest with paired = TRUE", {
+  mtcars2 <- mtcars
+  mtcars2$am[[1]] <- NA # test NA filtering
+  ret <- exp_ttest(mtcars2, mpg, am, paired = FALSE)
   ret %>% tidy(model, type="model")
   ret %>% tidy(model, type="data_summary")
   ret

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -236,6 +236,7 @@ test_that("test exp_ttest", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering
   ret <- exp_ttest(mtcars2, mpg, am)
+  ret %>% tidy(model, type="model")
   ret %>% tidy(model, type="data_summary")
   ret
 })
@@ -244,12 +245,14 @@ test_that("test exp_ttest with asint grouping", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering
   ret <- exp_ttest(mtcars2, mpg, am, func2 = "asint")
+  ret %>% tidy(model, type="model")
   ret %>% tidy(model, type="data_summary")
   ret
 })
 
 test_that("test exp_ttest with group_by", {
   ret <- mtcars %>% group_by(vs) %>% exp_ttest(mpg, am)
+  ret %>% tidy(model, type="model")
   ret %>% tidy(model, type="data_summary")
   ret
 })


### PR DESCRIPTION
### Description
Fixes exp_ttest failing with var.equal=TRUE
Working around missing estimate column from broom.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
