### PR TITLE
exploratory::parse_logical fixed argument name passed to readr::parse_logical

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -385,7 +385,7 @@ parse_character <- function(text, ...){
   if(!is.character(text)) {
     as.character(text)
   } else {
-    readr::parse_character(text = text, ...)
+    readr::parse_character(text, ...)
   }
 }
 
@@ -399,7 +399,7 @@ parse_number <- function(text, ...){
   if(is.numeric(text)) {
     text
   } else {
-    readr::parse_number(text = text, ...)
+    readr::parse_number(text, ...)
   }
 }
 
@@ -412,7 +412,7 @@ parse_logical <- function(text, ...){
   if(is.logical(text)) {
     text
   } else {
-    readr::parse_logical(x = text, ...)
+    readr::parse_logical(text, ...)
   }
 }
 

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -412,7 +412,7 @@ parse_logical <- function(text, ...){
   if(is.logical(text)) {
     text
   } else {
-    readr::parse_logical(text = text, ...)
+    readr::parse_logical(x = text, ...)
   }
 }
 


### PR DESCRIPTION
### Description

Argument name should be `x` instead of `text`.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
