### PR TITLE
build_lm, build_coxph: Show base level even when column name has space or special characters

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -600,7 +600,7 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
     # Quote variable name with backtick if it includes special characters or space.
-    # Special characters to detect besides space. Note that period should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
+    # Special characters to detect besides space. Note that period and underscore should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
     paste0(if_else(stringr::str_detect(vname,"[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -600,7 +600,8 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
     # Quote variable name with backtick if it includes special characters.
-    paste0(if_else(stringr::str_detect(vname,"[~!@#$%^&*()\\-+={}\\[\\]\\|:;'\"<>,?/]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
+    # Special characters to detect: ~!@#$%^&*()+={}|:;'<>,/?"[]-\
+    paste0(if_else(stringr::str_detect(vname,"[~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -600,7 +600,7 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
     # Quote variable name with backtick if it includes special characters or space.
-    # Special characters to detect besides space : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
+    # Special characters to detect besides space. Note that period should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
     paste0(if_else(stringr::str_detect(vname,"[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -599,7 +599,8 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 # Creates a data frame that maps term name to its base level.
 xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
-    paste0(if_else(stringr::str_detect(vname,' '),paste0('`',vname,'`'),vname),xlevels[[vname]])
+    # Quote variable name with backtick if it includes special characters.
+    paste0(if_else(stringr::str_detect(vname,"[~!@#$%^&*()\\-+={}\\[\\]\\|:;'\"<>,?/]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -599,9 +599,9 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 # Creates a data frame that maps term name to its base level.
 xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
-    # Quote variable name with backtick if it includes special characters.
-    # Special characters to detect: ~!@#$%^&*()+={}|:;'<>,/?"[]-\
-    paste0(if_else(stringr::str_detect(vname,"[~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
+    # Quote variable name with backtick if it includes special characters or space.
+    # Special characters to detect besides space : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
+    paste0(if_else(stringr::str_detect(vname,"[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -2,12 +2,16 @@ context("test build_coxph")
 
 test_that("test build_coxph.fast", {
   df <- survival::lung # this data has NAs.
-  df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age)
+  df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
-  df <- df %>% mutate(sex = sex==1) # test handling of logical
-  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, sex, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_n = 2)
+  df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
+  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_n = 2)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
   ret <- model_df %>% broom::tidy(model)
+  # Verify that base levels are not NA for `se-x` (testing - in the name) columns.
+  ret2 <- ret %>% dplyr::filter(stringr::str_detect(term,"(se-x)")) %>% dplyr::summarize(na_count=sum(is.na(base.level)))
+  expect_equal(ret2$na_count, 0)
+
   ret <- model_df %>% broom::glance(model, pretty.name=TRUE)
 })
 

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -146,22 +146,26 @@ test_that("prediction with target column name with space by build_lm.fast", {
     list(
       `CANCELLED:X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
       `logical col` = c(TRUE, FALSE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, NA, TRUE, FALSE, NA, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE),
-      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
+      `Carrier-Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
       CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
       # testing filtering of Inf, -Inf, NA here.
       DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
-    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED:X", "logical col", "Carrier Name", "CARRIER", "DISTANCE"))
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED:X", "logical col", "Carrier-Name", "CARRIER", "DISTANCE"))
 
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
   test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
 
-  model_data <- build_lm.fast(test_data, `CANCELLED:X`, `logical col`, `Carrier Name`, CARRIER, DISTANCE, predictor_n = 3, with_marginal_effects=TRUE, with_marginal_effects_confint=TRUE)
+  model_data <- build_lm.fast(test_data, `CANCELLED:X`, `logical col`, `Carrier-Name`, CARRIER, DISTANCE, predictor_n = 3, with_marginal_effects=TRUE, with_marginal_effects_confint=TRUE)
   ret <- model_data %>% broom::glance(model)
   # TODO: the returned coefficients does not show all input variables. 
   # most likely due to too few rows. look into it and add check for the values in the returned df. 
   ret <- model_data %>% broom::tidy(model)
+  # Verify that base levels are not NA for `logical col` (testing space in the name) and Carrier-Name (testing - in the name) columns.
+  ret2 <- ret %>% dplyr::filter(stringr::str_detect(term,"(logical col|Carrier-Name)")) %>% dplyr::summarize(na_count=sum(is.na(base.level)))
+  expect_equal(ret2$na_count, 0)
+
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)


### PR DESCRIPTION
### Description
Show base level even when column name has space or special characters.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
