### PR TITLE
Fix broken edarf chart by calling grouped_by on df after tidy() instead of before tidy()

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -666,7 +666,10 @@ rf_evaluation_by_class <- function(data, ...) {
 #' @export
 rf_partial_dependence <- function(df, ...) { # TODO: write test for this.
   res <- df %>% broom::tidy(model, type="partial_dependence", ...)
-  grouped_col <- grouped_by(df) # when called from analytics view, this should be a single column or empty.
+  grouped_col <- grouped_by(res) # When called from analytics view, this should be a single column or empty.
+                                 # grouped_by has to be on res rather than on df since dplyr::group_vars
+                                 # does not work on rowwise-grouped data frame.
+
   if (length(grouped_col) > 0) {
     res <- res %>% dplyr::ungroup() # ungroup to mutate group_by column.
     # add variable name to the group_by column, so that chart is repeated by the combination of group_by column and variable name.

--- a/tests/testthat/test_randomForest_tidiers.R
+++ b/tests/testthat/test_randomForest_tidiers.R
@@ -74,6 +74,7 @@ test_that("test calc_feature_imp predicting multi-class", {
   conf_mat <- tidy(model_df, model, type = "conf_mat", pretty.name = TRUE)
   ret <- model_df %>% rf_importance()
   ret <- model_df %>% rf_partial_dependence()
+  expect_equal(as.character(ret$Group[1]), "0 cat 10") # Check that format of Group column is good for our Analytics View. 
   ret <- model_df %>% rf_evaluation(pretty.name=TRUE) # TODO test that output is different from binary classification with TRUE/FALSE
   ret <- model_df %>% rf_evaluation_by_class(pretty.name=TRUE)
   ret <- model_df %>% tidy(model, type="boruta")


### PR DESCRIPTION
Fix broken edarf chart by calling grouped_by on df after tidy() instead of before tidy().


### Description
grouped_by() used to work on rowwise-grouped data frame, but not anymore.
Calling it on the dataframe after broom::tidy() call, since regular group-by state is put back at that point.

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
