### PR TITLE
WIP: Use new APIs of the text2vec (0.5.1)

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -190,7 +190,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
 }
 
 #' Get idf for terms
-calc_idf <- function(group, term, log_scale = log, smooth_idf = FALSE){
+calc_idf <- function(group, term, smooth_idf = FALSE){
   loadNamespace("Matrix")
   loadNamespace("text2vec")
   if(length(group)!=length(term)){
@@ -261,9 +261,8 @@ calc_tf_ <- function(df, group_col, term_col, weight="ratio"){
 #' @param df Data frame which has columns of groups and their terms
 #' @param group Column of group names
 #' @param term Column of terms
-#' @param idf_log_scale
-#' Function to scale IDF. It might be worth trying log2 or log10.
-#' log10 strongly suppress the increase of idf values and log2 does it more weakly.
+#' @param [DEPRECATED] idf_log_scale
+#' Function to scale IDF. "log" function is automatically set, other functions are ignored.
 #' @export
 do_tfidf <- function(df, group, term, idf_log_scale = log, tf_weight="raw", norm="l2"){
   validate_empty_data(df)
@@ -275,6 +274,10 @@ do_tfidf <- function(df, group, term, idf_log_scale = log, tf_weight="raw", norm
     stop("norm argument must be l1, l2 or FALSE")
   }
 
+  if(!missing(idf_log_scale)){
+	warnings("Argument `idf_log_scale` is deprecated. The set value is ignored.")
+  }
+
   group_col <- col_name(substitute(group))
   term_col <- col_name(substitute(term))
 
@@ -284,7 +287,7 @@ do_tfidf <- function(df, group, term, idf_log_scale = log, tf_weight="raw", norm
   cnames <- avoid_conflict(c(group_col, term_col), c("count_of_docs", "tfidf", "tf"))
 
   count_tbl <- calc_tf_(df, group_col, term_col, weight=tf_weight)
-  tfidf <- calc_idf(count_tbl[[group_col]], count_tbl[[term_col]], log_scale = idf_log_scale, smooth_idf = FALSE)
+  tfidf <- calc_idf(count_tbl[[group_col]], count_tbl[[term_col]], smooth_idf = FALSE)
   count_tbl[[cnames[[1]]]] <- tfidf$.df
   count_tbl[[cnames[[2]]]] <- tfidf$.idf * count_tbl[[cnames[[3]]]]
   count_tbl[[cnames[[3]]]] <- NULL

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -199,8 +199,11 @@ calc_idf <- function(group, term, log_scale = log, smooth_idf = FALSE){
   doc_fact <- as.factor(group)
   term_fact <- as.factor(term)
   sparseMat <- Matrix::sparseMatrix(i = as.numeric(doc_fact), j = as.numeric(term_fact))
-  idf <- text2vec::get_idf(sparseMat, log_scale=log_scale, smooth_idf=smooth_idf)
-  idf <- idf@x[term_fact]
+
+  m_tfidf <- text2vec::TfIdf$new(smooth_idf = smooth_idf, norm = "none")
+  result_tfidf <- m_tfidf$fit_transform(sparseMat)
+  idf <- result_tfidf@x[term_fact]
+
   df <- Matrix::colSums(sparseMat)[term_fact]
   data.frame(.df=df, .idf=idf)
 }


### PR DESCRIPTION
### Description
- Replace `text2vec::get_idf` to `text2vec::TfIdf` class
- Add deprecated warnings for `idf_log_scale` which is an argument of `do_tfidf` function.
  - `text2vec::TfIdf` has a function for calculation of TF-IDF, named `fit_transform` or `transform`, which internally calculates IDF by private function `get_idf`. This has **NO** parameter of log_scale. 
  - So there is no way to set log scale function to `text2vec::TfIdf`. 
  - For compatibility, idf_log_scale argument is available, but log function is used no matter what function is used for the argument. Also, in that case, a warning to that effect is output.

REF: [https://rdrr.io/cran/text2vec/man/TfIdf.html](https://rdrr.io/cran/text2vec/man/TfIdf.html)
### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
