### PR TITLE
WIP: Negative binomial regression analysis

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -707,7 +707,9 @@ model_coef <- function(df, pretty.name = FALSE, conf_int = NULL, ...){
 
   if ("glm" %in% class(df$model[[1]])) {
     if (!is.null(df$model[[1]]$family)) {
-      if (df$model[[1]]$family == "binomial"){
+      if (df$model[[1]]$family == "binomial" |
+          df$model[[1]]$family$family %>%
+            stringr::str_detect("Negative Binomial")){
         ret <- ret %>% dplyr::mutate(odds_ratio = exp(estimate))
       }
     }

--- a/R/build_glm.R
+++ b/R/build_glm.R
@@ -90,8 +90,6 @@ build_glm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, g
   source_col <- "source.data"
 
   caller <- match.call()
-  # this expands dots arguemtns to character
-  arg_char <- expand_args(caller, exclude = c("data", "keep.source", "augment", "group_cols", "test_rate", "seed"))
 
   # check if grouping columns are in the formula
   grouped_var <- group_col_names[group_col_names %in% fml_vars]
@@ -99,6 +97,20 @@ build_glm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, g
     stop(paste0(grouped_var, " is a grouping column. Please remove it from variables."))
   } else if (length(grouped_var) > 0) {
     stop(paste0(paste(grouped_var, collapse = ", "), " are grouping columns. Please remove them from variables."))
+  }
+
+  # family
+  exclude_arg_names <- c("data", "keep.source", "augment", "group_cols", "test_rate", "seed")
+  if(match.call()$family %>%
+       as.character() %>%
+       stringr::str_detect("negative\\.binomial") %>%
+       any() %>%
+       dplyr::if_else(is.na(.), FALSE, .)) {
+    arg_char <- expand_args(caller, exclude = c(exclude_arg_names, "family", "offset"))
+    glm_func_name = "MASS::glm.nb"
+  } else {
+    arg_char <- expand_args(caller, exclude = exclude_arg_names)
+    glm_func_name = "stats::glm"
   }
 
   ret <- tryCatch({
@@ -112,7 +124,7 @@ build_glm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, g
       dplyr::mutate(model = purrr::map2(source.data, .test_index, function(df, index){
         data <- safe_slice(df, index, remove = TRUE)
         # execute glm with parsed arguments
-        eval(parse(text = paste0("stats::glm(data = data, ", arg_char, ")")))
+        eval(parse(text = paste0(glm_func_name, "(data = data, ", arg_char, ")")))
       })) %>%
       dplyr::mutate(.model_metadata = purrr::map(source.data, function(df){
         if(!is.null(formula)){

--- a/R/build_glm.R
+++ b/R/build_glm.R
@@ -99,15 +99,18 @@ build_glm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, g
     stop(paste0(paste(grouped_var, collapse = ", "), " are grouping columns. Please remove them from variables."))
   }
 
-  # family
+  # define glm function by the family option
   exclude_arg_names <- c("data", "keep.source", "augment", "group_cols", "test_rate", "seed")
-  if(match.call()$family %>%
+
+  if((match.call()$family %>%
        as.character() %>%
        stringr::str_detect("negative\\.binomial") %>%
        any() %>%
-       dplyr::if_else(is.na(.), FALSE, .)) {
+       dplyr::if_else(is.na(.), FALSE, .)) && (class(list(...)$family) != "family")) {
+
     arg_char <- expand_args(caller, exclude = c(exclude_arg_names, "family", "offset"))
     glm_func_name = "MASS::glm.nb"
+
   } else {
     arg_char <- expand_args(caller, exclude = exclude_arg_names)
     glm_func_name = "stats::glm"

--- a/tests/testthat/test_build_glm_nb.R
+++ b/tests/testthat/test_build_glm_nb.R
@@ -1,0 +1,141 @@
+context("test build_glm_nb")
+
+checkSummaryOutput <- function(model_ret){
+  expect_equal(colnames(model_ret), c(".test_index", "source.data", "model", ".model_metadata"))
+
+  res <- capture.output(summary(model_ret$model[[1]]))
+  expect_lt(length(res), 50)
+}
+
+test_that("test build_glm with negative.binomial family(class family)", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/(Age + Eth*Lrn),
+              family = MASS::negative.binomial(theta = 1))
+  checkSummaryOutput(trial)
+})
+
+test_that("test build_glm with negative.binomial family(class character)", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/(Age + Eth*Lrn),
+              family = "negative.binomial")
+  checkSummaryOutput(trial)
+  
+})
+
+test_that("test build_glm with negative.binomial family(class function)", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/(Age + Eth*Lrn),
+              family = MASS::negative.binomial)
+  
+  checkSummaryOutput(trial)
+})
+
+test_that("test build_glm (nb) with keep.source FALSE", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/(Age + Eth*Lrn),
+              family = "negative.binomial",
+              keep.source = F)
+  expect_equal(colnames(trial), c(".test_index", "model", ".model_metadata"))
+})
+
+test_that("test build_glm (nb) with grouped", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/Age,
+              group_cols = c("Eth", "Lrn"),
+              family = "negative.binomial")
+  expect_equal(length(trial[["Eth"]]), 4)
+  expect_equal(length(trial[["Lrn"]]), 4)
+
+  expect_error(build_glm(MASS::quine, Days ~ Sex/(Age + Eth), group_cols = c("Eth", "Lrn")),
+               "Eth is a grouping column. Please remove it from variables.")
+})
+
+test_that("test build_glm (nb) with augment TRUE", {
+   trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/Age,
+              group_cols = c("Eth", "Lrn"),
+              family = "negative.binomial",
+              augment = TRUE)
+  expect_equal(length(trial[["Eth"]]), 146)
+  expect_equal(length(trial[["Lrn"]]), 146)
+})
+
+test_that("test build_glm (nb) name conflict avoid", {
+  test_df <- MASS::quine %>%
+    dplyr::rename(estimate = Eth,
+                  model = Lrn) %>%
+    dplyr::mutate(model.group = model)
+  model <- test_df %>%
+    build_glm(Days ~ Sex/Age,
+              group_cols = c("estimate", "model", "model.group"),
+              family = "negative.binomial")
+  expect_equal(colnames(model),
+               c("estimate.group", "model.group",
+                 "model.group1", "source.data", ".test_index",
+                 "model", ".model_metadata"))
+})
+
+test_that("predict glm.nb with new data", {
+  model <- MASS::quine %>%
+    build_glm(Days ~ Sex,
+              group_cols = "Lrn",
+              family = MASS::negative.binomial)
+  coef_ret <- model %>% model_coef()
+  expect_equal(colnames(coef_ret),
+               c("Lrn", "term", "estimate", "std_error",
+                 "t_ratio", "p_value", "odds_ratio"))
+  stats_ret <- model %>% model_stats()
+  expect_equal(colnames(stats_ret),
+               c("Lrn", "null_deviance",
+                 "df_for_null_model", "log_likelihood",
+                 "aic", "bic", "deviance", "residual_df",
+                 "Sex_base"))
+})
+
+test_that("prediction glm.nb with categorical columns", {
+  test_data <- MASS::quine %>%
+    dplyr::mutate(Sex = as.integer(Sex)) %>%
+    { dplyr::bind_rows(., .) }
+
+  model <- build_glm(test_data,
+                     Sex ~ Age + Lrn + Days,
+                     family = "negative.binomial",
+                     test_rate = 0.6)
+  ret <- prediction(model, data = "test",
+                    type.predict = "response")
+  test_ret <- prediction(model, data = "test")
+  train_ret <- prediction(model, data = "training")
+  expect_true(nrow(ret) > 0)
+  expect_true(all(ret["predicted_value"] >= 1 & ret["predicted_value"] <= 2))
+  expect_equal(colnames(test_ret),
+               c("Eth", "Sex", "Age",
+                 "Lrn", "Days", "predicted_value",
+                 "standard_error", "conf_low", "conf_high",
+                 "predicted_response"))
+  expect_equal(colnames(train_ret),
+               c("Eth", "Sex", "Age",
+                 "Lrn", "Days", "predicted_value",
+                 "standard_error", "conf_low", "conf_high",
+                 "residuals", "hat", "residual_standard_deviation",
+                 "cooks_distance", "standardised_residuals",
+                 "predicted_response"))
+})
+
+test_that("test prediction binary glm.nb", {
+  test_data <- MASS::quine %>%
+    dplyr::mutate(Sex = as.integer(Sex)) %>%
+    { dplyr::bind_rows(., .) }
+
+  model <- build_glm(test_data,
+                     Sex ~ Age + Lrn + Days,
+                     family = "negative.binomial",
+                     test_rate = 0.6)
+  coef_ret <- model %>% model_coef()
+  expect_true(!is.null(coef_ret[["odds_ratio"]]))
+  prediction_train_ret <- prediction_binary(model, data = "training")
+  expect_true("predicted_label" %in% colnames(prediction_train_ret))
+  expect_true("predicted_value" %in% colnames(prediction_train_ret))
+  expect_true("predicted_probability" %in% colnames(prediction_train_ret))
+
+ })
+

--- a/tests/testthat/test_build_glm_nb.R
+++ b/tests/testthat/test_build_glm_nb.R
@@ -30,6 +30,17 @@ test_that("test build_glm with negative.binomial family(class function)", {
   checkSummaryOutput(trial)
 })
 
+test_that("test build_glm (nb) with init theta params", {
+  trial <- MASS::quine %>%
+    build_glm(Days ~ Sex/(Age + Eth*Lrn),
+              family = MASS::negative.binomial(theta=500))
+  family_arg <- trial$model[[1]]$call %>% as.list() %>% .$family
+
+  expect_equal(family_arg$theta, 500)
+  expect_equal(family_arg %>% as.character() %>% `[`(1),
+               "MASS::negative.binomial")
+ })
+
 test_that("test build_glm (nb) with keep.source FALSE", {
   trial <- MASS::quine %>%
     build_glm(Days ~ Sex/(Age + Eth*Lrn),


### PR DESCRIPTION
### Description
- implement a Negative binomial regression analysis.
- use different GLM functions depending on the value of the family option passed to build_glm function.
   - when the family options is `"binomial.regression"`, use `MASS::glm.nb`
   - when the family options is `"MASS::binomial.regression"`, use `MASS::glm.nb`
   - when the family options is `"MASS::binomial.regression(theta=xx)"`, use `stats::glm`

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory

### Tested with Exploratory(Version 5.1.5.1 (Production))
<img width="1352" alt="スクリーンショット 2019-04-14 18 14 05" src="https://user-images.githubusercontent.com/19848791/56090840-8a742c80-5ee2-11e9-99d8-b715db868eaf.png">

<img width="1352" alt="スクリーンショット 2019-04-14 18 14 13" src="https://user-images.githubusercontent.com/19848791/56090843-8f38e080-5ee2-11e9-93c8-b5c235f7dc55.png">

<img width="1352" alt="スクリーンショット 2019-04-14 18 14 22" src="https://user-images.githubusercontent.com/19848791/56090848-94962b00-5ee2-11e9-9223-b03e784c2695.png">

