### PR TITLE
Detect error and expectation_failure with any_error() and get_num_errors

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -40,8 +40,8 @@ any_error <- function(test_results) {
   flattened <- purrr::flatten(results)
   # extract result class attr which has info on whether the result was success, warning, or error.
   result_classes <- purrr::map(flattened, function(x){attr(x,"class")})
-  # return TRUE if there is any result with class "expectation_error".
-  purrr::some(result_classes, function(x){"expectation_error" %in% x})
+  # return TRUE if there is any result with class "expectation_error", "expectation_failure", or "error".
+  purrr::some(result_classes, function(x){any(c("expectation_error", "expectation_failure", "error") %in% x)})
 }
 
 #' Returns number of errors in testthat result. For test automation.
@@ -53,7 +53,7 @@ get_num_errors <- function(test_results) {
   flattened <- purrr::flatten(results)
   # extract result class attr which has info on whether the result was success, warning, or error.
   result_classes <- purrr::map(flattened, function(x){attr(x,"class")})
-  # return TRUE if there is any result with class "expectation_error".
-  errors <- purrr::keep(result_classes, function(x){"expectation_error" %in% x})
+  # return TRUE if there is any result with class "expectation_error", "expectation_failure", or "error".
+  errors <- purrr::keep(result_classes, function(x){any(c("expectation_error", "expectation_failure", "error") %in% x)})
   length(errors)
 }


### PR DESCRIPTION
# Description
Detect error and expectation_failure with any_error() and get_num_errors(), which we use for our automated test.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
