### PR TITLE
Add separate arules test cases for no matching rule and with both lhs/rhs

### DIFF
--- a/tests/testthat/test_arules.R
+++ b/tests/testthat/test_arules.R
@@ -37,7 +37,22 @@ test_that("test do_apriori with lhs and rhs", {
     number = seq(60)
   )
 
+  ret <- suppressWarnings({
+    do_apriori(test_df, name, product, min_support=0.001, lhs="name1", rhs="name8")
+  })
+  expect_equal(colnames(ret), c("lhs", "rhs", "support", "confidence", "lift"))
+  expect_true(all(ret[, "lhs"] == "name1" & ret[, "rhs"] == "name8"))
+  get_arules_graph_data(ret)
+})
+
+test_that("test do_apriori with no matching rule", {
+  test_df <- data.frame(
+    name = rep(paste("name",seq(20), sep=""), each=3),
+    product = rep(paste("product",seq(5), sep=""), 12),
+    number = seq(60)
+  )
+
   expect_error({
-    do_apriori(test_df, name, product, min_support=0.9, lhs="name1", rhs="name2")
+    do_apriori(test_df, name, product, min_support=0.9, lhs="name1", rhs="name8")
   }, "No matching rule was found")
 })

--- a/tests/testthat/test_arules.R
+++ b/tests/testthat/test_arules.R
@@ -53,6 +53,7 @@ test_that("test do_apriori with no matching rule", {
   )
 
   expect_error({
+    # min_support is set high intentionally so that no matching rule will be found.
     do_apriori(test_df, name, product, min_support=0.9, lhs="name1", rhs="name8")
   }, "No matching rule was found")
 })


### PR DESCRIPTION


# Description
Add separate arules test cases for no matching rule and with both lhs/rhs.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
