### PR TITLE
 Add GLM (Negative Binomial) by build_lm.fast

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -484,7 +484,7 @@ build_lm.fast <- function(df,
 
           if (family_arg == "negativebinomial"){
             # In MASS::glm.nb function, the link arg must be one of log, sqrt or identity.
-            # So if the other is used, the link arg should be set to "log" which is a default value.
+            # So if the other is used, the link arg should be set to "log" which is the default value.
             if (is.null(link) || (!link %in% c("log", "sqrt", "identity"))){
               link <- "log"
             }
@@ -492,7 +492,7 @@ build_lm.fast <- function(df,
             # The argument link in MASS::glm.nb is evaluated by substitution with delay,
             # so the variable specified in the argument is interpreted as the link argument as it is.
             # For example, if you execute like MASS::glm.nb(fmt, data = df, link = link), the following error will occur
-            # link "link" not available for poisson family; available links are ‘log’, ‘identity’, ‘sqrt’
+            # link "link" not available for poisson family; available links are 'log', 'identity', 'sqrt'
             # Therefore, we used eval to pass the string (log etc.) specified in the argument to link as it is.
             rf <- eval(parse(text=paste0("MASS::glm.nb(fml, data=df, link=", link, ")")))
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -593,6 +593,16 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
   else {
     ret <- ret %>% dplyr::mutate(p.value=pvalue)
   }
+
+  # For GLM (Negative Binomial)
+  if("negbin" %in% class(x)) {
+    if(pretty.name) {
+      ret <- ret %>% dplyr::mutate(`Theta`=x$theta, `SE Theta`=x$SE.theta)
+    }
+    else {
+      ret <- ret %>% dplyr::mutate(theta=x$theta, SE.theta=x$SE.theta)
+    }
+  }
   
   if (x$family$family %in% c('binomial', 'quasibinomial')) { # only for logistic regression.
     # Calculate F Score, Accuracy Rate, Misclassification Rate, Precision, Recall, Data Size

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -224,7 +224,8 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
   expect_equal(colnames(ret),
                c("null.deviance", "df.null", "logLik",
                  "AIC", "BIC", "deviance",
-                 "df.residual", "p.value", "logical.col_base",
+                 "df.residual", "p.value", "theta", "SE.theta",
+                 "logical.col_base",
                  "Carrier.Name_base", "CARRIER_base"))
   ret <- model_data %>% broom::tidy(model)
   expect_equal(colnames(ret),
@@ -299,4 +300,26 @@ test_that("prediction with glm model with SMOTE by build_lm.fast", {
   ret <- model_data %>% broom::augment(model, pretty.name=TRUE)
 
   expect_true(nrow(ret) > 0)
+})
+
+test_that("test GLM (Negative Binomial) summary output", {
+  test_df <- data.frame(
+    num1 = seq(20),
+    num2 = seq(20) - 10,
+    num3 = seq(20) / 10.0
+  )
+  ret <- test_df %>% build_lm.fast(num1, num2, num3,
+                            model_type="glm",
+                            family="negativebinomial")
+  model_ret <- ret %>% broom::glance(model)
+  expect_equal(colnames(model_ret),
+               c("null.deviance", "df.null", "logLik",
+                 "AIC", "BIC", "deviance", "df.residual",
+                 "p.value", "theta", "SE.theta"))
+  model_ret_pretty <- ret %>% broom::glance(model, pretty.name=TRUE)
+  expect_equal(colnames(model_ret_pretty),
+               c("P Value", "Log Likelihood", "AIC",
+                 "BIC", "Deviance", "Null Deviance",
+                 "DF for Null Model", "Residual DF",
+                 "Theta", "SE Theta"))
 })

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -323,3 +323,38 @@ test_that("test GLM (Negative Binomial) summary output", {
                  "DF for Null Model", "Residual DF",
                  "Theta", "SE Theta"))
 })
+
+test_that("test GLM (Negative Binomial) with group columns", {
+  test_data <- structure(
+    list(
+      `CANCELLED X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
+      CARRIER = factor(c(NA, "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL")), # test with factor with NA
+      # testing filtering of Inf, -Inf, NA here.
+      DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "Carrier Name", "CARRIER", "DISTANCE"))
+
+  # duplicate rows to make some predictable data
+  # otherwise, the number of rows of the result of prediction becomes 0
+  test_data <- dplyr::bind_rows(test_data, test_data)
+  test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
+
+  ret <- test_data %>% dplyr::group_by(CARRIER) %>%
+           build_lm.fast(`CANCELLED X`,
+                         DISTANCE,
+                         predictor_n = 3,
+                         model_type = "glm",
+                         family = "negativebinomial")
+  expect_equal(length(ret[["CARRIER"]]), 8)
+  model_ret <- ret %>% broom::glance(model)
+  expect_equal(colnames(model_ret),
+               c("CARRIER", "null.deviance", "df.null", "logLik",
+                 "AIC", "BIC", "deviance", "df.residual",
+                 "p.value", "theta", "SE.theta"))
+  model_ret_pretty <- ret %>% broom::glance(model, pretty.name=TRUE)
+  expect_equal(colnames(model_ret_pretty),
+               c("CARRIER","P Value", "Log Likelihood", "AIC",
+                 "BIC", "Deviance", "Null Deviance",
+                 "DF for Null Model", "Residual DF",
+                 "Theta", "SE Theta"))
+})

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -210,6 +210,31 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
 
   expect_true(nrow(ret) > 0)
   expect_equal(colnames(ret), c("CANCELLED.X", "logical.col", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+
+  model_data <- build_lm.fast(test_data,
+                              `CANCELLED X`,
+                              `logical col`,
+                              `Carrier Name`,
+                              CARRIER, DISTANCE,
+                              predictor_n = 3,
+                              model_type = "glm",
+                              link = "log",
+                              family="negativebinomial")
+  ret <- model_data %>% broom::glance(model)
+  expect_equal(colnames(ret),
+               c("null.deviance", "df.null", "logLik",
+                 "AIC", "BIC", "deviance",
+                 "df.residual", "p.value", "logical.col_base",
+                 "Carrier.Name_base", "CARRIER_base"))
+  ret <- model_data %>% broom::tidy(model)
+  expect_equal(colnames(ret),
+               c("term", "estimate", "std.error", "statistic", "p.value",
+               "conf.high", "conf.low", "base.level"))
+
+  ret <- model_data %>% broom::augment(model)
+  expect_equal(colnames(ret),
+               c("CANCELLED.X", "logical.col", "Carrier.Name", "CARRIER", "DISTANCE",
+                 ".fitted", ".resid", ".hat", ".sigma", ".cooksd", ".std.resid"))
 })
 
 if (Sys.info()["sysname"] != "Windows") {


### PR DESCRIPTION
# Description
- add GLM (Negative Binomial) by build_lm.fast
   - At summary output, theta and SE.theta is additionally displayed

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [x] Test installing from github
- [x] Tested with Exploratory
