### PR TITLE
Work around for ranger error against parse_number output

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -399,7 +399,10 @@ parse_number <- function(text, ...){
   if(is.numeric(text)) {
     text
   } else {
-    readr::parse_number(text, ...)
+    # For some reason, output from parse_number returns FALSE for
+    # is.vector(), which becomes a problem when it is fed to ranger
+    # as the target variable. To work it around, we apply as.numeric().
+    as.numeric(readr::parse_number(text, ...))
   }
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -1236,7 +1236,7 @@ do_on_each_group <- function(df, func, params = quote(list()), name = "tmp", wit
   call <- rlang::new_language(func, rlang::as_pairlist(args))
   ret <- df %>%
     # UQ and UQ(get_expr()) evaluates those variables
-    dplyr::do(rlang::UQ(name) := rlang::UQ(rlang::get_expr(call)))
+    dplyr::do(UQ(name) := UQ(rlang::get_expr(call)))
   if(with_unnest){
     ret %>%
       dplyr::ungroup() %>%
@@ -1258,7 +1258,7 @@ do_on_each_group_2 <- function(df, func1, func2, params1 = quote(list()), params
   call2 <- rlang::new_language(func2, rlang::as_pairlist(args2))
   ret <- df %>%
     # UQ and UQ(get_expr()) evaluates those variables
-    dplyr::do(rlang::UQ(name1) := rlang::UQ(rlang::get_expr(call1)), rlang::UQ(name2) := rlang::UQ(rlang::get_expr(call2)))
+    dplyr::do(UQ(name1) := UQ(rlang::get_expr(call1)), UQ(name2) := UQ(rlang::get_expr(call2)))
   ret
 }
 

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -310,4 +310,3 @@ test_that("parse_logical", {
   ret <- exploratory::parse_logical(c(TRUE, FALSE))
   expect_equal(ret, c(TRUE, FALSE))
 })
-

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -296,8 +296,14 @@ test_that("parse_character", {
 })
 
 test_that("parse_number", {
+  # Parse characters
+  ret <- exploratory::parse_number(c("1", "2.1"))
+  expect_equal(ret, c(1, 2.1))
+  expect_true(is.vector(ret))
+  # Pass through input that is already numeric.
   ret <- exploratory::parse_number(c(1, 2.1))
   expect_equal(ret, c(1, 2.1))
+  expect_true(is.vector(ret))
 })
 
 test_that("parse_logical", {


### PR DESCRIPTION
# Description
- Work around for ranger error against parse_number output.
- Avoid deprecated way of calling UQ() with namespace like rlang::UQ().

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
