### PR TITLE
Fix build_lm test failure related to Negative Binomial

### DIFF
--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -228,9 +228,13 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
                  "logical.col_base",
                  "Carrier.Name_base", "CARRIER_base"))
   ret <- model_data %>% broom::tidy(model)
-  expect_equal(colnames(ret),
-               c("term", "estimate", "std.error", "statistic", "p.value",
-               "conf.high", "conf.low", "base.level"))
+  expect_colnames <- c("term", "estimate", "std.error", "statistic", "p.value",
+                       "conf.high", "conf.low", "base.level")
+  if(ret %>% dplyr::select(-term,-base.level) %>% is.na(.) %>% any(.)){
+    expect_equal(colnames(ret), c(expect_colnames, "note"))
+  } else {
+    expect_equal(colnames(ret), expect_colnames)
+  }
 
   ret <- model_data %>% broom::augment(model)
   expect_equal(colnames(ret),

--- a/tests/testthat/test_build_lm.R
+++ b/tests/testthat/test_build_lm.R
@@ -210,6 +210,18 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
 
   expect_true(nrow(ret) > 0)
   expect_equal(colnames(ret), c("CANCELLED.X", "logical.col", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+})
+
+test_that("prediction with glm family (negativebinomial) with target column name with space by build_lm.fast", {
+  test_data <- structure(
+    list(
+      `CANCELLED X` = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      `logical col` = c(TRUE, FALSE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, NA, TRUE, FALSE, NA, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE),
+      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", NA, "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines"),
+      CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+      # testing filtering of Inf, -Inf, NA here.
+      DISTANCE = c(Inf, -Inf, NA, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)), row.names = c(NA, -20L),
+    class = c("tbl_df", "tbl", "data.frame"), .Names = c("CANCELLED X", "logical col", "Carrier Name", "CARRIER", "DISTANCE"))
 
   model_data <- build_lm.fast(test_data,
                               `CANCELLED X`,
@@ -230,11 +242,10 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
   ret <- model_data %>% broom::tidy(model)
   expect_colnames <- c("term", "estimate", "std.error", "statistic", "p.value",
                        "conf.high", "conf.low", "base.level")
-  if(ret %>% dplyr::select(-term,-base.level) %>% is.na(.) %>% any(.)){
-    expect_equal(colnames(ret), c(expect_colnames, "note"))
-  } else {
-    expect_equal(colnames(ret), expect_colnames)
-  }
+
+  # when model has NA value in coefficients, broom::tidy(model) return note column
+  expect_true(identical(colnames(ret), expect_colnames) ||
+                identical(colnames(ret), c(expect_colnames, "note")))
 
   ret <- model_data %>% broom::augment(model)
   expect_equal(colnames(ret),


### PR DESCRIPTION
# Description
In only Jenkins env, `build_lm` test is falure like a below.

```
test_build_lm.R:231: failure: prediction with glm family (binomial) and link (probit) with target column name with space by build_lm.fast
colnames(ret) not equal to c(...).
Lengths differ: 9 is not 8
```
Because in only Jenkins env, coefficients of Negative Binomial Model has NA values, the `broom::tidy(model)` output has `note` column.
So the output result column is different from what I expected.
Therefore, I modified the test to consider this. 
 
# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
