### PR TITLE
Negative binomial regression analysis

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -712,15 +712,6 @@ model_coef <- function(df, pretty.name = FALSE, conf_int = NULL, ...){
       }
     }
   }
-  if ("negbin" %in% class(df$model[[1]])) {
-    x <- df$model[[1]]
-    if(pretty.name) {
-      ret <- ret %>% dplyr::mutate(`Theta`=x$theta, `SE Theta`=x$SE.theta)
-    }
-    else {
-      ret <- ret %>% dplyr::mutate(theta=x$theta, SE.theta=x$SE.theta)
-    }
-  }
   if ("coxph" %in% class(df$model[[1]])) {
     ret <- ret %>% dplyr::mutate(
       hazard_ratio = exp(estimate)
@@ -838,6 +829,15 @@ model_stats <- function(df, pretty.name = FALSE, ...){
     ret <- ret %>% dplyr::ungroup() %>% dplyr::select(-dummy_group_col)
   }
 
+  if ("negbin" %in% class(df$model[[1]])) {
+    x <- df$model[[1]]
+    if(pretty.name) {
+      ret <- ret %>% dplyr::mutate(`Theta`=x$theta, `SE Theta`=x$SE.theta)
+    }
+    else {
+      ret <- ret %>% dplyr::mutate(theta=x$theta, SE.theta=x$SE.theta)
+    }
+  }
 
   # adjust column name style
   if(pretty.name){

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -712,6 +712,15 @@ model_coef <- function(df, pretty.name = FALSE, conf_int = NULL, ...){
       }
     }
   }
+  if ("negbin" %in% class(df$model[[1]])) {
+    x <- df$model[[1]]
+    if(pretty.name) {
+      ret <- ret %>% dplyr::mutate(`Theta`=x$theta, `SE Theta`=x$SE.theta)
+    }
+    else {
+      ret <- ret %>% dplyr::mutate(theta=x$theta, SE.theta=x$SE.theta)
+    }
+  }
   if ("coxph" %in% class(df$model[[1]])) {
     ret <- ret %>% dplyr::mutate(
       hazard_ratio = exp(estimate)


### PR DESCRIPTION
### Description
- implement a Negative binomial regression analysis.
- use different GLM functions depending on the value of the family option passed to build_glm function.
   - when the family options is `"binomial.regression"`, use `MASS::glm.nb`
   - when the family options is `"MASS::binomial.regression"`, use `MASS::glm.nb`
   - when the family options is `"MASS::binomial.regression(theta=xx)"`, use `stats::glm`

### Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory

### Tested with Exploratory(Version 5.1.5.1 (Production))
<img width="1352" alt="スクリーンショット 2019-04-14 18 14 05" src="https://user-images.githubusercontent.com/19848791/56090840-8a742c80-5ee2-11e9-99d8-b715db868eaf.png">

<img width="1352" alt="スクリーンショット 2019-04-14 18 14 13" src="https://user-images.githubusercontent.com/19848791/56090843-8f38e080-5ee2-11e9-93c8-b5c235f7dc55.png">

<img width="1352" alt="スクリーンショット 2019-04-14 18 14 22" src="https://user-images.githubusercontent.com/19848791/56090848-94962b00-5ee2-11e9-9223-b03e784c2695.png">
