### PR TITLE
normality: prefilter columns after sampling

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -636,6 +636,10 @@ exp_normality<- function(df, ...,
 
         if (length(df[[col]]) > n_sample) {
           col_to_test <- sample(df[[col]], n_sample)
+          # If sampled, check if the column has only 1 unique value or only NAs again, to avoid error.
+          if (n_distinct(col_to_test, na.rm=TRUE) <= 1) {
+            next
+          }
           sample_size <- n_sample
         }
         else {

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -315,3 +315,12 @@ test_that("test exp_normality", {
   model_summary <- ret %>% tidy(model, type="model_summary", signif_level=0.1)
   ret
 })
+
+test_that("test exp_normality with column with almost always same value", {
+  # test for column with almost always same value, except for NA, to test column prefiltering logic to avoid error.
+  df <- mtcars %>% mutate(dummy=c(NA, 0, rep(1,n()-2)))
+  ret <- df %>% exp_normality(mpg, gear, dummy, n_sample=6, n_sample_qq=30)
+  qq <- ret %>% tidy(model, type="qq")
+  model_summary <- ret %>% tidy(model, type="model_summary", signif_level=0.1)
+  ret
+})


### PR DESCRIPTION
# Description
Exclude columns that has only less than or equal to 1 unique value after sampling.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
