### PR TITLE
Update argument name for bind_rows and set operations.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1478,7 +1478,7 @@ one_hot <- function(df, key) {
 
 #'Wrapper function for dplyr::bind_rows to support named data frames when it's called inside dplyr chain.
 #'@export
-bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = FALSE) {
+bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_data_type = FALSE) {
   # If the dplyr::bind_rows is called within a dplyr chain like df1 %>% dplyr::bind_rows(list(df_2 = df2, df_3 = df3), .id="id"),
   # since df1 does not have a name, the "id" column of the resulting data frame does not have the data frame name for rows from df1.
   # To workaround this issue, set a name to the first data frame with the value specified by fistLabel argument as a pre-process
@@ -1486,7 +1486,7 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
   dataframes_updated <- list()
   # with dplyr:::flatten_bindable API, create a list of data frames from arguments passed to bind_rows.
   dataframes <- dplyr:::flatten_bindable(rlang::dots_values(...))
-  if(ignore_column_data_type | stringr::str_length(first_id) >0) {
+  if(force_data_type | stringr::str_length(current_df_name) >0) {
     index <- 1;
     # for the case where a user passes a list that contains key (data frame name) and value (data frame) pair.
     if(!is.null(names(dataframes))) {
@@ -1494,12 +1494,12 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
       for (name in names(dataframes)) {
         # for the first item, it's the data frame passed via %>% operator, so it does not have a key (data frame name) yet.
         # so populate the key with the value passed by first_id argument.
-        if(stringr::str_length(first_id) > 0 & index == 1) {
-          # if ignore_column_data_type is set, force character as column data types
-          if(ignore_column_data_type) {
-            dataframes_updated[[first_id]] <- dplyr::mutate_all(dataframes[[1]], funs(as.character))
+        if(stringr::str_length(current_df_name) > 0 & index == 1) {
+          # if force_data_type is set, force character as column data types
+          if(force_data_type) {
+            dataframes_updated[[current_df_name]] <- dplyr::mutate_all(dataframes[[1]], funs(as.character))
           } else {
-            dataframes_updated[[first_id]] <- dataframes[[1]]
+            dataframes_updated[[current_df_name]] <- dataframes[[1]]
           }
         } else {
           # if the key (data frame name) is empty, use index instead.
@@ -1507,7 +1507,7 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
             name = index;
           }
           # force character as column data types
-          if(ignore_column_data_type) {
+          if(force_data_type) {
             dataframes_updated[[name]] <- dplyr::mutate_all(dataframes[[name]], funs(as.character))
           } else {
             dataframes_updated[[name]] <- dataframes[[name]]
@@ -1517,8 +1517,8 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
       }
     } else { # for the case that list does not have key (data frame name), use index number.
       for(i in 1:length(dataframes)) {
-        # if ignore_column_data_type is set, force character as column data types
-        if(ignore_column_data_type) {
+        # if force_data_type is set, force character as column data types
+        if(force_data_type) {
           dataframes_updated[[i]] <- dplyr::mutate_all(dataframes[[i]], funs(as.character))
         } else {
           dataframes_updated[[i]] <- dataframes[[i]]
@@ -1527,13 +1527,13 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
     }
     # create a name for the column that holds data frame name.
     # and make sure to make the column name uniqe with avoid_conflict API.
-    if(!is.null(.id)) {
-      new_id <- avoid_conflict(colnames(dataframes_updated[[1]]), .id)
+    if(!is.null(id_column_name)) {
+      new_id <- avoid_conflict(colnames(dataframes_updated[[1]]), id_column_name)
     } else {
-      new_id  = .id
+      new_id  = id_column_name
     }
     #re-evaluate column data types
-    if(ignore_column_data_type) {
+    if(force_data_type) {
       readr::type_convert(dplyr::bind_rows(dataframes_updated, .id = new_id))
     } else {
       dplyr::bind_rows(dataframes_updated, .id = new_id)
@@ -1541,10 +1541,10 @@ bind_rows <- function(..., .id = NULL, first_id = '', ignore_column_data_type = 
   } else {
     # if .id argument is passed, create a name for the column that holds data frame name.
     # and make sure to make the column name uniqe with avoid_conflict API.
-    if(!is.null(.id)) {
-      new_id <- avoid_conflict(colnames(dataframes[[1]]), .id)
+    if(!is.null(id_column_name)) {
+      new_id <- avoid_conflict(colnames(dataframes[[1]]), id_column_name)
     } else {
-      new_id <- .id
+      new_id <- id_column_name
     }
     dplyr::bind_rows(..., .id = new_id)
   }
@@ -1559,8 +1559,8 @@ set_operation_with_force_character <- function(func, x, y, ...) {
 
 #'Wrapper function for dplyr::union to support ignoring data type difference.
 #'@export
-union <- function(x, y, ignore_column_data_type = FALSE, ...){
-  if(!is.na(ignore_column_data_type) & class(ignore_column_data_type) ==  "logical" & ignore_column_data_type == FALSE)  {
+union <- function(x, y, force_data_type = FALSE, ...){
+  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
     dplyr::union(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::union, x, y, ...)
@@ -1569,8 +1569,8 @@ union <- function(x, y, ignore_column_data_type = FALSE, ...){
 
 #'Wrapper function for dplyr::union_all to support ignoring data type difference.
 #'@export
-union_all <- function(x, y, ignore_column_data_type = FALSE, ...){
-  if(!is.na(ignore_column_data_type) & class(ignore_column_data_type) ==  "logical" & ignore_column_data_type == FALSE)  {
+union_all <- function(x, y, force_data_type = FALSE, ...){
+  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
     dplyr::union_all(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::union_all, x, y, ...)
@@ -1579,8 +1579,8 @@ union_all <- function(x, y, ignore_column_data_type = FALSE, ...){
 
 #'Wrapper function for dplyr::intersect to support ignoring data type difference.
 #'@export
-intersect <- function(x, y, ignore_column_data_type = FALSE, ...){
-  if(!is.na(ignore_column_data_type) & class(ignore_column_data_type) ==  "logical" & ignore_column_data_type == FALSE)  {
+intersect <- function(x, y, force_data_type = FALSE, ...){
+  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
     dplyr::intersect(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::intersect, x, y, ...)
@@ -1589,8 +1589,8 @@ intersect <- function(x, y, ignore_column_data_type = FALSE, ...){
 
 #'Wrapper function for dplyr::setdiff to support ignoring data type difference.
 #'@export
-setdiff <- function(x, y, ignore_column_data_type = FALSE, ...){
-  if(!is.na(ignore_column_data_type) & class(ignore_column_data_type) ==  "logical" & ignore_column_data_type == FALSE)  {
+setdiff <- function(x, y, force_data_type = FALSE, ...){
+  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
     dplyr::setdiff(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::setdiff, x, y, ...)

--- a/R/util.R
+++ b/R/util.R
@@ -1530,13 +1530,13 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
         # check if we can get each data frame name from the arguments
         df_name <- args[[i]]
         if(is.na(df_name) | df_name == "") {
-          # if we cannot find it use index i.
+          # if we cannot find data fram name, use index i instead.
           df_name = i
         }
         # if force_data_type is set, force character as column data types
         if(force_data_type) {
           if(stringr::str_length(current_df_name) > 0) {
-            if(i == 1) {
+            if(i == 1) {  # for the first item, use current_df_name
               dataframes_updated[[current_df_name]] <- dplyr::mutate_all(dataframes[[i]], funs(as.character))
             } else {
               dataframes_updated[[df_name]] <- dplyr::mutate_all(dataframes[[i]], funs(as.character))

--- a/R/util.R
+++ b/R/util.R
@@ -1488,7 +1488,6 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   # only exception is the current data frame which is passed via dplyr pipe operation (%>%).
   # it becomes period (.) instead of actual df name.
   args <- extract_argument_names(...)
-  browser()
   # If the dplyr::bind_rows is called within a dplyr chain like df1 %>% dplyr::bind_rows(list(df_2 = df2, df_3 = df3), .id="id"),
   # since df1 does not have a name, the "id" column of the resulting data frame does not have the data frame name for rows from df1.
   # To workaround this issue, set a name to the first data frame with the value specified by fistLabel argument as a pre-process
@@ -1496,7 +1495,7 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   dataframes_updated <- list()
   # with dplyr:::flatten_bindable API, create a list of data frames from arguments passed to bind_rows.
   dataframes <- dplyr:::flatten_bindable(rlang::dots_values(...))
-  if(force_data_type | stringr::str_length(current_df_name) >0) {
+  if(force_data_type || stringr::str_length(current_df_name) >0) {
     index <- 1;
     # for the case where a user passes a list that contains key (data frame name) and value (data frame) pair.
     if(!is.null(names(dataframes))) {
@@ -1504,7 +1503,7 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
       for (name in names(dataframes)) {
         # for the first item, it's the data frame passed via %>% operator, so it does not have a key (data frame name) yet.
         # so populate the key with the value passed by first_id argument.
-        if(stringr::str_length(current_df_name) > 0 & index == 1) {
+        if(stringr::str_length(current_df_name) > 0 && index == 1) {
           # if force_data_type is set, force character as column data types
           if(force_data_type) {
             dataframes_updated[[current_df_name]] <- dplyr::mutate_all(dataframes[[1]], funs(as.character))
@@ -1529,7 +1528,7 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
       for(i in 1:length(dataframes)) {
         # check if we can get each data frame name from the arguments
         df_name <- args[[i]]
-        if(is.na(df_name) | df_name == "") {
+        if(is.na(df_name) || df_name == "") {
           # if we cannot find data fram name, use index i instead.
           df_name = i
         }
@@ -1593,7 +1592,7 @@ set_operation_with_force_character <- function(func, x, y, ...) {
 #'Wrapper function for dplyr::union to support ignoring data type difference.
 #'@export
 union <- function(x, y, force_data_type = FALSE, ...){
-  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
+  if(!is.na(force_data_type) && class(force_data_type) ==  "logical" && force_data_type == FALSE)  {
     dplyr::union(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::union, x, y, ...)
@@ -1603,7 +1602,7 @@ union <- function(x, y, force_data_type = FALSE, ...){
 #'Wrapper function for dplyr::union_all to support ignoring data type difference.
 #'@export
 union_all <- function(x, y, force_data_type = FALSE, ...){
-  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
+  if(!is.na(force_data_type) && class(force_data_type) ==  "logical" && force_data_type == FALSE)  {
     dplyr::union_all(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::union_all, x, y, ...)
@@ -1613,7 +1612,7 @@ union_all <- function(x, y, force_data_type = FALSE, ...){
 #'Wrapper function for dplyr::intersect to support ignoring data type difference.
 #'@export
 intersect <- function(x, y, force_data_type = FALSE, ...){
-  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
+  if(!is.na(force_data_type) && class(force_data_type) ==  "logical" && force_data_type == FALSE)  {
     dplyr::intersect(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::intersect, x, y, ...)
@@ -1623,7 +1622,7 @@ intersect <- function(x, y, force_data_type = FALSE, ...){
 #'Wrapper function for dplyr::setdiff to support ignoring data type difference.
 #'@export
 setdiff <- function(x, y, force_data_type = FALSE, ...){
-  if(!is.na(force_data_type) & class(force_data_type) ==  "logical" & force_data_type == FALSE)  {
+  if(!is.na(force_data_type) && class(force_data_type) ==  "logical" && force_data_type == FALSE)  {
     dplyr::setdiff(x, y, ...)
   } else {
     set_operation_with_force_character(dplyr::setdiff, x, y, ...)

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -2,9 +2,9 @@ context("check util functions")
 
 test_that("bind_rows", {
   library(dplyr)
-  res <- mtcars %>% exploratory::bind_rows(list(acars = mtcars, bcars = mtcars), .id="dataf", first_id="firstMtcars")
+  res <- mtcars %>% exploratory::bind_rows(list(acars = mtcars, bcars = mtcars), id_column_name="dataf", current_df_name="firstMtcars")
   expect_equal(unique(res$dataf), c("firstMtcars", "acars", "bcars"))
-  res2 <- mtcars %>% exploratory::bind_rows(mtcars, mtcars, .id="dataf", ignore_column_data_type = TRUE)
+  res2 <- mtcars %>% exploratory::bind_rows(mtcars, mtcars, id_column_name="dataf", force_data_type = TRUE)
   expect_equal(unique(res2$dataf), c(1,2,3))
   # For data1, test1 column is factor data type
   data1 <- data.frame(person = c("A","B","C"),
@@ -21,8 +21,8 @@ test_that("bind_rows", {
                       test4 = as.factor(c(15,21,29)),
                       test5 = as.factor(c(54,51,36)))
   # if this is dplyr::bind_rows, it fails because of factor vs character data type mismatch.
-  # but exploratory::bind_rows works if ignore_case argument is set as TRUE.
-  res3 <- exploratory::bind_rows(data1, data2, ignore_column_data_type = TRUE)
+  # but exploratory::bind_rows works if force_data_type is set as TRUE.
+  res3 <- exploratory::bind_rows(data1, data2, force_data_type = TRUE)
   expect_equal(unique(res3$person), c("A","B","C","D","E","F"))
 })
 
@@ -42,7 +42,7 @@ test_that("union", {
                       test3 = c(12.5,12.0,19.5),
                       test4 = as.factor(c(16,21,29)),
                       test5 = as.factor(c(49,51,36)))
-  res <- exploratory::union(x = data1, y = data2, ignore_column_data_type = TRUE)
+  res <- exploratory::union(x = data1, y = data2, force_data_type = TRUE)
   expect_equal(nrow(res), 5)
 })
 
@@ -62,7 +62,7 @@ test_that("union_all", {
                       test3 = c(12.5,12.0,19.5),
                       test4 = as.factor(c(16,21,29)),
                       test5 = as.factor(c(49,51,36)))
-  res <- exploratory::union_all(x = data1, y = data2, ignore_column_data_type = TRUE)
+  res <- exploratory::union_all(x = data1, y = data2, force_data_type = TRUE)
   expect_equal(nrow(res), 6)
 })
 
@@ -82,7 +82,7 @@ test_that("intersect", {
                       test3 = c(12.5,12.0,19.5),
                       test4 = as.factor(c(16,21,29)),
                       test5 = as.factor(c(49,51,36)))
-  res <- exploratory::intersect(x = data1, y = data2, ignore_column_data_type = TRUE)
+  res <- exploratory::intersect(x = data1, y = data2, force_data_type = TRUE)
   expect_equal(nrow(res), 1)
 })
 
@@ -102,7 +102,7 @@ test_that("setdiff", {
                       test3 = c(12.5,12.0,19.5),
                       test4 = as.factor(c(16,21,29)),
                       test5 = as.factor(c(49,51,36)))
-  res <- exploratory::setdiff(x = data1, y = data2, ignore_column_data_type = TRUE)
+  res <- exploratory::setdiff(x = data1, y = data2, force_data_type = TRUE)
   expect_equal(nrow(res), 2)
 })
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -24,6 +24,12 @@ test_that("bind_rows", {
   # but exploratory::bind_rows works if force_data_type is set as TRUE.
   res3 <- exploratory::bind_rows(data1, data2, force_data_type = TRUE)
   expect_equal(unique(res3$person), c("A","B","C","D","E","F"))
+  # test data frames without dedicated names
+  mtcars1 <- mtcars
+  mtcars2 <- mtcars
+  mtcars3 <- mtcars
+  res4 <- mtcars1 %>% exploratory::bind_rows(mtcars2, mtcars3, current_df_name = "mtcars1", id_column_name = "ID")
+  expect_equal(unique(res4$ID), c("mtcars1","mtcars2","mtcars3"))
 })
 
 test_that("union", {


### PR DESCRIPTION
# Description

Argument name update

### .id

Change it to `id_column_nam`

### first_id

Change it to `current_df_name`

### ignore_column_data_type

Change it to `force_data_type`

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
