### PR TITLE
Adjustments for prophet extra regressor

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -403,7 +403,13 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     # Join original aggregated dataframe to forecast dataframe.
     # Extra regressor columns will conflinct in names. We add _effect to the ones from forecast.
     # TODO: Can we safely assume that all conflicts are from extra regressors?
-    ret <- forecast %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"), suffix = c("_effect", ""))
+    # If there is future part of aggregated data, bind it too so that extra regressor values for future are also in the output.
+    if (!is.null(aggregated_future_data)) {
+      ret <- forecast %>% dplyr::full_join(dplyr::bind_rows(aggregated_data, aggregated_future_data), by = c("ds" = "ds"), suffix = c("_effect", ""))
+    }
+    else {
+      ret <- forecast %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"), suffix = c("_effect", ""))
+    }
     # drop cap_scaled column, which is just scaled capacity, which does not seem informative.
     if ("cap_scaled" %in% colnames(ret)) {
       ret <- ret %>% dplyr::select(-cap_scaled)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -198,7 +198,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         # data frames that succeed
         if(is.null(grouped_col) || length(grouped_col) == 0) {
           # Terminology is not consistent here, but we are calling extra regressor "external predictor" on the UI.
-          stop("No future external predictor values to base forecast on is provided.")
+          stop("To make a forecast with external predictor, external predictor values for the future periods to forecast are required. To try forecast with external predictor without future data, use Test Mode.")
         }
       }
 

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -387,7 +387,10 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     if (lubridate::is.Date(aggregated_data$ds)) {
       forecast$ds <- as.Date(forecast$ds)
     }
-    ret <- forecast %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"))
+    # Join original aggregated dataframe to forecast dataframe.
+    # Extra regressor columns will conflinct in names. We add _effect to the ones from forecast.
+    # TODO: Can we safely assume that all conflicts are from extra regressors?
+    ret <- forecast %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"), suffix = c("_effect", ""))
     # drop cap_scaled column, which is just scaled capacity, which does not seem informative.
     if ("cap_scaled" %in% colnames(ret)) {
       ret <- ret %>% dplyr::select(-cap_scaled)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -180,6 +180,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       df <- df[, !colnames(df) %in% grouped_col]
     }
 
+    aggregated_future_data <- NULL
     if (!is.null(regressors)) { # extra regressor case. separate the df into history and future based on the value is filled or not.
       # filter NAs on regressor columns
       df <- df %>% dplyr::filter(!!!filter_args)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -114,6 +114,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     names(summarise_args) <- regressors
   }
 
+  # To filter NAs on regressor columns
   filter_args <- list() # default empty list
   if (!is.null(regressors)) {
     filter_args <- purrr::map(regressors, function(cname) {

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -198,7 +198,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         # data frames that succeed
         if(is.null(grouped_col) || length(grouped_col) == 0) {
           # Terminology is not consistent here, but we are calling extra regressor "external predictor" on the UI.
-          stop("To make a forecast with external predictor, external predictor values for the future periods to forecast are required. To try forecast with external predictor without future data, use Test Mode.")
+          stop("External predictors require future data, or to be run in Test Mode.")
         }
       }
 

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -188,6 +188,18 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       max_floored_date <- max(df[[time_col]])
       future_df <- future_df %>% dplyr::filter(UQ(rlang::sym(time_col)) > max_floored_date)
 
+      if(nrow(future_df) == 0) {
+        # ignore the error if
+        # it is caused by subset of
+        # grouped data frame
+        # to show result of
+        # data frames that succeed
+        if(is.null(grouped_col) || length(grouped_col) == 0) {
+          # Terminology is not consistent here, but we are calling extra regressor "external predictor" on the UI.
+          stop("No future external predictor values to base forecast on is provided.")
+        }
+      }
+
       # TODO: in test mode, this is not really necessary. optimize.
       aggregated_future_data <- future_df %>%
         dplyr::transmute(

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -189,7 +189,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       max_floored_date <- max(df[[time_col]])
       future_df <- future_df %>% dplyr::filter(UQ(rlang::sym(time_col)) > max_floored_date)
 
-      if(nrow(future_df) == 0) {
+      # No future external regressor data is provided. For test mode, this is fine, but when it is not, this is a problem.
+      if(nrow(future_df) == 0 && !test_mode) {
         # ignore the error if
         # it is caused by subset of
         # grouped data frame

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -203,7 +203,8 @@ test_that("do_prophet test mode with extra regressor", {
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", regressors = c("regressor"), funs.aggregate.regressors = c(mean), test_mode = TRUE)
   # verify the last date with forecasted_value
-  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # Since it is test mode, end of original data is end of forecast.
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-01"))
   # verify the last date in the data is the end of regressor data
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -114,9 +114,10 @@ test_that("do_prophet with extra regressor", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", regressors = c("regressor"), funs.aggregate.regressors = c(mean))
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-11"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with extra regressor with holiday column", {
@@ -127,9 +128,10 @@ test_that("do_prophet with extra regressor with holiday column", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", regressors = c("regressor"), funs.aggregate.regressors = c(mean), holiday=holiday)
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-11"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with holiday column", {
@@ -142,9 +144,10 @@ test_that("do_prophet with holiday column", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", holiday=`holi day`)
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-11"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with regressor with holiday column with monthly data", {
@@ -157,9 +160,10 @@ test_that("do_prophet with regressor with holiday column with monthly data", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "month", regressors = c("regressor"), funs.aggregate.regressors = c(mean), holiday=`holi day`)
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-11-01"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with holiday column with hourly data", {
@@ -172,9 +176,10 @@ test_that("do_prophet with holiday column with hourly data", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "hour", holiday=holiday)
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.POSIXct("2010-01-15 10:00:00", tz="UTC"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with extra regressor with cap/floor", {
@@ -185,9 +190,10 @@ test_that("do_prophet with extra regressor with cap/floor", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", cap = 2, floor = -2, regressors = c("regressor"), funs.aggregate.regressors = c(mean))
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-11"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet test mode with extra regressor", {
@@ -200,9 +206,10 @@ test_that("do_prophet test mode with extra regressor", {
   combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "day", regressors = c("regressor"), funs.aggregate.regressors = c(mean), test_mode = TRUE)
-  # verify that the last forecasted_value is not NA
-  expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-01"))
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -175,7 +175,9 @@ test_that("do_prophet with holiday column with hourly data", {
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "hour", holiday=holiday)
   # verify the last date with forecasted_value
-  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.POSIXct("2010-01-15 10:00:00 UTC")) 
+  # Comparing between POSIXct is prone to false positive. 
+  # Comparing between characters is more stable with added bonus of printed evaluation result for easier debugging.
+  expect_equal(as.character(last((ret %>% filter(!is.na(forecasted_value)))$timestamp)), "2010-01-15 10:00:00")
 })
 
 test_that("do_prophet with extra regressor with cap/floor", {

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -146,8 +146,6 @@ test_that("do_prophet with holiday column", {
     do_prophet(timestamp, data, 10, time_unit = "day", holiday=`holi day`)
   # verify the last date with forecasted_value
   expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
-  # verify the last date in the data is the end of regressor data
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })
 
 test_that("do_prophet with regressor with holiday column with monthly data", {

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -175,9 +175,7 @@ test_that("do_prophet with holiday column with hourly data", {
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "hour", holiday=holiday)
   # verify the last date with forecasted_value
-  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
-  # verify the last date in the data is the end of regressor data
-  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.POSIXct("2010-01-15 10:00:00 UTC")) 
 })
 
 test_that("do_prophet with extra regressor with cap/floor", {

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -159,7 +159,7 @@ test_that("do_prophet with regressor with holiday column with monthly data", {
   ret <- combined_data %>%
     do_prophet(timestamp, data, 10, time_unit = "month", regressors = c("regressor"), funs.aggregate.regressors = c(mean), holiday=`holi day`)
   # verify the last date with forecasted_value
-  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-11-01")) 
   # verify the last date in the data is the end of regressor data
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
 })


### PR DESCRIPTION
# Description
Adjustments for prophet extra regressor
- Add _effect suffix to extra regressor effects to avoid name conflict with original data column name.
- Show error when future regressor values are not provided
- Bind future part of aggregated data to the output data

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
