### PR TITLE
bind_rows: added backward compatibility support

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1484,7 +1484,7 @@ extract_argument_names <- function(...) {
 #'Wrapper function for dplyr::bind_rows to support named data frames when it's called inside dplyr chain.
 #'@export
 bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_data_type = FALSE, .id = NULL) {
-  # for backward compatiblity
+  # for compatiblity with dply::bind_rows
   # if old .id argument is passed and id_column_name is NA
   # use old .id argumetn value as id_column_name
   if(!is.null(.id) && is.null(id_column_name)) {

--- a/R/util.R
+++ b/R/util.R
@@ -1483,7 +1483,13 @@ extract_argument_names <- function(...) {
 
 #'Wrapper function for dplyr::bind_rows to support named data frames when it's called inside dplyr chain.
 #'@export
-bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_data_type = FALSE) {
+bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_data_type = FALSE, .id = NULL) {
+  # for backward compatiblity
+  # if old .id argument is passed and id_column_name is NA
+  # use old .id argumetn value as id_column_name
+  if(!is.null(.id) && is.null(id_column_name)) {
+    id_column_name = .id
+  }
   # get a list of argument names to resolve data frame names passed to this bind_rows.
   # only exception is the current data frame which is passed via dplyr pipe operation (%>%).
   # it becomes period (.) instead of actual df name.

--- a/R/util.R
+++ b/R/util.R
@@ -1485,8 +1485,8 @@ extract_argument_names <- function(...) {
 #'@export
 bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_data_type = FALSE, .id = NULL) {
   # for compatiblity with dply::bind_rows
-  # if old .id argument is passed and id_column_name is NA
-  # use old .id argumetn value as id_column_name
+  # if dplyr::bind_rows' .id argument is passed and id_column_name is NA
+  # use dplyr::bind_rows' .id argumetn value as id_column_name
   if(!is.null(.id) && is.null(id_column_name)) {
     id_column_name = .id
   }

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -30,6 +30,9 @@ test_that("bind_rows", {
   mtcars3 <- mtcars
   res4 <- mtcars1 %>% exploratory::bind_rows(mtcars2, mtcars3, current_df_name = "mtcars1", id_column_name = "ID")
   expect_equal(unique(res4$ID), c("mtcars1","mtcars2","mtcars3"))
+  # backward compatibility check
+  res5 <- mtcars1 %>% exploratory::bind_rows(mtcars2, mtcars3, .id = "ID")
+  expect_equal(unique(res5$ID), c("1","2","3"))
 })
 
 test_that("union", {


### PR DESCRIPTION
# Description

Added backward compatibility support for bind_rows

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
