### PR TITLE
Fix for broken is_test_data column for do_prophet with future extra regressor

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -496,6 +496,9 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         }
       }
     }
+    if (test_mode) { # Bring is_test_data column to the last
+      ret <- ret %>% dplyr::select(-is_test_data, is_test_data)
+    }
 
     # revive original column names (time_col, value_col)
     if (time_col != "ds") { # if time_col happens to be "ds", do not do this, since it will make the column name "ds.new".

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -405,7 +405,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
 
     # Add is_test_data column before joining aggregated original data so that the end of forecast is correctly marked as test data.
     if (test_mode) {
-      ret <- forecast %>% dplyr::mutate(is_test_data = seq(1,n()) > n() - periods) # FALSE for training period, TRUE for test period.
+      ret <- forecast %>% dplyr::mutate(is_test_data = dplyr::row_number() > n() - periods) # FALSE for training period, TRUE for test period.
     }
     else {
       ret <- forecast

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -402,15 +402,24 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     if (lubridate::is.Date(aggregated_data$ds)) {
       forecast$ds <- as.Date(forecast$ds)
     }
+
+    # Add is_test_data column before joining aggregated original data so that the end of forecast is correctly marked as test data.
+    if (test_mode) {
+      ret <- forecast %>% dplyr::mutate(is_test_data = seq(1,n()) > n() - periods) # FALSE for training period, TRUE for test period.
+    }
+    else {
+      ret <- forecast
+    }
+
     # Join original aggregated dataframe to forecast dataframe.
     # Extra regressor columns will conflinct in names. We add _effect to the ones from forecast.
     # TODO: Can we safely assume that all conflicts are from extra regressors?
     # If there is future part of aggregated data, bind it too so that extra regressor values for future are also in the output.
     if (!is.null(aggregated_future_data)) {
-      ret <- forecast %>% dplyr::full_join(dplyr::bind_rows(aggregated_data, aggregated_future_data), by = c("ds" = "ds"), suffix = c("_effect", ""))
+      ret <- ret %>% dplyr::full_join(dplyr::bind_rows(aggregated_data, aggregated_future_data), by = c("ds" = "ds"), suffix = c("_effect", ""))
     }
     else {
-      ret <- forecast %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"), suffix = c("_effect", ""))
+      ret <- ret %>% dplyr::full_join(aggregated_data, by = c("ds" = "ds"), suffix = c("_effect", ""))
     }
     # drop cap_scaled column, which is just scaled capacity, which does not seem informative.
     if ("cap_scaled" %in% colnames(ret)) {
@@ -428,10 +437,6 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
     else {
       # there is no changepoint.
       ret <- ret %>% dplyr::mutate(trend_change = NA_real_)
-    }
-
-    if (test_mode) {
-      ret <- ret %>% dplyr::mutate(is_test_data = seq(1,n()) > n() - periods) # FALSE for training period, TRUE for test period.
     }
 
     # adjust order of output columns

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -207,8 +207,12 @@ test_that("do_prophet test mode with extra regressor", {
   # verify the last date with forecasted_value
   # Since it is test mode, end of original data is end of forecast.
   expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-01"))
+  # End of forecast should be test data
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$is_test_data), TRUE)
   # verify the last date in the data is the end of regressor data
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
+  # Unused regressor data should have NA value as is_test_data
+  expect_true(is.na(last((ret %>% filter(!is.na(forecasted_value)))$is_test_data)))
 })
 
 

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -212,7 +212,7 @@ test_that("do_prophet test mode with extra regressor", {
   # verify the last date in the data is the end of regressor data
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2013-01-01"))
   # Unused regressor data should have NA value as is_test_data
-  expect_true(is.na(last((ret %>% filter(!is.na(forecasted_value)))$is_test_data)))
+  expect_true(is.na(last(ret$is_test_data)))
 })
 
 


### PR DESCRIPTION
# Description
- Fix for broken is_test_data column for do_prophet when future extra regressor is included.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
