### PR TITLE
fix Data Source: Could not open an SPSS file and got No method asJSON S3 class: haven_labelled error

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1317,7 +1317,8 @@ scrape_html_table <- function(url, index, heading, encoding = NULL) {
 #' see https://github.com/exploratory-io/tam/issues/1481
 #' @export
 handleLabelledColumns = function(df){
-  is_labelled <- which(lapply(df, class) == "labelled")
+  # check if column class is labelled, have_labelled, etc
+  is_labelled <- which(stringr::str_detect(lapply(df, class), "labelled"))
   df[is_labelled] <- lapply(df[is_labelled], haven::as_factor)
   df
 }

--- a/R/system.R
+++ b/R/system.R
@@ -1317,7 +1317,7 @@ scrape_html_table <- function(url, index, heading, encoding = NULL) {
 #' see https://github.com/exploratory-io/tam/issues/1481
 #' @export
 handleLabelledColumns = function(df){
-  # check if column class is labelled, have_labelled, etc
+  # check if column class is labelled, haven_labelled, etc
   is_labelled <- which(stringr::str_detect(lapply(df, class), "labelled"))
   df[is_labelled] <- lapply(df[is_labelled], haven::as_factor)
   df

--- a/R/system.R
+++ b/R/system.R
@@ -1313,12 +1313,12 @@ scrape_html_table <- function(url, index, heading, encoding = NULL) {
 }
 
 
-#' function to convert labelled class to factoror
-#' see https://github.com/exploratory-io/tam/issues/1481
+#' function to convert labelled class to factor
 #' @export
 handleLabelledColumns = function(df){
   # check if column class is labelled, haven_labelled, etc
-  is_labelled <- which(stringr::str_detect(lapply(df, class), "labelled"))
+  # this causes and
+  is_labelled <- which(lapply(df, class) %in% c("labelled", "haven_labelled"))
   df[is_labelled] <- lapply(df[is_labelled], haven::as_factor)
   df
 }

--- a/R/system.R
+++ b/R/system.R
@@ -1316,8 +1316,8 @@ scrape_html_table <- function(url, index, heading, encoding = NULL) {
 #' function to convert labelled class to factor
 #' @export
 handleLabelledColumns = function(df){
-  # check if column class is labelled, haven_labelled, etc
-  # this causes and
+  # check if column class is labelled or haven_labelled, and conver them to factor.
+  # If labelled or haven_labelled are not converted to factor, appling jsonlite::toJSON to the data frame fails.
   is_labelled <- which(lapply(df, class) %in% c("labelled", "haven_labelled"))
   df[is_labelled] <- lapply(df[is_labelled], haven::as_factor)
   df


### PR DESCRIPTION
# Description

fix Data Source: Could not open an SPSS file and got No method asJSON S3 class: haven_labelled error

Since jsonlite cannot handle haven_labelled class, need to convert it as a factor.

# Checklist

Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
