### PR TITLE
Added new type "daytype" to extract_from_date

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1437,7 +1437,7 @@ extract_from_date <- function(x, type = "fltoyear") {
     wdaylong = {
       ret <- lubridate::wday(x, label=TRUE, abbr=FALSE)
     },
-    daytype = {
+    wdaytype = {
       ret <- dplyr::if_else(is.na(x), NA_character_,
                               #if it's 1: Sun or 7: Sat, assume it's Weekend.
                               dplyr::if_else(lubridate::wday(x, label = F, week_start = "7") %in% c(1,7),  'Weekend', "Weekday"))

--- a/R/util.R
+++ b/R/util.R
@@ -1437,6 +1437,11 @@ extract_from_date <- function(x, type = "fltoyear") {
     wdaylong = {
       ret <- lubridate::wday(x, label=TRUE, abbr=FALSE)
     },
+    daytype = {
+      ret <- dplyr::if_else(is.na(x), NA_character_,
+                              #if it's 1: Sun or 7: Sat, assume it's Weekend.
+                              dplyr::if_else(lubridate::wday(x, label = F, week_start = "7") %in% c(1,7),  'Weekend', "Weekday"))
+    },
     hour = {
       ret <- lubridate::hour(x)
     },

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -686,6 +686,12 @@ test_that("test extract_from_date", {
   expect_equal(ret, as.Date(c("2018-01-01","2018-01-01",NA,NA)))
 })
 
+test_that("test extract_from_date", {
+  data <- as.Date(c("2019-06-16", "2019-06-08", "2019-06-26", NA, NA))
+  ret <- extract_from_date(data, type="daytype")
+  expect_equal(ret, c("Weekend","Weekend", "Weekday", NA, NA))
+})
+
 test_that("test %in_or_all%", {
   ret <- c(1,2,3) %in_or_all% c(1,2)
   expect_equal(ret, c(TRUE, TRUE, FALSE))

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -688,7 +688,7 @@ test_that("test extract_from_date", {
 
 test_that("test extract_from_date", {
   data <- as.Date(c("2019-06-16", "2019-06-08", "2019-06-26", NA, NA))
-  ret <- extract_from_date(data, type="daytype")
+  ret <- extract_from_date(data, type="wdaytype")
   expect_equal(ret, c("Weekend","Weekend", "Weekday", NA, NA))
 })
 


### PR DESCRIPTION
# Description

extract_from_date now has new type "daytype" that returns Weekend if the day is Sat or Sun and Weekday anything else.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
