### PR TITLE
do_prophet: Support logical column for holiday

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -170,8 +170,9 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         dplyr::summarise(holiday = first(holiday[!is.na(holiday)])) %>% # take first non-NA value for aggregation.
         dplyr::filter(!is.na(holiday))
       # If holiday column is logical, create holiday df with only TRUE rows, with single value "Holiday".
-      if (is.logical(holidays_df$holiday)) {
-        holidays_df <- holidays_df %>% dplyr::filter(holiday) %>% dplyr::mutate(holiday = "Holiday")
+      # If it is numeric, first convert to logical (0:FALSE, Others:TRUE), then do the above.
+      if (is.logical(holidays_df$holiday) || is.numeric(holidays_df$holiday)) {
+        holidays_df <- holidays_df %>% dplyr::mutate(holiday = as.logical(holiday)) %>% dplyr::filter(holiday) %>% dplyr::mutate(holiday = "Holiday")
       }
       # Passing empty dataframe causes prophet error: "Column `ds` is of unsupported type NULL". Set it back to NULL if empty.
       if (nrow(holidays_df) == 0) {

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -50,6 +50,7 @@ do_prophet <- function(df, time, value = NULL, periods = 10, holiday = NULL, ...
 do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit = "day", include_history = TRUE, test_mode = FALSE,
                         fun.aggregate = sum, na_fill_type = NULL, na_fill_value = 0,
                         cap = NULL, floor = NULL, growth = NULL, weekly.seasonality = TRUE, yearly.seasonality = TRUE,
+                        daily.seasonality = "auto",
                         holiday_col = NULL, holidays = NULL,
                         regressors = NULL, funs.aggregate.regressors = NULL, ...){
   validate_empty_data(df)
@@ -277,6 +278,10 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
 
     if (time_unit %in% c("week", "month", "quarter", "year")) { # if time_unit is larger than day (the next level is week), having weekly.seasonality does not make sense.
       weekly.seasonality <- FALSE
+      daily.seasonality <- FALSE
+    }
+    else if (time_unit %in% c("day")) { # if time_unit is larger than hour (the next level is day), having daily.seasonality does not make sense.
+      daily.seasonality <- FALSE
     }
     # disabling this logic for now, since setting yearly.seasonality FALSE disables weekly.seasonality too.
     # if (time_unit == "year") { # if time_unit is year (the largest unit), having yearly.seasonality does not make sense.
@@ -340,7 +345,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         growth <- "linear"
         # if future data frame is without cap, use it just as a future data frame.
       }
-      m <- prophet::prophet(training_data, fit = FALSE, growth = growth, weekly.seasonality = weekly.seasonality, yearly.seasonality = yearly.seasonality, holidays = holidays_df, ...)
+      m <- prophet::prophet(training_data, fit = FALSE, growth = growth,
+                            daily.seasonality = daily.seasonality, weekly.seasonality = weekly.seasonality, yearly.seasonality = yearly.seasonality, holidays = holidays_df, ...)
       # add regressors to the model.
       if (!is.null(regressors)) {
         for (regressor in regressors) {
@@ -363,7 +369,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       else {
         growth <- "linear"
       }
-      m <- prophet::prophet(training_data, fit = FALSE, growth = growth, weekly.seasonality = weekly.seasonality, yearly.seasonality = yearly.seasonality, holidays = holidays_df, ...)
+      m <- prophet::prophet(training_data, fit = FALSE, growth = growth,
+                            daily.seasonality = daily.seasonality, weekly.seasonality = weekly.seasonality, yearly.seasonality = yearly.seasonality, holidays = holidays_df, ...)
       if (!is.null(regressors)) {
         for (regressor in regressors) {
           m <- add_regressor(m, regressor)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -169,6 +169,10 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         dplyr::group_by(ds) %>%
         dplyr::summarise(holiday = first(holiday[!is.na(holiday)])) %>% # take first non-NA value for aggregation.
         dplyr::filter(!is.na(holiday))
+      # If holiday column is logical, create holiday df with only TRUE rows, with single value "Holiday".
+      if (is.logical(holidays_df$holiday)) {
+        holidays_df <- holidays_df %>% dplyr::filter(holiday) %>% dplyr::mutate(holiday = "Holiday")
+      }
       # Passing empty dataframe causes prophet error: "Column `ds` is of unsupported type NULL". Set it back to NULL if empty.
       if (nrow(holidays_df) == 0) {
         holidays_df <- NULL

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -148,6 +148,19 @@ test_that("do_prophet with holiday column", {
   expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
 })
 
+test_that("do_prophet with logical holiday column", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  ts2 <- seq.Date(as.Date("2010-01-01"), as.Date("2013-01-01"), by="day")
+  regressor_data <- data.frame(timestamp=ts2, regressor=runif(length(ts2)), holiday=(runif(length(ts2)) > 0.90)) %>%
+    rename(`holi day`=holiday)
+  combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
+  ret <- combined_data %>%
+    do_prophet(timestamp, data, 10, time_unit = "day", holiday=`holi day`)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+})
+
 test_that("do_prophet with regressor with holiday column with monthly data", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="month")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -148,6 +148,20 @@ test_that("do_prophet with holiday column", {
   expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
 })
 
+test_that("do_prophet with factor holiday column", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  ts2 <- seq.Date(as.Date("2010-01-01"), as.Date("2013-01-01"), by="day")
+  regressor_data <- data.frame(timestamp=ts2, regressor=runif(length(ts2)), holiday=if_else(runif(length(ts2)) > 0.90,"holiday",NA_character_)) %>%
+    mutate(holiday=as.factor(holiday)) %>%
+    rename(`holi day`=holiday)
+  combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
+  ret <- combined_data %>%
+    do_prophet(timestamp, data, 10, time_unit = "day", holiday=`holi day`)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+})
+
 test_that("do_prophet with logical holiday column", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))

--- a/tests/testthat/test_prophet.R
+++ b/tests/testthat/test_prophet.R
@@ -161,6 +161,20 @@ test_that("do_prophet with logical holiday column", {
   expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
 })
 
+test_that("do_prophet with numeric holiday column", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  ts2 <- seq.Date(as.Date("2010-01-01"), as.Date("2013-01-01"), by="day")
+  regressor_data <- data.frame(timestamp=ts2, regressor=runif(length(ts2)), holiday=(runif(length(ts2)) > 0.90)) %>%
+    mutate(holiday = as.numeric(holiday)) %>%
+    rename(`holi day`=holiday)
+  combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
+  ret <- combined_data %>%
+    do_prophet(timestamp, data, 10, time_unit = "day", holiday=`holi day`)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-11")) 
+})
+
 test_that("do_prophet with regressor with holiday column with monthly data", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="month")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))

--- a/tests/testthat/test_prophet_2.R
+++ b/tests/testthat/test_prophet_2.R
@@ -39,3 +39,12 @@ test_that("do_prophet with daily POSIXct data with timezone with daylight saving
   # Check that aggretated value at a daylight saving day has a valid value. Once there was an issue that broke this with Anomaly Detection, which has similar logic.
   expect_true(ret$y[200] > 0)
 })
+
+test_that("do_prophet with changepoint.range specified.", {
+  ts <- lubridate::with_tz(as.POSIXct(seq.Date(as.Date("2010-01-01"), as.Date("2010-12-31"), by="day")), tz="America/Los_Angeles")
+  raw_data <- data.frame(timestamp=ts, y=runif(length(ts)))
+  ret <- raw_data %>%
+    do_prophet(timestamp, y, 10, time_unit = "day", na_fill_type = "previous", changepoint.range = 0.95)
+  # Check that last change point is close to the end of data.
+  expect_true((ret %>% filter(!is.na(trend_change)) %>% filter(row_number()==n()))$timestamp > as.Date("2010-12-01"))
+})


### PR DESCRIPTION
# Description
- Support logical, numeric column for holiday
- Disable daily.seasonality when it does not make sense for specified period (“day” or longer)

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
