### PR TITLE
summarize_group : support specifying output group column names

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1988,14 +1988,11 @@ summarize_group <- function(.data, group_cols = NULL, group_funs = NULL, ...){
           rlang::quo(UQ(func)(UQ(rlang::sym(cname))))
         }
       })
-      # create a name list
-      name_list <- purrr::map2(group_funs, group_cols, function(func, cname) {
-        if(is.na(func) || length(func)==0 || func == "none"){
-          cname
-        } else {
-          stringr::str_c(cname, func, sep = "_")
-        }
-      })
+      # Set names of group_by columns in the output.
+      name_list <- names(group_cols) # If names are specified in group_cols, use them for output.
+      if (is.null(name_list)) { # If name is not specified, use original column names.
+        name_list <- group_cols
+      }
       names(groupby_args) <- name_list
       .data %>% dplyr::group_by(!!!groupby_args) %>% summarize(...)
     } else {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -858,8 +858,8 @@ test_that("get_unknown_category_rows_index", {
 })
 
 test_that("summarize_group", {
- df <- mtcars %>% exploratory::summarize_group(group_cols = c("cyl", "mpg"), group_funs = c("none", "mean"), count = n())
- expect_equal(nrow(df),3)
+ df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl", mpg_int10="mpg"), group_funs = c("none", "asintby10"), count = n())
+ expect_equal(nrow(df),5)
  df2 <- mtcars %>% exploratory::summarize_group(group_cols = NULL, group_funs = NULL, count = n())
  expect_equal(nrow(df2),1)
 })


### PR DESCRIPTION
# Description
Support specifying output group column names.
With multibyte column names, composing new column name inside the function does not work well.
Specifying it from outside is more stable, and looks better as an interface to me.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
