### PR TITLE
Handle multicollinearity error from coxph and relaimpo

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -288,6 +288,13 @@ tidy.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
   )
   base_level_table <- xlevels_to_base_level_table(x$xlevels)
   ret <- ret %>% dplyr::left_join(base_level_table, by="term")
+
+  # Rows with NA estimates are due to perfect multicollinearity. Explain it in Note column.
+  # https://www.rdocumentation.org/packages/survival/versions/2.44-1.1/topics/coxph - Take a look at explanation for singular.ok.
+  if (any(is.na(ret$estimate))) {
+    ret <- ret %>% dplyr::mutate(note=if_else(is.na(estimate), "Dropped most likely due to perfect multicollinearity.", NA_character_))
+  }
+
   if (pretty.name){
     colnames(ret)[colnames(ret) == "term"] <- "Term"
     colnames(ret)[colnames(ret) == "statistic"] <- "t Ratio"
@@ -298,6 +305,7 @@ tidy.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
     colnames(ret)[colnames(ret) == "conf.high"] <- "Conf High"
     colnames(ret)[colnames(ret) == "hazard_ratio"] <- "Hazard Ratio"
     colnames(ret)[colnames(ret) == "base.level"] <- "Base Level"
+    colnames(ret)[colnames(ret) == "note"] <- "Note"
   } else {
     colnames(ret)[colnames(ret) == "statistic"] <- "t_ratio"
     colnames(ret)[colnames(ret) == "p.value"] <- "p_value"

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -551,7 +551,7 @@ build_lm.fast <- function(df,
                                                                                       diff = FALSE),
                                                                 bty = relimp_bootstrap_type, level = relimp_conf_level)
           }, error = function(e){
-            # This can fail when columns are not linearly independent. Record error and keep going. TODO: Show error in summary table.
+            # This can fail when columns are not linearly independent. Record error and keep going.
             model$relative_importance <<- e
           })
         }

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -551,7 +551,8 @@ build_lm.fast <- function(df,
                                                                                       diff = FALSE),
                                                                 bty = relimp_bootstrap_type, level = relimp_conf_level)
           }, error = function(e){
-            # This can fail when columns are not linearly independent. Keep going. TODO: Show error in summary table.
+            # This can fail when columns are not linearly independent. Record error and keep going. TODO: Show error in summary table.
+            model$relative_importance <- e
           })
         }
       }

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -795,6 +795,8 @@ tidy.lm_exploratory <- function(x, type = "coefficients", pretty.name = FALSE, .
       ret
     },
     relative_importance = {
+      # We are checking if it is of error class, since in build_lm.fast, if calculation of relative importance fails, we set the returned error
+      # so that we can report the error in Summary table (return from tidy()).
       if (!is.null(x$relative_importance) && "error" %nin% class(x$relative_importance)) {
         # Add columns for relative importance. NA for the first row is for the row for intercept.
         term <- x$relative_importance$namen[2:length(x$relative_importance$namen)] # Skip first element, which is the target variable name.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -645,6 +645,8 @@ glance.lm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
   # Drop sigma in favor of rmse.
   ret <- ret %>% dplyr::select(r.squared, adj.r.squared, rmse, everything(), -sigma)
 
+  # We are checking if it is of error class, since in build_lm.fast, if calculation of relative importance fails, we set the returned error
+  # so that we can report the error in Summary table (return from tidy()).
   if (!is.null(x$relative_importance) && "error" %in% class(x$relative_importance)) {
     note <- x$relative_importance$message
     if (note == "covg must be \n a positive definite covariance matrix \n or a data matrix / data frame with linearly independent columns.") {

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -654,7 +654,9 @@ glance.lm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
   }
 
   if(pretty.name) {
-    ret <- ret %>% dplyr::rename(`R Squared`=r.squared, `Adj R Squared`=adj.r.squared, `RMSE`=rmse, `F Ratio`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Log Likelihood`=logLik, Deviance=deviance, `Residual DF`=df.residual, Note=note)
+    ret <- ret %>% dplyr::rename(`R Squared`=r.squared, `Adj R Squared`=adj.r.squared, `RMSE`=rmse, `F Ratio`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Log Likelihood`=logLik, Deviance=deviance, `Residual DF`=df.residual)
+    # Note column might not exist. Rename if it is there.
+    colnames(ret)[colnames(ret) == "note"] <- "Note"
   }
   ret
 }


### PR DESCRIPTION
# Description
Handle multicollinearity error from coxph and relaimpo.
Show message in Note column of summary table (relaimpo case) or coefficients table  (coxph case).

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
