### PR TITLE
Update is_alphabet to handle non-ascii characters properly.

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -46,7 +46,7 @@ is_alphabet <- function(word){
   loadNamespace("stringr")
   # To treat non-ascii characters as FALSE, use [a-zA-Z]
   # instead of [:alpha:]
-  stringr::str_detect(word, "^[[a-zA-Z]]+$")
+  stringr::str_detect(word, "^[a-zA-Z]+$")
 }
 
 #' Get vector of stopwords

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -44,7 +44,9 @@ is_digit <- function(word){
 #' @export
 is_alphabet <- function(word){
   loadNamespace("stringr")
-  stringr::str_detect(word, "^[[:alpha:]]+$")
+  # To treat non-ascii characters as FALSE, use [a-zA-Z]
+  # instead of [:alpha:]
+  stringr::str_detect(word, "^[[a-zA-Z]]+$")
 }
 
 #' Get vector of stopwords


### PR DESCRIPTION
# Description

Switched regular expression so that is_alphabet returns FALSE for non-ASCII characters.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
