### PR TITLE
T-Test/ANOVA: Handle single category in group

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -786,7 +786,9 @@ exp_anova <- function(df, var1, var2, func2 = NULL, sig.level = 0.05, f = NULL, 
 
   anova_each <- function(df) {
     if(length(grouped_cols) > 0) {
-      n_distinct_res_each <- n_distinct(df[[var2_col]]) # check n_distinct again within group.
+      # Check n_distinct again within group.
+      # Group with NA and another category does not seem to work well with aov. Eliminating such case too. TODO: We could replace NA with an explicit level.
+      n_distinct_res_each <- n_distinct(df[[var2_col]], na.rm=TRUE)
       if (n_distinct_res_each < 2) {
         return(NULL)
       }

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -378,8 +378,8 @@ glance.chisq_exploratory <- function(x) {
         power_res <- pwr::pwr.chisq.test(df = x$parameter, N = N, w = x$cohens_w_to_detect, sig.level = x$sig.level)
         power_val <- power_res$power
       }, error = function(e) {
-        note <- e$message
-        power_val <- NA_real_
+        note <<- e$message
+        power_val <<- NA_real_
       })
     }
     else {
@@ -401,8 +401,8 @@ glance.chisq_exploratory <- function(x) {
       power_res <- pwr::pwr.chisq.test(df = x$parameter, w = x$cohens_w_to_detect, sig.level = x$sig.level, power = x$power)
       required_sample_size <- power_res$N
     }, error = function(e) {
-      note <- e$message
-      required_sample_size <- NA_real_
+      note <<- e$message
+      required_sample_size <<- NA_real_
     })
     ret <- ret %>% dplyr::mutate(w=!!(x$cohens_w), power=!!(x$power), beta=1.0-!!(x$power), current_sample_size=!!N, required_sample_size=!!required_sample_size)
     ret <- ret %>% rename(`Chi-Square`=statistic,
@@ -555,7 +555,7 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
         power_val <- power_res$power
       }, error = function(e) {
         note <- e$message
-        power_val <- NA_real_
+        power_val <<- NA_real_
       })
 
       ret <- ret %>% dplyr::select(statistic, p.value, parameter, estimate, conf.high, conf.low) %>%
@@ -577,8 +577,8 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
         power_res <- pwr::pwr.t.test(d = x$cohens_d_to_detect, sig.level = x$sig.level, power = x$power, alternative = x$alternative)
         required_sample_size <- power_res$n
       }, error = function(e) {
-        note <- e$message
-        required_sample_size <- NA_real_
+        note <<- e$message
+        required_sample_size <<- NA_real_
       })
       ret <- ret %>% dplyr::select(statistic, p.value, parameter, estimate, conf.high, conf.low) %>%
         dplyr::mutate(d=!!(x$cohens_d), power=!!(x$power), beta=1.0-!!(x$power)) %>%
@@ -859,8 +859,8 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95) {
         power_res <- pwr::pwr.anova.test(k = k, n= min_n_rows, f = x$cohens_f_to_detect, sig.level = x$sig.level)
         power_val <- power_res$power
       }, error = function(e) {
-        note <- e$message
-        power_val <- NA_real_
+        note <<- e$message
+        power_val <<- NA_real_
       })
       ret <- ret %>% dplyr::select(term, statistic, p.value, df, sumsq, meansq) %>%
         dplyr::mutate(f=c(!!(x$cohens_f), NA_real_), power=c(!!power_val, NA_real_), beta=c(1.0-!!power_val, NA_real_)) %>%
@@ -880,8 +880,8 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95) {
         power_res <- pwr::pwr.anova.test(k = k, f = x$cohens_f_to_detect, sig.level = x$sig.level, power = x$power)
         required_sample_size <- power_res$n
       }, error = function(e) {
-        note <- e$message
-        required_sample_size <- NA_real_
+        note <<- e$message
+        required_sample_size <<- NA_real_
       })
       ret <- ret %>% dplyr::select(term, statistic, p.value, df, sumsq, meansq) %>%
         dplyr::mutate(f=c(!!(x$cohens_f), NA_real_), power=c(!!(x$power), NA_real_), beta=c(1.0-!!(x$power), NA_real_)) %>%

--- a/tests/testthat/test_test_wrapper_4.R
+++ b/tests/testthat/test_test_wrapper_4.R
@@ -28,7 +28,7 @@ test_that("exp_ttest with groups with only single category", {
 
 test_that("exp_anova with groups with only single category", {
   flight_by_carrier <- flight %>% dplyr::group_by(`CAR RIER`)
-  model_df <- flight_by_carrier %>% filter(!is.na(`is UA or AA`)) %>% exp_anova(`ARR DELAY`, `is UA or AA`)
+  model_df <- flight_by_carrier %>% exp_anova(`ARR DELAY`, `is UA or AA`)
   res <- model_df %>% tidy(model, type="model")
   res <- model_df %>% tidy(model, type="data")
   res <- model_df %>% tidy(model, type="data_summary", conf_level=0.95)
@@ -46,12 +46,11 @@ test_that("exp_wilcox with groups with only single category", {
 
 test_that("exp_kruskal with groups with only single category", {
   flight_by_carrier <- flight %>% dplyr::group_by(`CAR RIER`)
-  model_df <- flight_by_carrier %>% filter(!is.na(`is UA or AA`)) %>% exp_kruskal(`ARR DELAY`, `is UA or AA`)
+  model_df <- flight_by_carrier %>% exp_kruskal(`ARR DELAY`, `is UA or AA`)
   res <- model_df %>% tidy(model, type="model")
   res <- model_df %>% tidy(model, type="data")
   res <- model_df %>% tidy(model, type="data_summary", conf_level=0.95)
   expect_true(is.data.frame(res)) #TODO: better expectation
 })
-
 
 


### PR DESCRIPTION
# Description
Handle case with single category within group.
From T-test, ANOVA:  got error with Repeat By when group has only one category.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
