### PR TITLE
Fix for flipped ranger binary prediction probability

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -197,7 +197,15 @@ rangerCore <- function(data, formula, na.action = na.omit,
   target_col <- colnames(data)[target_col_index]
 
   if(model_type %in% c("classification_binary", "classification_multi")){
-    data[[target_col]] <- as.factor(data[[target_col]])
+    if (is.logical(data[[target_col]])) {
+      # Convert logical to factor to make it work with ranger.
+      # For ranger, we consider the first level to be TRUE. So set levels that way.
+      # Keep this logic consistent with get_binary_predicted_value_from_probability and augment.ranger.classification
+      data[[target_col]] <- factor(data[[target_col]], levels=c("TRUE","FALSE"))
+    }
+    else {
+      data[[target_col]] <- as.factor(data[[target_col]])
+    }
   }
 
   if(!is.logical(original_val) &&


### PR DESCRIPTION
# Description
Fix following issues.
- Flipped predicted probability from ranger analytics view (calc_feature_imp)
- Flipped logical prediction from ranger step
- Flipped binary factor prediction from ranger step
- Fix flipped ROC on test data summary of rpart analytics view

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
