### PR TITLE
fix MailChimp date parameter issue.

### DIFF
--- a/R/get_mailchimp_data.R
+++ b/R/get_mailchimp_data.R
@@ -250,7 +250,7 @@ export_members <- function(id, dc, apikey, date_since){
     body = list(
       apikey = apikey,
       id = id,
-      since = date_since
+      since = as.character(date_since)
     )
   )
   text <- httr::content(res, as = "text")
@@ -304,7 +304,7 @@ export_activity <- function(id, dc, apikey, date_since, include_empty){
       apikey = apikey,
       id = id,
       include_empty = include_empty,
-      since = date_since
+      since = as.character(date_since)
     )
   )
   text <- httr::content(res, as = "text")

--- a/R/get_mailchimp_data.R
+++ b/R/get_mailchimp_data.R
@@ -245,6 +245,7 @@ access_api <- function(query, dc, apikey, endpoint){
 #' @param date_since From when members data should be returned
 export_members <- function(id, dc, apikey, date_since){
   url <- paste0("https://", dc, ".api.mailchimp.com/export/1.0/list/", sep = "")
+  # For "since" parameter, it needs to be character instead of Date.
   res <- httr::POST(
     url,
     body = list(
@@ -298,6 +299,7 @@ export_members <- function(id, dc, apikey, date_since){
 #' @param include_empty  If set to TRUE, a record for every email address sent to will be returned even if there is no activity data
 export_activity <- function(id, dc, apikey, date_since, include_empty){
   url <- paste0("https://", dc, ".api.mailchimp.com/export/1.0/campaignSubscriberActivity/", sep = "")
+  # For "since" parameter, it needs to be character instead of Date.
   res <- httr::POST(
     url,
     body = list(


### PR DESCRIPTION
# Description

This PR addresses the issue that MailChimp data source gives the following error when Date parameter is set.

```r
R error: Error in curl::handle_setform(handle, .list = req$fields) : 
  Unsupported value type for form field 'since'.
```

I checked Stirpe Data Source and other data sources and this is the only place that `httr:POST` is used and needs this treatment.  For other Data Sources, date parameter is embedded inside the query string so it's already taken care of.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
