### PR TITLE
Use correct ranger training prediction

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -706,8 +706,10 @@ prediction_binary <- function(df, threshold = 0.5, ...){
     }
   } else if (is.character(actual_val)) {
     if ("ranger" %in% class(first_model)) {
+      # In case of ranger, TRUE corresponds to 1st factor level.
       if_else(predicted, levels(first_model$y)[[1]], levels(first_model$y)[[2]])
       lev <- levels(first_model$y)
+      # TRUE turns into 1 by as.numeric, which makes the index of lev 1. (2-1). FALSE makes the index 2.
       factor(lev[2 - as.numeric(predicted)], lev)
     }
     else if(!is.null(first_model$model) && !is.null(first_model$model[[actual_col]])){

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -950,7 +950,7 @@ augment.ranger.regression <- function(x, data = NULL, newdata = NULL, data_type 
       training = {
         predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
         # Inserting once removed NA rows
-        predicted <- restore_na(x$predictions, x$na.action)
+        predicted <- restore_na(x$prediction_training$predictions, x$na.action)
         data[[predicted_value_col]] <- predicted
         data
       },
@@ -2062,6 +2062,7 @@ calc_feature_imp <- function(df,
         sample.fraction = sample.fraction,
         probability = (classification_type %in% c("multi", "binary"))
       )
+      rf$prediction_training <- predict(rf, model_df)
 
       if (test_rate > 0) {
         na_row_numbers_test <- ranger.find_na(c_cols, data = df_test)
@@ -2481,9 +2482,15 @@ glance.ranger <- function(x, pretty.name = FALSE, ...) {
 
 #' @export
 glance.ranger.regression <- function(x, pretty.name, ...) {
+  predicted <- x$prediction_training$predictions
+  actual <- x$df[[all.vars(x$formula_terms)[1]]]
+  root_mean_square_error <- rmse(predicted, actual)
+  rsq <- r_squared(actual, predicted)
   ret <- data.frame(
-    root_mean_square_error = sqrt(x$prediction.error),
-    r_squared = x$r.squared
+    # root_mean_square_error = sqrt(x$prediction.error),
+    # r_squared = x$r.squared
+    root_mean_square_error = root_mean_square_error,
+    r_squared = rsq
   )
 
   if(pretty.name){

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -861,7 +861,7 @@ augment.ranger.classification <- function(x, data = NULL, newdata = NULL, data_t
     switch(data_type,
       training = {
         predicted_label_nona <- ranger.predict_value_from_prob(x$forest$levels,
-                                                               x$predictions,
+                                                               x$prediction_training$predictions,
                                                                y_value, threshold = threshold)
         predicted_value <- restore_na(predicted_label_nona, x$na.action)
       },
@@ -879,7 +879,7 @@ augment.ranger.classification <- function(x, data = NULL, newdata = NULL, data_t
       switch(data_type,
         training = {
           # append predicted probability
-          predictions <- x$predictions
+          predictions <- x$prediction_training$predictions
           # With ranger, 1st category always is the one to be considered "TRUE",
           # and the probability for it is the probability for the binary classification.
           # Keep this logic consistent with get_binary_predicted_value_from_probability
@@ -900,8 +900,8 @@ augment.ranger.classification <- function(x, data = NULL, newdata = NULL, data_t
       switch(data_type,
         training = {
           # Inserting once removed NA rows
-          predicted_prob <- restore_na(apply(x$predictions, 1 , max), x$na.action)
-          data <- ranger.set_multi_predicted_values(data, x$predictions, predicted_value, x$na.action)
+          predicted_prob <- restore_na(apply(x$prediction_training$predictions, 1 , max), x$na.action)
+          data <- ranger.set_multi_predicted_values(data, x$prediction_training$predictions, predicted_value, x$na.action)
         },
         test = {
           # Inserting once removed NA rows

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2137,7 +2137,8 @@ calc_feature_imp <- function(df,
       imp_vars <- imp_vars[1:min(length(imp_vars), max_pd_vars)] # take max_pd_vars most important variables
       imp_vars <- as.character(imp_vars) # for some reason imp_vars is converted to factor at this point. turn it back to character.
       rf$imp_vars <- imp_vars
-      rf$partial_dependence <- edarf::partial_dependence(rf, vars=imp_vars, data=model_df, n=c(20,20))
+      # Second element of n argument needs to be less than or equal to sample size, to avoid error.
+      rf$partial_dependence <- edarf::partial_dependence(rf, vars=imp_vars, data=model_df, n=c(20, min(rf$num.samples, 20)))
 
       # these attributes are used in tidy of randomForest
       rf$classification_type <- classification_type

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2491,7 +2491,7 @@ glance.ranger <- function(x, pretty.name = FALSE, ...) {
 #' @export
 glance.ranger.regression <- function(x, pretty.name, ...) {
   predicted <- x$prediction_training$predictions
-  actual <- x$df[[all.vars(x$formula_terms)[1]]]
+  actual <- x$y
   root_mean_square_error <- rmse(predicted, actual)
   rsq <- r_squared(actual, predicted)
   ret <- data.frame(

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -510,9 +510,9 @@ glance.randomForest.classification <- function(x, pretty.name = FALSE,  ...) {
     )
 
     names(ret) <- if(pretty.name){
-      paste(class, c("F Score", "Precision", "Misclassification Rate", "Recall", "Accuracy"), sep = " ")
+      paste(class, c("F Score", "Accuracy", "Misclassification Rate", "Precision", "Recall"), sep = " ")
     } else {
-      paste(class, c("f_score", "precision", "misclassification_rate", "recall", "accuracy"), sep = "_")
+      paste(class, c("f_score", "accuracy", "misclassification_rate", "precision", "recall"), sep = "_")
     }
     ret
   }
@@ -2570,7 +2570,7 @@ glance.ranger.classification <- function(x, pretty.name, ...) {
     accuracy <- (tp + tn) / (tp + tn + fp + fn)
     f_score <- 2 * ((precision * recall) / (precision + recall))
 
-    ret <- data.frame(f_score, precision, 1 - precision, recall, accuracy)
+    ret <- data.frame(f_score, accuracy, 1 - accuracy, precision, recall)
     names(ret) <- if (pretty.name) {
       c("F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall")
     } else {

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -62,7 +62,38 @@ test_that("calc_feature_map(binary) evaluate training and test", {
   expect_equal(nrow(ret), 4) # 4 for train/test times TRUE/FALSE
 
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
+  model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
+                calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
+  ret <- model_df %>% prediction(data="training_and_test")
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  expect_equal(nrow(train_ret), 5000)
 
+  ret <- rf_evaluation_training_and_test(model_df)
+  expect_equal(nrow(ret), 1) # 1 for train
+
+  ret <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class")
+  ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
+})
+
+test_that("calc_feature_map(binary(factor)) evaluate training and test", {
+  # `is delayed` is not logical for some reason.
+  # To test binary prediction, need to cast it into logical.
+  model_df <- flight %>% dplyr::mutate(is_delayed = factor(as.logical(`is delayed`))) %>% filter(!is.na(is_delayed)) %>%
+                calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0.3)
+
+  ret <- model_df %>% prediction(data="training_and_test")
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1500) Fails now, since we filter numeric NA. Revive when we do not need to.
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3500) Fails now, since we filter numeric NA. Revive when we do not need to.
+
+  ret <- rf_evaluation_training_and_test(model_df, pretty.name=T, binary_classification_threshold=0.5)
+  expect_equal(nrow(ret), 2) # 2 for train and test
+
+  ret <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class")
+  expect_equal(nrow(ret), 4) # 4 for train/test times TRUE/FALSE
+
+  ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
   model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
                 calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
   ret <- model_df %>% prediction(data="training_and_test")
@@ -134,4 +165,3 @@ test_that("calc_feature_map(multi) evaluate training and test", {
   ret <- rf_evaluation_training_and_test(model_df)
   expect_equal(nrow(ret), 1) # 1 for train
 })
-

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -46,7 +46,7 @@ test_that("exp_rpart(regression) evaluate training and test", {
 
 test_that("exp_rpart(binary) evaluate training and test", {
   model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
-                exp_rpart(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0.3)
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
 
   ret <- model_df %>% prediction(data="training_and_test")
   test_ret <- ret %>% filter(is_test_data==TRUE)
@@ -54,7 +54,7 @@ test_that("exp_rpart(binary) evaluate training and test", {
   train_ret <- ret %>% filter(is_test_data==FALSE)
   # expect_equal(nrow(train_ret), 3461) # Not very stable for some reason. Will revisit.
 
-  ret <- rf_evaluation_training_and_test(model_df)
+  ret <- model_df %>% rf_evaluation_training_and_test()
   expect_equal(nrow(ret), 2) # 2 for train and test
 
   # Training only case


### PR DESCRIPTION
# Description
- As training prediction result from ranger, use prediction explicitly done with training data, instead of the one extracted from model, which is a worse prediction than the one done explicitly.
- Avoid edarf error from too small a sample size
- Correct wrong labels of metrics from glance.ranger and glance.randomForest
- Correct handling of which category becomes TRUE for ranger/rpart


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
