### PR TITLE
fix Data Wrangling: summarize_group should ungroup at the end to prevent unexpected group_by effect

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1994,10 +1994,12 @@ summarize_group <- function(.data, group_cols = NULL, group_funs = NULL, ...){
         name_list <- group_cols
       }
       names(groupby_args) <- name_list
-      .data %>% dplyr::group_by(!!!groupby_args) %>% summarize(...)
+      # make sure to ungroup result
+      .data %>% dplyr::group_by(!!!groupby_args) %>% summarize(...) %>% dplyr::ungroup()
     } else {
       if(!is.null(group_cols)) { # In case only group_by columns are provied, group_by with the columns
-        .data %>% dplyr::group_by(!!!rlang::sym(group_cols)) %>% summarize(...)
+        # make sure to ungroup result
+        .data %>% dplyr::group_by(!!!rlang::sym(group_cols)) %>% summarize(...) %>% dplyr::ungroup()
       } else { # In case no group_by columns are provided,skip group_by
         .data %>% summarize(...)
       }


### PR DESCRIPTION
# Description

When there are more than 2 group columns passed to summarize_group, group effect remains in the result but this would confuse users so we want to ungroup at the end of summarize_group.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
