### PR TITLE
Logistic/Linear Regression: Pre-filter date NA rows. Do relimp only with multiple predictors

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -542,7 +542,7 @@ build_lm.fast <- function(df,
         }
 
         model <- stats::lm(fml, data = df) 
-        if (relimp) {
+        if (relimp && length(c_cols) > 1) { # relimp seems to work only when there are multiple predictors, which makes sense since it is "relative".
           tryCatch({
             # Calculate relative importance.
             model$relative_importance <- relaimpo::booteval.relimp(relaimpo::boot.relimp(model, type = relimp_type,

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -329,10 +329,11 @@ build_lm.fast <- function(df,
       # to be done before factor level adjustments. Because of that, the for statement below has to
       # be separate from the for statement after that, and done first.
       for(col in clean_cols){
-        if(is.numeric(df[[col]])) {
-          # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
+        if(is.numeric(df[[col]]) || lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {
+          # For numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
           # if the remaining rows are with single value in any predictor column.
-          # filter Inf/-Inf too to avoid error at lm.
+          # Filter Inf/-Inf too to avoid error at lm.
+          # Do the same for Date/POSIXct, because we will create numeric columns from them.
           df <- df %>% dplyr::filter(!is.na(df[[col]]) & !is.infinite(df[[col]]))
         }
       }

--- a/tests/testthat/test_lm_3.R
+++ b/tests/testthat/test_lm_3.R
@@ -1,0 +1,34 @@
+# how to run this test:
+# devtools::test(filter="lm_1")
+
+context("lm/glm negative test")
+
+testdata_dir <- "~/.exploratory/"
+testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
+testdata_file_path <- paste0(testdata_dir, testdata_filename)
+
+filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
+  "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"
+} else {
+  testdata_file_path
+}
+
+flight <- exploratory::read_delim_file(filepath, ",", quote = "\"", skip = 0 , col_names = TRUE , na = c("","NA") , locale=readr::locale(encoding = "UTF-8", decimal_mark = "."), trim_ws = FALSE , progress = FALSE) %>% exploratory::clean_data_frame()
+
+if (!testdata_filename %in% list.files(testdata_dir)) {
+  set.seed(1)
+  flight <- flight %>% sample_n(5000)
+  write.csv(flight, testdata_file_path) # save sampled-down data for performance.
+}
+
+test_that("build_lm.fast (linear regression) with single predictor should skip relative importance", {
+  model_df <- flight %>%
+                build_lm.fast(`ARR DELAY`, `CAR RIER`, test_rate = 0.3, seed=1, relimp = TRUE, relimp_type = "first", relimp_bootstrap_type = "perc")
+
+  # Just running prediction.
+  ret <- model_df %>% prediction(data="training_and_test")
+
+  ret <- model_df %>% evaluate_lm_training_and_test(pretty.name=TRUE)
+  expect_true("Note" %nin% names(ret)) # There should *not* be the Note column with error.
+})
+

--- a/tests/testthat/test_lm_3.R
+++ b/tests/testthat/test_lm_3.R
@@ -21,11 +21,23 @@ if (!testdata_filename %in% list.files(testdata_dir)) {
   write.csv(flight, testdata_file_path) # save sampled-down data for performance.
 }
 
+test_that("build_lm.fast (logistic regression) with marginal effect with NA Date value for an entire category", {
+  # There used to be an issue where marginal effect throws error because of unused factor level. This is handled now by pre-filtering rows with NA Date values.
+  df <- flight %>% mutate(`FL DATE`=if_else(`CAR RIER`!="UA",`FL DATE`,as.Date(NA)))
+  model_df <- df %>%
+                build_lm.fast(`is delayed`, `CAR RIER`, `FL DATE`, model_type = "glm", test_rate = 0.3, variable_metric = "ame", with_marginal_effects_confint = FALSE)
+
+  # Just run prediction etc. for sanity.
+  ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)
+  ret <- model_df %>% evaluate_binary_training_and_test("is delayed", pretty.name=TRUE)
+  ret <- model_df %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
+})
+
 test_that("build_lm.fast (linear regression) with single predictor should skip relative importance", {
   model_df <- flight %>%
                 build_lm.fast(`ARR DELAY`, `CAR RIER`, test_rate = 0.3, seed=1, relimp = TRUE, relimp_type = "first", relimp_bootstrap_type = "perc")
 
-  # Just running prediction.
+  # Just run prediction for sanity.
   ret <- model_df %>% prediction(data="training_and_test")
 
   ret <- model_df %>% evaluate_lm_training_and_test(pretty.name=TRUE)


### PR DESCRIPTION
# Description
- Pre-filter date NA rows to avoid error from marginal effect, which does not allow unused factor level.
- Do relative importance only with multiple predictors to avoid error.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
