### PR TITLE
lm/glm Japanese column name garble issue

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -293,6 +293,7 @@ build_lm.fast <- function(df,
   else {
     # Cleaning of column names for marginal_effects(). Space is not handled well. Replace them with '.'.
     # Also, cleaning of column names for relaimpo. - is not handled well. Replace them with _.
+    # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
     # names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
     names(clean_df) <- gsub('\\-', '_', gsub(' ', '.', names(df)))
   }
@@ -925,7 +926,8 @@ augment.lm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = "
       },
       test = {
         # Minic broom:::augment.lm behavior of replacing spaces in column names. Without this, after bind_row in prediction(), such columns will end up in 2 separate columns.
-        #names(data) <- stringr::str_replace_all(names(data), ' ', '.')
+        # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
+        # names(data) <- stringr::str_replace_all(names(data), ' ', '.')
         names(data) <- gsub(' ', '.', names(data))
         # Augment data with already predicted result in the model.
         data$.fitted <- restore_na(x$prediction_test$fit, x$prediction_test$unknown_category_rows_index)
@@ -996,7 +998,8 @@ evaluate_lm_training_and_test <- function(df, pretty.name = FALSE){
         m <- df %>% filter(!is.null(model)) %>% `[[`(1, "model", 1)
         actual_val_col <- all.vars(df$model[[1]]$terms)[[1]]
         # Emulate the way lm replaces the column names in the output.
-        #actual_val_col_clean <- stringr::str_replace_all(actual_val_col, ' ', '.')
+        # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
+        # actual_val_col_clean <- stringr::str_replace_all(actual_val_col, ' ', '.')
         actual_val_col_clean <- gsub(' ', '.', actual_val_col)
 
         actual <- test_pred_ret[[actual_val_col_clean]]

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -22,7 +22,9 @@ calc_average_marginal_effects <- function(model, data=NULL, with_confint=FALSE) 
     else {
       me <- margins::marginal_effects(model)
     }
-    term <- stringr::str_replace(names(me), "^dydx_", "")
+    # For some reason, str_replace garbles column names generated from Date column with Japanese name. Using gsub instead to avoid the issue.
+    # term <- stringr::str_replace(names(me), "^dydx_", "")
+    term <- gsub("^dydx_", "", names(me))
     ame <- purrr::flatten_dbl(purrr::map(me, function(x){mean(x, na.rm=TRUE)}))
     ret <- data.frame(term=term, ame=ame)
     ret

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -293,7 +293,8 @@ build_lm.fast <- function(df,
   else {
     # Cleaning of column names for marginal_effects(). Space is not handled well. Replace them with '.'.
     # Also, cleaning of column names for relaimpo. - is not handled well. Replace them with _.
-    names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
+    # names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
+    names(clean_df) <- gsub('\\-', '_', gsub(' ', '.', names(df)))
   }
   # this mapping will be used to restore column names
   name_map <- colnames(clean_df)
@@ -924,7 +925,8 @@ augment.lm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = "
       },
       test = {
         # Minic broom:::augment.lm behavior of replacing spaces in column names. Without this, after bind_row in prediction(), such columns will end up in 2 separate columns.
-        names(data) <- stringr::str_replace_all(names(data), ' ', '.')
+        #names(data) <- stringr::str_replace_all(names(data), ' ', '.')
+        names(data) <- gsub(' ', '.', names(data))
         # Augment data with already predicted result in the model.
         data$.fitted <- restore_na(x$prediction_test$fit, x$prediction_test$unknown_category_rows_index)
         data$.se.fit <- restore_na(x$prediction_test$se.fit, x$prediction_test$unknown_category_rows_index)
@@ -994,7 +996,8 @@ evaluate_lm_training_and_test <- function(df, pretty.name = FALSE){
         m <- df %>% filter(!is.null(model)) %>% `[[`(1, "model", 1)
         actual_val_col <- all.vars(df$model[[1]]$terms)[[1]]
         # Emulate the way lm replaces the column names in the output.
-        actual_val_col_clean <- stringr::str_replace_all(actual_val_col, ' ', '.')
+        #actual_val_col_clean <- stringr::str_replace_all(actual_val_col, ' ', '.')
+        actual_val_col_clean <- gsub(' ', '.', actual_val_col)
 
         actual <- test_pred_ret[[actual_val_col_clean]]
         predicted <- test_pred_ret$predicted_value


### PR DESCRIPTION
# Description
Since str_replace sometimes garbles multibyte column names, replacing them with gsub.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
