### PR TITLE
Fix garbling of glm binary base class column name and prophet extra regressor output column names

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -953,7 +953,7 @@ xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
     # Quote variable name with backtick if it includes special characters or space.
     # Special characters to detect besides space. Note that period and underscore should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
-    paste0(if_else(stringr::str_detect(vname,"[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]"),paste0('`',vname,'`'),vname),xlevels[[vname]])
+    paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname),paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -954,7 +954,7 @@ xlevels_to_base_level_table <- function(xlevels) {
     # Quote variable name with backtick if it includes special characters or space.
     # Special characters to detect besides space. Note that period and underscore should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
     # Using grepl() as opposed to str_detect() because str_detect seems to return wrong decision when vname ends with SJIS damemoji.
-    paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname), paste0('`',vname,'`'),vname),xlevels[[vname]])
+    paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname, perl=TRUE), paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -954,6 +954,7 @@ xlevels_to_base_level_table <- function(xlevels) {
     # Quote variable name with backtick if it includes special characters or space.
     # Special characters to detect besides space. Note that period and underscore should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
     # Using grepl() as opposed to str_detect() because str_detect seems to return wrong decision when vname ends with SJIS damemoji.
+    # perl=TRUE is required here, since it seems this regex does not detect space, tilde, etc. without perl=TRUE for some reason.
     paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname, perl=TRUE), paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -953,7 +953,8 @@ xlevels_to_base_level_table <- function(xlevels) {
   term <- purrr::flatten_chr(purrr::map(names(xlevels), function(vname) {
     # Quote variable name with backtick if it includes special characters or space.
     # Special characters to detect besides space. Note that period and underscore should *not* be included here. : ~!@#$%^&*()+={}|:;'<>,/?"[]-\
-    paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname),paste0('`',vname,'`'),vname),xlevels[[vname]])
+    # Using grepl() as opposed to str_detect() because str_detect seems to return wrong decision when vname ends with SJIS damemoji.
+    paste0(if_else(grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname), paste0('`',vname,'`'),vname),xlevels[[vname]])
   }))
   base_level <- purrr::flatten_chr(purrr::map(xlevels, function(v){rep(v[[1]],length(v))}))
   ret <- data.frame(term=term, base.level=base_level)

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -406,6 +406,7 @@ evaluate_binary_training_and_test <- function(df, actual_val_col, threshold = "f
     base_cols <- colnames(ret)[stringr::str_detect(colnames(ret) , "_base$")]
     if (length(base_cols) > 0) {
       for (col in base_cols) {
+        # Using gsub as opposed to str_replace, since str_replace seems to garble Japanese column name on Windows.
         colnames(ret)[colnames(ret) == col] <- paste0("Base Level of ", gsub("_base$", "", col))
       }
     }

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -406,7 +406,7 @@ evaluate_binary_training_and_test <- function(df, actual_val_col, threshold = "f
     base_cols <- colnames(ret)[stringr::str_detect(colnames(ret) , "_base$")]
     if (length(base_cols) > 0) {
       for (col in base_cols) {
-        colnames(ret)[colnames(ret) == col] <- paste0("Base Level of ", stringr::str_replace(col, "_base$", ""))
+        colnames(ret)[colnames(ret) == col] <- paste0("Base Level of ", gsub("_base$", "", col))
       }
     }
   }

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -198,7 +198,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       regressor_final_output_cols <- regressors
     }
 
-    # But use temporary output column names like r1, r2...
+    # But use temporary output column names like r1, r2... We will rename them back before final output.
+    # We need this because prophet would garble those column names in the output.
     regressor_output_cols <- paste0("r", 1:length(regressors))
 
     names(summarise_args) <- regressor_output_cols
@@ -613,6 +614,8 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       if (value_col != "y") { # if value_col happens to be "y", do not do this, since it will make the column name "y.new".
         colnames(ret)[colnames(ret) == "y"] <- avoid_conflict(colnames(ret), value_col)
       }
+
+      # Replace temporary regressor column names (r1, r2, ...) with the name that includes original column names.
       if (!is.null(regressor_final_output_cols)) {
         i <- 1
         for (output_col in regressor_final_output_cols) {


### PR DESCRIPTION
# Description
- Garbling of glm binary base class column name in Summary table
- Base class column of Coef table had NA values when the predictor's name has SJIS damemoji.
- Garbling of prophet extra regressor output column names

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
