### PR TITLE
Make sure to pass googleAuthR::gar_auth skip_fetch argument.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 5.4.0.11
+Version: 5.4.0.12
 Date: 2019-10-30
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -1115,7 +1115,7 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
   if(!requireNamespace("googleCloudStorageR")){stop("package googleCloudStorageR must be installed.")}
   if(!requireNamespace("googleAuthR")){stop("package googleAuthR must be installed.")}
   token <- getGoogleTokenForBigQuery(tokenFileId)
-  googleAuthR::gar_auth(token = token)
+  googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
   googleCloudStorageR::gcs_global_bucket(bucket)
   objects <- googleCloudStorageR::gcs_list_objects()
   # set bucket
@@ -1143,7 +1143,7 @@ listGoogleCloudStorageBuckets <- function(project, tokenFileId){
   if(!requireNamespace("googleCloudStorageR")){stop("package googleCloudStorageR must be installed.")}
   if(!requireNamespace("googleAuthR")){stop("package googleAuthR must be installed.")}
   token <- getGoogleTokenForBigQuery(tokenFileId)
-  googleAuthR::gar_auth(token = token)
+  googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
   googleCloudStorageR::gcs_list_buckets(projectId = project, projection = c("full"))
 }
 


### PR DESCRIPTION
# Description

Since now we updated googleAuthR::gar_auth API with new argument. We need to uptake our existing APIs that depend on it.

- downloadDataFromGoogleCloudStorage
- listGoogleCloudStorageBuckets 

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
