### PR TITLE
Bring back integer column to integer after SMOTE

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1602,6 +1602,7 @@ exp_balance <- function(df,
       }
     }
 
+    # Remember integer column so that we can bring it back to integer later.
     integer_cols <- c()
     for(col in colnames(df)){
       if(col == target_col) { # skip target_col

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1602,6 +1602,15 @@ exp_balance <- function(df,
       }
     }
 
+    integer_cols <- c()
+    for(col in colnames(df)){
+      if(col == target_col) { # skip target_col
+      }
+      else if(is_integer(df[[col]])) {
+        integer_cols <- c(integer_cols, col)
+      }
+    }
+
     # record orig_df at this point so that the data type reverting works fine later when we have to return this instead of smoted df.
     orig_df <- df
 
@@ -1668,6 +1677,15 @@ exp_balance <- function(df,
     for(col in factorized_cols) { # set factorized columns back to character. TODO: take care of other types.
       df_balanced[[col]] <- as.character(df_balanced[[col]])
     }
+
+    # Round to make original integer columns back to integer.
+    # Not doing so has some drawback especially in tree-based models.
+    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/154
+    # TODO: Consider SMOTE-NC.
+    for(col in integer_cols) {
+      df_balanced[[col]] <- round(df_balanced[[col]])
+    }
+
     df_balanced
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -2024,6 +2024,7 @@ revert_factor_cols_to_logical <- function(df) {
   }, as.logical)
 }
 
+# Checks if a vector has only integer values.
 is_integer <- function(x) {
   # isTRUE is necessary since all.equal does not return FALSE for FALSE case. See ?all.equal.
   is.integer(x) || (is.numeric(x) && isTRUE(all.equal(x, as.integer(x))))

--- a/R/util.R
+++ b/R/util.R
@@ -2024,3 +2024,7 @@ revert_factor_cols_to_logical <- function(df) {
   }, as.logical)
 }
 
+is_integer <- function(x) {
+  # isTRUE is necessary since all.equal does not return FALSE for FALSE case. See ?all.equal.
+  is.integer(x) || (is.numeric(x) && isTRUE(all.equal(x, as.integer(x))))
+}

--- a/tests/testthat/test_smote.R
+++ b/tests/testthat/test_smote.R
@@ -191,6 +191,18 @@ test_that("test exp_balance with ordered factor with NA as a predictors", {
   expect_equal(levels(res$x), c("A", "B", "(Missing)"))
 })
 
+# TODO: This case is not getting synthesized data. Test with a case that generates some synthesized data.
+test_that("test exp_balance with integer numbers as a predictors", {
+  sample_data <- data.frame(
+    y = factor(c("a", "a", "b", "b", "b", "b", "b", "b", "b", "b")),
+    x = as.numeric(c(1:5, 1:5)),
+    num = runif(10)
+  )
+  res <- exp_balance(sample_data, y, target_size=12)
+  expect_true("data.frame" %in% class(res))
+  expect_true(is_integer(res$x))
+})
+
 test_that("test exp_balance with logical", {
   sample_data <- data.frame(
     y = c(TRUE, rep(FALSE,5)),

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -897,3 +897,8 @@ test_that("revert_factor_cols_to_logical", {
   expect_equal(res$col2, c(TRUE, FALSE, NA))
 })
 
+test_that("is_integer", {
+  expect_true(is_integer(c(0,1,2,3,4,5)))
+  expect_false(is_integer(c(0,1.5,2,3,4,5)))
+})
+


### PR DESCRIPTION
# Description
Bring back integer column to integer after SMOTE.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
