### PR TITLE
Update summarize_group to  support week_of_month option.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 5.4.0.18
+Version: 5.4.0.19
 Date: 2019-11-03
 Authors@R: c(person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut", "cre")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/util.R
+++ b/R/util.R
@@ -1425,6 +1425,9 @@ extract_from_date <- function(x, type = "fltoyear") {
     week = {
       ret <- lubridate::week(x)
     },
+    week_of_month = {
+      ret <- exploratory::get_week_of_month(x)
+    },
     day = {
       ret <- lubridate::day(x)
     },
@@ -1977,6 +1980,7 @@ summarize_group <- function(.data, group_cols = NULL, group_funs = NULL, ...){
             "monthnamelong",
             "monnamelong",
             "week",
+            "week_of_month",
             "dayofyear",
             "dayofquarter",
             "dayofweek",


### PR DESCRIPTION
# Description

Uptake new  get_week_of_month function to `summarrize_group`

- Added week_of_month option

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
