### PR TITLE
Remove reshape2 call from pivot()

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -830,6 +830,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
   # column names in lhs are collapsed by "_"
   rows <- all.vars(lazyeval::f_lhs(formula))
   cname <- paste0(rows, collapse = "_")
+  cols <- all.vars(lazyeval::f_rhs(formula))
 
   vars <- all.vars(formula)
 
@@ -864,7 +865,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
     casted <- if(is.null(value_col)) {
       # make a count matrix if value_col is NULL
       # reshape2::acast(df, formula = formula, fun.aggregate = length, fill = fill)
-      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = cols, values_from=value)
     } else {
       if(na.rm &&
          !identical(na_ratio, fun.aggregate) &&
@@ -877,7 +878,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
         df <- df[!is.na(df[[value_col]]),]
       }
       # reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
-      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = cols, values_from=value)
     }
     casted
   }

--- a/R/util.R
+++ b/R/util.R
@@ -863,7 +863,8 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
   pivot_each <- function(df) {
     casted <- if(is.null(value_col)) {
       # make a count matrix if value_col is NULL
-      reshape2::acast(df, formula = formula, fun.aggregate = length, fill = fill)
+      # reshape2::acast(df, formula = formula, fun.aggregate = length, fill = fill)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
     } else {
       if(na.rm &&
          !identical(na_ratio, fun.aggregate) &&
@@ -876,7 +877,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
         df <- df[!is.na(df[[value_col]]),]
       }
       # reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
-      df %>% group_by(!!!syms(vars)) %>% summarize(value=fun.aggregate(!!sym(value_col))) %>% pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
     }
     casted
   }

--- a/R/util.R
+++ b/R/util.R
@@ -875,11 +875,10 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
         # remove NA, unless fun.aggregate function is one of the above NA related ones.
         df <- df[!is.na(df[[value_col]]),]
       }
-      reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
+      # reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
+      df %>% group_by(!!!syms(vars)) %>% summarize(value=fun.aggregate(!!sym(value_col))) %>% pivot_wider(names_from = all.vars(lazyeval::f_rhs(formula)), values_from=value)
     }
-    casted %>%
-      as.data.frame %>%
-      tibble::rownames_to_column(var = cname)
+    casted
   }
 
   grouped_col <- grouped_by(df)

--- a/R/util.R
+++ b/R/util.R
@@ -865,7 +865,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
     casted <- if(is.null(value_col)) {
       # make a count matrix if value_col is NULL
       # reshape2::acast(df, formula = formula, fun.aggregate = length, fill = fill)
-      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = cols, values_from=value)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = !!cols, values_from=value, values_fill=list(value=!!fill))
     } else {
       if(na.rm &&
          !identical(na_ratio, fun.aggregate) &&
@@ -878,7 +878,7 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
         df <- df[!is.na(df[[value_col]]),]
       }
       # reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
-      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = cols, values_from=value)
+      df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = !!cols, values_from=value, values_fill=list(value=!!fill))
     }
     casted
   }

--- a/R/util.R
+++ b/R/util.R
@@ -896,15 +896,6 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
     dplyr::ungroup() %>%
     unnest_with_drop(!!rlang::sym(tmp_col))
 
-  if(length(rows) == 1){
-    # Set same data type with original data
-    # because it's always converted to character.
-    # When there are more than 2 rows,
-    # they are concatenated,
-    # so the data type can't be converted
-    ret[[rows]] <- same_type(ret[[rows]], original = df[[rows]])
-  }
-
   # replace NA values in new columns with fill value
   if(!is.na(fill)) {
     # exclude grouping columns and row label column

--- a/R/util.R
+++ b/R/util.R
@@ -864,7 +864,6 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
   pivot_each <- function(df) {
     casted <- if(is.null(value_col)) {
       # make a count matrix if value_col is NULL
-      # reshape2::acast(df, formula = formula, fun.aggregate = length, fill = fill)
       df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=dplyr::n()) %>% tidyr::pivot_wider(names_from = !!cols, values_from=value, values_fill=list(value=!!fill))
     } else {
       if(na.rm &&
@@ -877,7 +876,6 @@ pivot_ <- function(df, formula, value_col = NULL, fun.aggregate = mean, fill = N
         # remove NA, unless fun.aggregate function is one of the above NA related ones.
         df <- df[!is.na(df[[value_col]]),]
       }
-      # reshape2::acast(df, formula = formula, value.var = value_col, fun.aggregate = fun.aggregate, fill = fill)
       df %>% dplyr::group_by(!!!rlang::syms(vars)) %>% dplyr::summarize(value=fun.aggregate(!!rlang::sym(value_col))) %>% tidyr::pivot_wider(names_from = !!cols, values_from=value, values_fill=list(value=!!fill))
     }
     casted

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -574,7 +574,8 @@ test_that("test pivot", {
   )
 
   pivoted <- pivot(test_df, cat1+cat3 ~ cat2)
-  expect_true("cat1_cat3" %in% colnames(pivoted))
+  expect_true("cat1" %in% colnames(pivoted))
+  expect_true("cat3" %in% colnames(pivoted))
 
   pivoted_with_val <- pivot(test_df, cat1 ~ cat2 + cat3, value = num3, fun.aggregate=mean, fill = 0)
   expect_true(all(!is.na(pivoted_with_val)))


### PR DESCRIPTION
# Description
Remove now retired reshape2 calls from pivot().

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
