### PR TITLE
Rename column names for survival curve output

### DIFF
--- a/R/survival.R
+++ b/R/survival.R
@@ -162,13 +162,15 @@ tidy.survfit_exploratory <- function(x, ...) {
     ret <- complete_times_each(ret)
   }
 
-  colnames(ret)[colnames(ret) == "n.risk"] <- "n_risk"
-  colnames(ret)[colnames(ret) == "n.event"] <- "n_event"
-  colnames(ret)[colnames(ret) == "n.censor"] <- "n_censor"
-  colnames(ret)[colnames(ret) == "std.error"] <- "std_error"
-  colnames(ret)[colnames(ret) == "conf.low"] <- "conf_low"
-  colnames(ret)[colnames(ret) == "conf.high"] <- "conf_high"
-  colnames(ret)[colnames(ret) == "strata"] <- "cohort"
+  colnames(ret)[colnames(ret) == "time"] <- "Time"
+  colnames(ret)[colnames(ret) == "estimate"] <- "Estimate"
+  colnames(ret)[colnames(ret) == "n.risk"] <- "Observations"
+  colnames(ret)[colnames(ret) == "n.event"] <- "Events"
+  colnames(ret)[colnames(ret) == "n.censor"] <- "Censored"
+  colnames(ret)[colnames(ret) == "std.error"] <- "Std Error"
+  colnames(ret)[colnames(ret) == "conf.low"] <- "Conf Low"
+  colnames(ret)[colnames(ret) == "conf.high"] <- "Conf High"
+  colnames(ret)[colnames(ret) == "strata"] <- "Cohort"
   ret
 }
 

--- a/R/survival.R
+++ b/R/survival.R
@@ -163,7 +163,7 @@ tidy.survfit_exploratory <- function(x, ...) {
   }
 
   colnames(ret)[colnames(ret) == "time"] <- "Time"
-  colnames(ret)[colnames(ret) == "estimate"] <- "Estimate"
+  colnames(ret)[colnames(ret) == "estimate"] <- "Survival Rate"
   colnames(ret)[colnames(ret) == "n.risk"] <- "Observations"
   colnames(ret)[colnames(ret) == "n.event"] <- "Events"
   colnames(ret)[colnames(ret) == "n.censor"] <- "Censored"


### PR DESCRIPTION
# Description
Rename column names for survival curve output.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
