### PR TITLE
Use correct output row label column names to exclude columns for fill

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -916,7 +916,7 @@ pivot_ <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fu
   # replace NA values in new columns with fill value
   if(!is.na(fill)) {
     # exclude grouping columns and row label column
-    newcols <- setdiff(colnames(ret), c(grouped_col, row_cols))
+    newcols <- setdiff(colnames(ret), c(grouped_col, new_row_cols))
     # create key value with list
     # whose keys are value columns
     # and values are fill

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -625,6 +625,18 @@ test_that("test pivot with Date funcs", {
   expect_equal(colnames(pivoted), c("dt_wday","3", "52", "2"))
 })
 
+test_that("test pivot with Date funcs with fill", { # There was a case where error happened with this case with fill (commit 0745f491).
+  test_df <- data.frame(
+    dt = rep(as.Date("2019-12-20") + seq(3)*10, each = 5),
+    col = rep(seq(5), 3),
+    val = seq(15)
+  )
+
+  pivoted <- pivot(test_df, row_cols=c(dt_wday="dt"), row_funs=c("wday"), col_cols=c("dt"), col_funs=c("week"), value = val, fill=0)
+  expect_true(all(pivoted$dt_wday %in% c("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")))
+  expect_equal(colnames(pivoted), c("dt_wday","3", "52", "2"))
+})
+
 test_that("test pivot with POSIXct", {
   test_df <- data.frame(
     dt = rep(lubridate::now() + seq(3), each = 5),

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -118,7 +118,7 @@ test_that("setdiff", {
 test_that("test pivot with empty data frame", {
   df <- data.frame()
   expect_error({
-    pivot(df, row ~ col)
+    pivot(df, row_cols=c("row"), col_cols=c("col"))
   }, "Input data frame is empty.")
 })
 


### PR DESCRIPTION
# Description
Use correct output row label column names to exclude columns for fill to avoid error when row column is a Date column.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
