### PR TITLE
Add test for partial dependence binning data conf int

### DIFF
--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -34,6 +34,10 @@ test_that("calc_feature_map(regression) evaluate training and test", {
   ret <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
   expect_equal(nrow(ret), 2) # 2 for train and test
 
+  # retrieve partial dependence data.
+  ret <- model_df %>% rf_partial_dependence()
+  expect_equal(class(ret$conf_high), "numeric") # make sure that it is with conf int for actual binning data.
+
   model_df <- flight %>%
                 calc_feature_imp(`FL NUM`, `DIS TANCE`, `DEP TIME`, test_rate = 0, pd_with_bin_means = TRUE)
   ret <- model_df %>% prediction(data="training_and_test")


### PR DESCRIPTION
# Description
Add test for partial dependence binning data conf int.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
