### PR TITLE
Random Forest/Decision Tree: Consider only logical target case as binary classification.

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1119,7 +1119,7 @@ tidy.glm_exploratory <- function(x, type = "coefficients", pretty.name = FALSE, 
       target_col <- as.character(lazyeval::f_lhs(x$formula)) # get target column name
       actual_val = x$model[[target_col]]
 
-      predicted = x$fitted.value > 0.5 # TODO: make threshold adjustable
+      predicted = x$fitted.value > 0.5 # TODO: make threshold adjustable. Note: This part of code seems to be unused. Check and remove.
       # convert predicted to original set of values. should be either logical, numeric, or factor.
       predicted <- if (is.logical(actual_val)) {
         predicted

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2381,6 +2381,7 @@ evaluate_binary_classification <- function(actual, predicted, predicted_probabil
       # For ranger, even if level for label "TRUE" is 2, we always treat level 1 as TRUE, for simplicity for now.
       true_class <- levels(actual)[[1]]
     }
+    # Since multi_class = FALSE is specified, Number of Rows is not added here. Will add later.
     ret <- evaluate_classification(actual, predicted, true_class, multi_class = FALSE, pretty.name = pretty.name)
   }
   else {
@@ -2392,7 +2393,7 @@ evaluate_binary_classification <- function(actual, predicted, predicted_probabil
   else {
     ret <- ret %>% mutate(auc = auc)
   }
-  # TODO: Look into when Number of Rows is already added.
+  # Add Number of Rows here for the case ret came from evaluate_classification(multi_class = FALSE).
   if (is.null(ret$n) && is.null(ret$`Number of Rows`)) {
     sample_n <- sum(!is.na(predicted)) # Sample size for test.
     ret <- ret %>% dplyr::mutate(n = !!sample_n)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2381,7 +2381,7 @@ evaluate_binary_classification <- function(actual, predicted, predicted_probabil
     # Since multi_class = FALSE is specified, Number of Rows is not added here. Will add later.
     ret <- evaluate_classification(actual, predicted, true_class, multi_class = FALSE, pretty.name = pretty.name)
   }
-  else {
+  else { # Because get_classification_type() considers it binary classification only when target is logical, it should never come here, but cowardly keeping the code for now.
     ret <- evaluate_multi_(data.frame(predicted=predicted, actual=actual), "predicted", "actual", pretty.name = pretty.name)
   }
   if (pretty.name) {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1713,12 +1713,9 @@ get_classification_type <- function(v) {
   # if not, it is classification
   if (!is.numeric(v)) {
     if (!is.logical(v)) {
-      if (length(unique(v)) == 2) {
-        classification_type <- "binary"
-      }
-      else {
-        classification_type <- "multi"
-      }
+      # Even if number of unique number is 2, we treat it as multi-class as opposed to binary,
+      # since our logic for binary classification depends on the condition that the values are TRUE and FALSE.
+      classification_type <- "multi"
     }
     else {
       classification_type <- "binary"

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2392,10 +2392,13 @@ evaluate_binary_classification <- function(actual, predicted, predicted_probabil
   else {
     ret <- ret %>% mutate(auc = auc)
   }
-  sample_n <- sum(!is.na(predicted)) # Sample size for test.
-  ret <- ret %>% dplyr::mutate(n = !!sample_n)
-  if(pretty.name){
-    ret <- ret %>% dplyr::rename(`Number of Rows` = n)
+  # TODO: Look into when Number of Rows is already added.
+  if (is.null(ret$n) && is.null(ret$`Number of Rows`)) {
+    sample_n <- sum(!is.na(predicted)) # Sample size for test.
+    ret <- ret %>% dplyr::mutate(n = !!sample_n)
+    if(pretty.name){
+      ret <- ret %>% dplyr::rename(`Number of Rows` = n)
+    }
   }
   ret
 }

--- a/tests/testthat/test_lm_1.R
+++ b/tests/testthat/test_lm_1.R
@@ -35,8 +35,38 @@ test_that("build_lm.fast (linear regression) evaluate training and test", {
   expect_equal(nrow(ret), 2) # 2 for train and test
 })
 
-test_that("build_lm.fast (logistic regression) evaluate training and test", {
+test_that("build_lm.fast (logistic regression(numeric)) evaluate training and test", {
   model_df <- flight %>%
+                build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3)
+
+  ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1480) # Not very stable for some reason. Will revisit
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3454) # Not very stable for some reason. Will revisit
+  ret <- model_df %>% evaluate_binary_training_and_test("is delayed", pretty.name=TRUE, threshold=0.1)
+  expect_gt(ret$Recall[[1]], 0.8) # Expect Recall to be ok since threshold is as low as 0.1.
+  expect_equal(nrow(ret), 2) # 2 for train and test
+  ret <- model_df %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
+})
+
+test_that("build_lm.fast (logistic regression(logical)) evaluate training and test", {
+  model_df <- flight %>% mutate(`is delayed`=as.logical(`is delayed`)) %>%
+                build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3)
+
+  ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1480) # Not very stable for some reason. Will revisit
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3454) # Not very stable for some reason. Will revisit
+  ret <- model_df %>% evaluate_binary_training_and_test("is delayed", pretty.name=TRUE, threshold=0.1)
+  expect_gt(ret$Recall[[1]], 0.8) # Expect Recall to be ok since threshold is as low as 0.1.
+  expect_equal(nrow(ret), 2) # 2 for train and test
+  ret <- model_df %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
+})
+
+test_that("build_lm.fast (logistic regression(character)) evaluate training and test", {
+  model_df <- flight %>% mutate(`is delayed`=if_else(as.logical(`is delayed`), "A", "B")) %>%
                 build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3)
 
   ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -81,7 +81,7 @@ test_that("calc_feature_map(binary) evaluate training and test", {
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
 })
 
-test_that("calc_feature_map(binary(factor)) evaluate training and test", {
+test_that("calc_feature_map(binary(factor(logical))) evaluate training and test", {
   # `is delayed` is not logical for some reason.
   # To test binary prediction, need to cast it into logical.
   model_df <- flight %>% dplyr::mutate(is_delayed = factor(as.logical(`is delayed`))) %>% filter(!is.na(is_delayed)) %>%
@@ -95,7 +95,37 @@ test_that("calc_feature_map(binary(factor)) evaluate training and test", {
 
   ret <- rf_evaluation_training_and_test(model_df, pretty.name=T, binary_classification_threshold=0.5)
   expect_equal(nrow(ret), 2) # 2 for train and test
+  ret <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class")
+  expect_equal(nrow(ret), 4) # 4 for train/test times TRUE/FALSE
 
+  ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
+  model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
+                calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0, pd_with_bin_means = TRUE)
+  ret <- model_df %>% prediction(data="training_and_test")
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  expect_equal(nrow(train_ret), 5000)
+
+  ret <- rf_evaluation_training_and_test(model_df)
+  expect_equal(nrow(ret), 1) # 1 for train
+
+  ret <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class")
+  ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
+})
+
+test_that("calc_feature_map(binary(factor(character))) evaluate training and test", {
+  # `is delayed` is not logical for some reason.
+  # To test binary prediction, need to cast it into logical.
+  model_df <- flight %>% dplyr::mutate(is_delayed = factor(if_else(as.logical(`is delayed`), "A","B"))) %>% filter(!is.na(is_delayed)) %>%
+                calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0.3, pd_with_bin_means = TRUE)
+
+  ret <- model_df %>% prediction(data="training_and_test")
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1500) Fails now, since we filter numeric NA. Revive when we do not need to.
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3500) Fails now, since we filter numeric NA. Revive when we do not need to.
+
+  ret <- rf_evaluation_training_and_test(model_df, pretty.name=T, binary_classification_threshold=0.5)
+  expect_equal(nrow(ret), 2) # 2 for train and test
   ret <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class")
   expect_equal(nrow(ret), 4) # 4 for train/test times TRUE/FALSE
 

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -81,7 +81,7 @@ test_that("calc_feature_map(binary) evaluate training and test", {
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
 })
 
-test_that("calc_feature_map(binary(factor(logical))) evaluate training and test", {
+test_that("calc_feature_map(factor(TRUE, FALSE)) evaluate training and test", { # This case should be treated as multi-class.
   # `is delayed` is not logical for some reason.
   # To test binary prediction, need to cast it into logical.
   model_df <- flight %>% dplyr::mutate(is_delayed = factor(as.logical(`is delayed`))) %>% filter(!is.na(is_delayed)) %>%
@@ -112,7 +112,7 @@ test_that("calc_feature_map(binary(factor(logical))) evaluate training and test"
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
 })
 
-test_that("calc_feature_map(binary(factor(character))) evaluate training and test", {
+test_that("calc_feature_map(binary(factor(A,B))) evaluate training and test", {
   # `is delayed` is not logical for some reason.
   # To test binary prediction, need to cast it into logical.
   model_df <- flight %>% dplyr::mutate(is_delayed = factor(if_else(as.logical(`is delayed`), "A","B"))) %>% filter(!is.na(is_delayed)) %>%

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -74,7 +74,7 @@ test_that("exp_rpart(binary(logical)) evaluate training and test", {
   expect_equal(nrow(ret), 1) # 1 for train
 })
 
-test_that("exp_rpart(binary(character)) evaluate training and test", {
+test_that("exp_rpart(character(A,B)) evaluate training and test", { # This should be treated as multi-class
   model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B")) %>%
                 exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
 
@@ -90,7 +90,33 @@ test_that("exp_rpart(binary(character)) evaluate training and test", {
   expect_equal(nrow(ret), 2) # 2 for train and test
 
   # Training only case
-  model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B")) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
+  ret <- model_df %>% prediction(data="training_and_test")
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 4944) # Not very stable for some reason. Will revisit.
+
+  ret <- rf_evaluation_training_and_test(model_df)
+  expect_equal(nrow(ret), 1) # 1 for train
+})
+
+test_that("exp_rpart(character(TRUE,FALSE)) evaluate training and test", { # This should be treated as multi-class
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "TRUE", "FALSE")) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
+
+  ret <-  model_df %>% rf_partial_dependence()
+
+  ret <- model_df %>% prediction(data="training_and_test")
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1483) # Not very stable for some reason. Will revisit.
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3461) # Not very stable for some reason. Will revisit.
+
+  ret <- model_df %>% rf_evaluation_training_and_test()
+  expect_equal(nrow(ret), 2) # 2 for train and test
+
+  # Training only case
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "TRUE", "FALSE")) %>%
                 exp_rpart(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
   ret <- model_df %>% prediction(data="training_and_test")
   train_ret <- ret %>% filter(is_test_data==FALSE)

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -48,8 +48,34 @@ test_that("exp_rpart(regression) evaluate training and test", {
   expect_equal(nrow(ret), 1) # 1 for train
 })
 
-test_that("exp_rpart(binary) evaluate training and test", {
+test_that("exp_rpart(binary(logical)) evaluate training and test", {
   model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
+
+  ret <-  model_df %>% rf_partial_dependence()
+
+  ret <- model_df %>% prediction(data="training_and_test")
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1483) # Not very stable for some reason. Will revisit.
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3461) # Not very stable for some reason. Will revisit.
+
+  ret <- model_df %>% rf_evaluation_training_and_test()
+  expect_equal(nrow(ret), 2) # 2 for train and test
+
+  # Training only case
+  model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
+  ret <- model_df %>% prediction(data="training_and_test")
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 4944) # Not very stable for some reason. Will revisit.
+
+  ret <- rf_evaluation_training_and_test(model_df)
+  expect_equal(nrow(ret), 1) # 1 for train
+})
+
+test_that("exp_rpart(binary(character)) evaluate training and test", {
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B")) %>%
                 exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
 
   ret <-  model_df %>% rf_partial_dependence()


### PR DESCRIPTION
# Description
Consider only logical target case as binary classification, aligning with how our Analytics UI works.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
