### PR TITLE
Handle the case only single column is specified for K-Means Analytics View

### DIFF
--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -179,19 +179,19 @@ build_kmeans.cols <- function(df, ...,
   # this gets a vector of column names which are selected by dots argument
   selected_column <- evaluate_select(df, .dots=select_dots, grouped_column)
 
-  omit_df <- df[,selected_column] %>%
+  omit_df <- df[,selected_column, drop=FALSE] %>% # drop=FALSE to avoid getting converted to vector
     as_numeric_matrix_(selected_column) %>%
     na.omit()
   omit_row <- attr(omit_df, "na.action")
   if(!is.null(omit_row)){
-    df <- df[setdiff(seq(nrow(df)), omit_row), ]
+    df <- df[setdiff(seq(nrow(df)), omit_row), drop=FALSE] # drop=FALSE to avoid getting converted to vector
   }
 
   build_kmeans_each <- function(df){
     # remove grouping column
     # to avoid it appears as duplicated column
     # after unnesting the result
-    df <- df[, !colnames(df) %in% grouped_column]
+    df <- df[, !colnames(df) %in% grouped_column, drop=FALSE] # drop=FALSE to avoid getting converted to vector
     kmeans_ret <- tryCatch({
       if(nrow(df) == 0 | ncol(df) == 0){
         stop("No data after removing NA")

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -184,7 +184,7 @@ build_kmeans.cols <- function(df, ...,
     na.omit()
   omit_row <- attr(omit_df, "na.action")
   if(!is.null(omit_row)){
-    df <- df[setdiff(seq(nrow(df)), omit_row), drop=FALSE] # drop=FALSE to avoid getting converted to vector
+    df <- df[setdiff(seq(nrow(df)), omit_row),] # For row filtering like this, drop=FALSE is not necessary.
   }
 
   build_kmeans_each <- function(df){

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -1,7 +1,6 @@
 # how to run this test:
 # devtools::test(filter="kmeans")
 context("test kmeans analytics view functions")
-
 test_that("exp_kmeans", {
   df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
   model_df <- exp_kmeans(df, cyl, mpg, hp, max_nrow=30)
@@ -21,6 +20,16 @@ test_that("exp_kemans with strange column name", {
   model_df %>% tidy(model, type="variances")
   model_df %>% tidy(model, type="loadings")
   model_df %>% tidy(model, type="biplot")
+  model_df %>% tidy(model, type="data")
+  model_df %>% tidy(model, type="gathered_data")
+  res <- model_df %>% tidy(model, type="gathered_data", normalize_data=TRUE, n_sample=100) # testing n_sample more than nrow()
+})
+
+test_that("exp_kemans with single column name", {
+  model_df <- exp_kmeans(mtcars, mpg)
+  model_df %>% tidy(model, type="variances")
+  # model_df %>% tidy(model, type="loadings") # Not used.
+  # model_df %>% tidy(model, type="biplot") # Will skip for single column case.
   model_df %>% tidy(model, type="data")
   model_df %>% tidy(model, type="gathered_data")
   res <- model_df %>% tidy(model, type="gathered_data", normalize_data=TRUE, n_sample=100) # testing n_sample more than nrow()


### PR DESCRIPTION


# Description
Handle the case only single column is specified for K-Means Analytics View.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
