### PR TITLE
Update default clean_name case from old_janitor to new parsed

### DIFF
--- a/R/toplevel_util.R
+++ b/R/toplevel_util.R
@@ -21,7 +21,7 @@ row_as_header <- function(df, row_index = 1, prefix = "", clean_names = TRUE){
   ret <- safe_slice(df, row_index, remove = TRUE)
   colnames(ret) <- names
   if (clean_names) {
-    ret <- janitor::clean_names(ret, case="old_janitor")
+    ret <- janitor::clean_names(ret, case="parsed")
   }
   ret
 }

--- a/tests/testthat/test_toplevel_util.R
+++ b/tests/testthat/test_toplevel_util.R
@@ -13,7 +13,7 @@ test_that("test row_as_header", {
 
   expect_equal(ret, structure(
     list(x2 = c(1L, 3L), x_2 = c(-1L, -3L), b = c("a", "c")),
-    .Names = c("x2", "x_2", "b"),
+    .Names = c("X2", "X2_2", "b"),
     row.names = c(1L, 3L),
     class = "data.frame"))
 
@@ -34,7 +34,7 @@ test_that("test row_as_header with factor", {
   ret <- row_as_header(test_df, row_index = 2)
   ret2 <- row_as_header(test_df, row_index = 2, clean_names = FALSE)
 
-  expect_equal(c("x2", "x_2", "b"), colnames(ret))
+  expect_equal(c("X2", "X2_2", "b"), colnames(ret))
   expect_equal(c("2", "-2", "b"), colnames(ret2))
 })
 


### PR DESCRIPTION
# Description
Update default clean_name case from old "old_janitor" to new "parsed".
We decided it has a better behavior, like not converting cases or values.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
