### PR TITLE
fix exploratory::executeGoogleBigQuery direct stream mode did not work

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1212,7 +1212,11 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, dataSet, table, csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)
-    bigrquery::bq_auth(token = token)
+
+    # bigquery::set_access_cred is deprecated, however, switching to bigquery::bq_auth foreces the oauth token gets refreshed
+    # inside of it. We don't want this since Exploratory Desktop always sends a valid oauth token and use it without refreshing it.
+    # so for now, stick to bigrquery::set_access_cred
+    bigrquery::set_access_cred(token)
     # check if the query contains special key word for standardSQL
     # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
     isStandardSQL <- stringr::str_detect(query, "#standardSQL")

--- a/R/system.R
+++ b/R/system.R
@@ -1213,7 +1213,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
   } else {
     # direct import case (for refresh data frame case)
 
-    # bigquery::set_access_cred is deprecated, however, switching to bigquery::bq_auth foreces the oauth token gets refreshed
+    # bigquery::set_access_cred is deprecated, however, switching to bigquery::bq_auth forces the oauth token refresh
     # inside of it. We don't want this since Exploratory Desktop always sends a valid oauth token and use it without refreshing it.
     # so for now, stick to bigrquery::set_access_cred
     bigrquery::set_access_cred(token)


### PR DESCRIPTION
# Description

With change #679, we switched to use `bigquery::bq_auth` but this has a side effect of unexpected OAuth token refresh inside the API. We don't want this since Exploratory Desktop always sends a valid OAuth token and want to use it without refreshing it.
So for now, stick to `bigrquery::set_access_cred`


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
