### PR TITLE
Rename pdp "Model" type to "Predicted" type

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -330,14 +330,6 @@ tidy.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add tes
 glance.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
   ret <- broom:::glance.coxph(x, model, pretty.name = pretty.name, ...)
 
-  for(var in names(x$xlevels)) { # extract base levels info on factor/character columns from lm model
-    if(pretty.name) {
-      ret[paste0("Base Level of ", var)] <- x$xlevels[[var]][[1]]
-    }
-    else {
-      ret[paste0(var, "_base")] <- x$xlevels[[var]][[1]]
-    }
-  }
   if(pretty.name) {
     colnames(ret)[colnames(ret) == "r.squared"] <- "R Squared"
     colnames(ret)[colnames(ret) == "adj.r.squared"] <- "Adj R Squared"

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -822,14 +822,6 @@ build_lm.fast <- function(df,
 glance.lm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
   ret <- broom:::glance.lm(x)
 
-  for(var in names(x$xlevels)) { # extract base levels info on factor/character columns from lm model
-    if(pretty.name) {
-      ret[paste0("Base Level of ", var)] <- x$xlevels[[var]][[1]]
-    }
-    else {
-      ret[paste0(var, "_base")] <- x$xlevels[[var]][[1]]
-    }
-  }
   # Adjust the subtle difference between sigma (Residual Standard Error) and RMSE.
   # In RMSE, division is done by observation size, while it is by residual degree of freedom in sigma.
   # https://www.rdocumentation.org/packages/sjstats/versions/0.17.4/topics/cv
@@ -909,15 +901,6 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
     # Show number of rows for positive case and negative case, especially so that result of SMOTE is visible.
     ret$positives <- sum(x$y == 1, na.rm = TRUE)
     ret$negatives <- sum(x$y != 1, na.rm = TRUE)
-  }
-
-  for(var in names(x$xlevels)) { # extract base levels info on factor/character columns from lm model
-    if(pretty.name) {
-      ret[paste0("Base Level of ", var)] <- x$xlevels[[var]][[1]]
-    }
-    else {
-      ret[paste0(var, "_base")] <- x$xlevels[[var]][[1]]
-    }
   }
 
   if(pretty.name) {

--- a/R/partial_dependence.R
+++ b/R/partial_dependence.R
@@ -57,7 +57,7 @@ handle_partial_dependence <- function(x) {
   # }
 
   # For lm/glm, show plot of means of binned training data alongside with the partial dependence as "Actual" plot.
-  # Partial dependence is labeled as the "Model" plot to make comparison.
+  # Partial dependence is labeled as the "Predicted" plot to make comparison.
   if ("glm" %in% class(x) || "lm" %in% class(x)) {
     if (!is.null(x$data)) {  # For glm case.
       df <- x$data
@@ -67,16 +67,16 @@ handle_partial_dependence <- function(x) {
     }
     actual_ret <- calc_partial_binning_data(df, target_col, var_cols)
     ret <- ret %>% dplyr::bind_rows(actual_ret)
-    ret <- ret %>% dplyr::rename(Model=!!rlang::sym(target_col)) # Rename target column to Model to make comparison with Actual.
+    ret <- ret %>% dplyr::rename(Predicted=!!rlang::sym(target_col)) # Rename target column to Predicted to make comparison with Actual.
   }
   else if (!is.null(x$partial_binning)) { # For ranger/rpart, we calculate binning data at model building. Maybe we should do the same for glm/lm.
     actual_ret <- x$partial_binning
     ret <- ret %>% dplyr::bind_rows(actual_ret)
     if (!is.null(ret[[target_col]])) {
-      ret <- ret %>% dplyr::rename(Model=!!rlang::sym(target_col)) # Rename target column to Model to make comparison with Actual.
+      ret <- ret %>% dplyr::rename(Predicted=!!rlang::sym(target_col)) # Rename target column to Predicted to make comparison with Actual.
     }
     else if (!is.null(ret$`TRUE`)) { # Column with name that matches target_col is not there, but TRUE column is there. This must be a binary classification case.
-      ret <- ret %>% dplyr::rename(Model=`TRUE`) # Rename target column to Model to make comparison with Actual.
+      ret <- ret %>% dplyr::rename(Predicted=`TRUE`) # Rename target column to Predicted to make comparison with Actual.
       if (!is.null(ret$`FALSE`)) {
         ret <- ret %>% dplyr::select(-`FALSE`) # Drop FALSE column, which we will not use.
       }
@@ -106,7 +106,7 @@ handle_partial_dependence <- function(x) {
   # glm (binomial family) is exception here, since we only show probability of being TRUE,
   # and instead show mean of binned actual data.
   if ("glm" %in% class(x) || !is.null(x$partial_binning)) { # Or part is for ranger/rpart. They might not have partial_binning, because of being multiclass or published on server from older release.
-    ret <- ret %>%  dplyr::mutate(y_name = factor(y_name, levels=c("Actual", "Model", "conf_low", "conf_high")))
+    ret <- ret %>%  dplyr::mutate(y_name = factor(y_name, levels=c("Actual", "Predicted", "conf_low", "conf_high")))
   }
   else if (!is.null(x$orig_levels)) {
     ret <- ret %>%  dplyr::mutate(y_name = factor(y_name, levels=x$orig_levels))

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -246,9 +246,7 @@ test_that("prediction with glm family (negativebinomial) with target column name
   expect_equal(colnames(ret),
                c("null.deviance", "df.null", "logLik",
                  "AIC", "BIC", "deviance",
-                 "df.residual", "p.value", "n", "theta", "SE.theta",
-                 "logical.col_base",
-                 "Carrier.Name_base", "CARRIER_base"))
+                 "df.residual", "p.value", "n", "theta", "SE.theta"))
   ret <- model_data %>% broom::tidy(model)
   expect_colnames <- c("term", "estimate", "std.error", "statistic", "p.value",
                        "conf.high", "conf.low", "base.level")

--- a/tests/testthat/test_model_eval.R
+++ b/tests/testthat/test_model_eval.R
@@ -293,7 +293,7 @@ test_that("evaluate binary classification model by training and test", {
     eret <- evaluate_binary_training_and_test(ret, "CANCELLED X")
     expect_cols <-  c("is_test_data", "f_score", "accuracy_rate", "misclassification_rate", "precision", "recall", "auc",
                       "p.value", "n", "positives", "negatives", "logLik", "AIC", "BIC", "deviance",
-                      "null.deviance", "df.null", "df.residual", "Carrier.Name_base")
+                      "null.deviance", "df.null", "df.residual")
     expect_equal(colnames(eret), expect_cols)
     eret <- evaluate_binary_training_and_test(ret, "CANCELLED X", pretty.name = TRUE)
     expect_cols <- c("Data Type", "F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall", "AUC",

--- a/tests/testthat/test_model_eval.R
+++ b/tests/testthat/test_model_eval.R
@@ -298,7 +298,7 @@ test_that("evaluate binary classification model by training and test", {
     eret <- evaluate_binary_training_and_test(ret, "CANCELLED X", pretty.name = TRUE)
     expect_cols <- c("Data Type", "F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall", "AUC",
                      "P Value", "Number of Rows", "Number of Rows for TRUE", "Number of Rows for FALSE", "Log Likelihood", "AIC", "BIC",
-                     "Residual Deviance", "Null Deviance", "DF for Null Model", "Residual DF", "Base Level of Carrier.Name")
+                     "Residual Deviance", "Null Deviance", "DF for Null Model", "Residual DF")
 
     expect_equal(colnames(eret), expect_cols)
   })


### PR DESCRIPTION
# Description
- Rename pdp "Model" type to "Predicted" type.
- Remove base level info from lm/glm/cox summary table

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
