### PR TITLE
Merge pull request #701 from exploratory-io/hideaki_prophet_coef_handle_no_effect

### DIFF
--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -104,6 +104,18 @@ test_that("do_prophet test mode with year as time units", {
   expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
 })
 
+test_that("do_prophet with short data (test for coef)", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2010-01-13"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  model_df <- raw_data %>%
+    do_prophet(timestamp, data, 10, time_unit = "day", funs.aggregate.regressors = c(mean), yearly.seasonality = "auto", weekly.seasonality = "auto", output="model")
+  coef_df <- model_df %>% tidy(model, type="coef")
+  expect_equal(length(names(coef_df)), 0)
+  ret <- model_df %>% tidy(model)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2010-01-23")) 
+})
+
 test_that("do_prophet with extra regressors", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))


### PR DESCRIPTION
# Description
Handle the case where there is no effect column to avoid error on Exploratory that reads "`cols` must select at least one column. Call `rlang::last_error() to see a backtrace".

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
