### PR TITLE
GoogleSheeet: Support guess data type argument.

### DIFF
--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -18,9 +18,9 @@ uploadGoogleSheet <- function(filepath, title, overwrite = FALSE){
 #' @param treatTheseAsNA - character vector that each item represents NA
 #' @param firstRowAsHeader - argument to control if you want to treat first row as header
 #' @param commentChar - treat the character as comment.
-#' @param detectDataTypes - column types you want to assign.
+#' @param guessDataType - flag to tell if you want googlesheets::gs_read to guess column data type
 #' @export
-getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, detectDataTypes=TRUE, ...){
+getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, guessDataType=TRUE, ...){
   if(!requireNamespace("googlesheets")){stop("package googlesheets must be installed.")}
   if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
 
@@ -28,8 +28,8 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firs
   googlesheets::gs_auth(token)
   gsheet <- googlesheets::gs_title(title)
   col_types <- NULL
-  if(!detectDataTypes) {
-    # if detectDataTypes is FALSE, use character as the default column data type.
+  if(!guessDataType) {
+    # if guessDataType is FALSE, use character as the default column data type.
     col_types <- c(.default="c")
   }
   df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar, col_types = col_types)

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -18,13 +18,22 @@ uploadGoogleSheet <- function(filepath, title, overwrite = FALSE){
 #' @param treatTheseAsNA - character vector that each item represents NA
 #' @param firstRowAsHeader - argument to control if you want to treat first row as header
 #' @param commentChar - treat the character as comment.
+#' @param colTypes - column types you want to assign.
 #' @export
-getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, ...){
+getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, colTypes=NULL, ...){
   if(!requireNamespace("googlesheets")){stop("package googlesheets must be installed.")}
+  if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
+
   token <- getGoogleTokenForSheet(tokenFileId)
   googlesheets::gs_auth(token)
   gsheet <- googlesheets::gs_title(title)
-  df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar)
+  col_type <- colTypes
+  if(!is.null(colTypes)) {
+    # From Exploratory Desktop, colTypes parameter value is passed as a string like "colA='c', colB='c'"
+    # so need to convert it as an expression like c(colA='c', colB='c')
+    col_types <- rlang::parse_expr(stringr::str_c("c(", colTypes, ")"))
+  }
+  df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar, col_types = col_types )
   df
 }
 

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -30,7 +30,7 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firs
   col_type <- colTypes
   if(!is.null(colTypes)) {
     # From Exploratory Desktop, colTypes parameter value is passed as a string like "colA='c', colB='c'"
-    # so need to convert it as an expression like c(colA='c', colB='c')
+    # so need to convert it to an expression like c(colA='c', colB='c')
     col_types <- rlang::parse_expr(stringr::str_c("c(", colTypes, ")"))
   }
   df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar, col_types = col_types )

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -18,22 +18,21 @@ uploadGoogleSheet <- function(filepath, title, overwrite = FALSE){
 #' @param treatTheseAsNA - character vector that each item represents NA
 #' @param firstRowAsHeader - argument to control if you want to treat first row as header
 #' @param commentChar - treat the character as comment.
-#' @param colTypes - column types you want to assign.
+#' @param detectDataTypes - column types you want to assign.
 #' @export
-getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, colTypes=NULL, ...){
+getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA, firstRowAsHeader = TRUE, commentChar, tokenFileId=NULL, detectDataTypes=TRUE, ...){
   if(!requireNamespace("googlesheets")){stop("package googlesheets must be installed.")}
   if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
 
   token <- getGoogleTokenForSheet(tokenFileId)
   googlesheets::gs_auth(token)
   gsheet <- googlesheets::gs_title(title)
-  col_type <- colTypes
-  if(!is.null(colTypes)) {
-    # From Exploratory Desktop, colTypes parameter value is passed as a string like "colA='c', colB='c'"
-    # so need to convert it to an expression like c(colA='c', colB='c')
-    col_types <- rlang::parse_expr(stringr::str_c("c(", colTypes, ")"))
+  col_types <- NULL
+  if(!detectDataTypes) {
+    # if detectDataTypes is FALSE, use character as the default column data type.
+    col_types <- c(.default="c")
   }
-  df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar, col_types = col_types )
+  df <- gsheet %>% googlesheets::gs_read(ws = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, comment = commentChar, col_types = col_types)
   df
 }
 


### PR DESCRIPTION
# Description

Support colTypes argument for exploratory::getGoogleSheet

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
