### PR TITLE
lm/glm: Map column name to names like c1, c2... before building models to avoid column name related issues

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -580,9 +580,11 @@ prediction_training_and_test <- function(df, prediction_type="default", threshol
 
   if (prediction_type == "conf_mat") {
     target_col <- all.vars(model$formula)[[1]]
+    # Get original target column name.
+    target_col_orig <- df$model[[1]]$terms_mapping[[target_col]]
 
     each_mat_func <- function(df) {
-      actual_val <- df[[target_col]]
+      actual_val <- df[[target_col_orig]]
       predicted <- df$predicted_label
 
       df <- data.frame(
@@ -658,11 +660,9 @@ prediction_binary <- function(df, threshold = 0.5, ...){
     }
   }
 
-  # if there is terms_mapping for randomForest or ranger, use the original column name
-  if ("randomForest" %in% class(first_model) || "ranger" %in% class(first_model)) {
-    if (!is.na(first_model$terms_mapping) && !is.na(first_model$terms_mapping[[actual_col]])) {
-      actual_col <- first_model$terms_mapping[[actual_col]]
-    }
+  # if there is terms_mapping for randomForest, ranger, or glm_exploratory, use the original column name
+  if (!is.na(first_model$terms_mapping) && !is.na(first_model$terms_mapping[[actual_col]])) {
+    actual_col <- first_model$terms_mapping[[actual_col]]
   }
 
   actual_val <- ret[[actual_col]]

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -661,7 +661,7 @@ prediction_binary <- function(df, threshold = 0.5, ...){
   }
 
   # if there is terms_mapping for randomForest, ranger, or glm_exploratory, use the original column name
-  if (!is.na(first_model$terms_mapping) && !is.na(first_model$terms_mapping[[actual_col]])) {
+  if (!is.null(first_model$terms_mapping) && !is.null(first_model$terms_mapping[[actual_col]])) {
     actual_col <- first_model$terms_mapping[[actual_col]]
   }
 

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -580,8 +580,8 @@ prediction_training_and_test <- function(df, prediction_type="default", threshol
 
   if (prediction_type == "conf_mat") {
     target_col <- all.vars(model$formula)[[1]]
-    # Get original target column name.
-    target_col_orig <- df$model[[1]]$terms_mapping[[target_col]]
+    # Get original target column name. Use the model filtered above so that it is always a valid model rather than an error object.
+    target_col_orig <- model$terms_mapping[[target_col]]
 
     each_mat_func <- function(df) {
       actual_val <- df[[target_col_orig]]

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1291,12 +1291,10 @@ evaluate_lm_training_and_test <- function(df, pretty.name = FALSE){
         ## get Model Object
         m <- df %>% filter(!is.null(model)) %>% `[[`(1, "model", 1)
         actual_val_col <- all.vars(df$model[[1]]$terms)[[1]]
-        # Emulate the way lm replaces the column names in the output.
-        # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
-        # actual_val_col_clean <- stringr::str_replace_all(actual_val_col, ' ', '.')
-        actual_val_col_clean <- gsub(' ', '.', actual_val_col)
+        # Get original target column name.
+        actual_val_col_orig <- df$model[[1]]$terms_mapping[[actual_val_col]]
 
-        actual <- test_pred_ret[[actual_val_col_clean]]
+        actual <- test_pred_ret[[actual_val_col_orig]]
         predicted <- test_pred_ret$predicted_value
         root_mean_square_error <- rmse(actual, predicted)
         test_n <- sum(!is.na(predicted)) # Sample size for test.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -366,12 +366,20 @@ build_lm.fast <- function(df,
 
   # Replace spaces with dots in column names. margins::marginal_effects() fails without it.
   clean_df <- df
-  # Cleaning of column names for marginal_effects(). Comma and Space are not handled well. Replace them with '.'.
+  # Cleaning of column names for marginal_effects(). Space is not handled well. Replace them with '.'.
   # ()"' are known to be ok as of version 5.5.2.
   # Also, cleaning of column names for relaimpo. - is not handled well. Replace them with _.
+  # Also, cleaning of column names for mmpf::marginalPrediction (for partial dependence). Comma is not handled well. Replace them with '.'.
   # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
   # names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
-  names(clean_df) <- gsub('\\-', '_', gsub('[, ]', '.', names(df)))
+  if (model_type == "lm") {
+    # For lm, we can skip column names cleaning for marginal_effects (space), since we do not use them.
+    names(clean_df) <- gsub('\\-', '_', gsub('[,]', '.', names(df)))
+  }
+  else {
+    # For glm, we can skip column names cleaning for relaimpo (-), since we do not use them.
+    names(clean_df) <- gsub('[, ]', '.', names(df))
+  }
   # this mapping will be used to restore column names
   name_map <- colnames(clean_df)
   names(name_map) <- colnames(df)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1264,9 +1264,9 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
     # Calling broom:::augment.glm fails with 'NextMethod' called from an anonymous function
     # It seems augment.glm is only calling NextMethod, which is falling back to broom:::augment.lm.
     # So, we are just directly calling augment.lm here.
-    broom:::augment.lm(x, data = data, newdata = newdata, ...)
+    ret <- broom:::augment.lm(x, data = data, newdata = newdata, ...)
   } else if (!is.null(data)) {
-    switch(data_type,
+    ret <- switch(data_type,
       training = { # Call broom:::augment.lm as is
         broom:::augment.lm(x, data = data, newdata = newdata, ...)
       },
@@ -1278,8 +1278,11 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
       })
   }
   else {
-    broom:::augment.lm(x, ...)
+    ret <- broom:::augment.lm(x, ...)
   }
+  # Rename columns back to the original names.
+  names(ret) <- coalesce(x$terms_mapping[names(ret)], names(ret))
+  ret
 }
 
 # For some reason, find_data called from inside margins::marginal_effects() fails in Exploratory.

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1039,6 +1039,7 @@ tidy.lm_exploratory <- function(x, type = "coefficients", pretty.name = FALSE, .
           ret <- ret %>% rename(Note=note)
         }
       }
+      # Map coefficient names back to original.
       ret$term <- map_terms_to_orig(ret$term, x$terms_mapping)
       if (pretty.name) {
         ret <- ret %>% rename(Term=term, Coefficient=estimate, `Std Error`=std.error,
@@ -1131,6 +1132,8 @@ tidy.glm_exploratory <- function(x, type = "coefficients", pretty.name = FALSE, 
           ret <- ret %>% rename(Note=note)
         }
       }
+      # Map coefficient names back to original.
+      ret$term <- map_terms_to_orig(ret$term, x$terms_mapping)
       if (pretty.name) {
         ret <- ret %>% rename(Term=term, Coefficient=estimate, `Std Error`=std.error,
                               `t Ratio`=statistic, `P Value`=p.value, `Conf Low`=conf.low, `Conf High`=conf.high,

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1239,10 +1239,6 @@ augment.lm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = "
         broom:::augment.lm(x, data = data, newdata = newdata, ...)
       },
       test = {
-        # Minic broom:::augment.lm behavior of replacing spaces in column names. Without this, after bind_row in prediction(), such columns will end up in 2 separate columns.
-        # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
-        # names(data) <- stringr::str_replace_all(names(data), ' ', '.')
-        names(data) <- gsub(' ', '.', names(data))
         # Augment data with already predicted result in the model.
         data$.fitted <- restore_na(x$prediction_test$fit, x$prediction_test$unknown_category_rows_index)
         data$.se.fit <- restore_na(x$prediction_test$se.fit, x$prediction_test$unknown_category_rows_index)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -366,16 +366,12 @@ build_lm.fast <- function(df,
 
   # Replace spaces with dots in column names. margins::marginal_effects() fails without it.
   clean_df <- df
-  if (model_type == "lm") {
-    # For lm, we can skip column names cleaning, since we do not use marginal_effects().
-  }
-  else {
-    # Cleaning of column names for marginal_effects(). Space is not handled well. Replace them with '.'.
-    # Also, cleaning of column names for relaimpo. - is not handled well. Replace them with _.
-    # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
-    # names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
-    names(clean_df) <- gsub('\\-', '_', gsub(' ', '.', names(df)))
-  }
+  # Cleaning of column names for marginal_effects(). Comma and Space are not handled well. Replace them with '.'.
+  # ()"' are known to be ok as of version 5.5.2.
+  # Also, cleaning of column names for relaimpo. - is not handled well. Replace them with _.
+  # For some reason, str_replace garbles some column names in Japanese. Using gsub instead to avoid the issue.
+  # names(clean_df) <- stringr::str_replace_all(names(df), ' ', '.') %>% stringr::str_replace_all('-', '_')
+  names(clean_df) <- gsub('\\-', '_', gsub('[, ]', '.', names(df)))
   # this mapping will be used to restore column names
   name_map <- colnames(clean_df)
   names(name_map) <- colnames(df)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -374,6 +374,9 @@ build_lm.fast <- function(df,
   #   ()"' are known to be ok as of version 5.5.2.
   # - Column name issue for relaimpo. - is not handled well.
   # - Column name issue for mmpf::marginalPrediction (for partial dependence). Comma is not handled well.
+  # Note that the data frames in source_data column are with the replaced column names for simplicity,
+  # rather than the original column names, unlike what we do for ranger or rpart. (Maybe we should do it for ranger or rpart.)
+  # The reverse mapping of the column names are done in augment.lm_exploratory or augment.glm_exploratory.
   names(clean_df) <- paste0("c",1:length(colnames(clean_df)), "_")
   # this mapping will be used to restore column names
   name_map <- colnames(clean_df)

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -91,7 +91,6 @@ evaluate_binary_ <- function(df, pred_prob_col, actual_val_col, threshold = "f_s
   validate_empty_data(df)
 
   evaluate_binary_each <- function(df){
-
     actual_val <- df[[actual_val_col]]
     pred_prob <- df[[pred_prob_col]]
 
@@ -318,7 +317,8 @@ evaluate_multi_ <- function(df, pred_label_col, actual_val_col, pretty.name = FA
 
 # Generates Analytics View Summary Table for logistic/binomial regression. Handles Test Mode.
 #' @export
-evaluate_binary_training_and_test <- function(df, actual_val_col, threshold = "f_score", pretty.name = FALSE){
+evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_score", pretty.name = FALSE){
+  actual_val_col <- col_name(substitute(actual_val)) # Get name of column as string.
   training_ret <- df %>% broom::glance(model, binary_classification_threshold = threshold)
   ret <- training_ret
 
@@ -336,11 +336,7 @@ evaluate_binary_training_and_test <- function(df, actual_val_col, threshold = "f
       tryCatch({
         test_pred_ret <- prediction_binary(df, data = "test")
   
-        # Terms Mapping
-        ## get Model Object
-        m <- df %>% filter(!is.null(model)) %>% `[[`(1, "model", 1)
-        actual_val_col <- m$terms_mapping[m$terms_mapping == actual_val_col] %>% names(.)
-  
+        # Evaluate the binary classification result.
         eret <- evaluate_binary_(test_pred_ret, "predicted_probability", actual_val_col, threshold = threshold)
   
         test_ret <- eret %>% dplyr::mutate(n = true_positive + false_positive + true_negative + false_negative,

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1775,27 +1775,16 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
     }
   }
 
-  if (map_name) {
-    # randomForest fails if columns are not clean
-    clean_df <- df
+  # randomForest fails if columns are not clean
+  clean_df <- df
 
+  if (map_name) {
     # This mapping will be used to restore column names
     # We used to use janitor::clean_names(df), but
     # since we are setting the names back anyway,
     # we can use names like c1, c2 which is guaranteed to be safe
     # regardless of original column names.
     name_map <- paste0("c",1:length(colnames(df)))
-    names(name_map) <- colnames(df)
-
-    # clean_names changes column names
-    # without chaning grouping column name
-    # information in the data frame
-    # and it causes an error,
-    # so the value of grouping columns
-    # should be still the names of grouping columns
-    name_map[grouped_cols] <- grouped_cols
-    colnames(clean_df) <- name_map
-  }
   else {
     # do not do mapping.
     # we need this mode for rpart since the plotting will be done directly from the model
@@ -1803,10 +1792,18 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
     # fortunately, rpart seems to be robust enough against strange column names
     # even on sjis windows.
     # just create a map with same names so that the rest of the code works.
-    clean_df <- df
     name_map <- colnames(df)
-    names(name_map) <- colnames(df)
   }
+  names(name_map) <- colnames(df)
+
+  # clean_names changes column names
+  # without chaning grouping column name
+  # information in the data frame
+  # and it causes an error,
+  # so the value of grouping columns
+  # should be still the names of grouping columns
+  name_map[grouped_cols] <- grouped_cols
+  colnames(clean_df) <- name_map
 
   clean_target_col <- name_map[target_col]
   clean_cols <- name_map[cols]

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1787,13 +1787,16 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
     name_map <- paste0("c",1:length(colnames(df)))
   }
   else {
-    # do not do mapping.
+    # Do only mapping with minimum name changes to avoid error, which is explained below.
     # we need this mode for rpart since the plotting will be done directly from the model
     # and we want original column names to appear.
     # fortunately, rpart seems to be robust enough against strange column names
     # even on sjis windows.
-    # just create a map with same names so that the rest of the code works.
-    name_map <- colnames(df)
+    # just create a map with almost same names so that the rest of the code works.
+
+    # Cleaning of column names for marginal_effects(). Comma is not handled well. Replace them with '.'.
+    # ()"' and spaces are known to be ok as of version 5.5.2.
+    name_map <- gsub('[,]', '.', colnames(df))
   }
   names(name_map) <- colnames(df)
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1794,7 +1794,7 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
     # even on sjis windows.
     # just create a map with almost same names so that the rest of the code works.
 
-    # Cleaning of column names for marginal_effects(). Comma is not handled well. Replace them with '.'.
+    # Cleaning of column names for mmpf::marginalPrediction (for partial dependence). Comma is not handled well. Replace them with '.'.
     # ()"' and spaces are known to be ok as of version 5.5.2.
     name_map <- gsub('[,]', '.', colnames(df))
   }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1785,6 +1785,7 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
     # we can use names like c1, c2 which is guaranteed to be safe
     # regardless of original column names.
     name_map <- paste0("c",1:length(colnames(df)))
+  }
   else {
     # do not do mapping.
     # we need this mode for rpart since the plotting will be done directly from the model

--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -564,7 +564,7 @@ test_that("test prediction(data='training_and_test') by glm", {
                      "hat", "residual_standard_deviation",
                      "cooks_distance", "standardised_residuals",
                      "is_test_data")
-  expected_cols_2 <- c("klass", "Carrier.Name", "DISTANCE",
+  expected_cols_2 <- c("klass", "Carrier Name", "DISTANCE",
                      "ARR_TIME", "DERAY_TIME", "predicted_value",
                      "standard_error", "conf_low", "conf_high", "residuals",
                      "hat", "residual_standard_deviation",

--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -542,7 +542,7 @@ test_that("test prediction(data='training_and_test') by glm", {
                                      model_type = "lm",
                                      test_rate = 0.2)
   ret <- model_ret %>% prediction(data='training_and_test')
-  expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME",
+  expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME",
                      "DERAY_TIME", "predicted_value", "standard_error",
                      "conf_low", "conf_high", "residuals", "hat",
                      "residual_standard_deviation", "cooks_distance",
@@ -558,7 +558,7 @@ test_that("test prediction(data='training_and_test') by glm", {
   grp_ret <- grp_model_ret %>% prediction(data='training_and_test')
   # For some reason, cooks_distance and standardised_residuals does not show up with change in https://github.com/exploratory-io/exploratory_func/pull/656
   # Working it around now, but look into it.
-  expected_cols_1 <- c("klass", "Carrier.Name", "DISTANCE",
+  expected_cols_1 <- c("klass", "Carrier Name", "DISTANCE",
                      "ARR_TIME", "DERAY_TIME", "predicted_value",
                      "standard_error", "conf_low", "conf_high", "residuals",
                      "hat", "residual_standard_deviation",

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -179,7 +179,7 @@ test_that("prediction with target column name with space by build_lm.fast", {
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED.X", "logical.col", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+  expect_equal(colnames(ret), c("CANCELLED:X", "logical col", "Carrier-Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
 })
 
 test_that("prediction with glm family (binomial) and link (probit) with target column name with space by build_lm.fast", {
@@ -219,7 +219,7 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED.X", "logical.col", "Carrier.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+  expect_equal(colnames(ret), c("CANCELLED X", "logical col", "Carrier Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
 })
 
 test_that("prediction with glm family (negativebinomial) with target column name with space by build_lm.fast", {
@@ -257,7 +257,7 @@ test_that("prediction with glm family (negativebinomial) with target column name
 
   ret <- model_data %>% broom::augment(model)
   expect_equal(colnames(ret),
-               c("CANCELLED.X", "logical.col", "Carrier.Name", "CARRIER", "DISTANCE",
+               c("CANCELLED X", "logical col", "Carrier Name", "CARRIER", "DISTANCE",
                  ".fitted", ".resid", ".hat", ".sigma", ".cooksd", ".std.resid"))
 })
 
@@ -286,7 +286,7 @@ if (Sys.info()["sysname"] != "Windows") {
     ret <- model_data %>% broom::augment(model)
   
     expect_true(nrow(ret) > 0)
-    expect_equal(colnames(ret), c("キャンセル.X", "論理.col", "航空会社.Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+    expect_equal(colnames(ret), c("キャンセル X", "論理 col", "航空会社 Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
   })
 }
 

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -1,5 +1,4 @@
 context("test build_lm part 2")
-
 test_that("binary prediction with character target column", {
   test_data <- structure(
     list(
@@ -116,11 +115,11 @@ test_that("Linear Regression with test rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% broom::glance(model, pretty.name=TRUE)
@@ -152,11 +151,11 @@ test_that("Linear Regression with outlier filtering", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% broom::glance(model, pretty.name=TRUE)
@@ -215,11 +214,11 @@ test_that("GLM - Normal Destribution with test_rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -279,11 +278,11 @@ test_that("GLM - Gamma Destribution with test_rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -343,11 +342,11 @@ test_that("GLM - Inverse Gaussian Destribution with test_rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -407,11 +406,11 @@ test_that("GLM - poisson Destribution with test_rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -472,11 +471,11 @@ test_that("GLM - Negative Binomial Destribution with test_rate", {
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier.Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -533,16 +532,17 @@ test_that("Logistic Regression with test_rate", {
   training_rownum <- nrow(test_data) - test_rownum
 
   suppressWarnings({
+    pred_training_and_test <- ret %>% prediction_binary(data = 'training_and_test', threshold = 0.5)
     pred_training <- prediction(ret, data = "training")
     pred_test <- prediction(ret, data = "test")
     expect_equal(training_rownum, nrow(pred_training))
     expect_equal(test_rownum, nrow(pred_test))
 
-    expected_cols <- c("CANCELLED.X", "Carrier.Name", "ARR_TIME", "DERAY_TIME",
+    expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", "standard_error", "conf_low", "conf_high", "residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("CANCELLED.X", "Carrier.Name", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
+    expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -573,12 +573,12 @@ test_that("Group Logistic Regression with test_rate", {
     expect_equal(pred_test %>% summarize(n=n()) %>% `[[`("n"),
                  test_nrows)
 
-    expected_cols <- c("klass", "CANCELLED.X", "ARR_TIME", "predicted_value",
+    expected_cols <- c("klass", "CANCELLED X", "ARR_TIME", "predicted_value",
                        "standard_error", "conf_low", "conf_high", "residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "standardised_residuals", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
-    expected_cols <- c("klass", "CANCELLED.X", "ARR_TIME", "predicted_value",
+    expected_cols <- c("klass", "CANCELLED X", "ARR_TIME", "predicted_value",
                        "standard_error", "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -533,6 +533,7 @@ test_that("Logistic Regression with test_rate", {
 
   suppressWarnings({
     pred_training_and_test <- ret %>% prediction_binary(data = 'training_and_test', threshold = 0.5)
+    pred_training_and_test_conf_mat <- ret %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
     pred_training <- prediction(ret, data = "training")
     pred_test <- prediction(ret, data = "test")
     expect_equal(training_rownum, nrow(pred_training))

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -546,8 +546,9 @@ test_that("Logistic Regression with test_rate", {
     expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
                        "conf_low", "conf_high", "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
-
     res <- ret %>% broom::glance(model, pretty.name=TRUE)
+    res <- ret %>% evaluate_binary_training_and_test(`CANCELLED X`, threshold = 0.5, pretty.name=TRUE)
+    expect_equal(nrow(res), 2) # 2 for training and test.
     res <- ret %>% lm_partial_dependence()
    })
 })

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -17,8 +17,7 @@ test_that("binary prediction with character target column", {
   model_data <- build_lm.fast(test_data, `CANCELLED X`, `Carrier Name`, CARRIER, DISTANCE,
                               normalize_predictors = TRUE,
                               model_type = "glm", smote=FALSE, with_marginal_effects=TRUE, with_marginal_effects_confint=TRUE)
-  ret <- model_data %>% tidy(model, type="vif")
-
+  ret <- model_data %>% broom::tidy(model, type="vif")
   ret <- model_data %>% broom::glance(model, pretty.name=TRUE)
   expect_equal(ret$`Number of Rows`, 34)
   expect_equal(ret$`Number of Rows for Y`, 4) # This ends up to be 4 after doubling
@@ -103,8 +102,10 @@ test_that("Linear Regression with test rate", {
                                      model_type = "lm",
                                      test_rate = 0.1,
                                      test_split_type = "ordered") # testing ordered split too.
-  res <- ret %>% tidy(model, type="vif")
-
+  res <- ret %>% broom::tidy(model)
+  expect_true("Carrier Name: American Airlines" %in% res$term)
+  res <- ret %>% broom::tidy(model, type="vif")
+  expect_true("Carrier Name" %in% res$term)
   expect_equal(colnames(ret), c("model", ".test_index", "source.data"))
   test_rownum <- length(ret$.test_index[[1]])
   training_rownum <- nrow(test_data) - test_rownum
@@ -584,4 +585,3 @@ test_that("Group Logistic Regression with test_rate", {
     res <- ret %>% broom::glance(model, pretty.name=TRUE)
    })
 })
-


### PR DESCRIPTION
# Description
Map column name to names like c1, c2... before building models to avoid column name related issues.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
