### PR TITLE
Calculate means of bins only for logical/numeric target

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2772,6 +2772,9 @@ exp_rpart <- function(df,
 
   grouped_cols <- grouped_by(df)
 
+  # Remember if the target column was originally numeric or logical before converting type.
+  is_target_logical_or_numeric <- is.numeric(df[[target_col]]) || is.logical(df[[target_col]])
+
   clean_ret <- cleanup_df(df, target_col, selected_cols, grouped_cols, target_n, predictor_n, map_name=FALSE)
 
   clean_df <- clean_ret$clean_df
@@ -2850,7 +2853,8 @@ exp_rpart <- function(df,
         imp_vars <- names(model$variable.importance) # model$variable.importance is already sorted by importance.
         imp_vars <- imp_vars[1:min(length(imp_vars), max_pd_vars)] # Keep only max_pd_vars most important variables
         model$partial_dependence <- partial_dependence.rpart(model, clean_target_col, vars=imp_vars, data=df, n=c(pd_grid_resolution, min(nrow(df), pd_sample_size)))
-        if (pd_with_bin_means) {
+        if (pd_with_bin_means && is_target_logical_or_numeric) {
+          # We calculate means of bins only for logical or numeric target to keep the visualization simple.
           model$partial_binning <- calc_partial_binning_data(df, clean_target_col, imp_vars)
         }
       }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2022,6 +2022,9 @@ calc_feature_imp <- function(df,
 
   grouped_cols <- grouped_by(df)
 
+  # Remember if the target column was originally numeric or logical before converting type.
+  is_target_logical_or_numeric <- is.numeric(df[[target_col]]) || is.logical(df[[target_col]])
+
   orig_levels <- NULL
   if (is.factor(df[[target_col]])) {
     orig_levels <- levels(df[[target_col]])
@@ -2208,7 +2211,8 @@ calc_feature_imp <- function(df,
       # Second element of n argument needs to be less than or equal to sample size, to avoid error.
       if (length(imp_vars) > 0) {
         rf$partial_dependence <- edarf::partial_dependence(rf, vars=imp_vars, data=model_df, n=c(pd_grid_resolution, min(rf$num.samples, pd_sample_size)))
-        if (pd_with_bin_means) {
+        if (pd_with_bin_means && is_target_logical_or_numeric) {
+          # We calculate means of bins only for logical or numeric target to keep the visualization simple.
           rf$partial_binning <- calc_partial_binning_data(model_df, clean_target_col, imp_vars)
         }
       }

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -100,9 +100,36 @@ test_that("exp_rpart(character(A,B)) evaluate training and test", { # This shoul
   expect_equal(nrow(ret), 1) # 1 for train
 })
 
-test_that("exp_rpart(character(TRUE,FALSE)) evaluate training and test", { # This should be treated as multi-class
+test_that("exp_rpart(character(TRUE,FALSE)) with NAs evaluate training and test", { # This should be treated as multi-class
   model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "TRUE", "FALSE")) %>%
-                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, pd_with_bin_means = TRUE, test_rate = 0.3, binary_classification_threshold=0.5)
+
+  ret <-  model_df %>% rf_partial_dependence()
+
+  ret <- model_df %>% prediction(data="training_and_test")
+  test_ret <- ret %>% filter(is_test_data==TRUE)
+  # expect_equal(nrow(test_ret), 1483) # Not very stable for some reason. Will revisit.
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 3461) # Not very stable for some reason. Will revisit.
+
+  ret <- model_df %>% rf_evaluation_training_and_test()
+  expect_equal(nrow(ret), 2) # 2 for train and test
+
+  # Training only case
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "TRUE", "FALSE")) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0)
+  ret <- model_df %>% prediction(data="training_and_test")
+  train_ret <- ret %>% filter(is_test_data==FALSE)
+  # expect_equal(nrow(train_ret), 4944) # Not very stable for some reason. Will revisit.
+
+  ret <- rf_evaluation_training_and_test(model_df)
+  expect_equal(nrow(ret), 1) # 1 for train
+})
+
+test_that("exp_rpart(character(TRUE,FALSE)) without NAs evaluate training and test", { # This should be treated as multi-class
+  model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "TRUE", "FALSE")) %>%
+                filter(!is.na(is_delayed)) %>%
+                exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, pd_with_bin_means = TRUE, test_rate = 0.3, binary_classification_threshold=0.5)
 
   ret <-  model_df %>% rf_partial_dependence()
 


### PR DESCRIPTION
# Description
Calculate means of bins only for logical/numeric target.
This avoids 'subscript out of bounds' error when target is character/factor with values of 'TRUE'/'FALSE'.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
