### PR TITLE
make sure to call tm::stopwords only for supported languages.

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -106,6 +106,8 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     "swedis")) {
     loadNamespace("tm")
     tm::stopwords(kind = lang)
+  } else { # set empty string as a fallback.
+    c("")
   }
   # if is_twitter argument is true, append exploratory_stopwords which contains stopwords for twitter
   if(is_twitter) {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -106,7 +106,7 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     "swedish")) {
     loadNamespace("tm")
     tm::stopwords(kind = lang)
-  } else { # set empty string as a fallback.
+  } else { # set empty vector as a fallback.
     c()
   }
   # if is_twitter argument is true, append exploratory_stopwords which contains stopwords for twitter

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -103,7 +103,7 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     "portuguese",
     "russian",
     "spanish",
-    "swedis")) {
+    "swedish")) {
     loadNamespace("tm")
     tm::stopwords(kind = lang)
   } else { # set empty string as a fallback.

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -107,7 +107,7 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     loadNamespace("tm")
     tm::stopwords(kind = lang)
   } else { # set empty string as a fallback.
-    c("")
+    c()
   }
   # if is_twitter argument is true, append exploratory_stopwords which contains stopwords for twitter
   if(is_twitter) {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -90,7 +90,20 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     "japanese")){
     # these data are created from data-raw/create_internal_data.R
     get(paste0("stopwords_", lang))
-  } else {
+  } else if(lang %in% c( # tm only supports these language for stopwords
+    "danish",
+    "dutch",
+    "english",
+    "finnish",
+    "french",
+    "german",
+    "hungarian",
+    "italian",
+    "norwegian",
+    "portuguese",
+    "russian",
+    "spanish",
+    "swedis")) {
     loadNamespace("tm")
     tm::stopwords(kind = lang)
   }

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -24,6 +24,7 @@ test_that("check languages", {
     "spanish",
     "swedish",
     "japanese",
+    "tamil", # from tidystopwords
     "english_SMART",
     "english_snowball",
     "english_onix"


### PR DESCRIPTION
# Description

tm::stopwords only support below languages, so make sure to call tm::stopwords for only below languages:

- danish
- dutch
- english
- finnish
- french
- german
- hungarian
- italian
- norwegian
- portuguese
- russian
- spanish
- swedis


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
