### PR TITLE
GoogleBigQuery: Make sure to get a destination table and dataset information from job submission result

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1219,7 +1219,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     # so just pass query as is.
     result <- exploratory::submitGoogleBigQueryJob(project = bqProjectId, sqlquery = query, tokenFieldId =  tokenFileId, useStandardSQL = useStandardSQL);
     # extranct result from Google BigQuery to Google Cloud Storage and import
-    # Get dataSetId and tableID from result (result is a data frame).
+    # Get datasetId and tableId from result (result is a data frame).
     df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(unique(result$datasetId)), as.character(unique(result$tableId)), csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)

--- a/R/system.R
+++ b/R/system.R
@@ -1219,7 +1219,8 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     # so just pass query as is.
     result <- exploratory::submitGoogleBigQueryJob(project = bqProjectId, sqlquery = query, tokenFieldId =  tokenFileId, useStandardSQL = useStandardSQL);
     # extranct result from Google BigQuery to Google Cloud Storage and import
-    df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, dataSet, table, csBucket, bucketFolder, tokenFileId)
+    # Get dataSetId and tableID from result (result is a data frame).
+    df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(unique(result$datasetId)), as.character(unique(result$tableId)), csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)
 

--- a/R/system.R
+++ b/R/system.R
@@ -1219,7 +1219,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     # so just pass query as is.
     result <- exploratory::submitGoogleBigQueryJob(project = bqProjectId, sqlquery = query, tokenFieldId =  tokenFileId, useStandardSQL = useStandardSQL);
     # extranct result from Google BigQuery to Google Cloud Storage and import
-    # Get datasetId and tableId from result (result is a data frame).
+    # Since Google might assign new tableId and datasetId, always get datasetId and tableId from the job result (result is a data frame).
     df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(unique(result$datasetId)), as.character(unique(result$tableId)), csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)

--- a/R/system.R
+++ b/R/system.R
@@ -1220,6 +1220,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     result <- exploratory::submitGoogleBigQueryJob(project = bqProjectId, sqlquery = query, tokenFieldId =  tokenFileId, useStandardSQL = useStandardSQL);
     # extranct result from Google BigQuery to Google Cloud Storage and import
     # Since Google might assign new tableId and datasetId, always get datasetId and tableId from the job result (result is a data frame).
+    # To get the only one value for datasetId and tableId, use dplyr::first.
     df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(dplyr::first(result$datasetId)), as.character(dplyr::first(result$tableId)), csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)

--- a/R/system.R
+++ b/R/system.R
@@ -1220,7 +1220,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     result <- exploratory::submitGoogleBigQueryJob(project = bqProjectId, sqlquery = query, tokenFieldId =  tokenFileId, useStandardSQL = useStandardSQL);
     # extranct result from Google BigQuery to Google Cloud Storage and import
     # Since Google might assign new tableId and datasetId, always get datasetId and tableId from the job result (result is a data frame).
-    df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(unique(result$datasetId)), as.character(unique(result$tableId)), csBucket, bucketFolder, tokenFileId)
+    df <- getDataFromGoogleBigQueryTableViaCloudStorage(bqProjectId, as.character(dplyr::first(result$datasetId)), as.character(dplyr::first(result$tableId)), csBucket, bucketFolder, tokenFileId)
   } else {
     # direct import case (for refresh data frame case)
 


### PR DESCRIPTION
# Description

Previously, it was not using dataset id and destination table name returned fro job submission result and it ends up with getting cached old result for the job.

With this change, it always uses the datasetId and table name so that always get a correct result.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
