### PR TITLE
Changed the default value for hiragana_word_length_to_remove as 2.

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -251,9 +251,11 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
 #' @param with_id Whether output should contain original document id and sentence id in each document.
 #' @param output Set a column name for the new column to store the tokenized values.
 #' @param stopwords_lang Language for the stopwords that need to be excluded from the result.
+#' @param remove_punct Whether it should remove punctuations.
+#' @param remove_numbers Whether it should remove numbers.
 #' @return Data frame with tokenized column
 #' @export
-do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = TRUE, with_id = TRUE, output = token, stopwords_lang = NULL, ...){
+do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = TRUE, with_id = TRUE, output = token, stopwords_lang = NULL, remove_punct = TRUE, remove_numbers = TRUE, ...){
   validate_empty_data(df)
 
   loadNamespace("tidytext")
@@ -294,7 +296,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
     # so that it won't duplicate other columns,
     # which will be joined later
     tokenize_df <- df[,c(doc_id, input_col)]
-    sentences <- tidytext::unnest_tokens_(tokenize_df, output_col, input_col, token="sentences", drop=TRUE, ...)
+    sentences <- tidytext::unnest_tokens_(tokenize_df, output_col, input_col, token="sentences", drop=TRUE, strip_punct = remove_punct, ...)
 
     # as.symbol is used for colum names with backticks
     grouped <- dplyr::group_by(sentences, !!!rlang::syms(doc_id))
@@ -305,7 +307,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
 
     # split into tokens
     tokenize_df <- dplyr::ungroup(tokenize_df)
-    tokenized <- tidytext::unnest_tokens_(tokenize_df, output_col, output_col, token=token, drop=TRUE, ...)
+    tokenized <- tidytext::unnest_tokens_(tokenize_df, output_col, output_col, token=token, strip_punct=remove_punct, drop=TRUE, ...)
 
     if(drop){
       df[[input_col]] <- NULL
@@ -313,7 +315,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
 
     ret <- dplyr::right_join(df, tokenized, by=doc_id)
   } else {
-    ret <- tidytext::unnest_tokens_(df, col_name(substitute(output)), input_col, token=token, drop=drop, ...)
+    ret <- tidytext::unnest_tokens_(df, col_name(substitute(output)), input_col, token=token, strip_punct=remove_punct, drop=drop, ...)
   }
 
   # set the column name to original.
@@ -323,6 +325,10 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
   # if stopwords_lang is provided, remove the stopwords for the language.
   if(!is.null(stopwords_lang)) {
     ret <- ret %>% dplyr::filter(!is_stopword(!!rlang::sym(output_col), lang = stopwords_lang))
+  }
+  if(remove_numbers) {
+    # remoe if the token is all number characters.
+    ret <- ret %>% dplyr::filter(!stringr::str_detect(!!rlang::sym(output_col), '^[:digit:]+$'))
   }
   ret
 }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -170,7 +170,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
                                  remove_hyphens = FALSE, remove_separators = TRUE,
                                  remove_symbols = TRUE, remove_twitter = TRUE,
                                  remove_url = TRUE, stopwords_lang = NULL,
-                                 hiragana_word_length_to_remove = 0, ...){
+                                 hiragana_word_length_to_remove = 2, ...){
 
   if(!requireNamespace("quanteda")){stop("package quanteda must be installed.")}
   if(!requireNamespace("dplyr")){stop("package dplyr must be installed.")}

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -109,8 +109,29 @@ test_that("do_tokenize with keep_cols = TRUE with sentences", {
     stringsAsFactors = FALSE)
   result <- test_df %>%
     do_tokenize(input, drop=FALSE, token = "sentences", keep_cols = TRUE)
-  expect_equal(result$token[[1]], "hello world!")
+  expect_equal(result$token[[1]], "hello world")
   expect_equal(ncol(result), 4)
+})
+
+test_that("do_tokenize with remove_numbers", {
+  test_df <- data.frame(
+    input = c("12345 aaa", "12aabb33", "123456 34567 88999"),
+    extra_col = seq(3),
+    stringsAsFactors = FALSE)
+  result <- test_df %>%
+    do_tokenize(input, drop=FALSE, keep_cols = TRUE, remove_numbers = TRUE)
+  expect_equal(result$token[[1]], "aaa")
+  expect_equal(result$token[[2]], "12aabb33")
+})
+
+test_that("do_tokenize with remove_punct", {
+  test_df <- data.frame(
+    input = c("#1 )*^%$ 2345 ^&*()", ":;:+-][", "00:01:00"),
+    extra_col = seq(3),
+    stringsAsFactors = FALSE)
+  result <- test_df %>%
+    do_tokenize(input, drop=FALSE, keep_cols = TRUE, remove_punct = FALSE, remove_numbers = FALSE)
+  expect_equal(result$token[[1]], "#")
 })
 
 test_that("do_tokenize with token=words", {
@@ -133,14 +154,14 @@ test_that("do_tokenize when names conflict", {
 test_that("do_tokenize with token=sentence", {
   result <- test_df %>%
     do_tokenize(input, token="sentences")
-  expect_equal(result$token[[1]], "hello world!")
+  expect_equal(result$token[[1]], "hello world")
   expect_equal(ncol(result), 2)
 })
 
 test_that("do_tokenize should work with output", {
   result <- test_df %>%
     do_tokenize(input, output=sentence, token="sentences")
-  expect_equal(result$sentence[[2]], "this is a data frame for test.")
+  expect_equal(result$sentence[[2]], "this is a data frame for test")
 })
 
 test_that("calc_idf", {


### PR DESCRIPTION
### Description

1. Changed the default value for hiragana_word_length_to_remove as 2.
2. Supported Remove Numbers and Remove Punctuations parameters for do_tokenize. 

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
