### PR TITLE
fix: Google Analytics: dateHourMunite column data type is returned as interger instead of POSIXct.

### DIFF
--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -114,6 +114,12 @@ getGoogleAnalytics <- function(tableId, lastNDays = 30, dimensions, metrics, tok
     ga.data <- ga.data %>% dplyr::mutate( dateHour = lubridate::ymd_h(dateHour) )
   }
 
+  if("dateHourMinute" %in% colnames(ga.data)){
+    # modify date column to POSIXct object from integer like 202001210000
+    loadNamespace("lubridate")
+    ga.data <- ga.data %>% dplyr::mutate( dateHourMinute = lubridate::ymd_hms(dateHourMinute, truncated = 1) )
+  }
+
   if("sessionCount" %in% colnames(ga.data)){
     # sessionCount is sometimes returned as character and numeric other times.
     # let's always cast it to numeric


### PR DESCRIPTION
# Description

fix the issue that `dateHourMunite` column data type is returned as integer instead of POSIXct.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
