### PR TITLE
fix Data Source: MySQL (RMariaDB) error "external pointer is not valid" at fetching column info

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -559,7 +559,8 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
-    if (is.null(conn)) {
+    # if the connection is null or the connection is invalid, create a new one.
+    if (is.null(conn) || !DBI::dbIsValid(conn)) {
       conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
                                password = password, host = host, port = port)
       connection_pool[[key]] <- conn
@@ -594,7 +595,8 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
-    if (is.null(conn)) {
+    # if the connection is null or the connection is invalid, create a new one.
+    if (is.null(conn) || !DBI::dbIsValid(conn)) {
       drv <- RPostgres::Postgres()
       conn <- RPostgres::dbConnect(drv, dbname=databaseName, user = username,
                                      password = password, host = host, port = port)
@@ -629,7 +631,8 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
-    if (is.null(conn)) {
+    # if the connection is null or the connection is invalid, create a new one.
+    if (is.null(conn) || !DBI::dbIsValid(conn)) {
       loadNamespace("RPresto")
       drv <- RPresto::Presto()
       # To workaround Presto Authentication issue, set X-Presto-User to http header.


### PR DESCRIPTION
# Description

This PR addresses the issue that MySQL (RMariaDB) shows an error "external pointer is not valid" at fetching column info.

It seems ` result <- DBI::dbGetQuery(conn,"set names utf8")` does not errors out and connection object not cleared in Try/Catch clause. So we want to check if the connection is valid or not.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
