### PR TITLE
Added POSIXct related operations (round to hour, round to minute, round to second) for summarize_group function.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1405,18 +1405,15 @@ extract_from_date <- function(x, type = "fltoyear") {
     rtoday = {
       ret <- lubridate::floor_date(x, unit="day")
     },
-    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
-    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    # This key is required by Exploratory Desktop for Summarize Group Dialog
     rtohour = {
       ret <- lubridate::floor_date(x, unit="hour")
     },
-    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
-    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    # This key is required by Exploratory Desktop for Summarize Group Dialog
     rtomin = {
       ret <- lubridate::floor_date(x, unit="minute")
     },
-    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
-    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    # This key is required by Exploratory Desktop for Summarize Group Dialog
     rtosec = {
       ret <- lubridate::floor_date(x, unit="second")
     },

--- a/R/util.R
+++ b/R/util.R
@@ -1405,6 +1405,21 @@ extract_from_date <- function(x, type = "fltoyear") {
     rtoday = {
       ret <- lubridate::floor_date(x, unit="day")
     },
+    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
+    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    rtohour = {
+      ret <- lubridate::floor_date(x, unit="hour")
+    },
+    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
+    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    rtomin = {
+      ret <- lubridate::floor_date(x, unit="minute")
+    },
+    # This key is a synonym for fltoday and is required by Exploratory Desktop for Chart and Summarize Group Dialog.
+    # The reason for having the synonym is that Analytics and Chart/Summarize Group Dialog use two different keys for this function.
+    rtosec = {
+      ret <- lubridate::floor_date(x, unit="second")
+    },
     year = {
       ret <- lubridate::year(x)
     },
@@ -1815,7 +1830,7 @@ setdiff <- function(x, y, force_data_type = FALSE, ...){
   }
 }
 
-#'Wrapper function for dplyr::recode to workaround encoding info getting lost. 
+#'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
 recode <- function(x, ...){
   ret <- dplyr::recode(x, ...)
@@ -2012,6 +2027,9 @@ summarize_group <- function(.data, group_cols = NULL, group_funs = NULL, ...){
             "rtoweek",
             "fltoday",
             "rtoday",
+            "rtohour",
+            "rtomin",
+            "rtosec",
             "year",
             "halfyear",
             "quarter",


### PR DESCRIPTION
# Description

Added POSIXct related operations for summarize_group function:

- rtohourr (round to hour)
- rtomin (round to minute)
- rtosec (round to second)

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
