### PR TITLE
Add "Number of Rows" columns to summary table of t-test and Wilcoxon test

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -582,8 +582,10 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
     # Get sample sizes for the 2 groups (n1, n2).
     data_summary <- x$data %>% dplyr::group_by(!!rlang::sym(x$var2)) %>%
       dplyr::summarize(n_rows=length(!!rlang::sym(x$var1)))
-    n1 <- data_summary$n_rows[[1]]
-    n2 <- data_summary$n_rows[[2]]
+    n1 <- data_summary$n_rows[[1]] # number of 1st class
+    n2 <- data_summary$n_rows[[2]] # number of 2nd class
+    v1 <- data_summary[[x$var2]][[1]] # value for 1st class
+    v2 <- data_summary[[x$var2]][[2]] # value for 2nd class
     if (is.null(x$power)) {
       # If power is not specified in the arguments, estimate current power.
       # TODO: pwr functions does not seem to have argument for equal variance. Is it ok? 
@@ -638,6 +640,9 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
                       `Current Sample Size (Each Group)`=current_sample_size,
                       `Required Sample Size (Each Group)`=required_sample_size)
     }
+    ret <- ret %>% dplyr::mutate(`Number of Rows`=!!(n1+n2))
+    ret <- ret %>% dplyr::mutate(!!rlang::sym(paste0("Number of Rows for ", v1)):=!!n1)
+    ret <- ret %>% dplyr::mutate(!!rlang::sym(paste0("Number of Rows for ", v2)):=!!n2)
     if (!is.null(note)) { # Add Note column, if there was an error from pwr function.
       ret <- ret %>% dplyr::mutate(Note=!!note)
     }

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -750,6 +750,14 @@ tidy.wilcox_exploratory <- function(x, type="model", conf_level=0.95) {
       ret <- ret %>% dplyr::select(statistic, p.value, method)
     }
 
+    # Get sample sizes for the 2 groups (n1, n2).
+    data_summary <- x$data %>% dplyr::group_by(!!rlang::sym(x$var2)) %>%
+      dplyr::summarize(n_rows=length(!!rlang::sym(x$var1)))
+    n1 <- data_summary$n_rows[[1]] # number of 1st class
+    n2 <- data_summary$n_rows[[2]] # number of 2nd class
+    v1 <- data_summary[[x$var2]][[1]] # value for 1st class
+    v2 <- data_summary[[x$var2]][[2]] # value for 2nd class
+
     # Switch the name of statistic based on the type of performed test.
     if (stringr::str_detect(ret$method[[1]], "signed rank test")) {
       ret <- ret %>% dplyr::rename(`W Statistic`=statistic)
@@ -770,6 +778,9 @@ tidy.wilcox_exploratory <- function(x, type="model", conf_level=0.95) {
                      `Method`=method)
     }
 
+    ret <- ret %>% dplyr::mutate(`Number of Rows`=!!(n1+n2))
+    ret <- ret %>% dplyr::mutate(!!rlang::sym(paste0("Number of Rows for ", v1)):=!!n1)
+    ret <- ret %>% dplyr::mutate(!!rlang::sym(paste0("Number of Rows for ", v2)):=!!n2)
     if (!is.null(note)) { # Code to add Note column if there was an error. Not used for this particular function yet.
       ret <- ret %>% dplyr::mutate(Note=!!note)
     }

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -258,10 +258,10 @@ test_that("test exp_chisq with group_by with single class category in one of the
 test_that("test exp_ttest", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering
-  ret <- exp_ttest(mtcars2, mpg, am)
-  ret %>% tidy(model, type="model")
-  ret %>% tidy(model, type="data_summary")
-  ret
+  model_df <- exp_ttest(mtcars2, mpg, am)
+  ret <- model_df %>% tidy(model, type="model")
+  expect_true("Number of Rows" %in% colnames(ret))
+  model_df %>% tidy(model, type="data_summary")
 })
 
 test_that("test exp_ttest with var.equal = TRUE", {


### PR DESCRIPTION
# Description
Add "Number of Rows" columns to summary table of t-test and Wilcoxon test

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
