### PR TITLE
Google Sheets: support convertListToCharacter argument

### DIFF
--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -25,8 +25,9 @@ uploadGoogleSheet <- function(filepath, title, overwrite = FALSE){
 #' @param guessDataType - flag to tell if you want googlesheets::gs_read to guess column data type
 #' @param tzone - timezone
 #' @param id - ID of the sheet
+#' @param convertListToCharacter - flag to tell if you want to convert list data type to character.
 #' @export
-getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NULL, firstRowAsHeader = TRUE, commentChar, tokenFileId = NULL, guessDataType = TRUE, tzone = NULL, id = NULL, ...){
+getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NULL, firstRowAsHeader = TRUE, commentChar, tokenFileId = NULL, guessDataType = TRUE, tzone = NULL, id = NULL, convertListToCharacter = TRUE, ...){
   if(!requireNamespace("googlesheets4")){stop("package googlesheets4 must be installed.")}
   if(!requireNamespace("googledrive")){stop("package googledrive must be installed.")}
   if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
@@ -56,6 +57,11 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NUL
   }
   if(!is.null(tzone)) { # if timezone is specified, apply the timezeon to POSIXct columns
     df <- df %>% dplyr::mutate_if(lubridate::is.POSIXct, funs(lubridate::force_tz(., tzone=tzone)))
+  }
+  # googlesheets4 detects a column with mixed data (numeric, character, etc) as a list column so convert it as character
+  # if convertListToCharacter parameter is set as TRUE.
+  if(convertListToCharacter) {
+    df <- df %>% dplyr::mutate_if(is.list, funs(as.character))
   }
   df
 }


### PR DESCRIPTION
# Description

googlesheets4 detects a column with mixed data (numeric, character, etc) as a list column so introduce `convertListToCharacter` parameter to make it as a character if needed.


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
