### PR TITLE
Do not remove rows with NA at creation of sparse matrix for XGBoost

### DIFF
--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -286,10 +286,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, ...) {
       # Set na.action to na.pass.
       # Since XGBoost can predict with NAs in predictors, creation of sparse matrix should not remove NA rows.
       # https://stackoverflow.com/questions/29732720/sparse-model-matrix-loses-rows-in-r
-      na.action_tmp <- getOption('na.action')
-      options(na.action='na.pass')
-      mat <- Matrix::sparse.model.matrix(x$terms, ret_data, xlev = x$xlevels)
-      options(na.action=na.action_tmp)
+      mat <- Matrix::sparse.model.matrix(x$terms, model.frame(ret_data, na.action = na.pass, xlev = x$xlevels))
     } else {
       mat <- model.matrix(x$terms, model.frame(ret_data, na.action = na.pass, xlev = x$xlevels))
     }

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -619,4 +619,3 @@ glance.xgb.Booster <- function(x, pretty.name = FALSE, ...) {
   }
   ret
 }
-


### PR DESCRIPTION
# Description
Do not remove rows with NA at creation of sparse matrix for XGBoost, since XGBoost can predict even with NAs in predictors.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
