### PR TITLE
Add other_level option to preprocess_regression_data_after_sample

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 5.5.6.2
-Date: 2020-04-25
+Version: 5.5.6.3
+Date: 2020-04-27
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -307,13 +307,10 @@ preprocess_regression_data_before_sample <- function(df, target_col, predictor_c
 #' @param predictor_n
 #' @param name_map
 #' @param other_level - Level for "Other" group. Default is "Other".
-#' @param skip_fct_explicit_na - Since fct_explicit_na is a costly processing,
-#'        you can skip it if you don't need it. Default is FALSE.
 preprocess_regression_data_after_sample <- function(df, target_col, predictor_cols,
                                                     predictor_n = 12, # so that at least months can fit in it.
                                                     name_map = NULL, 
-                                                    other_level = "Other", 
-                                                    skip_fct_explicit_na = FALSE) {
+                                                    other_level = "Other") {
   c_cols <- predictor_cols
   for(col in predictor_cols){
     if(lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {
@@ -378,26 +375,18 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
         df[[col]] <- factor(df[[col]], ordered=FALSE)
       }
       # turn NA into (Missing) factor level. Without this, lm or glm drops rows internally.
-      if (!skip_fct_explicit_na) {
-        df[[col]] <- forcats::fct_explicit_na(df[[col]])
-      }
+      df[[col]] <- forcats::fct_explicit_na(df[[col]])
     } else if(is.logical(df[[col]])) {
       # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
       # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-      df[[col]] <- as.factor(df[[col]])
-      if (!skip_fct_explicit_na) {
-        df[[col]] <- forcats::fct_explicit_na(df[[col]])
-      }
+      df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
     } else if(!is.numeric(df[[col]])) {
       # 1. convert data to factor if predictors are not numeric or logical
       #    and limit the number of levels in factor by fct_lump.
       #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
       #    TODO: see if ties.method would make sense for calc_feature_imp.
       # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-      df[[col]] <- forcats::fct_lump(forcats::fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first", other_level=other_level)
-      if (!skip_fct_explicit_na) {
-        df[[col]] <- forcats::fct_explicit_na(df[[col]])
-      }
+      df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(forcats::fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first", other_level=other_level))
     }
   }
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -301,9 +301,19 @@ preprocess_regression_data_before_sample <- function(df, target_col, predictor_c
 #' Common preprocessing of regression data to be done AFTER sampling.
 #' Only common operations to be done, for example, in Summary View too.
 #' @export
+#' @param df
+#' @param target_col
+#' @param predictor_cols
+#' @param predictor_n
+#' @param name_map
+#' @param other_level - Level for "Other" group. Default is "Other".
+#' @param skip_fct_explicit_na - Since fct_explicit_na is a costly processing,
+#'        you can skip it if you don't need it. Default is FALSE.
 preprocess_regression_data_after_sample <- function(df, target_col, predictor_cols,
                                                     predictor_n = 12, # so that at least months can fit in it.
-                                                    name_map = NULL) {
+                                                    name_map = NULL, 
+                                                    other_level = "Other", 
+                                                    skip_fct_explicit_na = FALSE) {
   c_cols <- predictor_cols
   for(col in predictor_cols){
     if(lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {
@@ -362,24 +372,32 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
       #    lm/glm takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
       #    which we do not want for this function.
       if (length(levels(df[[col]])) > predictor_n + 1) { # +1 is for 'Others' group.
-        df[[col]] <- forcats::fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:predictor_n])
+        df[[col]] <- forcats::fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:predictor_n], other_level=other_level)
       }
       else {
         df[[col]] <- factor(df[[col]], ordered=FALSE)
       }
       # turn NA into (Missing) factor level. Without this, lm or glm drops rows internally.
-      df[[col]] <- forcats::fct_explicit_na(df[[col]])
+      if (!skip_fct_explicit_na) {
+        df[[col]] <- forcats::fct_explicit_na(df[[col]])
+      }
     } else if(is.logical(df[[col]])) {
       # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
       # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-      df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
+      df[[col]] <- as.factor(df[[col]])
+      if (!skip_fct_explicit_na) {
+        df[[col]] <- forcats::fct_explicit_na(df[[col]])
+      }
     } else if(!is.numeric(df[[col]])) {
       # 1. convert data to factor if predictors are not numeric or logical
       #    and limit the number of levels in factor by fct_lump.
       #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
       #    TODO: see if ties.method would make sense for calc_feature_imp.
       # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-      df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(forcats::fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first"))
+      df[[col]] <- forcats::fct_lump(forcats::fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first", other_level=other_level)
+      if (!skip_fct_explicit_na) {
+        df[[col]] <- forcats::fct_explicit_na(df[[col]])
+      }
     }
   }
 


### PR DESCRIPTION
# Description

Added `other_level` option to `preprocess_regression_data_after_sample`. It will be passed to the `fct_lump` call used inside the function.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
