### PR TITLE
Add grid option and with_auc option to do_roc

### DIFF
--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -14,6 +14,7 @@ do_roc <- function(df, pred_prob, actual_val, ...){
 #' @param pred_prob_col Column name for probability
 #' @param actual_val_col Column name for actual values
 #' @param grid Grid size to reduce data size for drawing chart.
+#' @param with_auc When set to TRUE, AUC is calculated and added as a column of the output.
 #' @export
 do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL, with_auc = FALSE){
   validate_empty_data(df)
@@ -24,7 +25,7 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL, with_auc = F
   fpr_col <- avoid_conflict(group_cols, "false_positive_rate")
 
   do_roc_each <- function(df){
-    if (with_auc) {
+    if (with_auc) { # Calculate AUC.
       auc <- auroc(df[[pred_prob_col]], df[[actual_val_col]])
     }
 

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -68,7 +68,7 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL, with_auc = F
     colnames(ret)[colnames(ret) == "fpr"] <- fpr_col
 
     if (with_auc) {
-      ret %>% dplyr::mutate(auc = auc)
+      ret <- ret %>% dplyr::mutate(auc = auc)
     }
 
     ret

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -3,18 +3,19 @@
 #' @param pred_prob Column name for probability
 #' @param actual_val Column name for actual values
 #' @export
-do_roc <- function(df, pred_prob, actual_val){
+do_roc <- function(df, pred_prob, actual_val, ...){
   pred_prob_col <- col_name(substitute(pred_prob))
   actual_val_col <- col_name(substitute(actual_val))
-  do_roc_(df, pred_prob_col, actual_val_col)
+  do_roc_(df, pred_prob_col, actual_val_col, ...)
 }
 
 #' Return cordinations for ROC curve
 #' @param df Data frame
 #' @param pred_prob_col Column name for probability
 #' @param actual_val_col Column name for actual values
+#' @param grid Grid size to reduce data size for drawing chart.
 #' @export
-do_roc_ <- function(df, pred_prob_col, actual_val_col){
+do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL){
   validate_empty_data(df)
 
   group_cols <- grouped_by(df)
@@ -52,6 +53,13 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col){
       tpr,
       fpr
     )
+
+    if (!is.null(grid)) { # Apply grid to reduce data size for drawing chart.
+      ret <- ret %>% dplyr::mutate(fpr = floor(fpr*grid)/grid) %>%
+        dplyr::group_by(fpr) %>%
+        dplyr::summarize(tpr=min(tpr)) 
+    }
+
     colnames(ret) <- c(tpr_col, fpr_col)
     ret
   }

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -15,7 +15,7 @@ do_roc <- function(df, pred_prob, actual_val, ...){
 #' @param actual_val_col Column name for actual values
 #' @param grid Grid size to reduce data size for drawing chart.
 #' @export
-do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL){
+do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL, with_auc = FALSE){
   validate_empty_data(df)
 
   group_cols <- grouped_by(df)
@@ -24,6 +24,10 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL){
   fpr_col <- avoid_conflict(group_cols, "false_positive_rate")
 
   do_roc_each <- function(df){
+    if (with_auc) {
+      auc <- auroc(df[[pred_prob_col]], df[[actual_val_col]])
+    }
+
     # sort descending order by predicted probability
     arranged <- df[order(-df[[pred_prob_col]]), ]
 
@@ -62,6 +66,11 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL){
 
     colnames(ret)[colnames(ret) == "tpr"] <- tpr_col
     colnames(ret)[colnames(ret) == "fpr"] <- fpr_col
+
+    if (with_auc) {
+      ret %>% dplyr::mutate(auc = auc)
+    }
+
     ret
   }
 

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -60,7 +60,8 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL){
         dplyr::summarize(tpr=min(tpr)) 
     }
 
-    colnames(ret) <- c(tpr_col, fpr_col)
+    colnames(ret)[colnames(ret) == "tpr"] <- tpr_col
+    colnames(ret)[colnames(ret) == "fpr"] <- fpr_col
     ret
   }
 

--- a/tests/testthat/test_model_eval.R
+++ b/tests/testthat/test_model_eval.R
@@ -14,8 +14,10 @@ test_that("test do_roc", {
   predicted <- prediction(model_data)
 
   ret <- do_roc(predicted, predicted_response, CANCELLED)
-
   expect_equal(colnames(ret), c("true_positive_rate", "false_positive_rate"))
+
+  ret <- do_roc(predicted, predicted_response, CANCELLED, grid=100, with_auc=TRUE)
+  expect_equal(colnames(ret), c("true_positive_rate", "false_positive_rate", "auc"))
 
 })
 
@@ -35,8 +37,10 @@ test_that("test do_roc with factor", {
   predicted <- prediction(model_data)
 
   ret <- do_roc(predicted, predicted_response, CANCELLED)
-
   expect_equal(colnames(ret), c("true_positive_rate", "false_positive_rate"))
+
+  ret <- do_roc(predicted, predicted_response, CANCELLED, grid=100, with_auc=TRUE)
+  expect_equal(colnames(ret), c("true_positive_rate", "false_positive_rate", "auc"))
 })
 
 test_that("test do_roc with 2 numeric values", {


### PR DESCRIPTION
# Description
Add following options to do_roc.
- grid - reduce amount of output data size.
- with_auc - With it set to TRUE, output is with AUC.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
