### PR TITLE
Fix error from column mapping in error handling of VIF calculation, etc.

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -386,8 +386,6 @@ build_coxph.fast <- function(df,
 
       # build formula for lm
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
-      # TODO: This clean_time_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
-      # TODO: see if the above is appropriate for coxph
       fml <- as.formula(paste0("survival::Surv(`", clean_time_col, "`, `", clean_status_col, "`) ~ ", rhs))
       model <- survival::coxph(fml, data = df)
       # these attributes are used in tidy of randomForest TODO: is this good for lm too?

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -502,7 +502,7 @@ build_coxph.fast <- function(df,
       model$survival_curves <- calc_survival_curves_with_strata(df, clean_time_col, clean_status_col, imp_vars)
 
       tryCatch({
-        model$vif <- calc_vif(model)
+        model$vif <- calc_vif(model, model$terms_mapping)
       }, error = function(e){
         model$vif <<- e
       })

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -369,7 +369,7 @@ build_coxph.fast <- function(df,
         df <- df %>% sample_rows(max_nrow)
       }
 
-      df <- preprocess_regression_data_after_sample(df, clean_target_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
+      df <- preprocess_regression_data_after_sample(df, clean_time_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
       name_map <- attr(df, 'name_map')
 
@@ -386,7 +386,7 @@ build_coxph.fast <- function(df,
 
       # build formula for lm
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
-      # TODO: This clean_target_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
+      # TODO: This clean_time_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
       # TODO: see if the above is appropriate for coxph
       fml <- as.formula(paste0("survival::Surv(`", clean_time_col, "`, `", clean_status_col, "`) ~ ", rhs))
       model <- survival::coxph(fml, data = df)

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -355,15 +355,11 @@ build_coxph.fast <- function(df,
 
   each_func <- function(df) {
     tryCatch({
-      # TODO: Make use of the common preprocessing functions used in build_lm.fast.
-      df <- df %>%
-        # dplyr::filter(!is.na(!!target_col))  TODO: this was not filtering, and replaced it with the next line. check other similar places.
-        # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
-        # if the remaining rows are with single value in any predictor column.
-        # filter Inf/-Inf too to avoid error at lm.
-        dplyr::filter(!is.na(df[[clean_time_col]]) & !is.infinite(df[[clean_time_col]])) # this form does not handle group_by. so moved into each_func from outside.
       df <- df %>%
         dplyr::filter(!is.na(df[[clean_status_col]])) # this form does not handle group_by. so moved into each_func from outside.
+
+      df <- preprocess_regression_data_before_sample(df, clean_time_col, clean_cols)
+      clean_cols <- attr(df, 'predictors') # predictors are updated (removed) in preprocess_pre_sample. Catch up with it.
 
       # sample the data for performance if data size is too large.
       sampled_nrow <- NULL
@@ -373,97 +369,9 @@ build_coxph.fast <- function(df,
         df <- df %>% sample_rows(max_nrow)
       }
 
-      c_cols <- clean_cols
-      for(col in clean_cols){
-        if(lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {
-          c_cols <- setdiff(c_cols, col)
-
-          absolute_time_col <- avoid_conflict(colnames(df), paste0(col, "_abs_time"))
-          wday_col <- avoid_conflict(colnames(df), paste0(col, "_w_"))
-          day_col <- avoid_conflict(colnames(df), paste0(col, "_day_of_month"))
-          yday_col <- avoid_conflict(colnames(df), paste0(col, "_day_of_year"))
-          month_col <- avoid_conflict(colnames(df), paste0(col, "_m_"))
-          year_col <- avoid_conflict(colnames(df), paste0(col, "_year"))
-          new_name <- c(absolute_time_col, wday_col, day_col, yday_col, month_col, year_col)
-          names(new_name) <- paste(
-            names(name_map)[name_map == col],
-            c(
-              "_abs_time",
-              "_w_",
-              "_day_of_month",
-              "_day_of_year",
-              "_m_",
-              "_year"
-            ), sep="")
-
-          name_map <- c(name_map, new_name)
-
-          c_cols <- c(c_cols, absolute_time_col, wday_col, day_col, yday_col, month_col, year_col)
-          df[[absolute_time_col]] <- as.numeric(df[[col]])
-          # turn it into unordered factor since if it is ordered factor, the name of term is broken
-          df[[wday_col]] <- factor(lubridate::wday(df[[col]], label=TRUE), ordered=FALSE)
-          df[[day_col]] <- lubridate::day(df[[col]])
-          df[[yday_col]] <- lubridate::yday(df[[col]])
-          # turn it into unordered factor since if it is ordered factor, the name of term is broken
-          df[[month_col]] <- factor(lubridate::month(df[[col]], label=TRUE), ordered=FALSE)
-          df[[year_col]] <- lubridate::year(df[[col]])
-          if(lubridate::is.POSIXct(df[[col]])) {
-            hour_col <- avoid_conflict(colnames(df), paste0(col, "_hour"))
-            new_name <- c(hour_col)
-            names(new_name) <- paste(
-              names(name_map)[name_map == col],
-              c(
-                "_hour"
-              ), sep="")
-            name_map <- c(name_map, new_name)
-
-            c_cols <- c(c_cols, hour_col)
-            df[[hour_col]] <- factor(lubridate::hour(df[[col]])) # treat hour as category
-          }
-          df[[col]] <- NULL # drop original Date/POSIXct column to pass SMOTE later.
-        } else if(is.factor(df[[col]])) {
-          # 1. if the data is factor, respect the levels and keep first 10 levels, and make others "Others" level.
-          # 2. if the data is ordered factor, turn it into unordered. For ordered factor,
-          #    coxph takes polynomial terms (Linear, Quadratic, Cubic, and so on) and use them as variables,
-          #    which we do not want for this function.
-          if (length(levels(df[[col]])) >= predictor_n + 2) {
-            df[[col]] <- forcats::fct_other(factor(df[[col]], ordered=FALSE), keep=levels(df[[col]])[1:predictor_n])
-          }
-          else {
-            df[[col]] <- factor(df[[col]], ordered=FALSE)
-          }
-        } else if(is.logical(df[[col]])) {
-          # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
-          # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
-        } else if(!is.numeric(df[[col]])) {
-          # 1. convert data to factor if predictors are not numeric or logical.
-          # 2. sort levels by frequency so that base level is the most frequent category.
-          # 3. limit the number of levels in factor by fct_lump.
-          #    we use ties.method to handle the case where there are many unique values. (without it, they all survive fct_lump.)
-          # 4. turn NA into (Missing) factor level so that lm will not drop all the rows.
-          df[[col]] <- forcats::fct_explicit_na(forcats::fct_lump(forcats::fct_infreq(as.factor(df[[col]])), n=predictor_n, ties.method="first"))
-        } else {
-          # for numeric cols, filter NA rows, because lm will anyway do this internally, and errors out
-          # if the remaining rows are with single value in any predictor column.
-          # filter Inf/-Inf too to avoid error at lm.
-          df <- df %>% dplyr::filter(!is.na(df[[col]]) & !is.infinite(df[[col]]))
-        }
-      }
-
-      # remove columns with only one unique value
-      cols_copy <- c_cols
-      for (col in cols_copy) {
-        unique_val <- unique(df[[col]])
-        if (length(unique_val[!is.na(unique_val)]) == 1) {
-          c_cols <- setdiff(c_cols, col)
-          df[[col]] <- NULL # drop the column so that SMOTE will not see it. 
-        }
-      }
-      if (length(c_cols) == 0) {
-        # Previous version of message - stop("The selected predictor variables are invalid since they have only one unique values.")
-        stop("Invalid Predictors: Only one unique value.") # Message is made short so that it fits well in the Summary table.
-      }
+      df <- preprocess_regression_data_after_sample(df, clean_target_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
+      c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
+      name_map <- attr(df, 'name_map')
 
       # split training and test data
       source_data <- df

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -139,7 +139,7 @@ vif <- function(mod, ...) {
 }
 
 # Calculate VIF and throw user friendly message in case of perfect collinearity.
-calc_vif <- function(model) {
+calc_vif <- function(model, terms_mapping) {
   tryCatch({
     vif(model)
   }, error = function(e){
@@ -838,7 +838,7 @@ build_lm.fast <- function(df,
       }
 
       tryCatch({
-        model$vif <- calc_vif(model)
+        model$vif <- calc_vif(model, terms_mapping)
       }, error = function(e){
         model$vif <<- e
       })

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -359,8 +359,8 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
         eret <- evaluate_binary_(test_pred_ret, "predicted_probability", actual_val_col, threshold = threshold)
   
         test_ret <- eret %>% dplyr::mutate(n = true_positive + false_positive + true_negative + false_negative,
-                                           positives = true_positive + false_positive,
-                                           negatives = true_negative + false_negative) %>%
+                                           positives = true_positive + false_negative,
+                                           negatives = true_negative + false_positive) %>%
                              dplyr::select(auc = AUC, f_score, accuracy_rate,
                                            misclassification_rate, precision, recall,
                                            n, positives, negatives)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2332,12 +2332,16 @@ evaluate_classification <- function(actual, predicted, class, multi_class = TRUE
     )
   }
   else { # class, n is not necessary when it is binary classification with TRUE/FALSE
+    nt <- tp + fn
+    nf <- fp + tn
     ret <- data.frame(
       f_score,
       accuracy,
       1- accuracy,
       precision,
-      recall
+      recall,
+      nt,
+      nf
     )
   }
 
@@ -2345,13 +2349,13 @@ evaluate_classification <- function(actual, predicted, class, multi_class = TRUE
     if (multi_class) {
       c("Class", "F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall", "Number of Rows")
     } else {
-      c("F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall")
+      c("F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall", "Number of Rows for TRUE", "Number of Rows for FALSE")
     }
   } else {
     if (multi_class) {
       c("class", "f_score", "accuracy_rate", "misclassification_rate", "precision", "recall", "n")
     } else {
-      c("f_score", "accuracy_rate", "misclassification_rate", "precision", "recall")
+      c("f_score", "accuracy_rate", "misclassification_rate", "precision", "recall", "n_true", "n_false")
     }
   }
   ret

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -239,7 +239,7 @@ exp_survival_forest <- function(df,
         df <- df %>% sample_rows(max_nrow)
       }
 
-      df <- preprocess_regression_data_after_sample(df, clean_target_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
+      df <- preprocess_regression_data_after_sample(df, clean_time_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
       name_map <- attr(df, 'name_map')
 
@@ -256,7 +256,7 @@ exp_survival_forest <- function(df,
 
       # build formula for survival forest.
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
-      # TODO: This clean_target_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
+      # TODO: This clean_time_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
       # TODO: see if the above is appropriate for coxph
       fml <- as.formula(paste0("survival::Surv(`", clean_time_col, "`, `", clean_status_col, "`) ~ ", rhs))
       # all or max_sample_size data will be used for randomForest

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -256,8 +256,6 @@ exp_survival_forest <- function(df,
 
       # build formula for survival forest.
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
-      # TODO: This clean_time_col is actually not a cleaned column name since we want lm to show real name. Clean up our variable name.
-      # TODO: see if the above is appropriate for coxph
       fml <- as.formula(paste0("survival::Surv(`", clean_time_col, "`, `", clean_status_col, "`) ~ ", rhs))
       # all or max_sample_size data will be used for randomForest
       # to grow a tree

--- a/tests/testthat/test_randomForest_tidiers_4.R
+++ b/tests/testthat/test_randomForest_tidiers_4.R
@@ -34,7 +34,6 @@ test_that("calc_feature_map(regression) evaluate training and test", {
   ret <- rf_evaluation_training_and_test(model_df, test_rate = 0.3)
   expect_equal(nrow(ret %>% filter(`CAR RIER`=="DUMMY")), 1) # Row for the group with error.
   expect_equal(nrow(ret %>% filter(`CAR RIER`=="DUMMY" & !is.na(Note))), 1) # Row for the group with error should have message in Note column. 
-  browser()
 
   ret <- model_df %>% prediction_training_and_test()
   test_ret <- ret %>% filter(is_test_data==TRUE)

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -1,6 +1,5 @@
 context("test exp_survival_forest")
 
-if(F){ # Temporarily skip failing test.
 test_that("test exp_survival_forest", {
   df <- survival::lung # this data has NAs.
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
@@ -13,7 +12,6 @@ test_that("test exp_survival_forest", {
   ret <- model_df %>% broom::tidy(model, type='partial_dependence')
   ret <- model_df %>% broom::tidy(model, type='importance')
 })
-}
 
 test_that("exp_survival_forest error handling for predictor with single unique value", {
   expect_error({


### PR DESCRIPTION
# Description
- Fix error from column mapping in error handling of VIF calculation
- Correct the wrong true/false row count on logistic regression summary
- Show row numbers for TRUE/FALSE for random forest and decision tree
- Use common preprocess function for survival forest and Cox regression

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
