### PR TITLE
ranger, rpart: Correct direction of TRUE/FALSE in step binary prediction metrics calculation

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -474,6 +474,7 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
     } else if(is.logical(df[[col]])) {
       # 1. convert data to factor if predictors are logical. (as.factor() on logical always puts FALSE as the first level, which is what we want for predictor.)
       # 2. turn NA into (Missing) factor level so that lm will not drop all the rows.
+      # For ranger, we need to convert logical to factor too since na.roughfix only works for numeric or factor.
       df[[col]] <- forcats::fct_explicit_na(as.factor(df[[col]]))
     } else if(!is.numeric(df[[col]])) {
       # 1. convert data to factor if predictors are not numeric or logical

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2230,22 +2230,14 @@ evaluate_classification <- function(actual, predicted, class, multi_class = TRUE
   fn <- sum(actual == class & predicted != class, na.rm = TRUE)
 
   precision <- tp / (tp + fp)
-  # this avoids NA
-  if(tp+fp == 0) {
-    precision <- 0
-  }
-
   recall <- tp / (tp + fn)
-  # this avoids NA
-  if(tp+fn == 0) {
-    recall <- 0
-  }
 
   accuracy <- (tp + tn) / (tp + fp + tn + fn)
 
   f_score <- 2 * ((precision * recall) / (precision + recall))
-  # this avoids NA
-  if(precision + recall == 0) {
+  # This avoids NaN. If both precision and recall are 0, it makes sense for f score to be 0.
+  # is.nan() on precision and recall is necessary to avoid error here.
+  if(!is.nan(precision) && !is.nan(recall) && precision + recall == 0) {
     f_score <- 0
   }
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1835,9 +1835,10 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
 }
 
 cleanup_df_per_group <- function(df, clean_target_col, max_nrow, clean_cols, name_map, predictor_n, revert_logical_levels=TRUE, filter_numeric_na=FALSE) {
-  if (is.factor(df[[clean_target_col]])) { # to avoid error in edarf::partial_dependence(), remove levels that is not used in this group.
-    df[[clean_target_col]] <- forcats::fct_drop(df[[clean_target_col]])
-  }
+  df <- preprocess_regression_data_before_sample(df, clean_target_col, clean_cols,
+                                                 filter_target_na_inf=FALSE,
+                                                 filter_predictor_numeric_na=filter_numeric_na)
+  clean_cols <- attr(df, 'predictors') # predictors are updated (removed) in preprocess_pre_sample. Catch up with it.
   # sample the data because randomForest takes long time
   # if data size is too large
   sampled_nrow <- NULL

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2530,39 +2530,6 @@ glance.ranger.classification <- function(x, pretty.name, ...) {
   predicted <- ranger.predict_value_from_prob(x$forest$levels, x$prediction_training$predictions, x$y)
   levels(predicted) <- levels(actual)
 
-  # Composes data.frame of classification evaluation summary.
-  multi_stat <- function(class) {
-    n <- sum(actual == class)
-
-    # calculate evaluation scores for each class
-    tp <- sum(actual == class & predicted == class)
-    tn <- sum(actual != class & predicted != class)
-    fp <- sum(actual != class & predicted == class)
-    fn <- sum(actual == class & predicted != class)
-
-    precision <- tp / (tp + fp)
-    recall <- tp / (tp + fn)
-    accuracy <- (tp + tn) / (tp + tn + fp + fn)
-    f_score <- 2 * ((precision * recall) / (precision + recall))
-
-    ret <- data.frame(
-      class,
-      f_score,
-      accuracy,
-      1 - accuracy,
-      precision,
-      recall,
-      n
-    )
-
-    names(ret) <- if(pretty.name){
-      c("Class", "F Score", "Accuracy Rate", "Misclassification Rate", "Precision", "Recall", "Number of Rows")
-    } else {
-      c("class", "f_score", "accuracy_rate", "misclassification_rate", "precision", "recall", "n")
-    }
-    ret
-  }
-
   # Composes data.frame of binary classification evaluation summary.
   single_stat <- function(act, pred) {
     #       predicted
@@ -2604,7 +2571,8 @@ glance.ranger.classification <- function(x, pretty.name, ...) {
     ret
 
   } else {
-    dplyr::bind_rows(lapply(levels(actual), multi_stat))
+    # Multiclass classification metrics
+    evaluate_multi_(data.frame(predicted=predicted, actual=actual), "predicted", "actual", pretty.name = pretty.name)
   }
 }
 

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -80,7 +80,7 @@ test_that("test ranger with binary classification with logical column", {
   expect_equal(colnames(coef_ret), c("variable", "importance"))
 
   model_stats <- suppressWarnings(model_stats(model_ret, pretty.name = TRUE))
-  expect_colnames <- c("F Score", "Accuracy Rate", "Misclassification Rate",
+  expect_colnames <- c("AUC", "F Score", "Accuracy Rate", "Misclassification Rate",
                        "Precision", "Recall")
   expect_equal(colnames(model_stats), expect_colnames)
 
@@ -125,7 +125,7 @@ test_that("test ranger with binary classification with factor", {
   expect_equal(colnames(coef_ret), c("variable", "importance"))
 
   model_stats <- suppressWarnings(model_stats(model_ret, pretty.name = TRUE))
-  expect_colnames <- c("F Score", "Accuracy Rate", "Misclassification Rate",
+  expect_colnames <- c("AUC", "F Score", "Accuracy Rate", "Misclassification Rate",
                        "Precision", "Recall")
   expect_equal(colnames(model_stats), expect_colnames)
 
@@ -170,7 +170,7 @@ test_that("test ranger with binary classification (all predictor_varials)", {
   expect_equal(colnames(coef_ret), c("variable", "importance"))
 
   model_stats <- suppressWarnings(model_stats(model_ret, pretty.name = TRUE))
-  expect_colnames <- c("F Score", "Accuracy Rate", "Misclassification Rate",
+  expect_colnames <- c("AUC", "F Score", "Accuracy Rate", "Misclassification Rate",
                        "Precision", "Recall")
   expect_equal(colnames(model_stats), expect_colnames)
 

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -209,8 +209,8 @@ test_that("test ranger with multinomial classification", {
   coef_ret <- model_coef(model_ret)
   expect_equal(colnames(coef_ret), c("variable", "importance"))
   model_stats <- suppressWarnings(model_stats(model_ret, pretty.name = TRUE))
-  expect_colnames <- c("Class", "F Score", "Accuracy Rate", "Misclassification Rate",
-                       "Precision", "Recall", "Number of Rows")
+  expect_colnames <- c("Micro-Averaged F Score", "Macro-Averaged F Score", "Accuracy Rate", "Misclassification Rate",
+                       "Number of Rows")
   expect_equal(colnames(model_stats), expect_colnames)
 
   expected_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",
@@ -239,8 +239,8 @@ test_that("test ranger with multinomial classification", {
   coef_ret <- model_coef(model_ret)
   expect_equal(colnames(coef_ret), c("variable", "importance"))
   model_stats <- suppressWarnings(model_stats(model_ret, pretty.name = TRUE))
-  expect_colnames <- c("Class", "F Score", "Accuracy Rate", "Misclassification Rate",
-                       "Precision", "Recall", "Number of Rows")
+  expect_colnames <- c("Micro-Averaged F Score", "Macro-Averaged F Score", "Accuracy Rate", "Misclassification Rate",
+                       "Number of Rows")
   expect_equal(colnames(model_stats), expect_colnames)
 
   expected_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",


### PR DESCRIPTION
# Description
- ranger, rpart: Correct direction of TRUE/FALSE in step binary prediction metrics calculation

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
