### PR TITLE
Trying setting seed before sampling to make boruta importance test result stable on our Mac test machine.

### DIFF
--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -16,6 +16,7 @@ filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
 flight <- exploratory::read_delim_file(filepath, ",", quote = "\"", skip = 0 , col_names = TRUE , na = c("","NA") , locale=readr::locale(encoding = "UTF-8", decimal_mark = "."), trim_ws = FALSE , progress = FALSE) %>% exploratory::clean_data_frame()
 
 if (!testdata_filename %in% list.files(testdata_dir)) {
+  set.seed(1) # Trying setting seed before sampling to make boruta importance test result stable on our Mac test machine.
   flight <- flight %>% sample_n(5000)
   write.csv(flight, testdata_file_path) # save sampled-down data for performance.
 }


### PR DESCRIPTION
# Description
Trying setting seed before sampling to make boruta importance test result stable on our Mac test machine.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
