### PR TITLE
Updated clean_deta_frame API to remove backslash from column name

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1636,8 +1636,8 @@ getObjectFromRdata <- function(rdata_path, object_name){
 clean_data_frame <- function(x) {
   df <- tibble::repair_names(jsonlite::flatten(x))
   original_names <- names(df)
-  # remove tab, new line, carriage return from column names
-  clean_names <- original_names  %>% gsub("[\r\n\t]", "", .)
+  # remove tab, new line, carriage return, and backspace from column names
+  clean_names <- original_names  %>% gsub("[\r\n\t\\]", "", .)
   names(df) <- clean_names
   df
 }

--- a/R/system.R
+++ b/R/system.R
@@ -1636,7 +1636,7 @@ getObjectFromRdata <- function(rdata_path, object_name){
 clean_data_frame <- function(x) {
   df <- tibble::repair_names(jsonlite::flatten(x))
   original_names <- names(df)
-  # remove tab, new line, carriage return, and backspace from column names
+  # Remove tab, new line, carriage return, and backslash from column names
   clean_names <- original_names  %>% gsub("[\r\n\t\\]", "", .)
   names(df) <- clean_names
   df

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -5,11 +5,16 @@ test_that("test clean_data_frame",{
   df <- data.frame(a = 1:5, a = 2:6)
   colnames(df)<-c("a", "a")
   df$b <- data.frame(c = 3:7, d = 4:8)
-
   result <- clean_data_frame(df)
   # data frame column should be flattened out and the result data frame should have 4 columns.
   expect_equal(length(colnames(result)), 4)
+  colnames(result)
   expect_equal(colnames(result), c("a", "a.1", "b.c", "b.d"))
+
+  df2 <- data.frame(a = 1:5)
+  colnames(df2)<-c("country \\ year")
+  result2 <- clean_data_frame(df2)
+  expect_equal(colnames(result2), c("country  year"))
 })
 
 test_that("test parse_html_tables",{


### PR DESCRIPTION
# Description

Updated clean_deta_frame API to remove backslash from column name

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
