### PR TITLE
For linear regression, join coefficient and P value for numeric predictors on pdp data

### DIFF
--- a/R/partial_dependence.R
+++ b/R/partial_dependence.R
@@ -169,6 +169,13 @@ handle_partial_dependence <- function(x) {
   }))
   ret <- nested %>% tidyr::unnest(cols=.temp.data) %>% dplyr::ungroup()
 
+  if ("lm" %in% class(x)) { # For linear regression, join coefficient and P value for numeric predictors.
+    ret2 <- broom:::tidy.lm(x)
+    # Coefficient/P value info is joined only for predicted numeric variables. 
+    ret <- ret %>% mutate(key=case_when(y_name=='Actual'~NA_character_,chart_type=='line'~x_name, TRUE~NA_character_)) %>% left_join(ret2, by = c(key="term"))
+    ret <- ret %>% select(-key)
+  }
+
   ret <- ret %>% dplyr::mutate(x_name = x$terms_mapping[x_name]) # map variable names to original.
   ret
 }


### PR DESCRIPTION
For linear regression, join coefficient and P value for numeric predictors on pdp data.

# Description
Describe your fix here

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
