### PR TITLE
Remove flatten_bindable dependency for dplyr 1.0 support.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1733,6 +1733,8 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   # then pass the updated list to dplyr::bind_rows.
   dataframes_updated <- list()
   # Create a list of data frames from arguments passed to bind_rows.
+  # In order to avoid unexpected data structure change by flattening, 
+  # we call dots_values here instead of dots_list. 
   dataframes <- rlang::dots_values(...)
   if(force_data_type || stringr::str_length(current_df_name) >0) {
     index <- 1;

--- a/R/util.R
+++ b/R/util.R
@@ -1732,8 +1732,8 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   # To workaround this issue, set a name to the first data frame with the value specified by fistLabel argument as a pre-process
   # then pass the updated list to dplyr::bind_rows.
   dataframes_updated <- list()
-  # with dplyr:::flatten_bindable API, create a list of data frames from arguments passed to bind_rows.
-  dataframes <- dplyr:::flatten_bindable(rlang::dots_values(...))
+  # Create a list of data frames from arguments passed to bind_rows.
+  dataframes <- rlang::dots_values(...)
   if(force_data_type || stringr::str_length(current_df_name) >0) {
     index <- 1;
     # for the case where a user passes a list that contains key (data frame name) and value (data frame) pair.


### PR DESCRIPTION
# Description
Remove flatten_bindable dependency for dplyr 1.0 support. I found that the output we expect is the same with or without flatten_bindable so I simply took out the API call. 


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
