### PR TITLE
fix issue that passing non-ascii character to parse number causes an issue.

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -555,14 +555,14 @@ parse_number <- function(text, ...){
     # so explicitly convert it to character before calling readr::parse_number
     # Passing non-ascii character to readr::parse_number causes an error so remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
-    as.numeric(readr::parse_number(gsub('[^ -~]', '', as.character(text)), ...))
+    as.numeric(readr::parse_number(gsub('[^\x20-\x7E]', '', as.character(text)), ...))
   } else {
     # For some reason, output from parse_number returns FALSE for
     # is.vector(), which becomes a problem when it is fed to ranger
     # as the target variable. To work it around, we apply as.numeric().
     # Passing non-ascii character to readr::parse_number causes an error so remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
-    as.numeric(readr::parse_number(gsub('[^ -~]', '', text), ...))
+    as.numeric(readr::parse_number(gsub('[^\x20-\x7E]', '', text), ...))
   }
 }
 

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -553,14 +553,19 @@ parse_number <- function(text, ...){
   } else if (!is.character(text)) {
     # non character data raises Error in parse_vector(x, col_number(), na = na, locale = locale, trim_ws = trim_ws) : is.character(x) is not TRUE
     # so explicitly convert it to character before calling readr::parse_number
-    as.numeric(readr::parse_number(as.character(text), ...))
+    # Ppassing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # ref: https://github.com/tidyverse/readr/issues/1111
+    as.numeric(readr::parse_number(gsub('[^ -~]', '', as.character(text)), ...))
   } else {
     # For some reason, output from parse_number returns FALSE for
     # is.vector(), which becomes a problem when it is fed to ranger
     # as the target variable. To work it around, we apply as.numeric().
-    as.numeric(readr::parse_number(text, ...))
+    # Ppassing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # ref: https://github.com/tidyverse/readr/issues/1111
+    as.numeric(readr::parse_number(gsub('[^ -~]', '', text), ...))
   }
 }
+
 
 #' Wrapper function for readr::parse_logical
 #' @param text to parse

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -553,14 +553,14 @@ parse_number <- function(text, ...){
   } else if (!is.character(text)) {
     # non character data raises Error in parse_vector(x, col_number(), na = na, locale = locale, trim_ws = trim_ws) : is.character(x) is not TRUE
     # so explicitly convert it to character before calling readr::parse_number
-    # Ppassing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # Passing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
     as.numeric(readr::parse_number(gsub('[^ -~]', '', as.character(text)), ...))
   } else {
     # For some reason, output from parse_number returns FALSE for
     # is.vector(), which becomes a problem when it is fed to ranger
     # as the target variable. To work it around, we apply as.numeric().
-    # Ppassing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # Passing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
     as.numeric(readr::parse_number(gsub('[^ -~]', '', text), ...))
   }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -553,14 +553,14 @@ parse_number <- function(text, ...){
   } else if (!is.character(text)) {
     # non character data raises Error in parse_vector(x, col_number(), na = na, locale = locale, trim_ws = trim_ws) : is.character(x) is not TRUE
     # so explicitly convert it to character before calling readr::parse_number
-    # Passing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # Passing non-ascii character to readr::parse_number causes an error so remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
     as.numeric(readr::parse_number(gsub('[^ -~]', '', as.character(text)), ...))
   } else {
     # For some reason, output from parse_number returns FALSE for
     # is.vector(), which becomes a problem when it is fed to ranger
     # as the target variable. To work it around, we apply as.numeric().
-    # Passing non-ascii character causes an error so, remove non-ascii character before calling readr::parse_number.
+    # Passing non-ascii character to readr::parse_number causes an error so remove non-ascii character before calling readr::parse_number.
     # ref: https://github.com/tidyverse/readr/issues/1111
     as.numeric(readr::parse_number(gsub('[^ -~]', '', text), ...))
   }


### PR DESCRIPTION
# Description

Fix the issue that passing non-ASCII character to parse number causes : `Error in nchar(x): invalid multibyte string, element 4`

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
