### PR TITLE
Cox Regression/Survival Forest: Sort categorical PDP values, improve default prediction time pick, remove -Inf from Boruta result

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -340,8 +340,12 @@ build_coxph.fast <- function(df,
     stop(paste0("Time column (", time_col, ") must be numeric"))
   }
 
-  if (is.null(pred_survival_time)) { # By default, use median of observations with event.
-    pred_survival_time <- median((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
+  if (is.null(pred_survival_time)) {
+    # By default, use mean of observations with event.
+    # median gave a point where survival rate was still predicted 100% in one of our test case.
+    pred_survival_time <- mean((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
+    # Pick maximum of existing values equal or less than the actual mean.
+    pred_survival_time <- max((df %>% dplyr::filter(!!rlang::sym(time_col) <= !!pred_survival_time))[[time_col]], na.rm=TRUE)
   }
 
   # cols will be filtered to remove invalid columns

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -331,16 +331,8 @@ build_coxph.fast <- function(df,
   }
 
   # check status_col.
-  if (!is.numeric(df[[status_col]]) && !is.logical(df[[status_col]])) {
-    stop(paste0("Status column (", status_col, ")  must be logical or numeric with values of 1 (dead) or 0 (alive)."))
-  }
-  if (is.numeric(df[[status_col]])) {
-    unique_val <- unique(df[[status_col]])
-    sorted_unique_val <- sort(unique_val[!is.na(unique_val)])
-    if (!all(sorted_unique_val == c(0,1)) & !all(sorted_unique_val == c(1,2))) {
-      # we allow 1,2 too since survivial works with it, but we are not promoting it for simplicity.
-      stop(paste0("Status column (", status_col, ")  must be logical or numeric with values of 1 (dead) or 0 (alive)."))
-    }
+  if (!is.logical(df[[status_col]])) {
+    stop(paste0("Status column (", status_col, ")  must be logical."))
   }
 
   # check time_col
@@ -348,8 +340,8 @@ build_coxph.fast <- function(df,
     stop(paste0("Time column (", time_col, ") must be numeric"))
   }
 
-  if (is.null(pred_survival_time)) { # By default, use median.
-    pred_survival_time <- median(df[[time_col]], na.rm=TRUE)
+  if (is.null(pred_survival_time)) { # By default, use median of observations with event.
+    pred_survival_time <- median((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
   }
 
   # cols will be filtered to remove invalid columns

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -496,6 +496,33 @@ build_coxph.fast <- function(df,
   do_on_each_group(clean_df, each_func, name = "model", with_unnest = FALSE)
 }
 
+survival_pdp_sort_categorical <- function(ret) {
+  # TODO: Modularize this part of the code, which is common for all the partial dependence code.
+  # Sort the rows for scatter plots for categorical predictor variables, by Predicted values.
+  nested <- ret %>% dplyr::group_by(variable) %>% tidyr::nest(.temp.data=c(-variable)) #TODO: avoid possibility of column name conflict between .temp.data and group_by columns.
+  nested <- nested %>% dplyr::mutate(.temp.data = purrr::map(.temp.data, function(df){
+    # We do the sorting only for scatter chart with Predicted values. This eliminates line charts or multiclass classifications.
+    if (df$chart_type[[1]]=="scatter" && "Prediction" %in% unique(df$type)) {
+      # Set value factor level order first for the sorting at the next step.
+      df <- df %>% dplyr::mutate(value = forcats::fct_reorder2(value, type, survival, function(name, value) {
+        if ("Prediction" %in% name) {
+          -first(value[name=="Prediction"]) # Since we want to eventually display event occurrence rate instead of survival, adding -.
+        }
+        else { # This should not happen but giving reasonable default just in case.
+          -first(value)
+        }
+      }))
+      df <- df %>% dplyr::arrange(value)
+      df %>% dplyr::mutate(value = as.character(value)) # After sorting, change it back to character, so that it does not mess up the chart.
+    }
+    else {
+      df
+    }
+  }))
+  ret <- nested %>% tidyr::unnest(cols=.temp.data) %>% dplyr::ungroup()
+  ret
+}
+
 #' special version of tidy.coxph function to use with build_coxph.fast.
 #' @export
 tidy.coxph_exploratory <- function(x, pretty.name = FALSE, type = 'coefficients', ...) { #TODO: add test
@@ -575,31 +602,7 @@ tidy.coxph_exploratory <- function(x, pretty.name = FALSE, type = 'coefficients'
       # set order to ret and turn it back to character, so that the order is kept when groups are bound.
       # if it were kept as factor, when groups are bound, only the factor order from the first group would be respected.
       ret <- ret %>% dplyr::arrange(variable) %>% dplyr::mutate(variable = as.character(variable))
-
-      # TODO: Modularize this part of the code, which is common for all the partial dependence code.
-      # Sort the rows for scatter plots for categorical predictor variables, by Predicted values.
-      nested <- ret %>% dplyr::group_by(variable) %>% tidyr::nest(.temp.data=c(-variable)) #TODO: avoid possibility of column name conflict between .temp.data and group_by columns.
-      nested <- nested %>% dplyr::mutate(.temp.data = purrr::map(.temp.data, function(df){
-        # We do the sorting only for scatter chart with Predicted values. This eliminates line charts or multiclass classifications.
-        if (df$chart_type[[1]]=="scatter" && "Prediction" %in% unique(df$type)) {
-          # Set value factor level order first for the sorting at the next step.
-          df <- df %>% dplyr::mutate(value = forcats::fct_reorder2(value, type, survival, function(name, value) {
-            if ("Prediction" %in% name) {
-              -first(value[name=="Prediction"]) # Since we want to eventually display event occurrence rate instead of survival, adding -.
-            }
-            else { # This should not happen but giving reasonable default just in case.
-              -first(value)
-            }
-          }))
-          df <- df %>% dplyr::arrange(value)
-          df %>% dplyr::mutate(value = as.character(value)) # After sorting, change it back to character, so that it does not mess up the chart.
-        }
-        else {
-          df
-        }
-      }))
-      ret <- nested %>% tidyr::unnest(cols=.temp.data) %>% dplyr::ungroup()
-
+      ret <- ret %>% survival_pdp_sort_categorical()
       ret <- ret %>% dplyr::mutate(variable = x$terms_mapping[variable]) # map variable names to original.
       ret
     },

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1897,7 +1897,10 @@ extract_importance_history_from_boruta <- function(x) {
   res <- tidyr::gather(as.data.frame(x$ImpHistory), "variable","importance")
   decisions <- data.frame(variable=names(x$finalDecision), decision=x$finalDecision)
   res <- res %>% dplyr::left_join(decisions, by = "variable")
-  res <- res %>% dplyr::filter(decision %in% c("Confirmed", "Tentative", "Rejected")) # Remove rows with NA, which are shadow variables
+  # Remove rows with NA, which are shadow variables.
+  # Also remove -Inf importance which seems to mean removed rejected variables in the iterations toward the end.
+  # If we kept those -Inf values, the x-axis ordering of boxplot would be messed up.
+  res <- res %>% dplyr::filter(decision %in% c("Confirmed", "Tentative", "Rejected") & importance != -Inf)
   res
 }
 

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -197,8 +197,8 @@ exp_survival_forest <- function(df,
     stop(paste0("Time column (", time_col, ") must be numeric"))
   }
 
-  if (is.null(pred_survival_time)) { # By default, use median.
-    pred_survival_time <- median(df[[time_col]], na.rm=TRUE)
+  if (is.null(pred_survival_time)) { # By default, use median of observations with event.
+    pred_survival_time <- median((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
   }
 
   # cols will be filtered to remove invalid columns

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -197,8 +197,12 @@ exp_survival_forest <- function(df,
     stop(paste0("Time column (", time_col, ") must be numeric"))
   }
 
-  if (is.null(pred_survival_time)) { # By default, use median of observations with event.
-    pred_survival_time <- median((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
+  if (is.null(pred_survival_time)) {
+    # By default, use mean of observations with event.
+    # median gave a point where survival rate was still predicted 100% in one of our test case.
+    pred_survival_time <- mean((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
+    # Pick maximum of existing values equal or less than the actual mean.
+    pred_survival_time <- max((df %>% dplyr::filter(!!rlang::sym(time_col) <= !!pred_survival_time))[[time_col]], na.rm=TRUE)
   }
 
   # cols will be filtered to remove invalid columns

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -188,16 +188,8 @@ exp_survival_forest <- function(df,
   }
 
   # check status_col.
-  if (!is.numeric(df[[status_col]]) && !is.logical(df[[status_col]])) {
-    stop(paste0("Status column (", status_col, ")  must be logical or numeric with values of 1 (dead) or 0 (alive)."))
-  }
-  if (is.numeric(df[[status_col]])) {
-    unique_val <- unique(df[[status_col]])
-    sorted_unique_val <- sort(unique_val[!is.na(unique_val)])
-    if (!all(sorted_unique_val == c(0,1)) & !all(sorted_unique_val == c(1,2))) {
-      # we allow 1,2 too since survivial works with it, but we are not promoting it for simplicity.
-      stop(paste0("Status column (", status_col, ")  must be logical or numeric with values of 1 (dead) or 0 (alive)."))
-    }
+  if (!is.logical(df[[status_col]])) {
+    stop(paste0("Status column (", status_col, ")  must be logical."))
   }
 
   # check time_col

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -424,6 +424,7 @@ tidy.ranger_survival_exploratory <- function(x, type = 'importance', ...) { #TOD
       # set order to ret and turn it back to character, so that the order is kept when groups are bound.
       # if it were kept as factor, when groups are bound, only the factor order from the first group would be respected.
       ret <- ret %>% dplyr::arrange(variable) %>% dplyr::mutate(variable = as.character(variable))
+      ret <- ret %>% survival_pdp_sort_categorical()
       ret <- ret %>% dplyr::mutate(variable = x$terms_mapping[variable]) # map variable names to original.
       ret
     })

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -2,6 +2,7 @@ context("test build_coxph")
 
 test_that("test build_coxph.fast", {
   df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
@@ -22,6 +23,7 @@ test_that("test build_coxph.fast", {
 
 test_that("test build_coxph.fast with outlier filtering", {
   df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
@@ -43,6 +45,7 @@ test_that("test build_coxph.fast with outlier filtering", {
 test_that("build_coxpy.fast() error handling for predictor with single unique value", {
   expect_error({
     df <- survival::lung # this data has NAs.
+    df <- df %>% mutate(status = status==2)
     df <- df %>% mutate(age = 50) # Test for single unique value error handling.
     df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
     df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
@@ -53,6 +56,7 @@ test_that("build_coxpy.fast() error handling for predictor with single unique va
 
 test_that("build_coxph()", {
   df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
   model_df <- df %>% build_coxph(survival::Surv(`ti me`, `sta tus`) ~ `a ge` + `se-x`, test_rate=0.3)

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -2,6 +2,7 @@ context("test exp_survival_forest")
 
 test_that("test exp_survival_forest", {
   df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
@@ -15,6 +16,7 @@ test_that("test exp_survival_forest", {
 
 test_that("test exp_survival_forest with outtlier filtering", {
   df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
@@ -29,6 +31,7 @@ test_that("test exp_survival_forest with outtlier filtering", {
 test_that("exp_survival_forest error handling for predictor with single unique value", {
   expect_error({
     df <- survival::lung # this data has NAs.
+    df <- df %>% mutate(status = status==2)
     df <- df %>% mutate(age = 50) # Test for single unique value error handling.
     df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
     df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor


### PR DESCRIPTION
# Description
- Sort categorical PDP values
- Improve default prediction time pick
- Remove -Inf from boruta result.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
