### PR TITLE
Support quote, escape argument on @{} parameter placeholder in SQL, MongoDB query

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -233,6 +233,7 @@ js_glue_transformer <- function(code, envir) {
   tokens <- stringr::str_split(code, ',')
   tokens <- tokens[[1]]
   code <- tokens[1]
+  values <- NULL;
 
   # Parse arguments part. e.g. @{param1, quote=FALSE}
   if (length(tokens) > 1) {
@@ -243,13 +244,13 @@ js_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {
@@ -307,6 +308,7 @@ sql_glue_transformer <- function(code, envir) {
   tokens <- stringr::str_split(code, ',')
   tokens <- tokens[[1]]
   code <- tokens[1]
+  values <- NULL;
 
   # Parse arguments part. e.g. @{param1, quote=FALSE}
   if (length(tokens) > 1) {
@@ -317,13 +319,13 @@ sql_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {
@@ -383,6 +385,7 @@ bigquery_glue_transformer <- function(code, envir) {
   tokens <- stringr::str_split(code, ',')
   tokens <- tokens[[1]]
   code <- tokens[1]
+  values <- NULL
 
   # Parse arguments part. e.g. @{param1, quote=FALSE}
   if (length(tokens) > 1) {
@@ -393,13 +396,13 @@ bigquery_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
+  if (!is.null(values) && !is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {

--- a/R/system.R
+++ b/R/system.R
@@ -286,7 +286,13 @@ sql_glue_transformer <- function(code, envir) {
     quote <- FALSE
   }
   else {
-    quote <- TRUE
+    quote <- TRUE # Quote string by default.
+  }
+  if (!is.null(values$escape) && values$escape== "FALSE") {
+    escape <- FALSE
+  }
+  else {
+    escape <- TRUE # Escape for single quote by default.
   }
 
   # Trim white spaces.
@@ -311,16 +317,24 @@ sql_glue_transformer <- function(code, envir) {
   else if (is.character(val) || is.factor(val)) {
     # escape for SQL
     # TODO: check if this makes sense for Dremio and Athena
-    val <- gsub("'", "''", val, fixed=TRUE) # both Oracle and SQL Server escapes single quote by doubling them.
-    val <- paste0("'", val, "'") # both Oracle and SQL Server quotes strings with single quote.
+    if (escape) {
+      val <- gsub("'", "''", val, fixed=TRUE) # both Oracle and SQL Server escapes single quote by doubling them.
+    }
+    if (quote) {
+      val <- paste0("'", val, "'") # both Oracle and SQL Server quotes strings with single quote.
+    }
   }
   else if (lubridate::is.Date(val)) {
     val <- as.character(val)
-    val <- paste0("'", val, "'") # Athena and PostgreSQL quotes date with single quote. e.g. '2019-01-01'
+    if (quote) {
+      val <- paste0("'", val, "'") # Athena and PostgreSQL quotes date with single quote. e.g. '2019-01-01'
+    }
   }
   else if (lubridate::is.POSIXt(val)) {
     val <- as.character(val)
-    val <- paste0("'", val, "'") # Athena and PostgreSQL quotes timestamp with single quote. e.g. '2019-01-01 00:00:00'
+    if (quote) {
+      val <- paste0("'", val, "'") # Athena and PostgreSQL quotes timestamp with single quote. e.g. '2019-01-01 00:00:00'
+    }
   }
 
   # TODO: How should we handle logical?

--- a/R/system.R
+++ b/R/system.R
@@ -269,6 +269,26 @@ js_glue_transformer <- function(code, envir) {
 }
 
 sql_glue_transformer <- function(code, envir) {
+  tokens <- stringr::str_split(code, ',')
+  tokens <- tokens[[1]]
+  code <- tokens[1]
+
+  # Parse arguments part. e.g. @{param1, quote=FALSE}
+  if (length(tokens) > 1) {
+    args <- tokens[2:length(tokens)]
+    args <- stringr::str_split(args, '=')
+    args <- purrr::map(args, trimws)
+    names <- purrr::map(args, function(x){x[1]})
+    values <- purrr::map(args, function(x){x[2]})
+    names(values) <- names
+  }
+  if (!is.null(values$quote) && values$quote == "FALSE") {
+    quote <- FALSE
+  }
+  else {
+    quote <- TRUE
+  }
+
   # Trim white spaces.
   code <- trimws(code)
 

--- a/R/system.R
+++ b/R/system.R
@@ -243,13 +243,13 @@ js_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote == "FALSE") {
+  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape== "FALSE") {
+  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {
@@ -317,13 +317,13 @@ sql_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote == "FALSE") {
+  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape== "FALSE") {
+  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {
@@ -393,13 +393,13 @@ bigquery_glue_transformer <- function(code, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values$quote) && values$quote == "FALSE") {
+  if (!is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
     quote <- FALSE
   }
   else {
     quote <- TRUE # Quote string by default.
   }
-  if (!is.null(values$escape) && values$escape== "FALSE") {
+  if (!is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -193,6 +193,8 @@ test_that("bigquery_glue_transformer", {
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=bigquery_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+  res <- glue_exploratory("@{ `v` , quote = FALSE }", .transformer=bigquery_glue_transformer)
+  expect_equal(as.character(res), "a, b, c") # No quote case
 
   exploratory_env$dept_names <- c("Sales","HR","CEO's secretary", "Data Science\\Statistics")
   exploratory_env$empid_above <- 1100

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -137,6 +137,12 @@ test_that("countycode", {
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
 
+  exploratory_env$v <- c("a","b","c")
+  res <- glue_exploratory("@{ `v` }", .transformer=js_glue_transformer)
+  expect_equal(as.character(res), '"a", "b", "c"') # default quote case.
+  res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=js_glue_transformer)
+  expect_equal(as.character(res), "a, b, c") # No quote case.
+
   exploratory_env$v <- c(T,F,NA)
   res <- glue_exploratory("@{v}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -166,6 +166,8 @@ test_that("sql_glue_transformer", {
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+  res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=sql_glue_transformer)
+  expect_equal(as.character(res), "a, b, c") # No quote case.
 
   exploratory_env$dept_names <- c("Sales","HR","CEO's secretary", "Data Science\\Statistics")
   exploratory_env$empid_above <- 1100


### PR DESCRIPTION
# Description
Support quote, escape argument on @{} parameter placeholder in SQL, MongoDB query.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
