### PR TITLE
Stabilize permutation importance result against predictor order change

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -322,6 +322,7 @@ build_coxph.fast <- function(df,
   status_col <- tidyselect::vars_select(names(df), !! rlang::enquo(status))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  # Sort predictors so that the result of permutation importance is stable against change of column order.
   selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -322,6 +322,7 @@ build_coxph.fast <- function(df,
   status_col <- tidyselect::vars_select(names(df), !! rlang::enquo(status))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -586,6 +586,7 @@ build_lm.fast <- function(df,
                     ){
   target_col <- tidyselect::vars_select(names(df), !! rlang::enquo(target))
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -607,7 +607,7 @@ build_lm.fast <- function(df,
 
   # If we do permutation importance, sort predictors so that the result of it is stable against change of column order.
   # Otherwise, avoid sorting so that user has control over the order of variables on partial dependence plot.
-  if (family %in% c("binomial", "gaussian") || (family == "poisson" && (is.null(link) || link == "log"))) {
+  if (model_type == "lm" || family %in% c("binomial", "gaussian") || (family == "poisson" && (is.null(link) || link == "log"))) {
     selected_cols <- sort(selected_cols)
   }
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1961,6 +1961,7 @@ calc_feature_imp <- function(df,
   target_col <- tidyselect::vars_select(names(df), !! rlang::enquo(target))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
 
@@ -2758,6 +2759,7 @@ exp_rpart <- function(df,
   target_col <- tidyselect::vars_select(names(df), !! rlang::enquo(target))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1961,6 +1961,7 @@ calc_feature_imp <- function(df,
   target_col <- tidyselect::vars_select(names(df), !! rlang::enquo(target))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  # Sort predictors so that the result of permutation importance is stable against change of column order.
   selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
@@ -2759,6 +2760,7 @@ exp_rpart <- function(df,
   target_col <- tidyselect::vars_select(names(df), !! rlang::enquo(target))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  # Sort predictors so that the result of permutation importance is stable against change of column order.
   selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -179,6 +179,7 @@ exp_survival_forest <- function(df,
   status_col <- tidyselect::vars_select(names(df), !! rlang::enquo(status))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  # Sort predictors so that the result of permutation importance is stable against change of column order.
   selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -179,6 +179,7 @@ exp_survival_forest <- function(df,
   status_col <- tidyselect::vars_select(names(df), !! rlang::enquo(status))
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
+  selected_cols <- sort(selected_cols)
 
   grouped_cols <- grouped_by(df)
 

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -125,6 +125,7 @@ test_that("build_lm with evaluation", {
                                       ))
 
 })
+
 test_that("prediction with categorical columns", {
   test_data <- structure(
     list(
@@ -164,9 +165,9 @@ test_that("prediction with target column name with space by build_lm.fast", {
   # duplicate rows to make some predictable data
   # otherwise, the number of rows of the result of prediction becomes 0
   test_data <- dplyr::bind_rows(test_data, test_data)
-  test_data <- test_data %>% mutate(CARRIER = factor(CARRIER, ordered=TRUE)) # test handling of ordered factor
+  test_data <- test_data %>% mutate(`Carrier-Name`= factor(`Carrier-Name`, ordered=TRUE)) # test handling of ordered factor
 
-  model_data <- build_lm.fast(test_data, `CANCELLED:X`, `logical col`, `Carrier-Name`, CARRIER, DISTANCE, predictor_n = 3, with_marginal_effects=TRUE, with_marginal_effects_confint=TRUE)
+  model_data <- build_lm.fast(test_data, `CANCELLED:X`, `logical col`, `Carrier-Name`, DISTANCE, predictor_n = 3, with_marginal_effects=TRUE, with_marginal_effects_confint=TRUE)
   ret <- model_data %>% broom::glance(model)
   # TODO: the returned coefficients does not show all input variables. 
   # most likely due to too few rows. look into it and add check for the values in the returned df. 
@@ -178,7 +179,7 @@ test_that("prediction with target column name with space by build_lm.fast", {
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED:X", "logical col", "Carrier-Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+  expect_equal(colnames(ret), c("CANCELLED:X", "Carrier-Name","DISTANCE","logical col", ".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
 })
 
 test_that("prediction with glm family (binomial) and link (probit) with target column name with space by build_lm.fast", {
@@ -218,7 +219,7 @@ test_that("prediction with glm family (binomial) and link (probit) with target c
   ret <- model_data %>% broom::augment(model)
 
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED X", "logical col", "Carrier Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+  expect_true(all(colnames(ret) %in% c("CANCELLED X", "logical col", "Carrier Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid")))
 })
 
 test_that("prediction with glm family (negativebinomial) with target column name with space by build_lm.fast", {
@@ -285,7 +286,7 @@ if (Sys.info()["sysname"] != "Windows") {
     ret <- model_data %>% broom::augment(model)
   
     expect_true(nrow(ret) > 0)
-    expect_equal(colnames(ret), c("キャンセル X", "論理 col", "航空会社 Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid"))
+    expect_true(all(colnames(ret) %in% c("キャンセル X", "論理 col", "航空会社 Name","CARRIER","DISTANCE",".fitted",".se.fit",".resid",".hat",".sigma",".cooksd",".std.resid")))
   })
 }
 

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -125,7 +125,6 @@ test_that("build_lm with evaluation", {
                                       ))
 
 })
-
 test_that("prediction with categorical columns", {
   test_data <- structure(
     list(


### PR DESCRIPTION
# Description
Stabilize permutation importance result against predictor order change.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
