### PR TITLE
Google BigQuery: Make sure to pass max_pages as Inf to get all the datasets

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1463,7 +1463,7 @@ getGoogleBigQueryDataSets <- function(project, tokenFileId=""){
   tryCatch({
     token <- getGoogleTokenForBigQuery(tokenFileId);
     bigrquery::set_access_cred(token)
-    # make sure to pass  max_pages as Inf to get all the datasets
+    # make sure to pass max_pages as Inf to get all the datasets
     resultdatasets <- bigrquery::bq_project_datasets(project, page_size=1000, max_pages=Inf);
     lapply(resultdatasets, function(x){x$dataset})
   }, error = function(err){

--- a/R/system.R
+++ b/R/system.R
@@ -1463,7 +1463,8 @@ getGoogleBigQueryDataSets <- function(project, tokenFileId=""){
   tryCatch({
     token <- getGoogleTokenForBigQuery(tokenFileId);
     bigrquery::set_access_cred(token)
-    resultdatasets <- bigrquery::bq_project_datasets(project);
+    # make sure to pass  max_pages as Inf to get all the datasets
+    resultdatasets <- bigrquery::bq_project_datasets(project, page_size=1000, max_pages=Inf);
     lapply(resultdatasets, function(x){x$dataset})
   }, error = function(err){
      c("")


### PR DESCRIPTION
# Description

Changed to pass Inf as  `max_pages`

### Test

Created more than 100 datasets on Google BigQuery and made sure all the datasets listed on  Exploratory Desktop.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
