### PR TITLE
Workaround: Invalid value at 'start_index' (TYPE_UINT64), "1e+05" [invalid]

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1454,7 +1454,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, max_connections = max_connections, quiet = TRUE)
     }
     df
-  } ,finally = {
+  }, finally = {
     # Set original scipen
     options(scipen = original_scipen)
   })


### PR DESCRIPTION
# Description

To workaround, `Invalid value at 'start_index' (TYPE_UINT64), "1e+05" [invalid]` error from Google BigQuery, use `options(scipen = 20)`.

## Test

With Exploratory Desktop

- [x] Import Google BigQuery (Both via Cloud Storage and normal)
- [x] Update Google BigQuery (Both via Cloud Storage and normal)
- [x] Refresh Google BigQuery (Both via Cloud Storage and normal)

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
