### PR TITLE
Allow specifying quote/escape character for parameter placeholder. Support configurable default for them.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -259,11 +259,11 @@ js_glue_transformer <- function(expr, envir) {
       # TRUE means same as default, which is double quote.
       quote <- '"'
     }
-    else if (grepl("^'.+'$", values$quote)) { # Single quoted.
+    else if (grepl("^'.*'$", values$quote)) { # Single quoted.
       quote <- sub("^'", "", values$quote)
       quote <- sub("'$", "", quote)
     }
-    else if (grepl('^".+"$', values$quote)) { # Double quoted.
+    else if (grepl('^".*"$', values$quote)) { # Double quoted.
       quote <- sub('^"', "", values$quote)
       quote <- sub('"$', "", quote)
     }
@@ -283,11 +283,11 @@ js_glue_transformer <- function(expr, envir) {
       # TRUE means same as default, which is double quote.
       escape <- '"'
     }
-    else if (grepl("^'.+'$", values$escape)) { # Single quoted.
+    else if (grepl("^'.*'$", values$escape)) { # Single quoted.
       escape <- sub("^'", "", values$escape)
       escape <- sub("'$", "", escape)
     }
-    else if (grepl('^".+"$', values$escape)) { # Double quoted.
+    else if (grepl('^".*"$', values$escape)) { # Double quoted.
       escape <- sub('^"', "", values$escape)
       escape <- sub('"$', "", escape)
     }

--- a/R/system.R
+++ b/R/system.R
@@ -251,8 +251,21 @@ js_glue_transformer <- function(expr, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values) && !is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
-    quote <- FALSE
+  if (!is.null(values) && !is.null(values$quote)) {
+    if (values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
+      quote <- ''
+    }
+    else if (grepl("^'.+'$", values$quote)) { # Single quoted.
+      quote <- sub("^'", "", values$quote)
+      quote <- sub("'$", "", quote)
+    }
+    else if (grepl('^".+"$', values$quote)) { # Double quoted.
+      quote <- sub('^"', "", values$quote)
+      quote <- sub('"$', "", quote)
+    }
+    else { # Double quote by default.
+      quote <- '"'
+    }
   }
   else {
     quote <- NULL # Check default config for the parameter.
@@ -280,7 +293,7 @@ js_glue_transformer <- function(expr, envir) {
   if (is.null(quote)) {
     quote <- get_variable_config(name, "quote", envir)
     if (is.null(quote)) {
-      quote <- TRUE
+      quote <- '"' # Double quote by default
     }
   }
   if (is.null(escape)) {
@@ -303,9 +316,7 @@ js_glue_transformer <- function(expr, envir) {
       val <- gsub("\\", "\\\\", val, fixed=TRUE)
       val <- gsub("\"", "\\\"", val, fixed=TRUE)
     }
-    if (quote) {
-      val <- paste0('"', val, '"')
-    }
+    val <- paste0(quote, val, quote)
   }
   else if (is.logical(val)) {
     val <- ifelse(val, "true", "false")

--- a/R/system.R
+++ b/R/system.R
@@ -255,7 +255,7 @@ js_glue_transformer <- function(expr, envir) {
     if (values$quote %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       quote <- ''
     }
-    if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+    else if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
       # TRUE means same as default, which is double quote.
       quote <- '"'
     }
@@ -279,7 +279,7 @@ js_glue_transformer <- function(expr, envir) {
     if (values$escape %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       escape <- ''
     }
-    if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+    else if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
       # TRUE means same as default, which is double quote.
       escape <- '"'
     }
@@ -383,7 +383,7 @@ sql_glue_transformer <- function(expr, envir) {
     if (values$quote %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       quote <- ''
     }
-    if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+    else if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
       # TRUE means same as default, which is single quote.
       quote <- "'"
     }
@@ -407,7 +407,7 @@ sql_glue_transformer <- function(expr, envir) {
     if (values$escape %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       escape <- ''
     }
-    if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+    else if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
       # TRUE means same as default, which is single quote.
       escape <- "'"
     }

--- a/R/system.R
+++ b/R/system.R
@@ -227,6 +227,12 @@ glue_exploratory <- function(text, .transformer, .envir = parent.frame()) {
   ret
 }
 
+get_variable_config <- function(variable_name, config_name, envir) {
+  code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", variable_name, "`),NULL,exploratory_env$.config$`", variable_name, "`$`", config_name, "`)")
+  ret <- eval(parse(text = code), envir)
+  ret
+}
+
 # glue transformer for mongo js query.
 # supports character, factor, logical, Date, POSIXct, POSIXlt, and numeric.
 js_glue_transformer <- function(expr, envir) {
@@ -356,15 +362,13 @@ sql_glue_transformer <- function(expr, envir) {
   val <- eval(parse(text = code), envir)
 
   if (is.null(quote)) {
-    code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", name, "`),NULL,exploratory_env$.config$`", name, "`$quote)")
-    quote <- eval(parse(text = code), envir)
+    quote <- get_variable_config(name, "quote", envir)
     if (is.null(quote)) {
       quote <- TRUE
     }
   }
   if (is.null(escape)) {
-    code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", name, "`),NULL,exploratory_env$.config$`", name, "`$escape)")
-    escape <- eval(parse(text = code), envir)
+    escape <- get_variable_config(name, "escape", envir)
     if (is.null(escape)) {
       escape <- TRUE
     }

--- a/R/system.R
+++ b/R/system.R
@@ -379,17 +379,49 @@ sql_glue_transformer <- function(expr, envir) {
     values <- purrr::map(args, function(x){x[2]})
     names(values) <- names
   }
-  if (!is.null(values) && !is.null(values$quote) && values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
-    quote <- FALSE
+  if (!is.null(values) && !is.null(values$quote)) {
+    if (values$quote %in% c("FALSE", "F", "false", "NO", "No", "no")) {
+      quote <- ''
+    }
+    if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+      # TRUE means same as default, which is single quote.
+      quote <- "'"
+    }
+    else if (grepl("^'.*'$", values$quote)) { # Single quoted.
+      quote <- sub("^'", "", values$quote)
+      quote <- sub("'$", "", quote)
+    }
+    else if (grepl('^".*"$', values$quote)) { # Double quoted.
+      quote <- sub('^"', "", values$quote)
+      quote <- sub('"$', "", quote)
+    }
+    else { # Double quote by default.
+      quote <- NULL # Check default config for the parameter.
+    }
   }
   else {
     quote <- NULL # Check default config for the parameter.
   }
-  if (!is.null(values) && !is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
-    escape <- FALSE
-  }
-  else {
-    escape <- NULL # Check default config for the parameter.
+
+  if (!is.null(values) && !is.null(values$escape)) {
+    if (values$escape %in% c("FALSE", "F", "false", "NO", "No", "no")) {
+      escape <- ''
+    }
+    if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+      # TRUE means same as default, which is single quote.
+      escape <- "'"
+    }
+    else if (grepl("^'.*'$", values$escape)) { # Single quoted.
+      escape <- sub("^'", "", values$escape)
+      escape <- sub("'$", "", escape)
+    }
+    else if (grepl('^".*"$', values$escape)) { # Double quoted.
+      escape <- sub('^"', "", values$escape)
+      escape <- sub('"$', "", escape)
+    }
+    else {
+      escape <- NULL # Check default config for the parameter.
+    }
   }
 
   # Trim white spaces.
@@ -406,16 +438,22 @@ sql_glue_transformer <- function(expr, envir) {
 
   val <- eval(parse(text = code), envir)
 
+  # Check the default config for the variable.
   if (is.null(quote)) {
     quote <- get_variable_config(name, "quote", envir)
     if (is.null(quote)) {
-      quote <- TRUE
+      if (is.numeric(val)) {
+        quote <- '' # No quote by default for numeric.
+      }
+      else {
+        quote <- "'" # Double quote by default
+      }
     }
   }
   if (is.null(escape)) {
     escape <- get_variable_config(name, "escape", envir)
     if (is.null(escape)) {
-      escape <- TRUE
+      escape <- quote # Match with quote by default.
     }
   }
 
@@ -425,28 +463,26 @@ sql_glue_transformer <- function(expr, envir) {
   else if (is.numeric(val)) {
     # Do not convert number to scientific notation.
     val <- format(val, scientific = FALSE)
+    val <- paste0(quote, val, quote)
   }
   else if (is.character(val) || is.factor(val)) {
     # escape for SQL
     # TODO: check if this makes sense for Dremio and Athena
-    if (escape) {
+    if (escape == '"') { # Escape for double quote (Checked that SQL Server's double quote works this way.)
+      val <- gsub('"', '""', val, fixed=TRUE)
+    }
+    else if (escape == "'") { # Escape for single quote
       val <- gsub("'", "''", val, fixed=TRUE) # both Oracle and SQL Server escapes single quote by doubling them.
     }
-    if (quote) {
-      val <- paste0("'", val, "'") # both Oracle and SQL Server quotes strings with single quote.
-    }
+    val <- paste0(quote, val, quote)
   }
   else if (lubridate::is.Date(val)) {
     val <- as.character(val)
-    if (quote) {
-      val <- paste0("'", val, "'") # Athena and PostgreSQL quotes date with single quote. e.g. '2019-01-01'
-    }
+    val <- paste0(quote, val, quote) # Athena and PostgreSQL quotes date with single quote. e.g. '2019-01-01'
   }
   else if (lubridate::is.POSIXt(val)) {
     val <- as.character(val)
-    if (quote) {
-      val <- paste0("'", val, "'") # Athena and PostgreSQL quotes timestamp with single quote. e.g. '2019-01-01 00:00:00'
-    }
+    val <- paste0(quote, val, quote) # Athena and PostgreSQL quotes timestamp with single quote. e.g. '2019-01-01 00:00:00'
   }
 
   # TODO: How should we handle logical?

--- a/R/system.R
+++ b/R/system.R
@@ -236,14 +236,15 @@ get_variable_config <- function(variable_name, config_name, envir) {
 # glue transformer for mongo js query.
 # supports character, factor, logical, Date, POSIXct, POSIXlt, and numeric.
 js_glue_transformer <- function(expr, envir) {
+  # expr is 'param1, quote=FALSE, escape=FALSE' if the whole placeholder is '@{param1, quote=FALSE, escape=FALSE}'
   tokens <- stringr::str_split(expr, ',')
   tokens <- tokens[[1]]
   name <- tokens[1]
   values <- NULL;
 
-  # Parse arguments part. e.g. @{param1, quote=FALSE}
+  # Parse arguments part. e.g. 'quote=FALSE, escape=FALSE'
   if (length(tokens) > 1) {
-    args <- tokens[2:length(tokens)]
+    args <- tokens[2:length(tokens)] # Index 1 that is eliminated is the name of the variable. 
     args <- stringr::str_split(args, '=')
     args <- purrr::map(args, trimws)
     names <- purrr::map(args, function(x){x[1]})

--- a/R/system.R
+++ b/R/system.R
@@ -423,6 +423,9 @@ sql_glue_transformer <- function(expr, envir) {
       escape <- NULL # Check default config for the parameter.
     }
   }
+  else {
+    escape <- NULL # Check default config for the parameter.
+  }
 
   # Trim white spaces.
   name <- trimws(name)

--- a/R/system.R
+++ b/R/system.R
@@ -356,10 +356,18 @@ sql_glue_transformer <- function(expr, envir) {
   val <- eval(parse(text = code), envir)
 
   if (is.null(quote)) {
-    quote <- TRUE
+    code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", name, "`),NULL,exploratory_env$.config$`", name, "`$quote)")
+    quote <- eval(parse(text = code), envir)
+    if (is.null(quote)) {
+      quote <- TRUE
+    }
   }
   if (is.null(escape)) {
-    escape <- TRUE
+    code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", name, "`),NULL,exploratory_env$.config$`", name, "`$escape)")
+    escape <- eval(parse(text = code), envir)
+    if (is.null(escape)) {
+      escape <- TRUE
+    }
   }
 
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.

--- a/R/system.R
+++ b/R/system.R
@@ -227,6 +227,7 @@ glue_exploratory <- function(text, .transformer, .envir = parent.frame()) {
   ret
 }
 
+# Get variable's configured default value.
 get_variable_config <- function(variable_name, config_name, envir) {
   code <- paste0("if(is.null(exploratory_env$.config$`", variable_name, "`)){NULL}else{exploratory_env$.config$`", variable_name, "`$`", config_name, "`}")
   ret <- eval(parse(text = code), envir)
@@ -364,6 +365,7 @@ js_glue_transformer <- function(expr, envir) {
   glue::glue_collapse(val, sep=", ")
 }
 
+# Common routine for sql_glue_transformer and bigquery_glue_transformer.
 sql_glue_transformer_internal <- function(expr, envir, bigquery=FALSE) {
   tokens <- stringr::str_split(expr, ',')
   tokens <- tokens[[1]]

--- a/R/system.R
+++ b/R/system.R
@@ -252,8 +252,12 @@ js_glue_transformer <- function(expr, envir) {
     names(values) <- names
   }
   if (!is.null(values) && !is.null(values$quote)) {
-    if (values$quote %in% c("FALSE", "F", "false", "NO", "no")) {
+    if (values$quote %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       quote <- ''
+    }
+    if (values$quote %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+      # TRUE means same as default, which is double quote.
+      quote <- '"'
     }
     else if (grepl("^'.+'$", values$quote)) { # Single quoted.
       quote <- sub("^'", "", values$quote)
@@ -264,7 +268,7 @@ js_glue_transformer <- function(expr, envir) {
       quote <- sub('"$', "", quote)
     }
     else { # Double quote by default.
-      quote <- '"'
+      quote <- NULL # Check default config for the parameter.
     }
   }
   else {
@@ -272,8 +276,12 @@ js_glue_transformer <- function(expr, envir) {
   }
 
   if (!is.null(values) && !is.null(values$escape)) {
-    if (values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
+    if (values$escape %in% c("FALSE", "F", "false", "NO", "No", "no")) {
       escape <- ''
+    }
+    if (values$escape %in% c("TRUE", "T", "true", "YES", "Yes", "yes")) {
+      # TRUE means same as default, which is double quote.
+      escape <- '"'
     }
     else if (grepl("^'.+'$", values$escape)) { # Single quoted.
       escape <- sub("^'", "", values$escape)
@@ -283,8 +291,8 @@ js_glue_transformer <- function(expr, envir) {
       escape <- sub('^"', "", values$escape)
       escape <- sub('"$', "", escape)
     }
-    else { # Double quote by default.
-      escape <- '"'
+    else {
+      escape <- NULL # Check default config for the parameter.
     }
   }
   else {
@@ -308,7 +316,12 @@ js_glue_transformer <- function(expr, envir) {
   if (is.null(quote)) {
     quote <- get_variable_config(name, "quote", envir)
     if (is.null(quote)) {
-      quote <- '"' # Double quote by default
+      if (is.numeric(val)) {
+        quote <- '' # No quote by default for numeric.
+      }
+      else {
+        quote <- '"' # Double quote by default
+      }
     }
   }
   if (is.null(escape)) {
@@ -324,6 +337,7 @@ js_glue_transformer <- function(expr, envir) {
   else if (is.numeric(val)) {
     # Do not convert number to scientific notation.
     val <- format(val, scientific = FALSE)
+    val <- paste0(quote, val, quote)
   }
   else if (is.character(val) || is.factor(val)) {
     if (escape == '"') { # Escape for double quote

--- a/R/system.R
+++ b/R/system.R
@@ -228,7 +228,7 @@ glue_exploratory <- function(text, .transformer, .envir = parent.frame()) {
 }
 
 get_variable_config <- function(variable_name, config_name, envir) {
-  code <- paste0("dplyr::if_else(is.null(exploratory_env$.config$`", variable_name, "`),NULL,exploratory_env$.config$`", variable_name, "`$`", config_name, "`)")
+  code <- paste0("if(is.null(exploratory_env$.config$`", variable_name, "`)){NULL}else{exploratory_env$.config$`", variable_name, "`$`", config_name, "`}")
   ret <- eval(parse(text = code), envir)
   ret
 }

--- a/R/system.R
+++ b/R/system.R
@@ -277,10 +277,16 @@ js_glue_transformer <- function(expr, envir) {
   val <- eval(parse(text = code), envir)
 
   if (is.null(quote)) {
-    quote <- TRUE
+    quote <- get_variable_config(name, "quote", envir)
+    if (is.null(quote)) {
+      quote <- TRUE
+    }
   }
   if (is.null(escape)) {
-    escape <- TRUE
+    escape <- get_variable_config(name, "escape", envir)
+    if (is.null(escape)) {
+      escape <- TRUE
+    }
   }
 
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
@@ -454,10 +460,16 @@ bigquery_glue_transformer <- function(expr, envir) {
   val <- eval(parse(text = code), envir)
 
   if (is.null(quote)) {
-    quote <- TRUE
+    quote <- get_variable_config(name, "quote", envir)
+    if (is.null(quote)) {
+      quote <- TRUE
+    }
   }
   if (is.null(escape)) {
-    escape <- TRUE
+    escape <- get_variable_config(name, "escape", envir)
+    if (is.null(escape)) {
+      escape <- TRUE
+    }
   }
 
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.

--- a/R/system.R
+++ b/R/system.R
@@ -304,10 +304,10 @@ js_glue_transformer <- function(code, envir) {
   glue::glue_collapse(val, sep=", ")
 }
 
-sql_glue_transformer <- function(code, envir) {
-  tokens <- stringr::str_split(code, ',')
+sql_glue_transformer <- function(expr, envir) {
+  tokens <- stringr::str_split(expr, ',')
   tokens <- tokens[[1]]
-  code <- tokens[1]
+  name <- tokens[1]
   values <- NULL;
 
   # Parse arguments part. e.g. @{param1, quote=FALSE}
@@ -323,27 +323,36 @@ sql_glue_transformer <- function(code, envir) {
     quote <- FALSE
   }
   else {
-    quote <- TRUE # Quote string by default.
+    quote <- NULL # Check default config for the parameter.
   }
   if (!is.null(values) && !is.null(values$escape) && values$escape %in% c("FALSE", "F", "false", "NO", "no")) {
     escape <- FALSE
   }
   else {
-    escape <- TRUE # Escape for single quote by default.
+    escape <- NULL # Check default config for the parameter.
   }
 
   # Trim white spaces.
-  code <- trimws(code)
+  name <- trimws(name)
 
   # Strip quote by ``.
-  should_strip <- grepl("^`.+`$", code)
+  should_strip <- grepl("^`.+`$", name)
   if (should_strip) {
-    code <- sub("^`", "", code)
-    code <- sub("`$", "", code)
+    name <- sub("^`", "", name)
+    name <- sub("`$", "", name)
   }
-  code <- paste0("exploratory_env$`", code, "`")
+
+  code <- paste0("exploratory_env$`", name, "`")
 
   val <- eval(parse(text = code), envir)
+
+  if (is.null(quote)) {
+    quote <- TRUE
+  }
+  if (is.null(escape)) {
+    escape <- TRUE
+  }
+
   if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
     val <- "NULL" # With PostgreSQL, "IN (NULL)" is valid while "IN ()" is syntax error. TODO: Test other databases.
   }

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -136,15 +136,18 @@ test_that("js_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$.config <- new.env()
 
-  exploratory_env$v <- c("a","b","c")
+  exploratory_env$v <- c('a"',"b'","c")
   res <- glue_exploratory("@{ `v` }", .transformer=js_glue_transformer)
-  expect_equal(as.character(res), '"a", "b", "c"') # default quote case.
+  expect_equal(as.character(res), '"a\\\"", "b\'", "c"') # default quote case.
+
   res <- glue_exploratory("@{`v`, quote=''}", .transformer=js_glue_transformer)
-  expect_equal(as.character(res), "a, b, c") # No quote case.
+  expect_equal(as.character(res), "a\", b', c") # No quote case.
+
   exploratory_env$.config$v <- new.env()
   exploratory_env$.config$v$quote <- "" # Made the default no quote.
   res <- glue_exploratory("@{`v`}", .transformer=js_glue_transformer)
-  expect_equal(as.character(res), "a, b, c") # No quote result 
+  expect_equal(as.character(res), "a\", b', c") # No quote result 
+
   rm("v", envir=exploratory_env$.config) # clear config.
 
   exploratory_env$v <- c(T,F,NA)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -136,6 +136,7 @@ test_that("countycode", {
 
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
+  exploratory_env$.config <- new.env()
 
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=js_glue_transformer)
@@ -164,6 +165,7 @@ test_that("js_glue_transformer", {
 
 test_that("sql_glue_transformer", {
   exploratory_env <- new.env()
+  exploratory_env$.config <- new.env()
 
   exploratory_env$v <- c(1,2,3)
   res <- glue_exploratory("@{ v }", .transformer=sql_glue_transformer)
@@ -191,6 +193,7 @@ test_that("sql_glue_transformer", {
 
 test_that("bigquery_glue_transformer", {
   exploratory_env <- new.env()
+  exploratory_env$.config <- new.env()
 
   exploratory_env$v <- c(1,2,3)
   res <- glue_exploratory("@{ v }", .transformer=bigquery_glue_transformer)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -132,7 +132,6 @@ test_that("countycode", {
   ret2 <- countycode(c("MD", "MD", "MD"),c("Baltimore", "Baltimore City", "City of Baltimore"))
   expect_equal(ret2, c("24005", "24510", "24510"))
 })
-
 test_that("js_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$.config <- new.env()
@@ -140,10 +139,10 @@ test_that("js_glue_transformer", {
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=js_glue_transformer)
   expect_equal(as.character(res), '"a", "b", "c"') # default quote case.
-  res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=js_glue_transformer)
+  res <- glue_exploratory("@{`v`, quote=''}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote case.
   exploratory_env$.config$v <- new.env()
-  exploratory_env$.config$v$quote <- FALSE # Made the default no quote.
+  exploratory_env$.config$v$quote <- "" # Made the default no quote.
   res <- glue_exploratory("@{`v`}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote result 
   rm("v", envir=exploratory_env$.config) # clear config.

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -177,9 +177,9 @@ test_that("sql_glue_transformer", {
   res <- glue_exploratory("@{ v }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "1, 2, 3")
 
-  exploratory_env$v <- c("a","b","c")
+  exploratory_env$v <- c('a"',"b'","c")
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
-  expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+  expect_equal(as.character(res), "'a\"', 'b''', 'c'") # Not sure if this behavior works for all types of databases.
 
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=sql_glue_transformer)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -168,6 +168,7 @@ test_that("js_glue_transformer", {
   res <- glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "{stock:{$in:[]}}", "message")
 })
+
 test_that("sql_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$.config <- new.env()
@@ -180,6 +181,7 @@ test_that("sql_glue_transformer", {
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
 
+  exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote case.
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -1,5 +1,4 @@
 context("test system functions")
-
 test_that("test clean_data_frame",{
   # create df with dupicated columns names and data frame type column
   df <- data.frame(a = 1:5, a = 2:6)
@@ -143,6 +142,11 @@ test_that("js_glue_transformer", {
   expect_equal(as.character(res), '"a", "b", "c"') # default quote case.
   res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote case.
+  exploratory_env$.config$v <- new.env()
+  exploratory_env$.config$v$quote <- FALSE # Made the default no quote.
+  res <- glue_exploratory("@{`v`}", .transformer=js_glue_transformer)
+  expect_equal(as.character(res), "a, b, c") # No quote result 
+  rm("v", envir=exploratory_env$.config) # clear config.
 
   exploratory_env$v <- c(T,F,NA)
   res <- glue_exploratory("@{v}", .transformer=js_glue_transformer)
@@ -162,7 +166,6 @@ test_that("js_glue_transformer", {
   res <- glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=js_glue_transformer)
   expect_equal(as.character(res), "{stock:{$in:[]}}", "message")
 })
-
 test_that("sql_glue_transformer", {
   exploratory_env <- new.env()
   exploratory_env$.config <- new.env()

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -179,6 +179,7 @@ test_that("sql_glue_transformer", {
   exploratory_env$v <- c("a","b","c")
   res <- glue_exploratory("@{ `v` }", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "'a', 'b', 'c'") # Not sure if this behavior works for all types of databases.
+
   res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote case.
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -185,6 +185,10 @@ test_that("sql_glue_transformer", {
   res <- glue_exploratory("@{`v`, quote=FALSE}", .transformer=sql_glue_transformer)
   expect_equal(as.character(res), "a, b, c") # No quote case.
 
+  exploratory_env$v <- c('a"',"b'","c")
+  res <- glue_exploratory("@{ `v`, quote=\"\", escape=\"'\" }", .transformer=sql_glue_transformer)
+  expect_equal(as.character(res), "a\", b'', c") # No quote but with escape.
+
   exploratory_env$dept_names <- c("Sales","HR","CEO's secretary", "Data Science\\Statistics")
   exploratory_env$empid_above <- 1100
   res <- glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=sql_glue_transformer)


### PR DESCRIPTION
# Description
- Allow specifying quote/escape character for parameter placeholder. 
- Support configurable default for them.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
