### PR TITLE
Call necessary loadNamespace() before calling predict() to avoid error

### DIFF
--- a/R/build_multinom.R
+++ b/R/build_multinom.R
@@ -29,7 +29,7 @@ build_multinom <- function(data, formula, ...){
 #' @param newdata Data to predict
 #' @export
 augment.multinom <- function(model, data = NULL, newdata = NULL, ...) {
-  # loadNamespace("nnet") # This is necessary for predict() to successfully figure out which runction to call internally for ranger, etc. But it seems nnet do not need it.
+  # loadNamespace("nnet") # This is necessary for predict() to successfully figure out which function to call internally for ranger, etc. But it seems nnet do not need it.
   predicted_label_col <- avoid_conflict(colnames(data), "predicted_label")
   predicted_prob_col <- avoid_conflict(colnames(data), "predicted_probability")
 

--- a/R/build_multinom.R
+++ b/R/build_multinom.R
@@ -29,7 +29,7 @@ build_multinom <- function(data, formula, ...){
 #' @param newdata Data to predict
 #' @export
 augment.multinom <- function(model, data = NULL, newdata = NULL, ...) {
-
+  # loadNamespace("nnet") # This is necessary for predict() to successfully figure out which runction to call internally for ranger, etc. But it seems nnet do not need it.
   predicted_label_col <- avoid_conflict(colnames(data), "predicted_label")
   predicted_prob_col <- avoid_conflict(colnames(data), "predicted_probability")
 

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -457,7 +457,7 @@ augment.xgboost_reg <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgb.Booster <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which function to call internally.
   class(x) <- class(x)[class(x) != "xgboost_binary" &
                          class(x) != "xgboost_multi" &
                          class(x) != "xgboost_reg" &

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -272,6 +272,7 @@ xgboost_reg <- function(data, formula, output_type = "linear", eval_metric = "rm
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
   class(x) <- class(x)[class(x) != c("xgboost_multi")]
 
   if(!is.null(x$terms)){
@@ -343,6 +344,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_binary <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
   class(x) <- class(x)[!class(x) %in% c("xgboost_binary", "xgb.Booster.formula")]
   if(!is.null(x$terms)){
     ret_data <- if(!is.null(newdata)){
@@ -411,6 +413,7 @@ augment.xgboost_binary <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_reg <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
   class(x) <- class(x)[class(x) != "xgboost_reg" &
                        class(x) != "xgb.Booster.formula"]
 
@@ -454,6 +457,7 @@ augment.xgboost_reg <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgb.Booster <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
   class(x) <- class(x)[class(x) != "xgboost_binary" &
                          class(x) != "xgboost_multi" &
                          class(x) != "xgboost_reg" &

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -272,7 +272,7 @@ xgboost_reg <- function(data, formula, output_type = "linear", eval_metric = "rm
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which function to call internally.
   class(x) <- class(x)[class(x) != c("xgboost_multi")]
 
   if(!is.null(x$terms)){

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -344,7 +344,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_binary <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which function to call internally.
   class(x) <- class(x)[!class(x) %in% c("xgboost_binary", "xgb.Booster.formula")]
   if(!is.null(x$terms)){
     ret_data <- if(!is.null(newdata)){

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -413,7 +413,7 @@ augment.xgboost_binary <- function(x, data = NULL, newdata = NULL, ...) {
 #' @param ... Not used for now.
 #' @export
 augment.xgboost_reg <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("xgboost") # This is necessary for predict() to successfully figure out which function to call internally.
   class(x) <- class(x)[class(x) != "xgboost_reg" &
                        class(x) != "xgb.Booster.formula"]
 

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -779,7 +779,7 @@ augment.randomForest <- augment.randomForest.formula
 #' augment for randomForest(ranger) model
 #' @export
 augment.ranger <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("ranger") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("ranger") # This is necessary for predict() to successfully figure out which function to call internally.
   if ("error" %in% class(x)) {
     ret <- data.frame()
     return(ret)
@@ -3236,4 +3236,3 @@ glance.Boruta_exploratory <- function(x, pretty.name = FALSE, ...) {
   }
   res
 }
-

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -991,6 +991,7 @@ augment.ranger.regression <- function(x, data = NULL, newdata = NULL, data_type 
 #' augment for rpart model
 #' @export
 augment.rpart <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("rpart") # This is necessary for predict() to successfully figure out which runction to call internally.
   if ("error" %in% class(x)) {
     ret <- data.frame()
     return(ret)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -991,7 +991,7 @@ augment.ranger.regression <- function(x, data = NULL, newdata = NULL, data_type 
 #' augment for rpart model
 #' @export
 augment.rpart <- function(x, data = NULL, newdata = NULL, ...) {
-  loadNamespace("rpart") # This is necessary for predict() to successfully figure out which runction to call internally.
+  loadNamespace("rpart") # This is necessary for predict() to successfully figure out which function to call internally.
   if ("error" %in% class(x)) {
     ret <- data.frame()
     return(ret)

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -779,6 +779,7 @@ augment.randomForest <- augment.randomForest.formula
 #' augment for randomForest(ranger) model
 #' @export
 augment.ranger <- function(x, data = NULL, newdata = NULL, ...) {
+  loadNamespace("ranger") # This is necessary for predict() to successfully figure out which runction to call internally.
   if ("error" %in% class(x)) {
     ret <- data.frame()
     return(ret)


### PR DESCRIPTION
# Description
Call necessary loadNamespace() before calling predict() to avoid error.
This is for being able to predict from cached model step without getting error from predict().

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
