### PR TITLE
Hide robust statistics for Cox regression for now

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -685,6 +685,12 @@ glance.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add t
   if (!is.null(ret$nobs)) { # glance.coxph's newly added nobs seems to be same as n, which we use as Number of Rows. Suppressing it for now.
     ret <- ret %>% dplyr::select(-nobs)
   }
+  if (!is.null(ret$statistic.robust)) { # The value shows up as NA for some reason. Hide for now.
+    ret <- ret %>% dplyr::select(-statistic.robust)
+  }
+  if (!is.null(ret$p.value.robust)) { # The value shows up as NA for some reason. Hide for now.
+    ret <- ret %>% dplyr::select(-p.value.robust)
+  }
 
   if(pretty.name) {
     colnames(ret)[colnames(ret) == "r.squared"] <- "R Squared"
@@ -705,8 +711,8 @@ glance.coxph_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add t
     colnames(ret)[colnames(ret) == "p.value.sc"] <- "Score Test P Value"
     colnames(ret)[colnames(ret) == "statistic.wald"] <- "Wald Test"
     colnames(ret)[colnames(ret) == "p.value.wald"] <- "Wald Test P Value"
-    colnames(ret)[colnames(ret) == "statistic.robust"] <- "Robust Statistic"
-    colnames(ret)[colnames(ret) == "p.value.robust"] <- "Robust P Value"
+    # colnames(ret)[colnames(ret) == "statistic.robust"] <- "Robust Statistic"
+    # colnames(ret)[colnames(ret) == "p.value.robust"] <- "Robust P Value"
     colnames(ret)[colnames(ret) == "r.squared.max"] <- "R Squared Max"
     colnames(ret)[colnames(ret) == "concordance"] <- "Concordance"
     colnames(ret)[colnames(ret) == "std.error.concordance"] <- "Std Error Concordance"

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -23,7 +23,8 @@ test_that("test build_coxph.fast", {
   ret <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
   expect_equal(colnames(ret),
                c("Number of Rows","Number of Events","Likelihood Ratio Test","Likelihood Ratio Test P Value",
-                 "Score Test","Score Test P Value","Wald Test","Wald Test P Value","Robust Statistic","Robust P Value",
+                 "Score Test","Score Test P Value","Wald Test","Wald Test P Value",
+                 # "Robust Statistic","Robust P Value", # These columns are hidden for now.
                  "R Squared","R Squared Max","Concordance","Std Error Concordance",
                  "Log Likelihood","AIC","BIC")) 
   ret <- model_df %>% augment_rowwise(model)


### PR DESCRIPTION
# Description
Hide robust statistics for Cox regression for now, since the values come up as NAs for some reason.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
