### PR TITLE
Strip environments to save rds size when cached.

### DIFF
--- a/R/build_glm.R
+++ b/R/build_glm.R
@@ -169,6 +169,18 @@ build_glm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, g
         data <- safe_slice(df, index, remove = TRUE)
         # execute glm with parsed arguments
         model <- eval(parse(text = paste0(glm_func_name, "(data = data, ", arg_char, ")")))
+
+        # Strip environments to save rds size when cached.
+        if (!is.null(model$terms)) {
+          attr(model$terms,".Environment")<-NULL
+        }
+        if (!is.null(model$formula)) {
+          attr(model$formula,".Environment")<-NULL
+        }
+        if (!is.null(model$model) && !is.null(attr(model$model,"terms"))) {
+          attr(attr(model$model,"terms"),".Environment") <- NULL
+        }
+
         if (!is.null(model_class_name)) {
           class(model) <- c(model_class_name, class(model))
         }

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -314,6 +314,15 @@ build_lm <- function(data, formula, ..., keep.source = TRUE, augment = FALSE, gr
 
         # execute lm with parsed arguments
         model <- eval(parse(text = paste0("stats::lm(data = data, ", arg_char, ")")))
+
+        # Strip environments to save rds size when cached.
+        if (!is.null(model$terms)) {
+          attr(model$terms,".Environment")<-NULL
+        }
+        if (!is.null(model$model) && !is.null(attr(model$model,"terms"))) {
+          attr(attr(model$model,"terms"),".Environment") <- NULL
+        }
+
         class(model) <- c("lm_exploratory_0", class(model))
         model
       })) %>%


### PR DESCRIPTION
# Description
Strip environments to save rds size when cached.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
