### PR TITLE
Correct direction of difference when grouping variable is logical for exp_ttest, exp_wilcox

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -458,6 +458,7 @@ exp_ttest <- function(df, var1, var2, func2 = NULL, sig.level = 0.05, d = NULL, 
   var2_col <- col_name(substitute(var2))
   grouped_cols <- grouped_by(df)
 
+  # Apply func2 to var2.
   if (!is.null(func2)) {
     if (lubridate::is.Date(df[[var2_col]]) || lubridate::is.POSIXct(df[[var2_col]])) {
       df <- df %>% dplyr::mutate(!!rlang::sym(var2_col) := extract_from_date(!!rlang::sym(var2_col), type=!!func2))
@@ -465,6 +466,12 @@ exp_ttest <- function(df, var1, var2, func2 = NULL, sig.level = 0.05, d = NULL, 
     else if (is.numeric(df[[var2_col]])) {
       df <- df %>% dplyr::mutate(!!rlang::sym(var2_col) := extract_from_numeric(!!rlang::sym(var2_col), type=!!func2))
     }
+  }
+
+  # For logical explanatory variable, make it a factor and adjust label order so that
+  # the calculated difference it TRUE case - FALSE case, which intuitively makes better sense.
+  if (is.logical(df[[var2_col]])) {
+    df <- df %>% dplyr::mutate(!!rlang::sym(var2_col) := factor(!!rlang::sym(var2_col), levels=c("TRUE", "FALSE")))
   }
   
   n_distinct_res <- n_distinct(df[[var2_col]]) # save n_distinct result to avoid repeating the relatively expensive call.

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -681,6 +681,12 @@ exp_wilcox <- function(df, var1, var2, func2 = NULL, ...) {
       df <- df %>% dplyr::mutate(!!rlang::sym(var2_col) := extract_from_numeric(!!rlang::sym(var2_col), type=!!func2))
     }
   }
+
+  # For logical explanatory variable, make it a factor and adjust label order so that
+  # the calculated difference it TRUE case - FALSE case, which intuitively makes better sense.
+  if (is.logical(df[[var2_col]])) {
+    df <- df %>% dplyr::mutate(!!rlang::sym(var2_col) := factor(!!rlang::sym(var2_col), levels=c("TRUE", "FALSE")))
+  }
   
   n_distinct_res <- n_distinct(df[[var2_col]]) # save n_distinct result to avoid repeating the relatively expensive call.
   if (n_distinct_res != 2) {

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -274,6 +274,17 @@ test_that("test exp_ttest", {
   model_df %>% tidy_rowwise(model, type="data_summary")
 })
 
+test_that("test exp_ttest with logical explanatory variable", {
+  mtcars2 <- mtcars
+  mtcars2$am[[1]] <- NA # test NA filtering
+  mtcars2 <- mtcars2 %>% dplyr::mutate(am=as.logical(am))
+  model_df <- exp_ttest(mtcars2, mpg, am)
+  ret <- model_df %>% tidy_rowwise(model, type="model")
+  expect_gt(ret$Difference, 0) # Checking the direction of Difference is correct.
+  expect_true("Number of Rows" %in% colnames(ret))
+  model_df %>% tidy_rowwise(model, type="data_summary")
+})
+
 test_that("test exp_ttest with var.equal = TRUE", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering

--- a/tests/testthat/test_test_wrapper_2.R
+++ b/tests/testthat/test_test_wrapper_2.R
@@ -12,6 +12,17 @@ test_that("test exp_wilcox", {
                  "Minimum","Maximum"))
 })
 
+test_that("test exp_wilcox with logical explanatory variable", {
+  mtcars2 <- mtcars
+  mtcars2$am[[1]] <- NA # test NA filtering
+  mtcars2 <- mtcars2 %>% dplyr::mutate(am=as.logical(am))
+  model_df <- exp_wilcox(mtcars2, mpg, am, conf.int=TRUE) # Set conf.int TRUE to check direction of Difference.
+  ret <- model_df %>% tidy_rowwise(model, type="model")
+  expect_gt(ret$Difference, 0) # Checking the direction of Difference is correct.
+  expect_true("Number of Rows" %in% colnames(ret))
+  model_df %>% tidy_rowwise(model, type="data_summary")
+})
+
 test_that("test exp_wilcox with conf.int = TRUE", {
   mtcars2 <- mtcars
   mtcars2$am[[1]] <- NA # test NA filtering


### PR DESCRIPTION
Correct direction of difference when grouping variable is logical for exp_ttest and exp_wilcox.

# Description
Describe your fix here

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
