### PR TITLE
XGBoost: Fix missing test data rows from confusion matrix

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1353,7 +1353,7 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
       # Extract test prediction result embedded in the model.
       test_pred_ret <- df %>% prediction(data = "test", ...)
 
-      tryCatch({
+      tryCatch({ #TODO: Not too sure why this tryCatch is needed. It could hide errors that should be properly reported.
         model_object <- df$model[[1]]
         if ("xgboost_exp" %in% class(model_object)) {
           actual <- extract_actual(model_object, type = "test")

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1442,7 +1442,7 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
             model_object <- df$model[[1]]
             if ("xgboost_exp" %in% class(model_object)) {
               if (get_prediction_type(model_object) == "binary") {
-                predicted <- extract_predicted_binary_labels(model_object, type = "test", binary_classification_threshold = binary_classification_threshold)
+                predicted <- extract_predicted_binary_labels(model_object, type = "test", threshold = binary_classification_threshold)
               }
               else {
                 predicted <- extract_predicted_multiclass_labels(model_object, type = "test")

--- a/tests/testthat/test_xgboost_1.R
+++ b/tests/testthat/test_xgboost_1.R
@@ -94,6 +94,8 @@ test_that("exp_xgboost(binary) evaluate training and test", {
   expect_gt(nrow(train_ret), 3400)
 
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
+  expect_equal(n_distinct(ret$is_test_data), 2) # There should be both training and test.
+
   model_df <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`)) %>%
                 exp_xgboost(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0, pd_with_bin_means = TRUE)
   ret <- model_df %>% prediction(data="training_and_test")


### PR DESCRIPTION
# Description
Fix missing test data rows from confusion matrix.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
