### PR TITLE
Use data argument rather than newdata for augment for coxph

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -512,7 +512,8 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
 
       # Use formula to support expanded aug_args (especially for type.predict for logistic regression)
       # because ... can't be passed to a function inside mutate directly.
-      if (!is.null(df$model[[1]]$prediction_training) || # Check if model already has training prediction result. # TODO: Make this model agnostic.
+      if ("coxph" %in% class(df$model[[1]]) || # For cox model, prediction results are always included.
+          !is.null(df$model[[1]]$prediction_training) || # Check if model already has training prediction result. # TODO: Make this model agnostic.
           class(df$model[[1]])[[1]] %in% c("lm_exploratory", "glm_exploratory")) { # For lm/glm, we retrieve training prediction inside vanilla lm/glm model.
         aug_fml <- if(aug_args == ""){
           "broom::augment(m, data = df)"

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -745,7 +745,6 @@ augment.coxph_exploratory <- function(x, ...) {
   colnames(ret)[colnames(ret) == ".fitted"] <- "Linear Predictor"
   colnames(ret)[colnames(ret) == ".se.fit"] <- "Std Error"
   colnames(ret)[colnames(ret) == ".resid"] <- "Residual"
-  colnames(ret)[colnames(ret) == ".resid"] <- "Residual"
   colnames(ret)[colnames(ret) == "time_for_prediction"] <- "Survival Time for Prediction"
   colnames(ret)[colnames(ret) == "predicted_probability"] <- "Predicted Survival Rate"
 

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -73,6 +73,7 @@ test_that("build_coxph()", {
   res <- model_df %>% model_coef(conf_int = "default", conf.level = 0.95)
   res <- model_df %>% model_anova()
   res <- model_df %>% prediction_coxph(data = "training", type.predict = "lp", type.residuals = "martingale")
+  expect_true("residuals" %in% colnames(res)) # Make sure residuals column is there. For newdata, it is not there in the output from broom::augment, but this is with training data.
   res <- model_df %>% prediction_survfit(newdata = expand.grid(`a ge` = c(40, 50) , `se-x` = c(1,2)))
 })
 


### PR DESCRIPTION
# Description
Use data argument rather than newdata for augment for coxph.
This is to avoid losing residual column in the output.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
