### PR TITLE
Make %in_or_all% work for our case-insensitive filter condition.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1719,7 +1719,7 @@ mase <- function(actual, predicted, is_test_data, period = 1) {
 #' skipped when the variable is empty or NULL.
 #' @export
 `%in_or_all%` <- function(x,y) {
-  if (is.null(y)) {
+  if (length(y) == 0) {
     return(!(x %in% y))
   }
   else {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -741,6 +741,8 @@ test_that("test %in_or_all%", {
   expect_equal(ret, c(TRUE, TRUE, TRUE))
   ret <- c(1,2,3) %in_or_all% c()
   expect_equal(ret, c(TRUE, TRUE, TRUE))
+  ret <- c('a','b','c') %in_or_all% stringr::str_to_lower(c()) # Test for our case-insensitive filter condition.
+  expect_equal(ret, c(TRUE, TRUE, TRUE))
 })
 
 test_that("test mase", {


### PR DESCRIPTION
# Description
Make %in_or_all% work for our case-insensitive filter condition.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
