### PR TITLE
Relocate logistic/binomial Data tab columns

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -655,10 +655,8 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
     ret[[conf_low_colname]] <- get_confint(ret[[".fitted"]], ret[[".se.fit"]], conf_int = lower)
     ret[[conf_high_colname]] <- get_confint(ret[[".fitted"]], ret[[".se.fit"]], conf_int = higher)
 
-    # move confidece interval columns next to standard error
-    ret <- move_col(ret, '.se.fit', which(colnames(ret) == ".fitted") + 1)
-    ret <- move_col(ret, conf_low_colname, which(colnames(ret) == ".se.fit") + 1)
-    ret <- move_col(ret, conf_high_colname, which(colnames(ret) == conf_low_colname) + 1)
+    # Bring conf_low and conf_high right after predicted_value, instead of .se.fit column.
+    ret <- ret %>% dplyr::relocate(any_of(c(!!conf_low_colname, !!conf_high_colname, ".se.fit")), .after=.fitted)
   }
 
   colnames(ret)[colnames(ret) == ".fitted"] <- avoid_conflict(colnames(ret), "predicted_value")

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1031,9 +1031,14 @@ prediction_binary <- function(df, threshold = 0.5, ...){
 
   colnames(ret)[colnames(ret) == prob_col_name] <- "predicted_probability"
 
+  if (!is.null(ret$predicted_value)) {
+    # Bring those columns as the first of the prediction result related additional columns.
+    ret <- ret %>% dplyr::relocate(any_of(c("predicted_probability", "conf_low", "conf_high", "predicted_label")), .before=predicted_value)
+  }
+
   # Move is_test_data to the last again, since new columns were added to the last in this function.
   if (!is.null(ret$is_test_data)) {
-    ret <- ret %>% select(-is_test_data, everything(), is_test_data)
+    ret <- ret %>% dplyr::select(-is_test_data, everything(), is_test_data)
   }
   ret
 }

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -788,6 +788,11 @@ augment.coxph_exploratory <- function(x, data_type = "training", ...) {
   ret <- ret %>% dplyr::mutate(time_for_prediction = time,
                                predicted_probability = 1 - exp(-cumhaz_base * exp(.fitted)))
 
+
+  if (!is.null(ret$.fitted)) {
+    # Bring those columns as the first of the prediction result related additional columns.
+    ret <- ret %>% dplyr::relocate(any_of(c("time_for_prediction", "predicted_probability")), .before=.fitted)
+  }
   # Prettify names.
   colnames(ret)[colnames(ret) == ".fitted"] <- "Linear Predictor"
   colnames(ret)[colnames(ret) == ".se.fit"] <- "Std Error"

--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -496,7 +496,8 @@ test_that("test prediction(data='training_and_test') by glm", {
   ret <- model_ret %>% prediction(data='training_and_test')
   expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME",
                      "DERAY_TIME", "predicted_value",
-                     "standard_error", "conf_low", "conf_high", 
+                     "conf_low", "conf_high", 
+                     "standard_error", 
                      "residuals", "standardised_residuals", "hat",
                      "residual_standard_deviation", "cooks_distance",
                      "is_test_data")
@@ -513,13 +514,17 @@ test_that("test prediction(data='training_and_test') by glm", {
   # Working it around now, but look into it.
   expected_cols_1 <- c("klass", "Carrier Name", "DISTANCE",
                      "ARR_TIME", "DERAY_TIME", "predicted_value",
-                     "standard_error", "conf_low", "conf_high", "residuals",
+                     "conf_low", "conf_high",
+                     "standard_error",
+                     "residuals",
                      "standardised_residuals", "hat", "residual_standard_deviation",
                      "cooks_distance",
                      "is_test_data")
   expected_cols_2 <- c("klass", "Carrier Name", "DISTANCE",
                      "ARR_TIME", "DERAY_TIME", "predicted_value",
-                     "standard_error", "conf_low", "conf_high", "residuals",
+                     "conf_low", "conf_high",
+                     "standard_error",
+                     "residuals",
                      "hat", "residual_standard_deviation",
                      "is_test_data")
   expect_true(all(colnames(grp_ret) == expected_cols_1) || all(colnames(grp_ret) == expected_cols_2))

--- a/tests/testthat/test_build_glm.R
+++ b/tests/testthat/test_build_glm.R
@@ -122,14 +122,21 @@ test_that("prediction with categorical columns", {
 
   expect_true(nrow(ret) > 0)
   expect_true(all(ret["predicted_value"] >= 0 & ret["predicted_value"] <= 1))
-  expect_equal(colnames(ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value", "standard_error", "conf_low", "conf_high"))
+  expect_equal(colnames(ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value",
+                                "conf_low", "conf_high",
+                                "standard_error"))
 
   expect_true(all(both_ret["predicted_response"] >= 0 & both_ret["predicted_response"] <= 1))
-  expect_equal(colnames(both_ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value", "standard_error", "conf_low", "conf_high", "predicted_response"))
+  expect_equal(colnames(both_ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value",
+                                     "conf_low", "conf_high",
+                                     "standard_error",
+                                     "predicted_response"))
 
   expect_true(all(train_ret["predicted_response"] >= 0 & train_ret["predicted_response"] <= 1))
   expect_equal(colnames(train_ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value",
-                                      "standard_error", "conf_low", "conf_high", "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
+                                      "conf_low", "conf_high",
+                                      "standard_error",
+                                      "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                                       "cooks_distance", "predicted_response"))
 
   add_prediction_ret <- test_data %>% add_prediction(model_data, type.predict = "response")

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -117,13 +117,19 @@ test_that("build_lm with evaluation", {
 
   evaluated <- lm_model %>%
     prediction(data = "test")
-  expect_equal(colnames(evaluated), c("group", "num1", "num2", "predicted_value", "standard_error", "conf_low", "conf_high", "residuals"))
+  expect_equal(colnames(evaluated), c("group", "num1", "num2", "predicted_value",
+                                      "conf_low", "conf_high",
+                                      "standard_error",
+                                      "residuals"))
 
   test_eval <- lm_model %>%
     prediction(data = "training")
 
   expect_equal(colnames(test_eval), c("group", "num1", "num2",
-                                      "predicted_value", "standard_error", "conf_low", "conf_high", "residuals",
+                                      "predicted_value",
+                                      "conf_low", "conf_high",
+                                      "standard_error",
+                                      "residuals",
                                       "standardised_residuals",
                                       "hat", "residual_standard_deviation", "cooks_distance"
                                       ))
@@ -147,7 +153,10 @@ test_that("prediction with categorical columns", {
 
   ret <- prediction(model_data, data = "test", pretty.name = TRUE)
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value", "standard_error", "conf_low", "conf_high", "residuals"))
+  expect_equal(colnames(ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value",
+                                "conf_low", "conf_high",
+                                "standard_error",
+                                "residuals"))
 
   grouped <- test_data %>%
     dplyr::group_by(CARRIER)

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -134,11 +134,14 @@ test_that("Linear Regression with test rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -174,11 +177,14 @@ test_that("Linear Regression with outlier filtering", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value", 
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error", "conf_low", "conf_high")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -208,14 +214,15 @@ test_that("Group Linear Regression with test_rate", {
                  test_nrows)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high"
-                       )
+                       "conf_low", "conf_high",
+                       "standard_error")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -243,12 +250,14 @@ test_that("GLM - Normal Destribution with test_rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -281,13 +290,15 @@ test_that("Group GLM - Normal Destribution with test_rate", {
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
@@ -317,12 +328,15 @@ test_that("GLM - Gamma Destribution with test_rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
-                       "conf_low", "conf_high", "predicted_response")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -352,13 +366,16 @@ test_that("Group GLM - Gamma Destribution with test_rate", {
                  test_nrows)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high", "predicted_response")
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -386,12 +403,15 @@ test_that("GLM - Inverse Gaussian Destribution with test_rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
-                       "conf_low", "conf_high", "predicted_response")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -421,13 +441,16 @@ test_that("Group GLM - Inverse Gaussian Destribution with test_rate", {
                  test_nrows)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high", "predicted_response")
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -455,12 +478,15 @@ test_that("GLM - poisson Destribution with test_rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
-                       "conf_low", "conf_high", "predicted_response")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -491,13 +517,16 @@ test_that("Group GLM - Poisson Destribution with test_rate", {
                  test_nrows)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high", "predicted_response")
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -527,12 +556,15 @@ test_that("GLM - Negative Binomial Destribution with test_rate", {
 
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error","conf_low","conf_high",
+                       "conf_low","conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
-                       "conf_low", "conf_high", "predicted_response")
+    expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -564,13 +596,16 @@ test_that("Group GLM - Negative Binomial Destribution with test_rate", {
                  test_nrows)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error","conf_low","conf_high",
+                       "conf_low","conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high", "predicted_response")
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
@@ -602,12 +637,15 @@ test_that("Logistic Regression with test_rate", {
 
     expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME",
                        "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
-    expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME", "predicted_value", "standard_error",
-                       "conf_low", "conf_high", "predicted_response")
+    expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME", "predicted_value",
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% evaluate_binary_training_and_test(`CANCELLED X`, threshold = 0.5, pretty.name=TRUE)
@@ -641,13 +679,16 @@ test_that("Group Logistic Regression with test_rate", {
 
     # Since broom 0.7.0, I sometimes see "residuals" missing here, but not consistently. Will keep watching.
     expected_cols <- c("klass", "CANCELLED X", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high",
+                       "conf_low", "conf_high",
+                       "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
     expect_equal(colnames(pred_training), expected_cols)
 
     expected_cols <- c("klass", "CANCELLED X", "ARR_TIME", "predicted_value",
-                       "standard_error", "conf_low", "conf_high", "predicted_response")
+                       "conf_low", "conf_high",
+                       "standard_error",
+                       "predicted_response")
     expect_equal(colnames(pred_test), expected_cols)
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)


### PR DESCRIPTION
# Description
-  logistic regression and binomial regression: Brought columns "predicted_probability", "conf_low", "conf_high", and "predicted_label" at the beginning of the additional prediction result columns in the Data tab table.
- Linear regression/GLM: Brought conf_low and conf_high right after predicted_value
- Cox regression:Brought "Survival Time for Prediction" and "Predicted Survival Rate" right after "Survival Time".


# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
