### PR TITLE
prophet: Allow 0 as forecast period

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -549,7 +549,21 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         else {
           time_unit_for_future_dataframe = time_unit
         }
-        future <- prophet::make_future_dataframe(m, periods = periods, freq = time_unit_for_future_dataframe, include_history = include_history) #includes past dates
+
+        # make_future_dataframe can't handle periods=0. Work it around.
+        if (periods == 0) {
+          periods_ <- 1
+        }
+        else {
+          periods_ <- periods
+        }
+
+        future <- prophet::make_future_dataframe(m, periods = periods_, freq = time_unit_for_future_dataframe, include_history = include_history) #includes past dates
+
+        if (periods == 0) { # Remove the last extra row in case we passed period 1 instead of 0.
+          future <- head(future, -1)
+        }
+
         if (!is.null(regressor_output_cols)) {
           regressor_data <- aggregated_data %>%
             dplyr::select(-y) %>%

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -314,19 +314,6 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
         max_floored_date <- max(df[[time_col]])
         future_df <- future_df %>% dplyr::filter(UQ(rlang::sym(time_col)) > max_floored_date)
   
-        # No future external regressor data is provided. For test mode, this is fine, but when it is not, this is a problem.
-        #if(nrow(future_df) == 0 && !test_mode) {
-        #  # ignore the error if
-        #  # it is caused by subset of
-        #  # grouped data frame
-        #  # to show result of
-        #  # data frames that succeed
-        #  if(is.null(grouped_col) || length(grouped_col) == 0) {
-        #    # Terminology is not consistent here, but we are calling extra regressor "external predictor" on the UI.
-        #    stop("In order to use the External Predictors, you need future data or switch to Test Mode in the Property dialog.")
-        #  }
-        #}
-  
         if (nrow(future_df) > 0) {
           # TODO: in test mode, this is not really necessary. optimize.
           aggregated_future_data <- future_df %>%

--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -153,6 +153,23 @@ test_that("do_prophet with extra regressors with no future data", {
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-01"))
 })
 
+test_that("do_prophet with extra regressors with no future data with explicit 0 period", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  ts2 <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day") # No future data.
+  regressor_data <- data.frame(timestamp=ts2, regressor1=runif(length(ts2)), regressor2=runif(length(ts2)))
+  combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
+  model_df <- combined_data %>%
+    do_prophet(timestamp, data, 0, time_unit = "day", regressors = c("regressor1","regressor2"), funs.aggregate.regressors = c(mean), output="model")
+  coef_df <- model_df %>% tidy_rowwise(model, type="coef")
+  expect_equal(names(coef_df), c("Variable","Importance"))
+  ret <- model_df %>% tidy_rowwise(model)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-01")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-01"))
+})
+
 test_that("do_prophet with no extra regressors with no future data", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))

--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -153,6 +153,23 @@ test_that("do_prophet with extra regressors with no future data", {
   expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-01"))
 })
 
+test_that("do_prophet with no extra regressors with no future data", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))
+  ts2 <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day") # No future data.
+  regressor_data <- data.frame(timestamp=ts2, regressor1=runif(length(ts2)), regressor2=runif(length(ts2)))
+  combined_data <- raw_data %>% full_join(regressor_data, by=c("timestamp"="timestamp"))
+  model_df <- combined_data %>%
+    do_prophet(timestamp, data, 0, time_unit = "day", funs.aggregate.regressors = c(mean), output="model")
+  coef_df <- model_df %>% tidy_rowwise(model, type="coef")
+  expect_equal(names(coef_df), c("Variable","Importance"))
+  ret <- model_df %>% tidy_rowwise(model)
+  # verify the last date with forecasted_value
+  expect_equal(last((ret %>% filter(!is.na(forecasted_value)))$timestamp), as.Date("2012-01-01")) 
+  # verify the last date in the data is the end of regressor data
+  expect_equal(ret$timestamp[[length(ret$timestamp)]], as.Date("2012-01-01"))
+})
+
 test_that("do_prophet with extra regressor with holiday column", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2012-01-01"), by="day")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts)))


### PR DESCRIPTION
# Description
Allow 0 as forecast period, just do not add any future rows.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
