### PR TITLE
Data Wrangling: Support an option to summarize the count by Token, not by Document ID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.3.0.7
-Date: 2020-11-14
+Version: 6.3.0.8
+Date: 2020-11-15
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -173,7 +173,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
                                  remove_symbols = TRUE, remove_twitter = TRUE,
                                  remove_url = TRUE, stopwords_lang = NULL,
                                  hiragana_word_length_to_remove = 2,
-                                 summary_level = "row", sort_by = "count", ...){
+                                 summary_level = "row", sort_by = "", ...){
 
   if(!requireNamespace("quanteda")){stop("package quanteda must be installed.")}
   if(!requireNamespace("dplyr")){stop("package dplyr must be installed.")}

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -250,7 +250,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   }
   # if the summary_level is "all", summarize it by token.
   if(summary_level == "all") {
-    result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := sum(!!rlang::sym(count_col)))
+    result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := sum(!!rlang::sym(count_col)), na.rm = TRUE)
   }
   # Sort handling. if count is specified, sort by count descending.
   if(sort_by == "count") {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -161,7 +161,9 @@ word_to_sentiment <- function(words, lexicon="bing"){
 #' @param remove_twitter Whether it should remove remove Twitter characters @ and #.
 #' @param remove_url Whether it should remove URL starts with http(s).
 #' @param stopwords_lang Language for the stopwords that need to be excluded from the result.
-#' @param hiragana_word_length_to_remove Legnth of a Hiragana word that needs to be excluded from the result.
+#' @param hiragana_word_length_to_remove Length of a Hiragana word that needs to be excluded from the result.
+#' @param summary_level Either "document" or "token". If this is not "token", it summarize the result by token.
+#' @param sort_by Either "count" or "name"
 #' @return Data frame with tokenized column.
 #' @export
 do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -245,7 +245,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   # result column order should be document_id, <token_col>, <count_col> ...
   if(!with_id) {
     result <-result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
-    if(drop && !keep_cols && summary_level != "document") { # if it's only token and count, then summarize it by token.
+    if(drop && !keep_cols && summary_level == "token") { # if it's only token and count, then summarize it by token.
       result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
     }
     if(sort_by == "count") {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -245,7 +245,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   # result column order should be document_id, <token_col>, <count_col> ...
   if(!with_id) {
     result <-result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
-    if(drop && !keep_cols && summary_level == "token") { # if it's only token and count, then summarize it by token.
+    if(drop && !keep_cols && summary_level == "token") { # if the summary_level is token and resulting columns are only token and count, summarize it by token.
       result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
     }
     if(sort_by == "count") {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -170,7 +170,8 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
                                  remove_hyphens = FALSE, remove_separators = TRUE,
                                  remove_symbols = TRUE, remove_twitter = TRUE,
                                  remove_url = TRUE, stopwords_lang = NULL,
-                                 hiragana_word_length_to_remove = 2, ...){
+                                 hiragana_word_length_to_remove = 2,
+                                 summary_level = "document", sort_by = "count", ...){
 
   if(!requireNamespace("quanteda")){stop("package quanteda must be installed.")}
   if(!requireNamespace("dplyr")){stop("package dplyr must be installed.")}
@@ -242,8 +243,13 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   # result column order should be document_id, <token_col>, <count_col> ...
   if(!with_id) {
     result <-result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
-    if(drop && !keep_cols) { # if it's only token and count, then summarize it by token.
+    if(drop && !keep_cols && summary_level != "document") { # if it's only token and count, then summarize it by token.
       result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
+    }
+    if(sort_by == "count") {
+      result <- result %>% arrange(desc(!!rlang::sym(count_col)))
+    } else {
+      result <- result %>% arrange(!!rlang::sym(token_col))
     }
     result
   } else {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -162,7 +162,7 @@ word_to_sentiment <- function(words, lexicon="bing"){
 #' @param remove_url Whether it should remove URL starts with http(s).
 #' @param stopwords_lang Language for the stopwords that need to be excluded from the result.
 #' @param hiragana_word_length_to_remove Length of a Hiragana word that needs to be excluded from the result.
-#' @param summary_level Either "document" or "token". If this is not "token", it summarize the result by token.
+#' @param summary_level Either "document" or "token". If this is "token" and with_id is FALSE, it summarizes the result by token.
 #' @param sort_by Either "count" or "name"
 #' @return Data frame with tokenized column.
 #' @export

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -248,7 +248,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
     }
     if(sort_by == "count") {
       result <- result %>% arrange(desc(!!rlang::sym(count_col)))
-    } else {
+    } else if (sort_by == "token"){
       result <- result %>% arrange(!!rlang::sym(token_col))
     }
     result

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -250,7 +250,7 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   }
   # if the summary_level is "all", summarize it by token.
   if(summary_level == "all") {
-    result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
+    result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := sum(!!rlang::sym(count_col)))
   }
   # Sort handling. if count is specified, sort by count descending.
   if(sort_by == "count") {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -245,19 +245,20 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   # result column order should be document_id, <token_col>, <count_col> ...
   if(!with_id) {
     result <- result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
-    if(summary_level == "all") { # if the summary_level is "all", summarize it by token.
-      result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
-    }
-    # Sort handling. if count is specified, sort by count descending.
-    if(sort_by == "count") {
-      result <- result %>% arrange(desc(!!rlang::sym(count_col)))
-    } else if (sort_by == "token"){ #if token is specified, sort by token alphabetically.
-      result <- result %>% arrange(!!rlang::sym(token_col))
-    }
-    result
   } else {
-    result %>% select(document_id, !!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
+    result <- result %>% select(document_id, !!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
   }
+  # if the summary_level is "all", summarize it by token.
+  if(summary_level == "all") {
+    result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
+  }
+  # Sort handling. if count is specified, sort by count descending.
+  if(sort_by == "count") {
+    result <- result %>% arrange(desc(!!rlang::sym(count_col)))
+  } else if (sort_by == "token"){ #if token is specified, sort by token alphabetically.
+    result <- result %>% arrange(!!rlang::sym(token_col))
+  }
+  result
 }
 
 #' Tokenize text and unnest

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -241,7 +241,11 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
   }
   # result column order should be document_id, <token_col>, <count_col> ...
   if(!with_id) {
-    result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
+    result <-result %>% select(!!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
+    if(drop && !keep_cols) { # if it's only token and count, then summarize it by token.
+      result <- result %>% dplyr::group_by(!!rlang::sym(token_col)) %>% dplyr::summarise(!!rlang::sym(count_col) := n())
+    }
+    result
   } else {
     result %>% select(document_id, !!rlang::sym(token_col), !!rlang::sym(count_col), dplyr::everything())
   }
@@ -332,7 +336,7 @@ do_tokenize <- function(df, input, token = "words", keep_cols = FALSE,  drop = T
     ret <- ret %>% dplyr::filter(!is_stopword(!!rlang::sym(output_col), lang = stopwords_lang))
   }
   if(remove_numbers) {
-    # remoe if the token is all number characters.
+    # remove if the token is all number characters.
     ret <- ret %>% dplyr::filter(!stringr::str_detect(!!rlang::sym(output_col), '^[:digit:]+$'))
   }
   ret

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -126,13 +126,13 @@ test_that("do_tokenize_icu with keep_cols = TRUE with sentences", {
   expect_equal(ncol(result), 5)
 })
 
-test_that("do_tokenize_icu with summary_level = token", {
+test_that("do_tokenize_icu with summary_level = all", {
   test_df <- data.frame(
     input = c("Hello world!", "This is a data frame for test. This is second sentence. Hello Hello!"),
     extra_col = seq(2),
     stringsAsFactors = FALSE)
   result <- test_df %>%
-    do_tokenize_icu(input, drop=TRUE, token = "word", keep_cols = FALSE, summary_level = "token", with_id = FALSE)
+    do_tokenize_icu(input, drop=TRUE, token = "word", keep_cols = FALSE, summary_level = "all", with_id = FALSE)
   #  token   count
   #  <chr>   <int>
   #  1 hello       2

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -126,6 +126,30 @@ test_that("do_tokenize_icu with keep_cols = TRUE with sentences", {
   expect_equal(ncol(result), 5)
 })
 
+test_that("do_tokenize_icu with summary_level = token", {
+  test_df <- data.frame(
+    input = c("Hello world!", "This is a data frame for test. This is second sentence. Hello Hello!"),
+    extra_col = seq(2),
+    stringsAsFactors = FALSE)
+  result <- test_df %>%
+    do_tokenize_icu(input, drop=TRUE, token = "word", keep_cols = FALSE, summary_level = "token", with_id = FALSE)
+  #  token   count
+  #  <chr>   <int>
+  #  1 hello       2
+  #  2 a           1
+  #  3 data        1
+  #  4 for         1
+  #  5 frame       1
+  #  6 is          1
+  #  7 second      1
+  #  8 sentenc     1
+  #  9 test        1
+  #  10 this       1
+  #  11 world      1
+  expect_equal(result$token[[1]], "hello")
+  expect_equal(nrow(result), 11)
+})
+
 test_that("do_tokenize with remove_numbers", {
   test_df <- data.frame(
     input = c("12345 aaa", "12aabb33", "123456 34567 88999"),

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -147,6 +147,7 @@ test_that("do_tokenize_icu with summary_level = all", {
   #10 test       1
   #11 world      1
   expect_equal(result$token[[1]], "hello")
+  expect_equal(result$count[[1]], 3)
   expect_equal(nrow(result), 11)
 })
 

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -132,20 +132,20 @@ test_that("do_tokenize_icu with summary_level = all", {
     extra_col = seq(2),
     stringsAsFactors = FALSE)
   result <- test_df %>%
-    do_tokenize_icu(input, drop=TRUE, token = "word", keep_cols = FALSE, summary_level = "all", with_id = FALSE)
+    do_tokenize_icu(input, drop=TRUE, token = "word", keep_cols = FALSE, summary_level = "all", with_id = FALSE, sort_by = "count")
   #  token   count
   #  <chr>   <int>
-  #  1 hello       2
-  #  2 a           1
-  #  3 data        1
-  #  4 for         1
-  #  5 frame       1
-  #  6 is          1
-  #  7 second      1
-  #  8 sentenc     1
-  #  9 test        1
-  #  10 this       1
-  #  11 world      1
+  #1 hello       3
+  #2 is          2
+  #3 this        2
+  #4 a           1
+  #5 data        1
+  #6 for         1
+  #7 frame       1
+  #8 second      1
+  #9 sentenc     1
+  #10 test       1
+  #11 world      1
   expect_equal(result$token[[1]], "hello")
   expect_equal(nrow(result), 11)
 })


### PR DESCRIPTION
# Description

As for do_tokenize_icu, change it to show summarized count by token if drop argument is TRUE and keep_cols argument is FALSE.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
