### PR TITLE
On Windows, Web Scraping shows invalid multibyte error for some of the Japanese characters.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1616,8 +1616,18 @@ parse_html_tables <- function(url, encoding = NULL) {
 scrape_html_table <- function(url, index, heading, encoding = NULL) {
   loadNamespace("rvest");
   loadNamespace("tibble");
+  current_locale = Sys.getlocale(category = "LC_CTYPE")
   .htmltables <- parse_html_tables(url, encoding)
-  tibble::repair_names(rvest::html_table(.htmltables[[index]], fill=TRUE ,header=heading))
+  if (Sys.info()["sysname"] == "Windows") {
+    # For Windows, temporary change LC_CTYPE to C to workaround the "invalid multibyte string" error raised from rvest.
+    Sys.setlocale(category="LC_CTYPE", locale="C");
+  }
+  res <- tibble::repair_names(rvest::html_table(.htmltables[[index]], fill=TRUE ,header=heading))
+  if (Sys.info()["sysname"] == "Windows") {
+    # Set back original LC_TYPE
+    Sys.setlocale(category="LC_CTYPE", locale=current_locale);
+  }
+  res
 }
 
 

--- a/R/system.R
+++ b/R/system.R
@@ -1616,17 +1616,20 @@ parse_html_tables <- function(url, encoding = NULL) {
 scrape_html_table <- function(url, index, heading, encoding = NULL) {
   loadNamespace("rvest");
   loadNamespace("tibble");
-  current_locale = Sys.getlocale(category = "LC_CTYPE")
-  .htmltables <- parse_html_tables(url, encoding)
-  if (Sys.info()["sysname"] == "Windows") {
-    # For Windows, temporary change LC_CTYPE to C to workaround the "invalid multibyte string" error raised from rvest.
-    Sys.setlocale(category="LC_CTYPE", locale="C");
-  }
-  res <- tibble::repair_names(rvest::html_table(.htmltables[[index]], fill=TRUE ,header=heading))
-  if (Sys.info()["sysname"] == "Windows") {
-    # Set back original LC_TYPE
-    Sys.setlocale(category="LC_CTYPE", locale=current_locale);
-  }
+  original_locale = Sys.getlocale(category = "LC_CTYPE")
+  tryCatch({
+    .htmltables <- parse_html_tables(url, encoding)
+    if (Sys.info()["sysname"] == "Windows") {
+      # For Windows, temporary change LC_CTYPE to C to workaround the "invalid multibyte string" error raised from rvest.
+      Sys.setlocale(category="LC_CTYPE", locale="C");
+    }
+    res <- tibble::repair_names(rvest::html_table(.htmltables[[index]], fill=TRUE ,header=heading))
+  }, finally = {
+    if (Sys.info()["sysname"] == "Windows") {
+      # Set back original LC_TYPE
+      Sys.setlocale(category="LC_CTYPE", locale=original_locale);
+    }
+  })
   res
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -1621,6 +1621,7 @@ scrape_html_table <- function(url, index, heading, encoding = NULL) {
     .htmltables <- parse_html_tables(url, encoding)
     if (Sys.info()["sysname"] == "Windows") {
       # For Windows, temporary change LC_CTYPE to C to workaround the "invalid multibyte string" error raised from rvest.
+      # please see https://github.com/r-lib/devtools/issues/544 for locale "C" workround for invalid multibyte string.
       Sys.setlocale(category="LC_CTYPE", locale="C");
     }
     res <- tibble::repair_names(rvest::html_table(.htmltables[[index]], fill=TRUE ,header=heading))


### PR DESCRIPTION
# Description

On Windows, Web Scraping shows invalid multibyte error for some of the Japanese characters.
To address the issue, change the code to switch local to "C" before data import then bring back the original locale once it's done.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
