### PR TITLE
Show 0 for negative importance, which can be caused by chance in case of permutation importance.

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -292,7 +292,7 @@ calc_permutation_importance_coxph <- function(fit, time_col, status_col, vars, d
                                 loss.fun = function(x,y){-calc_efron_log_likelihood(x[,1], y, x[,2])})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(term=vars, importance=importances)
+  importances_df <- tibble::tibble(term=vars, importance=pmax(importances, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   importances_df
 }
 

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -8,7 +8,7 @@ calc_permutation_importance_binomial <- function(fit, target, vars, data) {
                                 loss.fun = function(x,y){-sum(log(1- abs(x - y)),na.rm = TRUE)})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(term=vars, importance=importances)
+  importances_df <- tibble::tibble(term=vars, importance=pmax(importances, 0))
   importances_df
 }
 
@@ -22,7 +22,7 @@ calc_permutation_importance_linear <- function(fit, target, vars, data) {
                                 loss.fun = function(x,y){sum((x - y)^2, na.rm = TRUE)/length(x)})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(term=vars, importance=importances)
+  importances_df <- tibble::tibble(term=vars, importance=pmax(importances, 0))
   importances_df
 }
 
@@ -37,7 +37,7 @@ calc_permutation_importance_gaussian <- function(fit, target, vars, data) {
                                 loss.fun = function(x,y){sum((x - y)^2, na.rm = TRUE)/length(x)})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(term=vars, importance=importances)
+  importances_df <- tibble::tibble(term=vars, importance=pmax(importances, 0))
   importances_df
 }
 
@@ -54,7 +54,7 @@ calc_permutation_importance_poisson <- function(fit, target, vars, data) {
                                 loss.fun = function(x,y){-sum(y*x-exp(x), na.rm = TRUE)})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(term=vars, importance=importances)
+  importances_df <- tibble::tibble(term=vars, importance=pmax(importances, 0))
   importances_df
 }
 
@@ -1042,7 +1042,7 @@ build_lm.fast <- function(df,
         coef_df <- broom:::tidy.glm(model)
         # str_detect matches with all categorical class terms that belongs to the variable.
         p_values_list <- c_cols_list %>% purrr::map(function(x){(coef_df %>% filter(stringr::str_detect(term, paste0("^`?", x))) %>% summarize(p.value=min(p.value, na.rm=TRUE)))$p.value})
-        p_values_df <- tibble(term=c_cols, p.value=purrr::flatten_dbl(p_values_list))
+        p_values_df <- tibble::tibble(term=c_cols, p.value=purrr::flatten_dbl(p_values_list))
         imp_vars <- (p_values_df %>% dplyr::arrange(p.value))$term
         imp_vars <- imp_vars[1:min(length(imp_vars), max_pd_vars)] # Keep only max_pd_vars most important variables
 

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -785,7 +785,7 @@ calc_permutation_importance_xgboost_regression <- function(fit, target, vars, da
                                 loss.fun = function(x,y){sum((x - y)^2, na.rm = TRUE)/length(x)})
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(variable=vars, importance=importances)
+  importances_df <- tibble::tibble(variable=vars, importance=pmax(importances, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   importances_df <- importances_df %>% dplyr::arrange(-importance)
   importances_df
 }
@@ -800,7 +800,7 @@ calc_permutation_importance_xgboost_binary <- function(fit, target, vars, data) 
                                 )
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(variable=vars, importance=importances)
+  importances_df <- tibble(variable=vars, importance=pmax(importances, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   importances_df <- importances_df %>% dplyr::arrange(-importance)
   importances_df
 }
@@ -815,7 +815,7 @@ calc_permutation_importance_xgboost_multiclass <- function(fit, target, vars, da
                                 )
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble(variable=vars, importance=importances)
+  importances_df <- tibble(variable=vars, importance=pmax(importances, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   importances_df <- importances_df %>% dplyr::arrange(-importance)
   importances_df
 }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2075,6 +2075,7 @@ importance_ranger <- function(model) {
     variable = names(imp),
     importance = imp
   ) %>% dplyr::arrange(-importance)
+  imp_df <- imp_df %>% dplyr::mutate(importance = pmax(importance, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   imp_df
 }
 

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -33,7 +33,7 @@ calc_permutation_importance_ranger_survival <- function(fit, time_col, status_co
                                 })
   })
   importances <- purrr::flatten_dbl(importances)
-  importances_df <- tibble::tibble(variable=vars, importance=importances)
+  importances_df <- tibble::tibble(variable=vars, importance=pmax(importances, 0)) # Show 0 for negative importance, which can be caused by chance in case of permutation importance.
   importances_df <- importances_df %>% dplyr::arrange(-importance)
   importances_df
 }


### PR DESCRIPTION
# Description
Show 0 for negative importance, which can be caused by chance in case of permutation importance.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
