### PR TITLE
Support anonymous function for mutate_predictors

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2150,7 +2150,9 @@ restore_na <- function(value, na_row_numbers){
 
 # Returns a quosure that can be used as right-hand-side of arguments of mutate. Used in mutate_predictors and group_by arguments for summarize_group.
 column_mutate_quosure <- function(func, cname) {
-  if(is.na(func) || length(func)==0 || func == "none"){
+  if(is.function(func)) { # func is already a function. Use it as is.
+    rlang::quo(UQ(func)(UQ(rlang::sym(cname))))
+  } else if(is.na(func) || length(func)==0 || func == "none"){
     rlang::quo((UQ(rlang::sym(cname))))
   } else if (func %in% c("fltoyear","rtoyear",
       "fltohalfyear",

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -974,7 +974,7 @@ test_that("calc_confint_ratio", {
 })
 
 test_that("mutate_predictors", {
-  df <- tibble::tibble(x=1, t=as.Date("2020-01-01"), y=4)
-  res <- df %>% exploratory:::mutate_predictors(c("x", "t", "y"), list(x="log", list(t_mon="mon", t_wday="wday", t_week_of_quarter="week_of_quarter"), y="log2"))
-  expect_true(all(c("x","y","t_mon","t_wday","t_week_of_quarter") %in% colnames(res)))
+  df <- tibble::tibble(x=1, t=as.Date("2020-01-01"), y=4, z=8)
+  res <- df %>% exploratory:::mutate_predictors(c("x", "t", "y", "z"), list(x="log", list(t_mon="mon", t_wday="wday", t_week_of_quarter="week_of_quarter"), y="log2", z=function(x){log(x, base=2)}))
+  expect_true(all(c("x", "t_mon", "t_wday", "t_week_of_quarter", "y", "z") %in% colnames(res)))
 })


### PR DESCRIPTION
# Description
Support anonymous function for mutate_predictors, to apply fct_relevel().

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
