### PR TITLE
Organize column names and orders of prediction results on Data tabs

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1067,7 +1067,7 @@ prediction_binary <- function(df, threshold = 0.5, pretty.name = FALSE, ...){
 
   if (!is.null(ret$predicted_value)) {
     # Bring those columns as the first of the prediction result related additional columns.
-    ret <- ret %>% dplyr::relocate(any_of(c("predicted_probability", "conf_low", "conf_high", "predicted_label")), .before=predicted_value)
+    ret <- ret %>% dplyr::relocate(any_of(c("predicted_label", "predicted_probability", "conf_low", "conf_high")), .before=predicted_value)
   }
 
   # Move is_test_data to the last again, since new columns were added to the last in this function.

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -390,7 +390,7 @@ kmeans_info <- function(df){
 #' @param data "training" or "test" or "newdata". Which source data should be used.
 #' @param ... Additional argument to be passed to broom::augment
 #' @export
-prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95, ...){
+prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95, pretty.name = FALSE, ...){
   validate_empty_data(df)
 
   df_cnames <- colnames(df)
@@ -675,6 +675,21 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
   colnames(ret)[colnames(ret) == ".sigma"] <- avoid_conflict(colnames(ret), "residual_standard_deviation")
   colnames(ret)[colnames(ret) == ".cooksd"] <- avoid_conflict(colnames(ret), "cooks_distance")
   colnames(ret)[colnames(ret) == ".std.resid"] <- avoid_conflict(colnames(ret), "standardised_residuals")
+
+  if (pretty.name) {
+    colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    colnames(ret)[colnames(ret) == "predicted_label"] <- avoid_conflict(colnames(ret), "Predicted Label")
+    colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Response")
+    colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
+    colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
+    colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
+    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Residual Standard Deviation")
+    colnames(ret)[colnames(ret) == "cooks_distance"] <- avoid_conflict(colnames(ret), "Cook's Distance")
+    colnames(ret)[colnames(ret) == "standardised_residuals"] <- avoid_conflict(colnames(ret), "Standardised Residuals")
+    colnames(ret)[colnames(ret) == "conf_low"] <- avoid_conflict(colnames(ret), "Conf Low")
+    colnames(ret)[colnames(ret) == "conf_high"] <- avoid_conflict(colnames(ret), "Conf High")
+    colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
+  }
 
   dplyr::group_by(ret, !!!rlang::syms(grouping_cols))
 }

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -677,9 +677,16 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
   colnames(ret)[colnames(ret) == ".std.resid"] <- avoid_conflict(colnames(ret), "standardised_residuals")
 
   if (pretty.name) {
-    colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    if (!is.null(ret$predicted_response) && !is.null(ret$predicted_value)) {
+      # If there are both predicted_response and predicted_value, predicted_value there most likely is linear predictor from glm.
+      colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Linear Predictor")
+      colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    }
+    else { # If not, whichever that exists should become Predicted Value
+      colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+      colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    }
     colnames(ret)[colnames(ret) == "predicted_label"] <- avoid_conflict(colnames(ret), "Predicted Label")
-    colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Response")
     colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
     colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
     colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
@@ -1069,7 +1076,13 @@ prediction_binary <- function(df, threshold = 0.5, pretty.name = FALSE, ...){
   }
 
   if (pretty.name) {
-    colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    if (!is.null(ret$predicted_probability) && !is.null(ret$predicted_value)) {
+      # If there is predicted_probability, predicted_value there most likely is linear predictor from glm.
+      colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Linear Predictor")
+    }
+    else { # Not too sure if there is actual case for this case.
+      colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    }
     colnames(ret)[colnames(ret) == "predicted_label"] <- avoid_conflict(colnames(ret), "Predicted Label")
     colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Response")
     colnames(ret)[colnames(ret) == "predicted_probability"] <- avoid_conflict(colnames(ret), "Predicted Probability")

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -917,7 +917,7 @@ prediction_training_and_test <- function(df, prediction_type="default", threshol
 #' @param df Data frame to predict. This should have model column.
 #' @param threshold Threshold value for predicted probability or what to optimize. It can be "f_score", "accuracy", "precision", "sensitivity" or "specificity" to optimize.
 #' @export
-prediction_binary <- function(df, threshold = 0.5, ...){
+prediction_binary <- function(df, threshold = 0.5, pretty.name = FALSE, ...){
   # ungroup() is necessary to avoid error under rowwise(). Putting rowwise at the end to put it back to rowwise again. TODO: Is it possible that the input is not under rowwise and our adding rowwise affect processing that follows?
   df <- df %>% ungroup() %>% dplyr::filter(purrr::flatten_lgl(purrr::map(model, function(x){!is.null(x) & "error" %nin% class(x)}))) %>% dplyr::rowwise()
 
@@ -1066,6 +1066,22 @@ prediction_binary <- function(df, threshold = 0.5, ...){
   # Move is_test_data to the last again, since new columns were added to the last in this function.
   if (!is.null(ret$is_test_data)) {
     ret <- ret %>% dplyr::select(-is_test_data, everything(), is_test_data)
+  }
+
+  if (pretty.name) {
+    colnames(ret)[colnames(ret) == "predicted_value"] <- avoid_conflict(colnames(ret), "Predicted Value")
+    colnames(ret)[colnames(ret) == "predicted_label"] <- avoid_conflict(colnames(ret), "Predicted Label")
+    colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Response")
+    colnames(ret)[colnames(ret) == "predicted_probability"] <- avoid_conflict(colnames(ret), "Predicted Probability")
+    colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
+    colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
+    colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
+    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Residual Standard Deviation")
+    colnames(ret)[colnames(ret) == "cooks_distance"] <- avoid_conflict(colnames(ret), "Cook's Distance")
+    colnames(ret)[colnames(ret) == "standardised_residuals"] <- avoid_conflict(colnames(ret), "Standardised Residuals")
+    colnames(ret)[colnames(ret) == "conf_low"] <- avoid_conflict(colnames(ret), "Conf Low")
+    colnames(ret)[colnames(ret) == "conf_high"] <- avoid_conflict(colnames(ret), "Conf High")
+    colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
   }
   ret
 }

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -705,7 +705,7 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
 
 # Simplified prediction() that works only with new Analytics View model df. This should be kept model-agnostic.
 # This one does not use .test_index and source.data columns.
-prediction2 <- function(df, data_frame = NULL, conf_int = 0.95, ...){
+prediction2 <- function(df, data_frame = NULL, conf_int = 0.95, pretty.name=FALSE, ...){
   validate_empty_data(df)
 
   pred_survival_time <- attr(df, "pred_survival_time")
@@ -787,6 +787,10 @@ prediction2 <- function(df, data_frame = NULL, conf_int = 0.95, ...){
   colnames(ret)[colnames(ret) == ".sigma"] <- avoid_conflict(colnames(ret), "residual_standard_deviation")
   colnames(ret)[colnames(ret) == ".cooksd"] <- avoid_conflict(colnames(ret), "cooks_distance")
   colnames(ret)[colnames(ret) == ".std.resid"] <- avoid_conflict(colnames(ret), "standardised_residuals")
+
+  if (pretty.name) {
+    colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
+  }
 
   if (length(grouping_cols) > 0) {
     ret <- dplyr::group_by(ret, !!!rlang::syms(grouping_cols))

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -687,6 +687,7 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
       colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "Predicted Value")
     }
     colnames(ret)[colnames(ret) == "predicted_label"] <- avoid_conflict(colnames(ret), "Predicted Label")
+    colnames(ret)[colnames(ret) == "predicted_probability"] <- avoid_conflict(colnames(ret), "Predicted Probability") # For ranger etc. we handle classifications with this function, as opposed to in prediction_binary().
     colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
     colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
     colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
@@ -696,6 +697,7 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
     colnames(ret)[colnames(ret) == "conf_low"] <- avoid_conflict(colnames(ret), "Conf Low")
     colnames(ret)[colnames(ret) == "conf_high"] <- avoid_conflict(colnames(ret), "Conf High")
     colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
+    ret <- ret %>% dplyr::rename_with(function(x){gsub("predicted_probability_","Predicted Probability for ", x)}, starts_with("predicted_probability_")) # For multiclass classification.
   }
 
   dplyr::group_by(ret, !!!rlang::syms(grouping_cols))

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -439,6 +439,11 @@ build_coxph.fast <- function(df,
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
       name_map <- attr(df, 'name_map')
 
+      # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
+      c_cols_without_names <- c_cols
+      names(c_cols_without_names) <- NULL # remove names to eliminate renaming effect of select.
+      df <- df %>% dplyr::select(!!!rlang::syms(c_cols_without_names), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
+
       df <- remove_outliers_for_regression_data(df, clean_time_col, c_cols,
                                                 NULL, #target_outlier_filter_type
                                                 NULL, #target_outlier_filter_threshold

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1683,7 +1683,9 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
       broom:::augment.glm(x, data = NULL, newdata = cleaned_data, se = FALSE, ...)
     })
   } else if (!is.null(data)) {
-    data <- data %>% dplyr::relocate(!!rlang::sym(x$target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
+    # Bring the target column to the last so that it is next to the predicted value in the output.
+    # Note that source.data of lm/glm model df has mapped column names, unlike that of ranger.
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$target_col), .after = last_col())
     ret <- switch(data_type,
       training = {
         tryCatch({

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1710,6 +1710,10 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
   }
 
   ret <- add_response(ret, x, "predicted_response") # Add response.
+  if (!is.null(ret$.fitted)) {
+    # Bring predicted_response column as the first of the prediction result related additional columns, so that it comes next to the actual values.
+    ret <- ret %>% dplyr::relocate(any_of(c("predicted_response")), .before=.fitted)
+  }
 
   if (x$family$family == "binomial") { # Add predicted label in case of binomial (including logistic regression).
     ret$predicted_label <- ret$predicted_response > binary_classification_threshold

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1074,6 +1074,8 @@ build_lm.fast <- function(df,
         model$predictor_funs <- predictor_funs
       }
 
+      model$target_col <- clean_target_col # We use target column info to bring the column next to the predicted value in the prediction() output.
+
       list(model = model, test_index = test_index, source_data = source_data)
     }, error = function(e){
       if(length(grouped_cols) > 0) {
@@ -1625,6 +1627,7 @@ augment.lm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = "
     ret <- broom:::augment.lm(x, data = NULL, newdata = cleaned_data, se = TRUE, ...)
     # TODO: Restore removed rows.
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     ret <- switch(data_type,
       training = { # Call broom:::augment.lm as is
         broom:::augment.lm(x, data = data, newdata = newdata, se = TRUE, ...)
@@ -1680,6 +1683,7 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
       broom:::augment.glm(x, data = NULL, newdata = cleaned_data, se = FALSE, ...)
     })
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     ret <- switch(data_type,
       training = {
         tryCatch({

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -331,6 +331,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, data_type = "t
     if (nrow(data) == 0) { #TODO: better place to do this check?
       return(data.frame())
     }
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     predicted_prob_col <- avoid_conflict(colnames(data), "predicted_probability")
     switch(data_type,
       training = {
@@ -437,6 +438,7 @@ augment.xgboost_binary <- function(x, data = NULL, newdata = NULL, data_type = "
     if (nrow(data) == 0) { #TODO: better place to do this check?
       return(data.frame())
     }
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     predicted_value_col <- avoid_conflict(colnames(data), "predicted_label")
     predicted_probability_col <- avoid_conflict(colnames(data), "predicted_probability")
     switch(data_type,
@@ -518,6 +520,7 @@ augment.xgboost_reg <- function(x, data = NULL, newdata = NULL, data_type = "tra
     if (nrow(data) == 0) { #TODO: better place to do this check?
       return(data.frame())
     }
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     switch(data_type,
       training = {
         predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
@@ -1262,8 +1265,8 @@ exp_xgboost <- function(df,
       model$formula_terms <- terms(fml)
       model$sampled_nrow <- clean_df_ret$sampled_nrow
 
+      model$orig_target_col <- target_col # Used for relocating columns as well as for applying function.
       if (!is.null(target_funs)) {
-        model$orig_target_col <- target_col
         model$target_funs <- target_funs
       }
       if (!is.null(predictor_funs)) {

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -321,10 +321,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, data_type = "t
       predicted_label <- x$y_levels[colmax]
       predicted_label <- restore_na(predicted_label, na_row_numbers)
 
-      original_data <- ranger.set_multi_predicted_values(original_data, as.data.frame(predicted), predicted_label, na_row_numbers)
-
-      # predicted_prob_col is a column for probabilities of chosen values
-      original_data[[predicted_prob_col]] <- max_prob
+      original_data <- ranger.set_multi_predicted_values(original_data, as.data.frame(predicted), predicted_label, max_prob, na_row_numbers)
     }
     original_data
   } else if (!is.null(data)) { # For Analytics View.
@@ -344,8 +341,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, data_type = "t
         colmax <- max.col(predicted)
         max_prob <- predicted[(colmax - 1) * nrow(predicted) + seq(nrow(predicted))]
 
-        data <- ranger.set_multi_predicted_values(data, as.data.frame(predicted), predicted_value, c())
-        data[[predicted_prob_col]] <- max_prob
+        data <- ranger.set_multi_predicted_values(data, as.data.frame(predicted), predicted_value, max_prob, c())
         data
       },
       test = {
@@ -361,8 +357,7 @@ augment.xgboost_multi <- function(x, data = NULL, newdata = NULL, data_type = "t
         max_prob_nona <- restore_na(max_prob_nona, attr(x$prediction_test, "unknown_category_rows_index"))
         max_prob <- restore_na(max_prob_nona, attr(x$prediction_test, "na.action"))
 
-        data <- ranger.set_multi_predicted_values(data, as.data.frame(predicted), predicted_value, attr(x$prediction_test, "na.action"), attr(x$prediction_test, "unknown_category_rows_index"))
-        data[[predicted_prob_col]] <- max_prob
+        data <- ranger.set_multi_predicted_values(data, as.data.frame(predicted), predicted_value, max_prob, attr(x$prediction_test, "na.action"), attr(x$prediction_test, "unknown_category_rows_index"))
         data
       })
   }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1125,7 +1125,7 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
       return (data)
     }
     y_value <- attributes(x)$ylevels[x$y]
-    predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
+    predicted_label_col <- avoid_conflict(colnames(data), "predicted_label")
     predicted_probability_col <- avoid_conflict(colnames(data), "predicted_probability")
     switch(data_type,
       training = {
@@ -1145,12 +1145,8 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
         predicted_probability <- restore_na(predicted_probability_nona, x$na_row_numbers_test)
       })
 
-    data[[predicted_value_col]] <- predicted_value
+    data[[predicted_label_col]] <- predicted_value
     data[[predicted_probability_col]] <- predicted_probability
-    if (!is.null(data[[predicted_value_col]])) { # Avoid error in case data_type is 'test' and there is no test data.
-      data <- data %>% dplyr::rename(predicted_label = predicted_value_col) %>%
-             dplyr::select(-predicted_label, everything(), predicted_label)
-    }
     data
 
   } else {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -897,7 +897,9 @@ augment.ranger.classification <- function(x, data = NULL, newdata = NULL, data_t
     }
     newdata
   } else if (!is.null(data)) {
-    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
+    if (!is.null(x$orig_target_col)) { # This is only for Analytics View.
+      data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
+    }
     if (nrow(data) == 0) {
       # Handle the case where, for example, test_rate is 0 here,
       # rather than trying to make it pass through following code, which can be complex.
@@ -1001,7 +1003,9 @@ augment.ranger.regression <- function(x, data = NULL, newdata = NULL, data_type 
 
     newdata
   } else if (!is.null(data)) {
-    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
+    if (!is.null(x$orig_target_col)) { # This is only for Analytics View.
+      data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
+    }
     switch(data_type,
       training = {
         predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -898,6 +898,7 @@ augment.ranger.classification <- function(x, data = NULL, newdata = NULL, data_t
     }
     newdata
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     if (nrow(data) == 0) {
       # Handle the case where, for example, test_rate is 0 here,
       # rather than trying to make it pass through following code, which can be complex.
@@ -1002,6 +1003,7 @@ augment.ranger.regression <- function(x, data = NULL, newdata = NULL, data_type 
 
     newdata
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     switch(data_type,
       training = {
         predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
@@ -1116,6 +1118,7 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
                   dplyr::select(-predicted_label, everything(), predicted_label)
     newdata
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     if (nrow(data) == 0) {
       # Handle the case where, for example, test_rate is 0 here,
       # rather than trying to make it pass through following code, which can be complex.
@@ -1187,6 +1190,7 @@ augment.rpart.regression <- function(x, data = NULL, newdata = NULL, data_type =
 
     newdata
   } else if (!is.null(data)) {
+    data <- data %>% dplyr::relocate(!!rlang::sym(x$orig_target_col), .after = last_col()) # Bring the target column to the last so that it is next to the predicted value in the output.
     switch(data_type,
       training = {
         predicted_value_col <- avoid_conflict(colnames(data), "predicted_value")
@@ -2353,8 +2357,8 @@ calc_feature_imp <- function(df,
       model$formula_terms <- terms(fml)
       model$sampled_nrow <- clean_df_ret$sampled_nrow
 
+      model$orig_target_col <- target_col # Used for relocating columns as well as for applying function.
       if (!is.null(target_funs)) {
-        model$orig_target_col <- target_col
         model$target_funs <- target_funs
       }
       if (!is.null(predictor_funs)) {
@@ -3084,8 +3088,8 @@ exp_rpart <- function(df,
         }
       }
 
+      model$orig_target_col <- target_col # Used for relocating columns as well as for applying function.
       if (!is.null(target_funs)) {
-        model$orig_target_col <- target_col
         model$target_funs <- target_funs
       }
       if (!is.null(predictor_funs)) {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1096,11 +1096,11 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
     # Inserting once removed NA rows
     predicted_value <- restore_na(predicted_label_nona, na_row_numbers)
 
-    predicted_value_col <- avoid_conflict(colnames(newdata), "predicted_value")
+    predicted_label_col <- avoid_conflict(colnames(newdata), "predicted_label")
     predicted_probability_col <- avoid_conflict(colnames(newdata), "predicted_probability")
 
     if (x$classification_type == "binary") {
-      newdata[[predicted_value_col]] <- predicted_value
+      newdata[[predicted_label_col]] <- predicted_value
 
       # Since now we consider only logical column as the tarted for binary classification, the label for "TRUE" class should be always "TRUE".
       predicted_prob <- pred_res[, "TRUE"]

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -339,14 +339,16 @@ exp_survival_forest <- function(df,
                                                 predictor_outlier_filter_type,
                                                 predictor_outlier_filter_threshold)
 
+      # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
+      clean_cols_without_names <- clean_cols
+      names(clean_cols_without_names) <- NULL
+      df <- df %>% dplyr::select(!!!rlang::syms(clean_cols_without_names), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
+
       df <- preprocess_regression_data_after_sample(df, clean_time_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
       name_map <- attr(df, 'name_map')
 
-      # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
-      c_cols_without_names <- c_cols
-      names(c_cols_without_names) <- NULL
-      source_data <- df %>% dplyr::select(!!!rlang::syms(c_cols_without_names), !!rlang::sym(clean_status_col), rlang::sym(clean_time_col))
+      source_data <- df
 
       # split training and test data
       test_index <- sample_df_index(source_data, rate = test_rate, ordered = (test_split_type == "ordered"))

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -343,8 +343,12 @@ exp_survival_forest <- function(df,
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.
       name_map <- attr(df, 'name_map')
 
+      # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
+      c_cols_without_names <- c_cols
+      names(c_cols_without_names) <- NULL
+      source_data <- df %>% dplyr::select(!!!rlang::syms(c_cols_without_names), !!rlang::sym(clean_status_col), rlang::sym(clean_time_col))
+
       # split training and test data
-      source_data <- df
       test_index <- sample_df_index(source_data, rate = test_rate, ordered = (test_split_type == "ordered"))
       df <- safe_slice(source_data, test_index, remove = TRUE)
       if (test_rate > 0) {

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -341,7 +341,7 @@ exp_survival_forest <- function(df,
 
       # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
       clean_cols_without_names <- clean_cols
-      names(clean_cols_without_names) <- NULL
+      names(clean_cols_without_names) <- NULL # remove names to eliminate renaming effect of select.
       df <- df %>% dplyr::select(!!!rlang::syms(clean_cols_without_names), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
 
       df <- preprocess_regression_data_after_sample(df, clean_time_col, clean_cols, predictor_n = predictor_n, name_map = name_map)

--- a/tests/testthat/test_broom_wrapper.R
+++ b/tests/testthat/test_broom_wrapper.R
@@ -494,8 +494,10 @@ test_that("test prediction(data='training_and_test') by glm", {
                                      model_type = "lm",
                                      test_rate = 0.2)
   ret <- model_ret %>% prediction(data='training_and_test')
-  expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME",
-                     "DERAY_TIME", "predicted_value",
+  expected_cols <- c("Carrier Name",
+                     "ARR_TIME", "DERAY_TIME",
+                     "DISTANCE",
+                     "predicted_value",
                      "conf_low", "conf_high", 
                      "standard_error", 
                      "residuals", "standardised_residuals", "hat",
@@ -512,16 +514,20 @@ test_that("test prediction(data='training_and_test') by glm", {
   grp_ret <- grp_model_ret %>% prediction(data='training_and_test')
   # For some reason, cooks_distance and standardised_residuals does not show up with change in https://github.com/exploratory-io/exploratory_func/pull/656
   # Working it around now, but look into it.
-  expected_cols_1 <- c("klass", "Carrier Name", "DISTANCE",
-                     "ARR_TIME", "DERAY_TIME", "predicted_value",
+  expected_cols_1 <- c("klass", "Carrier Name",
+                     "ARR_TIME", "DERAY_TIME",
+                     "DISTANCE",
+                     "predicted_value",
                      "conf_low", "conf_high",
                      "standard_error",
                      "residuals",
                      "standardised_residuals", "hat", "residual_standard_deviation",
                      "cooks_distance",
                      "is_test_data")
-  expected_cols_2 <- c("klass", "Carrier Name", "DISTANCE",
-                     "ARR_TIME", "DERAY_TIME", "predicted_value",
+  expected_cols_2 <- c("klass", "Carrier Name",
+                     "ARR_TIME", "DERAY_TIME",
+                     "DISTANCE",
+                     "predicted_value",
                      "conf_low", "conf_high",
                      "standard_error",
                      "residuals",

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -7,6 +7,7 @@ test_that("build_coxph.fast basic", {
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
   model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
+  ret <- model_df %>% prediction2(pretty.name=TRUE)
   ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
   ret <- model_df %>% prediction2()

--- a/tests/testthat/test_build_lm_0.R
+++ b/tests/testthat/test_build_lm_0.R
@@ -151,12 +151,14 @@ test_that("prediction with categorical columns", {
 
   model_data <- build_lm(test_data, CANCELLED ~ `Carrier Name` + CARRIER + DISTANCE, test_rate = 0.6)
 
-  ret <- prediction(model_data, data = "test", pretty.name = TRUE)
+  ret <- prediction(model_data, data = "test")
   expect_true(nrow(ret) > 0)
-  expect_equal(colnames(ret), c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "predicted_value",
-                                "conf_low", "conf_high",
-                                "standard_error",
-                                "residuals"))
+  expect_true(all(c("CANCELLED", 
+                    "Carrier Name", "CARRIER", "DISTANCE",
+                    "predicted_value",
+                    "conf_low", "conf_high",
+                    "standard_error",
+                    "residuals") %in% colnames(ret)))
 
   grouped <- test_data %>%
     dplyr::group_by(CARRIER)
@@ -269,9 +271,10 @@ test_that("prediction with glm family (negativebinomial) with target column name
                 identical(colnames(ret), c(expect_colnames, "note")))
 
   ret <- model_data %>% augment_rowwise(model)
-  expect_equal(colnames(ret),
-               c("CANCELLED X", "logical col", "Carrier Name", "CARRIER", "DISTANCE",
-                 ".fitted", ".resid", ".std.resid", ".hat", ".sigma", ".cooksd", "predicted_response"))
+  expect_true(all(colnames(ret) %in%
+                  c("CANCELLED X", 
+                    "logical col", "Carrier Name", "CARRIER", "DISTANCE",
+                    ".fitted", ".resid", ".std.resid", ".hat", ".sigma", ".cooksd", "predicted_response")))
 })
 
 if (Sys.info()["sysname"] != "Windows") {

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -333,6 +333,7 @@ test_that("GLM - Gamma Destribution with test_rate", {
   training_rownum <- nrow(test_data) - test_rownum
 
   suppressWarnings({
+    res <- prediction(ret, data = "training_and_test", pretty.name=TRUE)
     pred_new <- prediction(ret, data = "newdata", data_frame=test_data)
     pred_training <- prediction(ret, data = "training")
     pred_test <- prediction(ret, data = "test")

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -151,11 +151,11 @@ test_that("Linear Regression with test rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(res$`Number of Rows`, 17)
@@ -194,11 +194,11 @@ test_that("Linear Regression with outlier filtering", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(res$`Number of Rows`, 12)
@@ -231,12 +231,12 @@ test_that("Group Linear Regression with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })
@@ -267,12 +267,12 @@ test_that("GLM - Normal Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -307,13 +307,13 @@ test_that("Group GLM - Normal Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -346,12 +346,12 @@ test_that("GLM - Gamma Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })
@@ -384,13 +384,13 @@ test_that("Group GLM - Gamma Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })
@@ -421,12 +421,12 @@ test_that("GLM - Inverse Gaussian Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })
@@ -459,13 +459,13 @@ test_that("Group GLM - Inverse Gaussian Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })
@@ -507,12 +507,12 @@ test_that("GLM - poisson Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -546,13 +546,13 @@ test_that("Group GLM - Poisson Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -585,12 +585,12 @@ test_that("GLM - Negative Binomial Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("Carrier Name", "DISTANCE", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -625,13 +625,13 @@ test_that("Group GLM - Negative Binomial Destribution with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "DISTANCE", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% tidy_rowwise(model, type="permutation_importance")
@@ -677,12 +677,12 @@ test_that("Logistic Regression with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat",
                        "residual_standard_deviation", "cooks_distance", "predicted_response", "predicted_label")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
     expected_cols <- c("CANCELLED X", "Carrier Name", "ARR_TIME", "DERAY_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response", "predicted_label")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     res <- ret %>% evaluate_binary_training_and_test(`CANCELLED X`, threshold = 0.5, pretty.name=TRUE)
     expect_equal(nrow(res), 2) # 2 for training and test.
@@ -719,13 +719,13 @@ test_that("Group Logistic Regression with test_rate", {
                        "standard_error",
                        "residuals", "standardised_residuals", "hat", "residual_standard_deviation",
                        "cooks_distance", "predicted_response", "predicted_label")
-    expect_equal(colnames(pred_training), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_training)))
 
     expected_cols <- c("klass", "CANCELLED X", "ARR_TIME", "predicted_value",
                        "conf_low", "conf_high",
                        "standard_error",
                        "predicted_response", "predicted_label")
-    expect_equal(colnames(pred_test), expected_cols)
+    expect_true(all(expected_cols %in% colnames(pred_test)))
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
    })

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -26,6 +26,7 @@ test_that("build_lm.fast (linear regression) evaluate training and test", {
   model_df <- flight %>%
                 build_lm.fast(`ARR DELAY`, `DIS TANCE`, `DEP DELAY`, `CAR RIER`, test_rate = 0.3, seed=1)
 
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
   ret <- model_df %>% prediction(data="training_and_test")
   test_ret <- ret %>% filter(is_test_data==TRUE)
   # expect_equal(nrow(test_ret), 1475) # Not very stable for some reason. Will revisit.
@@ -65,6 +66,7 @@ test_that("build_lm.fast (logistic regression(logical)) evaluate training and te
   model_df <- flight %>% mutate(`is delayed`=as.logical(`is delayed`)) %>%
                 build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3)
 
+  ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5, pretty.name=TRUE)
   ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)
   test_ret <- ret %>% filter(is_test_data==TRUE)
   # expect_equal(nrow(test_ret), 1480) # Not very stable for some reason. Will revisit

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -393,7 +393,7 @@ test_that("test build_xgboost with multi softprob", {
   prediction_ret <- prediction(model_ret)
   prob <- prediction_ret$predicted_probability
   expect_true(all(prob[!is.na(prob)] > 0))
-  expect_true(length(unique(prediction_ret$predicted_value)) > 1)
+  expect_true(length(unique(prediction_ret$predicted_label)) > 1)
 })
 
 test_that("test build_xgboost with linear booster", {

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -94,27 +94,28 @@ test_that("test ranger with binary classification with logical column", {
   )
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "IS AA", "predicted_probability", "predicted_label")
-  expect_equal(colnames(pred_train_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_train_ret2 <- suppressWarnings(
     prediction(model_ret, data = "training", threshold = "f_score")
   )
-  expect_equal(colnames(pred_train_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret2)))
 
   pred_test_ret <- suppressWarnings(prediction_binary(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret)))
 
   pred_test_ret2 <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret2)))
 
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction_binary(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret)))
 
   pred_test_newdata_ret2 <- suppressWarnings(prediction_binary(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret2)))
 })
+
 test_that("test ranger with binary classification with factor", {
   test_data[["IS AA"]] <- if_else(test_data$CARRIER == "AA", "AA", "Not AA") # test target column name with space
   test_data[1, "IS AA"] <- NA
@@ -140,26 +141,26 @@ test_that("test ranger with binary classification with factor", {
   )
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "IS AA", "predicted_probability", "predicted_label")
-  expect_equal(colnames(pred_train_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_train_ret2 <- suppressWarnings(
     prediction(model_ret, data = "training", threshold = "f_score")
   )
-  expect_equal(colnames(pred_train_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret2)))
 
   pred_test_ret <- suppressWarnings(prediction_binary(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret)))
 
   pred_test_ret2 <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret2)))
 
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction_binary(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret)))
 
   pred_test_newdata_ret2 <- suppressWarnings(prediction_binary(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret2)))
 })
 
 test_that("test ranger with binary classification (all predictor_varials)", {
@@ -184,25 +185,25 @@ test_that("test ranger with binary classification (all predictor_varials)", {
   )
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "IS AA", "predicted_probability", "predicted_label")
-  expect_equal(colnames(pred_train_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_train_ret2 <- suppressWarnings(
     prediction(model_ret, data = "training", threshold = "f_score")
   )
-  expect_equal(colnames(pred_train_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret2)))
 
   pred_test_ret <- suppressWarnings(prediction_binary(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret)))
   pred_test_ret2 <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret2)))
 
   expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER",
                        "DISTANCE", "FNUMBER", "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction_binary(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret)))
 
   pred_test_newdata_ret2 <- suppressWarnings(prediction(model_ret, data = "newdata", data_frame = test_data %>% select(-`IS AA`)))
-  expect_equal(colnames(pred_test_newdata_ret2), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret2)))
 })
 
 test_that("test ranger with multinomial classification", {
@@ -220,23 +221,23 @@ test_that("test ranger with multinomial classification", {
                        "Number of Rows")
   expect_equal(colnames(model_stats), expect_colnames)
 
-  expected_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",
+  expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability_9E", "predicted_probability", "predicted_label")
 
   pred_train_ret <- suppressWarnings(prediction(model_ret, data = "training"))
-  expect_equal(colnames(pred_train_ret), expected_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_test_ret <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expected_colnames)
+  expect_equal(colnames(pred_test_ret), expect_colnames)
 
-  expected_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
+  expect_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability_9E", "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction(model_ret, data = "newdata", data_frame = test_data %>% select(-CARRIER)))
-  expect_equal(colnames(pred_test_newdata_ret), expected_colnames)
+  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
 })
 
 test_that("test ranger with multinomial classification", {
@@ -254,23 +255,23 @@ test_that("test ranger with multinomial classification", {
                        "Number of Rows")
   expect_equal(colnames(model_stats), expect_colnames)
 
-  expected_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",
+  expect_colnames <- c("CANCELLED", "Carrier Name", "CARRIER", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability", "predicted_label")
 
   pred_train_ret <- suppressWarnings(prediction(model_ret, data = "training"))
-  expect_equal(colnames(pred_train_ret), expected_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_test_ret <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expected_colnames)
+  expect_equal(colnames(pred_test_ret), expect_colnames)
 
-  expected_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
+  expect_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction(model_ret, data = "newdata", data_frame = test_data %>% select(-CARRIER)))
-  expect_equal(colnames(pred_test_newdata_ret), expected_colnames)
+  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
 })
 
 

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -327,10 +327,15 @@ test_that("ranger.set_multi_predicted_values", {
                                                          df[["z"]])
   na_at <- exploratory:::ranger.find_na(c("x", "y"), df) 
   predicted_value <- exploratory:::restore_na(predicted_value_nona, na_at)
-  ret <- exploratory:::ranger.set_multi_predicted_values(df, m_m$predictions, predicted_value, na_at)
+  predicted_prob_nona <- rep(0.5, length(predicted_value_nona)) # Dummy probability just to pass this test.
+  predicted_prob <- restore_na(predicted_prob_nona, na_at)
+  ret <- exploratory:::ranger.set_multi_predicted_values(df, m_m$predictions, predicted_value, predicted_prob, na_at)
   expected_colnames <-  c("x", "y", "z",
+                          "predicted_label",
+                          "predicted_probability",
                           "predicted_probability_A", "predicted_probability_D", "predicted_probability_E",
-                          "predicted_probability_B", "predicted_probability_C", "predicted_probability_F", "predicted_value")
+                          "predicted_probability_B", "predicted_probability_C", "predicted_probability_F"
+                          )
   expect_equal(colnames(ret), expected_colnames)
 })
 

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -230,14 +230,14 @@ test_that("test ranger with multinomial classification", {
   expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_test_ret <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret)))
 
   expect_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability_9E", "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction(model_ret, data = "newdata", data_frame = test_data %>% select(-CARRIER)))
-  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret)))
 })
 
 test_that("test ranger with multinomial classification", {
@@ -264,14 +264,14 @@ test_that("test ranger with multinomial classification", {
   expect_true(all(expect_colnames %in% colnames(pred_train_ret)))
 
   pred_test_ret <- suppressWarnings(prediction(model_ret, data = "test"))
-  expect_equal(colnames(pred_test_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_ret)))
 
   expect_colnames <- c("CANCELLED", "Carrier Name", "DISTANCE", "FNUMBER",
                          "IS_AA", "predicted_probability_DL", "predicted_probability_AA",
                          "predicted_probability_MQ", "predicted_probability_EV", "predicted_probability_US",
                          "predicted_probability", "predicted_label")
   pred_test_newdata_ret <- suppressWarnings(prediction(model_ret, data = "newdata", data_frame = test_data %>% select(-CARRIER)))
-  expect_equal(colnames(pred_test_newdata_ret), expect_colnames)
+  expect_true(all(expect_colnames %in% colnames(pred_test_newdata_ret)))
 })
 
 

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -149,6 +149,7 @@ test_that("calc_feature_map(binary(factor(A,B))) evaluate training and test", {
   model_df <- flight %>% dplyr::mutate(is_delayed = factor(if_else(as.logical(`is delayed`), "A","B"))) %>% filter(!is.na(is_delayed)) %>%
                 calc_feature_imp(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0.3, pd_with_bin_means = TRUE)
 
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
   ret <- model_df %>% prediction(data="newdata", data_frame=flight)
 
   ret <- model_df %>% prediction(data="training_and_test")

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -25,7 +25,7 @@ test_that("exp_rpart(regression) evaluate training and test", {
                 exp_rpart(`FL NUM`, `DIS TANCE`, `DEP TIME`,
                           test_rate = 0.3,
                           test_split_type = "ordered") # testing ordered split too.
-
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
   ret <- flight %>% select(-`FL NUM`) %>% add_prediction(model_df=model_df)
   ret <- model_df %>% prediction(data="newdata", data_frame = flight)
   ret <-  model_df %>% rf_partial_dependence()
@@ -65,6 +65,8 @@ test_that("exp_rpart evaluate training and test - logical", {
   data <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`))
   model_df <- data %>% exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, `ORI GIN`, test_rate = 0.4, binary_classification_threshold=0.5)
 
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
+
   ret1 <- data %>% select(-is_delayed) %>% add_prediction(model_df=model_df, binary_classification_threshold=0.5)
   ret2 <- data %>% select(-is_delayed) %>% add_prediction(model_df=model_df, binary_classification_threshold=0.01)
   expect_gt(sum(ret2$predicted_label=="TRUE",na.rm=TRUE), sum(ret1$predicted_label=="TRUE",na.rm=TRUE)) # Change of threshold should make difference.
@@ -100,6 +102,8 @@ test_that("exp_rpart evaluate training and test - logical", {
 test_that("exp_rpart(character(A,B)) evaluate training and test", { # This should be treated as multi-class
   data <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B"))
   model_df <- data %>% exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
+
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
 
   ret <- data %>% select(-is_delayed) %>% add_prediction(model_df=model_df)
   ret <- model_df %>% prediction(data="newdata", data_frame = flight)

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -8,6 +8,7 @@ test_that("exp_survival_forest basic", {
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
   model_df <- df %>% exp_survival_forest(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss,
                                          predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
+  ret <- model_df %>% prediction2(pretty.name=TRUE)
   ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
   ret <- model_df %>% evaluation()
   expect_false("Data Type" %in% colnames(ret))

--- a/tests/testthat/test_xgboost_1.R
+++ b/tests/testthat/test_xgboost_1.R
@@ -29,6 +29,8 @@ test_that("exp_xgboost(regression) evaluate training and test", {
                                  test_rate = 0.3,
                                  test_split_type = "ordered", pd_with_bin_means = TRUE, # testing ordered split too.
                                  watchlist_rate = 0.1)
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
+
   ret <- flight %>% select(-`ARR DELAY`) %>% add_prediction(model_df=model_df)
   ret <- model_df %>% prediction(data="newdata", data_frame=flight)
 
@@ -118,15 +120,17 @@ test_that("exp_xgboost evaluate training and test - binary", {
   ret <- rf_evaluation_training_and_test(model_df, type = "conf_mat")
 })
 
-test_that("exp_xgboost(factor(TRUE, FALSE)) evaluate training and test", { # This case should be treated as multi-class.
+test_that("exp_xgboost - factor of TRUE/FALSE - evaluate training and test", { # This case should be treated as multi-class.
   set.seed(1) # For stability of result.
   # `is delayed` is not logical for some reason.
   # To test binary prediction, need to cast it into logical.
   data <- flight %>% dplyr::mutate(is_delayed = factor(as.logical(`is delayed`))) %>% filter(!is.na(is_delayed))
   model_df <- data %>% exp_xgboost(is_delayed, `DIS TANCE`, `DEP TIME`, test_rate = 0.3, pd_with_bin_means = TRUE)
 
+  ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
+
   ret <- data %>% select(-is_delayed) %>% add_prediction(model_df=model_df)
-  expect_true(all(c("predicted_probability_FALSE","predicted_probability_TRUE","predicted_value","predicted_probability") %in% colnames(ret)))
+  expect_true(all(c("predicted_probability_FALSE","predicted_probability_TRUE","predicted_label","predicted_probability") %in% colnames(ret)))
   ret <- model_df %>% prediction(data="training_and_test")
   test_ret <- ret %>% filter(is_test_data==TRUE)
   # expect_equal(nrow(test_ret), 1500) Fails now, since we filter numeric NA. Revive when we do not need to.


### PR DESCRIPTION
# Description
Organize column names and orders of prediction results on Data tabs.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
