### PR TITLE
Supported encoding argument for getDBConnection API.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -948,8 +948,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # For Windows, set encoding to make sure non-ascii data is handled properly.
         if(is.win <- Sys.info()['sysname'] == 'Windows'){
           loc <- Sys.getlocale(category = "LC_CTYPE")
-          encoding <- stringr::str_split(loc, pattern = "\\.")[[1]][[2]]
-          connstr <- stringr::str_c(connstr, ", encoding = '", encoding, "'")
+          # loc looks like "Japanese_Japan.932", so split it with dot ".".
+          encoding <- stringr::str_split(loc, pattern = "\\.")
+          if(length(encoding[[1]] == 2)) {
+            # like [1] "Japanese_Japan" "932" so check the second part exists or not.
+            connstr <- stringr::str_c(connstr, ", encoding = '", encoding[[1]][[2]], "'")
+          }
         }
         if(additionalParams == ""){
           connstr <- stringr::str_c(connstr, ")")

--- a/R/system.R
+++ b/R/system.R
@@ -945,6 +945,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         if(password != ""){
           connstr <- stringr::str_c(connstr, ", pwd = '", password, "'")
         }
+        # For Windows, set encoding to make sure non-ascii data is handled properly.
+        if(is.win <- Sys.info()['sysname'] == 'Windows'){
+          loc <- Sys.getlocale(category = "LC_CTYPE")
+          encoding <- stringr::str_split(loc, pattern = "\\.")[[1]][[2]]
+          connstr <- stringr::str_c(connstr, ", encoding = '", encoding, "'")
+        }
         if(additionalParams == ""){
           connstr <- stringr::str_c(connstr, ")")
         } else {

--- a/R/system.R
+++ b/R/system.R
@@ -946,11 +946,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
           connstr <- stringr::str_c(connstr, ", pwd = '", password, "'")
         }
         # For Windows, set encoding to make sure non-ascii data is handled properly.
-        if(is.win <- Sys.info()['sysname'] == 'Windows'){
+        # ref: https://github.com/r-dbi/odbc/issues/153
+        if (is.win <- Sys.info()['sysname'] == 'Windows') {
           loc <- Sys.getlocale(category = "LC_CTYPE")
           # loc looks like "Japanese_Japan.932", so split it with dot ".".
           encoding <- stringr::str_split(loc, pattern = "\\.")
-          if(length(encoding[[1]] == 2)) {
+          if (length(encoding[[1]] == 2)) {
             # encoding looks like: [1] "Japanese_Japan" "932" so check the second part exists or not.
             connstr <- stringr::str_c(connstr, ", encoding = '", encoding[[1]][[2]], "'")
           }

--- a/R/system.R
+++ b/R/system.R
@@ -951,7 +951,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
           # loc looks like "Japanese_Japan.932", so split it with dot ".".
           encoding <- stringr::str_split(loc, pattern = "\\.")
           if(length(encoding[[1]] == 2)) {
-            # like [1] "Japanese_Japan" "932" so check the second part exists or not.
+            # encoding looks like: [1] "Japanese_Japan" "932" so check the second part exists or not.
             connstr <- stringr::str_c(connstr, ", encoding = '", encoding[[1]][[2]], "'")
           }
         }


### PR DESCRIPTION
# Description

On getDBConnection, supported encoding argument for Windows 

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [x] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
