### PR TITLE
Chi-sq test: Reorder summary table columns to unify order with t-test

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -476,13 +476,14 @@ glance.chisq_exploratory <- function(x) {
       power_val <- NA_real_
     }
     ret <- ret %>% dplyr::mutate(w=!!(x$cohens_w), power=!!power_val, beta=1.0-!!power_val, n=!!N)
-    ret <- ret %>% rename(`Chi-Square`=statistic,
-                          `Degree of Freedom`=parameter,
-                          `P Value`=p.value,
-                          `Effect Size (Cohen's w)`=w,
-                          `Power`=power,
-                          `Probability of Type 2 Error`=beta,
-                          `Number of Rows`=n)
+    ret <- ret %>% dplyr::select(statistic, p.value, parameter, everything()) # Reorder to unify order with t-test.
+    ret <- ret %>% dplyr::rename(`Chi-Square`=statistic,
+                                 `P Value`=p.value,
+                                 `Degree of Freedom`=parameter,
+                                 `Effect Size (Cohen's w)`=w,
+                                 `Power`=power,
+                                 `Probability of Type 2 Error`=beta,
+                                 `Number of Rows`=n)
   }
   else {
     # If required power is specified in the arguments, estimate required sample size. 
@@ -495,14 +496,15 @@ glance.chisq_exploratory <- function(x) {
       required_sample_size <<- NA_real_
     })
     ret <- ret %>% dplyr::mutate(w=!!(x$cohens_w), power=!!(x$power), beta=1.0-!!(x$power), n=!!N, required_n=!!required_sample_size)
-    ret <- ret %>% rename(`Chi-Square`=statistic,
-                          `Degree of Freedom`=parameter,
-                          `P Value`=p.value,
-                          `Effect Size (Cohen's w)`=w,
-                          `Target Power`=power,
-                          `Target Probability of Type 2 Error`=beta,
-                          `Current Sample Size`=n,
-                          `Required Sample Size`=required_n)
+    ret <- ret %>% dplyr::select(statistic, p.value, parameter, everything()) # Reorder to unify order with t-test.
+    ret <- ret %>% dplyr::rename(`Chi-Square`=statistic,
+                                 `P Value`=p.value,
+                                 `Degree of Freedom`=parameter,
+                                 `Effect Size (Cohen's w)`=w,
+                                 `Target Power`=power,
+                                 `Target Probability of Type 2 Error`=beta,
+                                 `Current Sample Size`=n,
+                                 `Required Sample Size`=required_n)
   }
   if (!is.null(note)) { # Add Note column, if there was an error from pwr function.
     ret <- ret %>% dplyr::mutate(Note=!!note)

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -208,9 +208,9 @@ test_that("test exp_chisq", {
   observed <- ret %>% tidy_rowwise(model, type="observed")
   summary <- ret %>% glance_rowwise(model)
   residuals <- ret %>% tidy_rowwise(model, type="residuals")
-  expect_equal(colnames(summary),
-               c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)","Power",
-                 "Probability of Type 2 Error","Number of Rows"))
+  expect_true(all(c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)",
+                    "Power", "Probability of Type 2 Error","Number of Rows") %in% colnames(summary)
+  ))
   prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
 })
 
@@ -219,17 +219,17 @@ test_that("test exp_chisq with power", {
   ret <- model_df %>% glance_rowwise(model)
   model_df <- exp_chisq(mtcars, gear, carb, value=cyl, power = 0.8)
   ret <- model_df %>% glance_rowwise(model)
-  expect_equal(colnames(ret),
-               c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)",
-                 "Target Power","Target Probability of Type 2 Error","Current Sample Size","Required Sample Size"))
+  expect_true(all(c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)",
+                     "Target Power","Target Probability of Type 2 Error","Current Sample Size","Required Sample Size") %in% colnames(ret)
+  ))
 })
 
 test_that("test exp_chisq with grouping functions", {
   model_df <- exp_chisq(mtcars, disp, drat, func1="asintby10", func2="asint", value=mpg)
   ret <- model_df %>% glance_rowwise(model)
-  expect_equal(colnames(ret),
-               c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)","Power",
-                 "Probability of Type 2 Error","Number of Rows"))
+  expect_true(all(c("Chi-Square","Degree of Freedom","P Value","Effect Size (Cohen's w)","Power",
+                 "Probability of Type 2 Error","Number of Rows") %in% colnames(ret)
+  ))
 })
 
 test_that("test exp_chisq with logical", {


### PR DESCRIPTION
# Description
Reorder summary table columns to unify order with t-test.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
