### PR TITLE
Time series clustering by number of rows

### DIFF
--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -104,7 +104,7 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
       # Drop columns (represents category) that has more NAs than max_category_na_ratio, considering them to have not enough data.
       df <- df %>% dplyr::select_if(function(x){sum(is.na(x))/length(x) < max_category_na_ratio})
       if (length(colnames(df)) <= centers) {
-        stop("Too few time series were left after removing the ones with too many NAs. Using longer time unit might help.")
+        stop("There is not enough data left after removing high NA ratio data.")
       }
       # Fill NAs in time series
       df <- df %>% dplyr::mutate(across(-time, ~fill_ts_na(.x, time, type = na_fill_type, val = na_fill_value)))

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -83,6 +83,9 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
       df <- df %>% complete_date("time", time_unit = time_unit)
       # Drop columns (represents category) that has more NAs than max_category_na_ratio, considering them to have not enough data.
       df <- df %>% dplyr::select_if(function(x){sum(is.na(x))/length(x) < max_category_na_ratio})
+      if (length(colnames(df)) <= centers) {
+        stop("Too few time series were left after removing the ones with too many NAs. Using longer time unit might help.")
+      }
       # Fill NAs in time series
       df <- df %>% dplyr::mutate(across(-time, ~fill_ts_na(.x, time, type = na_fill_type, val = na_fill_value)))
       time_values <- df$time

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -4,7 +4,10 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
                            variables = NULL, funs.aggregate.variables = NULL,
                            centers = 3L, with_centroids = FALSE, distance = "sdtw", centroid = "sdtw_cent", output = "data") {
   time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(time))
-  value_col <- if (missing(value)) {
+  value_col <- if (missing(value) || is.null(value)) {
+    # Using empty string instead of NULL, because using NULL here would cause error from UQ(rlang::sym(value_col)),
+    # which seems to be evaluated as soon as the parent function is called, which is before if-condition for it to be not NULL is evaluated.
+    # (rlang::sym("") does not seem to throw error unlike rlang::sym(NULL).)
     ""
   }
   else {

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -104,7 +104,7 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
       # Drop columns (represents category) that has more NAs than max_category_na_ratio, considering them to have not enough data.
       df <- df %>% dplyr::select_if(function(x){sum(is.na(x))/length(x) < max_category_na_ratio})
       if (length(colnames(df)) <= centers) {
-        stop("There is not enough data left after removing high NA ratio data.")
+        stop("EXP-ANA-2 :: [] :: There is not enough data left after removing high NA ratio data.")
       }
       # Fill NAs in time series
       df <- df %>% dplyr::mutate(across(-time, ~fill_ts_na(.x, time, type = na_fill_type, val = na_fill_value)))

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -159,7 +159,7 @@ tidy.PartitionalTSClusters <- function(x, with_centroids = TRUE) {
   value_col <- attr(x, "value_col")
   if (value_col == "") {
     res <- res %>% dplyr::rename(!!rlang::sym(attr(x,"time_col")):=time,
-                                 Count=value,
+                                 Number_of_Rows=value,
                                  !!rlang::sym(attr(x,"category_col")):=name)
   }
   else {

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -4,7 +4,7 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
                            variables = NULL, funs.aggregate.variables = NULL,
                            centers = 3L, with_centroids = FALSE, distance = "sdtw", centroid = "sdtw_cent", output = "data") {
   time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(time))
-  value_col <- if (missing(value) || is.null(value)) {
+  value_col <- if (missing(value)) {
     # Using empty string instead of NULL, because using NULL here would cause error from UQ(rlang::sym(value_col)),
     # which seems to be evaluated as soon as the parent function is called, which is before if-condition for it to be not NULL is evaluated.
     # (rlang::sym("") does not seem to throw error unlike rlang::sym(NULL).)
@@ -12,6 +12,10 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
   }
   else {
     tidyselect::vars_select(names(df), !! rlang::enquo(value))
+  }
+  # Handle the case where NULL was specified for value argument. We handle this case this way because is.null(value) throws error when value actuall has value.
+  if (length(value_col) == 0) {
+    value_col = ""
   }
   category_col <- tidyselect::vars_select(names(df), !! rlang::enquo(category))
 

--- a/tests/testthat/test_ts_cluster.R
+++ b/tests/testthat/test_ts_cluster.R
@@ -51,3 +51,9 @@ test_that("exp_ts_cluster with max_category_na_ratio", {
   expect_equal(colnames(ret), c("FL DATE","CAR RIER","ARR DELAY","Cluster"))
   expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
 })
+
+test_that("exp_ts_cluster with max_category_na_ratio", {
+  expect_error({
+    ret <- flight %>% exp_ts_cluster(`FL DATE`, `ARR DELAY`, `CAR RIER`, max_category_na_ratio=0) # Setting zero max_category_na_ratio for test.
+  }, "Too few time series were left")
+})

--- a/tests/testthat/test_ts_cluster.R
+++ b/tests/testthat/test_ts_cluster.R
@@ -55,5 +55,5 @@ test_that("exp_ts_cluster with max_category_na_ratio", {
 test_that("exp_ts_cluster with max_category_na_ratio", {
   expect_error({
     ret <- flight %>% exp_ts_cluster(`FL DATE`, `ARR DELAY`, `CAR RIER`, max_category_na_ratio=0) # Setting zero max_category_na_ratio for test.
-  }, "Too few time series were left")
+  }, "There is not enough data left")
 })

--- a/tests/testthat/test_ts_cluster.R
+++ b/tests/testthat/test_ts_cluster.R
@@ -30,13 +30,13 @@ test_that("exp_ts_cluster basic", {
 
 test_that("exp_ts_cluster with aggregated number of rows by missing value column", {
   ret <- flight %>% exp_ts_cluster(`FL DATE`, , `CAR RIER`)
-  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Count","Cluster"))
+  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Number_of_Rows","Cluster"))
   expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
 })
 
 test_that("exp_ts_cluster with aggregated number of rows by specifying NULL for value column", {
   ret <- flight %>% exp_ts_cluster(`FL DATE`, NULL, `CAR RIER`)
-  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Count","Cluster"))
+  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Number_of_Rows","Cluster"))
   expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
 })
 

--- a/tests/testthat/test_ts_cluster.R
+++ b/tests/testthat/test_ts_cluster.R
@@ -28,6 +28,18 @@ test_that("exp_ts_cluster basic", {
   expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
 })
 
+test_that("exp_ts_cluster with aggregated number of rows by missing value column", {
+  ret <- flight %>% exp_ts_cluster(`FL DATE`, , `CAR RIER`)
+  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Count","Cluster"))
+  expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
+})
+
+test_that("exp_ts_cluster with aggregated number of rows by specifying NULL for value column", {
+  ret <- flight %>% exp_ts_cluster(`FL DATE`, NULL, `CAR RIER`)
+  expect_equal(colnames(ret), c("FL DATE","CAR RIER","Count","Cluster"))
+  expect_equal(sort(unique(ret$Cluster)), c(1,2,3))
+})
+
 test_that("exp_ts_cluster with other variables to aggregate", {
   ret <- flight %>% exp_ts_cluster(`FL DATE`, `ARR DELAY`, `CAR RIER`, variables=c(`ORI GIN_mode`="ORI GIN"), funs.aggregate.variables=c("get_mode"))
   expect_equal(colnames(ret), c("FL DATE", "CAR RIER", "ARR DELAY", "ORI GIN_mode", "Cluster"))


### PR DESCRIPTION
# Description
- Run time series clustering by number of rows if value column is not specified.
- Detect the case where too few time series is left after removing ones with too many NAs and throw error.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
