### PR TITLE
Fix column name conflict of group_by column in glance_with_ts_metric

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -716,6 +716,12 @@ glance_with_ts_metric <- function(df) {
   else {
     ret2 <- ret2 %>% dplyr::summarize(RMSE=exploratory::rmse(!!rlang::sym(value_col), forecasted_value, !is.na(!!rlang::sym(value_col))), MAE=exploratory::mae(!!rlang::sym(value_col), forecasted_value, !is.na(!!rlang::sym(value_col))), MAPE=exploratory::mape(!!rlang::sym(value_col), forecasted_value, !is.na(!!rlang::sym(value_col))), `Number of Rows`=sum(!is.na(!!rlang::sym(value_col))))
   }
+
+  group_col <- grouped_by(ret1)
+  if (length(group_col) > 0) { # Remove group_by column from ret1 before bind_cols to avoid column name conflict.
+    ret1 <- ret1 %>% ungroup() %>% select(-!!rlang::sym(group_col))
+  }
+
   ret <- dplyr::bind_cols(ret2, ret1) # We show the model agnostic metrics first.
   if ("Number of Rows" %in% colnames(ret)) {
     ret <- ret %>% dplyr::select(-`Number of Rows`, everything(), `Number of Rows`)

--- a/R/arima.R
+++ b/R/arima.R
@@ -719,7 +719,7 @@ glance_with_ts_metric <- function(df) {
 
   group_col <- grouped_by(ret1)
   if (length(group_col) > 0) { # Remove group_by column from ret1 before bind_cols to avoid column name conflict.
-    ret1 <- ret1 %>% ungroup() %>% select(-!!rlang::sym(group_col))
+    ret1 <- ret1 %>% dplyr::ungroup() %>% dplyr::select(-!!rlang::sym(group_col))
   }
 
   ret <- dplyr::bind_cols(ret2, ret1) # We show the model agnostic metrics first.

--- a/tests/testthat/test_arima_1.R
+++ b/tests/testthat/test_arima_1.R
@@ -293,7 +293,7 @@ test_that("exp_arima test mode with extra regressor", {
 })
 
 
-test_that("exp_arima grouped case", {
+test_that("exp_arima wrong grouping case", {
   data("raw_data", package = "AnomalyDetection")
   raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
   expect_error({
@@ -307,6 +307,23 @@ test_that("exp_arima grouped case", {
       dplyr::group_by(count) %>%
       exp_arima(timestamp, count, 10)
   }, "count is grouped. Please ungroup it.")
+})
+
+test_that("exp_arima grouped case", {
+  data("raw_data", package = "AnomalyDetection")
+  raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
+  raw_data1 <- raw_data
+  raw_data2 <- raw_data
+  raw_data1 <- raw_data1 %>% mutate(group='A')
+  raw_data2 <- raw_data2 %>% mutate(group='B')
+  raw_data3 <- raw_data1 %>% bind_rows(raw_data2) %>% group_by(group)
+
+  model_df <- raw_data3 %>%
+    exp_arima(timestamp, count, 10)
+  ret <- model_df %>% glance_with_ts_metric()
+  expect_true(all(c("group", "RMSE", "MAE", "MAPE", ".model", "AIC", "BIC", "AICc",
+                    "p", "d", "q", "P", "D", "Q", "Frequency", "Ljung-Box Test Statistic",
+                    "Ljung-Box Test P Value", "Number of Rows") %in% colnames(ret)))
 })
 
 test_that("exp_arima without value_col", {


### PR DESCRIPTION
# Description
Fix column name conflict of group_by column in glance_with_ts_metric.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
