### PR TITLE
Cox regression / Survival forest: Take start/end date as arguments. Add survival prediction in boolean

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -320,6 +320,7 @@ build_coxph.fast <- function(df,
   # ref: http://dplyr.tidyverse.org/articles/programming.html
   # ref: https://github.com/tidyverse/tidyr/blob/3b0f946d507f53afb86ea625149bbee3a00c83f6/R/spread.R
   time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(time))
+  time_unit_days <- attr(df[[time_col]], "time_unit_days") # Preprocessor may attach time unit info as attribute of the time column.
   status_col <- tidyselect::vars_select(names(df), !! rlang::enquo(status))
   # this evaluates select arguments like starts_with
   orig_selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
@@ -554,6 +555,21 @@ build_coxph.fast <- function(df,
   ret <- do_on_each_group(clean_df, each_func, name = "model", with_unnest = FALSE)
   # Pass down survival time used for prediction. This is for the post-processing for time-dependent ROC.
   attr(ret, "pred_survival_time") <- pred_survival_time
+
+  time_unit <- if (time_unit_days == 365.25) {
+    "year"
+  } else if (time_unit_days == 365.25/4) {
+    "quarter"
+  } else if (time_unit_days == 365.25/12) {
+    "month"
+  } else if (time_unit_days == 7) {
+    "week"
+  } else if (time_unit_days == 1) {
+    "day"
+  } else {
+    NULL
+  }
+  attr(ret, "time_unit") <- time_unit
   ret
 }
 

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -296,6 +296,51 @@ calc_permutation_importance_coxph <- function(fit, time_col, status_col, vars, d
   importances_df
 }
 
+get_time_unit_days <- function(type="auto", x, y) {
+  # If the type is specified explicitly.  
+  if (type == "year") {
+    res <- 365.25
+  } else if (type == "quarter") {
+    res <- 365.25/4
+  } else if (type == "month") {
+    res <- 365.25/12
+  } else if (type == "week") {
+    res <- 7
+  } else if (type == "day") {
+    res <- 1
+  } else {
+    # type=="auto" case.  
+    # Pick the time unit automatically based on the date range of start/end date.
+    xy <- c(x, y)
+    a <- min(xy, na.rm = TRUE)
+    b <- max(xy, na.rm = TRUE);
+    timeinterval <- lubridate::interval(a, b)
+    # Year - default
+    res <- 365.25
+    type <- 'year'
+    
+    if (lubridate::time_length(timeinterval, "year") < 5) {
+      # Month unit if the range is less than 5 years.
+      res <- 365.25/12
+      type <- 'month'
+      
+      if (lubridate::time_length(timeinterval, "year") < 1) {
+        # Week unit if the range is less than 1 year.
+        res <- 7
+        type <- 'week'
+
+        if (lubridate::time_length(timeinterval, "day") <=31) {
+          # Day unit if the range is less than 1 month (less than or equal to 31 days).
+          res <- 1
+          type <- 'day'
+        }
+      }
+    }
+  }
+  attr(res, "label") <- type
+  res
+}
+
 #' builds cox model quickly by way of sampling or fct_lumn, for analytics view.
 #' @export
 build_coxph.fast <- function(df,

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -372,6 +372,7 @@ build_coxph.fast <- function(df,
     start_date_col <- tidyselect::vars_select(names(df), !! rlang::enquo(start_date))
     end_date_col <- tidyselect::vars_select(names(df), !! rlang::enquo(end_date))
     time_unit_days <- get_time_unit_days(time_unit, df[[start_date_col]], df[[end_date_col]])
+    time_unit <- attr(time_unit_days, "label") # Get label like "day", "week".
     df <- df %>% dplyr::mutate(.time = ceiling(as.numeric(!!rlang::sym(end_date_col) - !!rlang::sym(start_date_col), units = "days")/time_unit_days))
     time_col <- ".time"
   }
@@ -612,19 +613,6 @@ build_coxph.fast <- function(df,
   attr(ret, "pred_survival_time") <- pred_survival_time
 
   # Pass down time unit for prediction step UI.
-  time_unit <- if (time_unit_days == 365.25) {
-    "year"
-  } else if (time_unit_days == 365.25/4) {
-    "quarter"
-  } else if (time_unit_days == 365.25/12) {
-    "month"
-  } else if (time_unit_days == 7) {
-    "week"
-  } else if (time_unit_days == 1) {
-    "day"
-  } else {
-    NULL
-  }
   attr(ret, "time_unit") <- time_unit
   ret
 }

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -347,8 +347,8 @@ build_coxph.fast <- function(df,
                     time,
                     status,
                     ...,
-                    start_date = NULL,
-                    end_date = NULL,
+                    start_time = NULL,
+                    end_time = NULL,
                     time_unit = "day",
                     predictor_funs = NULL,
                     max_nrow = 50000, # With 50000 rows, taking 6 to 7 seconds on late-2016 Macbook Pro.
@@ -367,15 +367,16 @@ build_coxph.fast <- function(df,
   # using the new way of NSE column selection evaluation
   # ref: http://dplyr.tidyverse.org/articles/programming.html
   # ref: https://github.com/tidyverse/tidyr/blob/3b0f946d507f53afb86ea625149bbee3a00c83f6/R/spread.R
+  browser()
   time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(time))
   if (length(time_col) == 0) { # This means time was NULL
-    start_date_col <- tidyselect::vars_select(names(df), !! rlang::enquo(start_date))
-    end_date_col <- tidyselect::vars_select(names(df), !! rlang::enquo(end_date))
-    time_unit_days <- get_time_unit_days(time_unit, df[[start_date_col]], df[[end_date_col]])
+    start_time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(start_time))
+    end_time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(end_time))
+    time_unit_days <- get_time_unit_days(time_unit, df[[start_time_col]], df[[end_time_col]])
     time_unit <- attr(time_unit_days, "label") # Get label like "day", "week".
     # We are ceiling survival time to make it integer in the specified time unit, just like we do for Survival Curve analytics view.
     # This is to make resulting survival curve to have integer data point in the specified time unit. TODO: Think if this really makes sense here for Cox and Survival Forest.
-    df <- df %>% dplyr::mutate(.time = ceiling(as.numeric(!!rlang::sym(end_date_col) - !!rlang::sym(start_date_col), units = "days")/time_unit_days))
+    df <- df %>% dplyr::mutate(.time = ceiling(as.numeric(!!rlang::sym(end_time_col) - !!rlang::sym(start_time_col), units = "days")/time_unit_days))
     time_col <- ".time"
   }
     
@@ -467,6 +468,7 @@ build_coxph.fast <- function(df,
 
   each_func <- function(df) {
     tryCatch({
+      browser()
       if(!is.null(seed)){
         set.seed(seed)
       }

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -467,6 +467,8 @@ build_coxph.fast <- function(df,
   clean_status_col <- name_map[status_col]
   clean_time_col <- name_map[time_col]
   clean_cols <- name_map[cols]
+  clean_start_time_col <- NULL
+  clean_end_time_col <- NULL
   if (!is.null(start_time_col)) {
     clean_start_time_col <- name_map[start_time_col]
     clean_end_time_col <- name_map[end_time_col]

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -556,6 +556,7 @@ build_coxph.fast <- function(df,
   # Pass down survival time used for prediction. This is for the post-processing for time-dependent ROC.
   attr(ret, "pred_survival_time") <- pred_survival_time
 
+  # Pass down time unit for prediction step UI.
   time_unit <- if (time_unit_days == 365.25) {
     "year"
   } else if (time_unit_days == 365.25/4) {

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -373,6 +373,8 @@ build_coxph.fast <- function(df,
     end_date_col <- tidyselect::vars_select(names(df), !! rlang::enquo(end_date))
     time_unit_days <- get_time_unit_days(time_unit, df[[start_date_col]], df[[end_date_col]])
     time_unit <- attr(time_unit_days, "label") # Get label like "day", "week".
+    # We are ceiling survival time to make it integer in the specified time unit, just like we do for Survival Curve analytics view.
+    # This is to make resulting survival curve to have integer data point in the specified time unit. TODO: Think if this really makes sense here for Cox and Survival Forest.
     df <- df %>% dplyr::mutate(.time = ceiling(as.numeric(!!rlang::sym(end_date_col) - !!rlang::sym(start_date_col), units = "days")/time_unit_days))
     time_col <- ".time"
   }

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -325,6 +325,8 @@ exp_survival_forest <- function(df,
   clean_status_col <- name_map[status_col]
   clean_time_col <- name_map[time_col]
   clean_cols <- name_map[cols]
+  clean_start_time_col <- NULL
+  clean_end_time_col <- NULL
   if (!is.null(start_time_col)) {
     clean_start_time_col <- name_map[start_time_col]
     clean_end_time_col <- name_map[end_time_col]

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -228,6 +228,8 @@ exp_survival_forest <- function(df,
   # ref: http://dplyr.tidyverse.org/articles/programming.html
   # ref: https://github.com/tidyverse/tidyr/blob/3b0f946d507f53afb86ea625149bbee3a00c83f6/R/spread.R
   time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(time))
+  start_time_col <- NULL
+  end_time_col <- NULL
   if (length(time_col) == 0) { # This means time was NULL
     start_time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(start_time))
     end_time_col <- tidyselect::vars_select(names(df), !! rlang::enquo(end_time))
@@ -322,6 +324,10 @@ exp_survival_forest <- function(df,
   clean_status_col <- name_map[status_col]
   clean_time_col <- name_map[time_col]
   clean_cols <- name_map[cols]
+  if (!is.null(start_time_col)) {
+    clean_start_time_col <- name_map[start_time_col]
+    clean_end_time_col <- name_map[end_time_col]
+  }
 
   each_func <- function(df) {
     tryCatch({
@@ -355,7 +361,12 @@ exp_survival_forest <- function(df,
       # Temporarily remove unused columns for uniformity. TODO: Revive them when we do that across the product.
       clean_cols_without_names <- clean_cols
       names(clean_cols_without_names) <- NULL # remove names to eliminate renaming effect of select.
-      df <- df %>% dplyr::select(!!!rlang::syms(clean_cols_without_names), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
+      if (is.null(clean_start_time_col)) {
+        df <- df %>% dplyr::select(!!!rlang::syms(clean_cols_without_names), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
+      }
+      else {
+        df <- df %>% dplyr::select(!!!rlang::syms(clean_cols_without_names), !!rlang::sym(clean_start_time_col), !!rlang::sym(clean_end_time_col), !!rlang::sym(clean_time_col), rlang::sym(clean_status_col))
+      }
 
       df <- preprocess_regression_data_after_sample(df, clean_time_col, clean_cols, predictor_n = predictor_n, name_map = name_map)
       c_cols <- attr(df, 'predictors') # predictors are updated (added and/or removed) in preprocess_post_sample. Catch up with it.

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -44,6 +44,51 @@ test_that("build_coxph.fast basic", {
   ret <- model_df %>% augment_rowwise(model)
 })
 
+test_that("build_coxph.fast with start_date and end_date", {
+  df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
+  df <- df %>% mutate(start = as.Date("2021-01-01"), end = start + days(time))
+  df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
+  df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
+  df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
+  model_df <- df %>% build_coxph.fast(NULL, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, start_date=start, end_date=end, time_unit="auto", predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
+  ret <- model_df %>% prediction2(pretty.name=TRUE)
+  ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
+  expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
+  ret <- model_df %>% prediction2()
+  ret2 <- ret %>% do_survival_roc_("Predicted Survival Rate","Survival Time","sta tus", at=NULL, grid=10, revert=TRUE)
+  # Most of the time, true positive rate should be larger than false positive rate. If this is 
+  expect_true(sum((ret2 %>% mutate(positive=true_positive_rate >= false_positive_rate))$positive) > 0.8 * nrow(ret2))
+
+  ret <- model_df %>% evaluation(pretty.name=TRUE)
+  expect_false("Data Type" %in% colnames(ret))
+  ret <- model_df %>% tidy_rowwise(model, type='permutation_importance')
+  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence')
+  expect_true(all(c("estimate", "p.value") %in% colnames(ret))) # Make sure that estimate and p.value are joined to the result for hover on Prediction tab.
+  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence_survival_curve')
+  ret <- model_df %>% tidy_rowwise(model, type='vif')
+  ret <- model_df %>% tidy_rowwise(model)
+  expect_equal(colnames(ret),
+               c("term","estimate","std_error","t_ratio",
+                 "p_value","conf_low","conf_high","hazard_ratio","base.level"))
+  # Verify that base levels are not NA for `se-x` (testing - in the name) columns.
+  ret2 <- ret %>% dplyr::filter(stringr::str_detect(term,"(se-x)")) %>% dplyr::summarize(na_count=sum(is.na(base.level)))
+  expect_equal(ret2$na_count, 0)
+
+  ret <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
+  expect_equal(colnames(ret),
+               c("Concordance","Std Error Concordance",
+                 "Time-dependent AUC",
+                 "Likelihood Ratio Test","Likelihood Ratio Test P Value",
+                 "Score Test","Score Test P Value","Wald Test","Wald Test P Value",
+                 # "Robust Statistic","Robust P Value", # These columns are hidden for now.
+                 "R Squared","R Squared Max",
+                 "Log Likelihood","AIC","BIC",
+                 "VIF Max",
+                 "Number of Rows","Number of Events")) 
+  ret <- model_df %>% augment_rowwise(model)
+})
+
 test_that("build_coxph.fast basic with group-by", {
   df <- survival::lung # this data has NAs.
   df <- df %>% mutate(status = status==2)

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -47,7 +47,7 @@ test_that("build_coxph.fast basic", {
 test_that("build_coxph.fast with start_date and end_date", {
   df <- survival::lung # this data has NAs.
   df <- df %>% mutate(status = status==2)
-  df <- df %>% mutate(start = as.Date("2021-01-01"), end = start + days(time))
+  df <- df %>% mutate(start = as.Date("2021-01-01"), end = start + lubridate::days(time))
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -44,14 +44,14 @@ test_that("build_coxph.fast basic", {
   ret <- model_df %>% augment_rowwise(model)
 })
 
-test_that("build_coxph.fast with start_date and end_date", {
+test_that("build_coxph.fast with start_time and end_time", {
   df <- survival::lung # this data has NAs.
   df <- df %>% mutate(status = status==2)
   df <- df %>% mutate(start = as.Date("2021-01-01"), end = start + lubridate::days(time))
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
-  model_df <- df %>% build_coxph.fast(NULL, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, start_date=start, end_date=end, time_unit="auto", predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
+  model_df <- df %>% build_coxph.fast(NULL, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, start_time=start, end_time=end, time_unit="auto", predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
   ret <- model_df %>% prediction2(pretty.name=TRUE)
   ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -26,6 +26,33 @@ test_that("exp_survival_forest basic", {
   ret <- model_df %>% tidy_rowwise(model, type='importance')
 })
 
+test_that("exp_survival_forest basic with start_time and end_time", {
+  df <- survival::lung # this data has NAs.
+  df <- df %>% mutate(status = status==2)
+  df <- df %>% mutate(start = as.Date("2021-01-01"), end = start + lubridate::days(time))
+  df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
+  df <- df %>% mutate(ph.ecog = factor(ph.ecog))
+  df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
+  model_df <- df %>% exp_survival_forest(NULL, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, start_time=start, end_time=end, time_unit="auto", 
+                                         predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog=rlang::expr(forcats::fct_relevel(.,"1")), ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
+  ret <- model_df %>% prediction2(pretty.name=TRUE)
+  ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
+  ret <- model_df %>% evaluation()
+  expect_false("Data Type" %in% colnames(ret))
+  ret <- model_df %>% prediction2()
+  ret2 <- ret %>% do_survival_roc_("Predicted Survival Rate","Survival Time","sta tus", at=NULL, grid=10, revert=TRUE, with_auc=TRUE)
+  # Most of the time, true positive rate should be larger than false positive rate. If this is 
+  expect_true(sum((ret2 %>% mutate(positive=true_positive_rate >= false_positive_rate))$positive) > 0.8 * nrow(ret2))
+
+  ret <- model_df %>% glance_rowwise(model)
+  ret <- model_df %>% augment_rowwise(model)
+
+  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence_survival_curve')
+  expect_equal(class(model_df$model[[1]]), c("ranger_survival_exploratory", "ranger"))
+  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence')
+  ret <- model_df %>% tidy_rowwise(model, type='importance')
+})
+
 test_that("exp_survival_forest with group-by", {
   df <- survival::lung # this data has NAs.
   df <- df %>% mutate(status = status==2)


### PR DESCRIPTION
# Description
- Take start/end date as argument
- Add survival prediction in boolean based on a threshold
- Pass down time unit 

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
