### PR TITLE
Load survival/ranger before calling predict() so that the prediction method is found.

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -876,6 +876,9 @@ glance.coxph_exploratory <- function(x, data_type = "training", pretty.name = FA
 
 #' @export
 augment.coxph_exploratory <- function(x, newdata = NULL, data_type = "training", pred_survival_time = NULL, pred_survival_threshold = NULL, ...) {
+  # For predict() to find the prediction method, survival needs to be loaded beforehand.
+  # This becomes necessary when the model was restored from rds, and model building has not been done in the R session yet.
+  loadNamespace("survival")
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -605,6 +605,9 @@ glance.ranger_survival_exploratory <- function(x, data_type = "training", ...) {
 
 #' @export
 augment.ranger_survival_exploratory <- function(x, newdata = NULL, data_type = "training", pred_survival_time = NULL, pred_survival_threshold = NULL, ...) {
+  # For predict() to find the prediction method, ranger needs to be loaded beforehand.
+  # This becomes necessary when the model was restored from rds, and model building has not been done in the R session yet.
+  loadNamespace("ranger")
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)


### PR DESCRIPTION
Load survival/ranger before calling predict() so that the prediction method is found.
This becomes necessary when the model was restored from rds, and model building has not been done in the R session yet.

# Description
Describe your fix here

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
