### PR TITLE
Keep column order after add_prediction for Cox regression, survival forest, lm, glm

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -892,9 +892,9 @@ augment.coxph_exploratory <- function(x, newdata = NULL, data_type = "training",
     predictor_variables <- all.vars(x$terms)[c(-1,-2)] # c(-1,-2) to skip time and status columns.
     predictor_variables_orig <- x$terms_mapping[predictor_variables]
 
-    # This select() also renames columns since predictor_variables_orig is a named vector.
-    # everything() is to keep the other columns in the output. #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
-    cleaned_data <- newdata %>% dplyr::select(predictor_variables_orig, everything())
+    # Rename columns via predictor_variables_orig, which is a named vector.
+    #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
+    cleaned_data <- newdata %>% dplyr::rename(predictor_variables_orig)
 
     # Align factor levels including Others and (Missing) to the model.
     cleaned_data <- align_predictor_factor_levels(cleaned_data, x$xlevels, predictor_variables)

--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -925,6 +925,8 @@ augment.coxph_exploratory <- function(x, newdata = NULL, data_type = "training",
     data <- x$test_data
     ret <- broom:::augment.coxph(x, newdata = data, ...)
   }
+  # it seems it is possible that broom::augment.coxph adds .rownames. In such case, remove it.
+  ret$.rownames <- NULL
 
   if (is.null(pred_survival_time)) {
     pred_survival_time <- x$pred_survival_time

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1663,9 +1663,9 @@ augment.lm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = "
     predictor_variables <- all.vars(x$terms)[-1]
     predictor_variables_orig <- x$terms_mapping[predictor_variables]
 
-    # This select() also renames columns since predictor_variables_orig is a named vector.
-    # everything() is to keep the other columns in the output. #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
-    cleaned_data <- newdata %>% dplyr::select(predictor_variables_orig, everything())
+    # Rename columns via predictor_variables_orig, which is a named vector.
+    # TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
+    cleaned_data <- newdata %>% dplyr::rename(predictor_variables_orig)
 
     # Align factor levels including Others and (Missing) to the model. TODO: factor level order can be different from the model training data. Is this ok?
     cleaned_data <- align_predictor_factor_levels(cleaned_data, x$xlevels, predictor_variables)
@@ -1712,9 +1712,9 @@ augment.glm_exploratory <- function(x, data = NULL, newdata = NULL, data_type = 
     predictor_variables <- all.vars(x$terms)[-1]
     predictor_variables_orig <- x$terms_mapping[predictor_variables]
 
-    # This select() also renames columns since predictor_variables_orig is a named vector.
-    # everything() is to keep the other columns in the output. #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
-    cleaned_data <- newdata %>% dplyr::select(predictor_variables_orig, everything())
+    # Rename columns via predictor_variables_orig, which is a named vector.
+    # TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
+    cleaned_data <- newdata %>% dplyr::rename(predictor_variables_orig)
 
     # Align factor levels including Others and (Missing) to the model. TODO: factor level order can be different from the model training data. Is this ok?
     cleaned_data <- align_predictor_factor_levels(cleaned_data, x$xlevels, predictor_variables)

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -621,9 +621,9 @@ augment.ranger_survival_exploratory <- function(x, newdata = NULL, data_type = "
     predictor_variables <- attr(x$df,"predictors")
     predictor_variables_orig <- x$terms_mapping[predictor_variables]
 
-    # This select() also renames columns since predictor_variables_orig is a named vector.
-    # everything() is to keep the other columns in the output. #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
-    cleaned_data <- newdata %>% dplyr::select(predictor_variables_orig, everything())
+    # Rename columns via predictor_variables_orig, which is a named vector.
+    #TODO: What if names of the other columns conflicts with our temporary name, c1_, c2_...?
+    cleaned_data <- newdata %>% dplyr::rename(predictor_variables_orig)
 
     # Align factor levels including Others and (Missing) to the model. TODO: factor level order can be different from the model training data. Is this ok?
     cleaned_data <- align_predictor_factor_levels(cleaned_data, x$xlevels, predictor_variables)

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -6,10 +6,15 @@ test_that("build_coxph.fast basic", {
   df <- df %>% rename(`ti me`=time, `sta tus`=status, `a ge`=age, `se-x`=sex)
   df <- df %>% mutate(ph.ecog = factor(ph.ecog, ordered=TRUE)) # test handling of ordered factor
   df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
-  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
-  ret <- model_df %>% prediction2(pretty.name=TRUE)
-  ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
+
+  model_df <- df %>% build_coxph.fast(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none"), predictor_n = 2)
   expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
+
+  df2 <- df %>% select(-`ti me`, -`sta tus`)
+  ret <- df2 %>% add_prediction(model_df=model_df, pred_survival_time=5)
+  expect_equal(colnames(df2), colnames(ret)[1:length(colnames(df2))]) # Check that the df2 column order is kept.
+
+  ret <- model_df %>% prediction2(pretty.name=TRUE)
   ret <- model_df %>% prediction2()
   ret2 <- ret %>% do_survival_roc_("Predicted Survival Rate","ti me","sta tus", at=NULL, grid=10, revert=TRUE)
   # Most of the time, true positive rate should be larger than false positive rate. If this is 

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -118,6 +118,11 @@ test_that("add_prediction with linear regression", {
                                      predictor_funs=list(ARR_TIME="log", DELAY_TIME="none", "Carrier Name"="none"),
                                      model_type = "lm")
   ret <- test_data %>% select(-DISTANCE) %>% add_prediction(model_df=model_df)
+
+  df2 <- test_data %>% select(-DISTANCE)
+  ret <- df2 %>% add_prediction(model_df=model_df)
+  expect_equal(colnames(df2), colnames(ret)[1:length(colnames(df2))]) # Check that the df2 column order is kept.
+
   expect_error({
     ret <- test_data %>% select(-DISTANCE, -ARR_TIME) %>% add_prediction(model_df=model_df)
   }, regexp=".*ARR_TIME.*Columns are required for the model, but do not exist.*")

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -9,7 +9,11 @@ test_that("exp_survival_forest basic", {
   model_df <- df %>% exp_survival_forest(`ti me`, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss,
                                          predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog=rlang::expr(forcats::fct_relevel(.,"1")), ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
   ret <- model_df %>% prediction2(pretty.name=TRUE)
-  ret <- df %>% select(-`ti me`, -`sta tus`) %>% add_prediction(model_df=model_df, pred_survival_time=5)
+
+  df2 <- df %>% select(-`ti me`, -`sta tus`)
+  ret <- df2 %>% add_prediction(model_df=model_df, pred_survival_time=5)
+  expect_equal(colnames(df2), colnames(ret)[1:length(colnames(df2))]) # Check that the df2 column order is kept.
+
   ret <- model_df %>% evaluation()
   expect_false("Data Type" %in% colnames(ret))
   ret <- model_df %>% prediction2()


### PR DESCRIPTION
# Description
Keep column order for add_prediction for Cox regression, survival forest, lm, glm.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
