### PR TITLE
Improve error message for dirty column names at xgboost step

### DIFF
--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -49,7 +49,7 @@ fml_xgboost <- function(data, formula, nrounds= 10, weights = NULL, watchlist_ra
           if (e$message == "fnames == names(mf) are not all TRUE"){
             # if there are not clean column names like including spaces or special characters,
             # Matrix::sparse.model.matrix causes this error
-            stop("Invalid column names are found. Please run clean_names function beforehand.")
+            stop("EXP-ANA-3 :: [] :: Invalid column names are found. Please run clean_names function beforehand.")
           }
           stop(e)
         })


### PR DESCRIPTION
# Description
Improved error message for dirty column names at xgboost step to make use of message ID schema of Exploratory.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
