### PR TITLE
Make model_info work with column names other than "model"

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -100,14 +100,15 @@ augment_rowwise_data <- function(df, model, data, ...) {
 #' tidy/glance/augment wrapper
 #' @export
 model_info <- function(df, model, output = "summary", ...) {
+  model_col <- tidyselect::vars_select(names(df), !! rlang::enquo(model))
   if (output == "summary") {
-    glance_rowwise(df, model, ...)
+    glance_rowwise(df, !!rlang::sym(model_col), ...)
   }
   else if (output == "variables") {
-    tidy_rowwise(df, model, ...)
+    tidy_rowwise(df, !!rlang::sym(model_col), ...)
   }
   else if (output == "data") {
-    augment_rowwise(df, model, ...)
+    augment_rowwise(df, !!rlang::sym(model_col), ...)
   }
   else {
     stop('output argument has to be "summary", "variables", or "data".')

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -202,8 +202,9 @@ test_that("test exp_chisq", {
   ret <- exp_chisq(mtcars2, gear, carb, value=cyl, fun.aggregate=sum)
 
   # Test model_info function.
-  observed <- ret %>% model_info(model, output="variables", type="observed")
-  summary <- ret %>% model_info(model, output="summary")
+  # Rename model column so that we test the case where the column name is not "model". There was an issue this case.
+  observed <- ret %>% rename(model1=model) %>% model_info(model1, output="variables", type="observed")
+  summary <- ret %>% rename(model1=model) %>% model_info(model1, output="summary")
 
   observed <- ret %>% tidy_rowwise(model, type="observed")
   summary <- ret %>% glance_rowwise(model)

--- a/tests/testthat/test_test_wrapper.R
+++ b/tests/testthat/test_test_wrapper.R
@@ -205,6 +205,7 @@ test_that("test exp_chisq", {
   # Rename model column so that we test the case where the column name is not "model". There was an issue this case.
   observed <- ret %>% rename(model1=model) %>% model_info(model1, output="variables", type="observed")
   summary <- ret %>% rename(model1=model) %>% model_info(model1, output="summary")
+  data <- ret %>% rename(model1=model) %>% model_info(model1, output="data")
 
   observed <- ret %>% tidy_rowwise(model, type="observed")
   summary <- ret %>% glance_rowwise(model)


### PR DESCRIPTION
# Description
Make model_info work with column names other than "model".

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
