### PR TITLE
Google Drive and Amazon S3 Data Source: changed to force character data type when merged as a single data frame.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.5.0.4
-Date: 2021-03-19
+Version: 6.5.0.5
+Date: 2021-03-21
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/aws_s3.R
+++ b/R/aws_s3.R
@@ -90,6 +90,10 @@ getCSVFileFromS3 <- function(fileName, region, username, password, bucket, delim
 }
 
 #'API that imports multiple same structure CSV files and merge it to a single data frame
+#'
+#'For col_types parameter, by default it forces character to make sure that merging the CSV based data frames doesn't error out due to column data types mismatch.
+# Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
+
 #'@export
 getCSVFilesFromS3 <- function(files, region, username, password, bucket, fileName, delim, quote = '"',
                              escape_backslash = FALSE, escape_double = TRUE,

--- a/R/aws_s3.R
+++ b/R/aws_s3.R
@@ -93,7 +93,7 @@ getCSVFileFromS3 <- function(fileName, region, username, password, bucket, delim
 #'@export
 getCSVFilesFromS3 <- function(files, region, username, password, bucket, fileName, delim, quote = '"',
                              escape_backslash = FALSE, escape_double = TRUE,
-                             col_names = TRUE, col_types = NULL,
+                             col_names = TRUE, col_types = readr::cols(.default = readr::col_character()),
                              locale = readr::default_locale(),
                              na = c("", "NA"), quoted_na = TRUE,
                              comment = "", trim_ws = FALSE,

--- a/R/aws_s3.R
+++ b/R/aws_s3.R
@@ -118,21 +118,21 @@ getCSVFilesFromS3 <- function(files, region, username, password, bucket, fileNam
 
 #'API that imports a Excel file from AWS S3.
 #'@export
-getExcelFileFromS3 <- function(fileName, region, username, password, bucket, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, ...) {
+getExcelFileFromS3 <- function(fileName, region, username, password, bucket, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = FALSE, ...) {
   filePath <- downloadDataFileFromS3(region = region, bucket = bucket, key = username, secret = password, fileName = fileName, as = "raw")
-  exploratory::read_excel_file(path = filePath, sheet = sheet, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl, detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = FALSE, tzone = tzone, ...)
+  exploratory::read_excel_file(path = filePath, sheet = sheet, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl, detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names, tzone = tzone, convertDataTypeToChar = convertDataTypeToChar, ...)
 }
 
 
 #'API that imports multiple Excel files from AWS S3.
 #'@export
-getExcelFilesFromS3 <- function(files, region, username, password, bucket, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, ...) {
+getExcelFilesFromS3 <- function(files, region, username, password, bucket, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
   # set name to the files so that it can be used for the "id" column created by purrr:map_dfr.
   files <- setNames(as.list(files), files)
   df <- purrr::map_dfr(files, exploratory::getExcelFileFromS3, region = region, username = username, password = password, bucket = bucket, sheet = sheet,
                        col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl,
-                       detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = FALSE,
-                       tzone = tzone, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
+                       detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names,
+                       tzone = tzone, convertDataTypeToChar = convertDataTypeToChar, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
   id_col <- avoid_conflict(colnames(df), "id")
   # copy internal exp.file.id to the id column.
   df[[id_col]] <- df[["exp.file.id"]]

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -68,6 +68,10 @@ getCSVFileFromGoogleDrive <- function(fileId, delim, quote = '"',
 }
 
 #'API that imports multiple same structure CSV files and merge it to a single data frame
+#'
+#'For col_types parameter, by default it forces character to make sure that merging the CSV based data frames doesn't error out due to column data types mismatch.
+# Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
+
 #'@export
 getCSVFilesFromGoogleDrive <- function(fileIds, fileNames, region, username, password, bucket, fileName, delim, quote = '"',
                               escape_backslash = FALSE, escape_double = TRUE,

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -96,21 +96,24 @@ getCSVFilesFromGoogleDrive <- function(fileIds, fileNames, region, username, pas
 
 #'API that imports a Excel file from Google Drive.
 #'@export
-getExcelFileFromGoogleDrive <- function(fileId, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, ...) {
+getExcelFileFromGoogleDrive <- function(fileId, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = FALSE, ...) {
   filePath <- downloadDataFileFromGoogleDrive(fileId = fileId, type = "xlsx")
-  exploratory::read_excel_file(path = filePath, sheet = sheet, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl, detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = FALSE, tzone = tzone, ...)
+  exploratory::read_excel_file(path = filePath, sheet = sheet, col_names = col_names, col_types = col_types,
+                               na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl,
+                               detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols,
+                               check.names = FALSE, tzone = tzone, convertDataTypeToChar = convertDataTypeToChar, ...)
 }
 
 
 #'API that imports multiple Excel files from Google Drive
 #'@export
-getExcelFilesFromGoogleDrive <- function(fileIds, fileNames, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, ...) {
+getExcelFilesFromGoogleDrive <- function(fileIds, fileNames, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, convertDataTypeToChar = TRUE, tzone = NULL, ...) {
   # set name to the files so that it can be used for the "id" column created by purrr:map_dfr.
   files <- setNames(as.list(fileIds), fileNames)
   df <- purrr::map_dfr(files, exploratory::getExcelFileFromGoogleDrive, sheet = sheet,
                        col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, use_readxl = use_readxl,
                        detectDates = detectDates, skipEmptyRows =  skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = FALSE,
-                       tzone = tzone, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
+                       tzone = tzone, convertDataTypeToChar = convertDataTypeToChar, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
   id_col <- avoid_conflict(colnames(df), "id")
   # copy internal exp.file.id to the id column.
   df[[id_col]] <- df[["exp.file.id"]]

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -71,7 +71,7 @@ getCSVFileFromGoogleDrive <- function(fileId, delim, quote = '"',
 #'@export
 getCSVFilesFromGoogleDrive <- function(fileIds, fileNames, region, username, password, bucket, fileName, delim, quote = '"',
                               escape_backslash = FALSE, escape_double = TRUE,
-                              col_names = TRUE, col_types = NULL,
+                              col_names = TRUE, col_types = readr::cols(.default = readr::col_character()),
                               locale = readr::default_locale(),
                               na = c("", "NA"), quoted_na = TRUE,
                               comment = "", trim_ws = FALSE,

--- a/R/system.R
+++ b/R/system.R
@@ -2446,6 +2446,7 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   # by default the convertDataTypeToChar is set as TRUE to covert the resulting data frame columns' data type as character.
   # This is required to make sure that merging the Excel based data frames doesn't error out due to column data types mismatch.
   # Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
+  # We don't want to reply on readxl::read_excel's col_types argument "text" since this option converts Date or POSIXct column data as number instead of "2021-01-01" style text.
   if(convertDataTypeToChar) {
     df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(), as.character));
   }

--- a/R/system.R
+++ b/R/system.R
@@ -2474,7 +2474,7 @@ get_excel_sheets <- function(path){
 #'@export
 read_delim_files <- function(files, delim, quote = '"',
                               escape_backslash = FALSE, escape_double = TRUE,
-                              col_names = TRUE, col_types = NULL,
+                              col_names = TRUE, col_types = readr::cols(.default = readr::col_character()),
                               locale = readr::default_locale(),
                               na = c("", "NA"), quoted_na = TRUE,
                               comment = "", trim_ws = FALSE,

--- a/R/system.R
+++ b/R/system.R
@@ -2446,8 +2446,8 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   # by default the convertDataTypeToChar is set as TRUE to covert the resulting data frame columns' data type as character.
   # This is required to make sure that merging the Excel based data frames doesn't error out due to column data types mismatch.
   # Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
-  # We don't want to reply on readxl::read_excel's col_types argument "text" since this option converts Date or POSIXct column data as number instead of "2021-01-01" style text.
-  if(convertDataTypeToChar) {
+  # We don't want to rely on readxl::read_excel's col_types argument "text" since this option converts Date or POSIXct column data as number instead of "2021-01-01" style text.
+  if (convertDataTypeToChar) {
     df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(), as.character));
   }
   df

--- a/R/system.R
+++ b/R/system.R
@@ -2442,7 +2442,10 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
   if(!is.null(tzone)) { # if timezone is specified, apply the timezeon to POSIXct columns
     df <- df %>% dplyr::mutate_if(lubridate::is.POSIXct, funs(lubridate::force_tz(., tzone=tzone)))
   }
-  # for .xlsx file extension, since openxlsx::read.xlsx does not have parameter for data types, explicitly sets as data types as text if col_types is set as text.
+  # When this API is called from getExcelFilesFromS3, getExcelFilesFromGoogleDrive, and read_excel_files,
+  # by default the convertDataTypeToChar is set as TRUE to covert the resulting data frame columns' data type as character.
+  # This is required to make sure that merging the Excel based data frames doesn't error out due to column data types mismatch.
+  # Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
   if(convertDataTypeToChar) {
     df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(), as.character));
   }
@@ -2476,6 +2479,10 @@ get_excel_sheets <- function(path){
 }
 
 #'API that imports multiple same structure CSV files and merge it to a single data frame
+#'
+#'For col_types parameter, by default it forces character to make sure that merging the CSV based data frames doesn't error out due to column data types mismatch.
+# Once the data frames merging is done, readr::type_convert is called from Exploratory Desktop to restore the column data types.
+
 #'@export
 read_delim_files <- function(files, delim, quote = '"',
                               escape_backslash = FALSE, escape_double = TRUE,


### PR DESCRIPTION
# Description

As for Google Drive and Amazon S3 Data Source, changed to force character data type when merged as a single data frame.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
