### PR TITLE
Calculate FIRM even when there is NaN in predictions in PDP

### DIFF
--- a/R/partial_dependence.R
+++ b/R/partial_dependence.R
@@ -47,7 +47,11 @@ calc_partial_binning_data <- function(df, target_col, var_cols) {
 # Standard deviation with weight by how many rows have the same value.
 # Using it to calculate FIRM while the PDP data has only single row even when multiple quantile-based grid points have a same value.
 sd_with_weight <- function(v, w) {
-  sd(purrr::flatten_dbl(purrr::map2(v,w,function(x,y){rep(x,y)})))
+  # na.rm is in case some of the predicted values in the partial dependence data are NaN.
+  # It can happen for example in inverse gaussian regression with inverse square link function,
+  # when linear predictor is negative.
+  # In such case, we ignore that part of PDP and calculate sd from the rest.
+  sd(purrr::flatten_dbl(purrr::map2(v,w,function(x,y){rep(x,y)})), na.rm=TRUE)
 }
 
 # ... is for vectors of partial dependence.

--- a/tests/testthat/test_build_lm_3.R
+++ b/tests/testthat/test_build_lm_3.R
@@ -72,11 +72,11 @@ test_that("build_lm.fast (linear regression) evaluate training and test with per
 
 test_that("build_lm.fast (logistic regression) evaluate training and test FIRM importance", {
   model_df <- flight %>%
-                build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3, importance_measure="FIRM")
+                build_lm.fast(`is delayed`, `DIS TANCE`, `DEP TIME`, model_type = "glm", test_rate = 0.3, importance_measure="firm")
 
   # Check variable importance output.
   ret <- model_df %>% tidy_rowwise(model, type="importance")
-  # expect_equal(colnames(ret), c("CAR RIER", "variable", "importance", "p.value")) # TODO: This fails. Look into it.
+  expect_equal(colnames(ret), c("CAR RIER", "variable", "importance", "p.value")) # TODO: This fails. Look into it.
 
   ret <- model_df %>% tidy_rowwise(model, converged_only=TRUE) # Test converged_only
   ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)

--- a/tests/testthat/test_build_lm_3.R
+++ b/tests/testthat/test_build_lm_3.R
@@ -76,7 +76,7 @@ test_that("build_lm.fast (logistic regression) evaluate training and test FIRM i
 
   # Check variable importance output.
   ret <- model_df %>% tidy_rowwise(model, type="importance")
-  expect_equal(colnames(ret), c("CAR RIER", "variable", "importance", "p.value")) # TODO: This fails. Look into it.
+  expect_equal(colnames(ret), c("CAR RIER", "variable", "importance", "p.value"))
 
   ret <- model_df %>% tidy_rowwise(model, converged_only=TRUE) # Test converged_only
   ret <- model_df %>% prediction_binary(data="training_and_test", threshold = 0.5)


### PR DESCRIPTION
# Description
Calculate FIRM even when there is NaN in predictions in PDP.
It can happen for example in inverse gaussian regression with inverse square link function, when linear predictor is negative.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
