### PR TITLE
prophet: Set weekly/yearly seasonality default to auto 

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -109,7 +109,7 @@ do_prophet <- function(df, time, value = NULL, periods = 10, holiday = NULL, ...
 #' @export
 do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit = "day", include_history = TRUE, test_mode = FALSE,
                         fun.aggregate = sum, na_fill_type = NULL, na_fill_value = 0,
-                        cap = NULL, floor = NULL, growth = NULL, weekly.seasonality = TRUE, yearly.seasonality = TRUE,
+                        cap = NULL, floor = NULL, growth = NULL, weekly.seasonality = "auto", yearly.seasonality = "auto",
                         quarterly.seasonality = FALSE, monthly.seasonality = FALSE,
                         daily.seasonality = "auto",
                         holiday_col = NULL, holidays = NULL, holiday_country_names = NULL,
@@ -137,6 +137,9 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
   # which does not look convincing.
   # since there seems to be cases where 'auto' on yearly.seasonality triggers this situation, we are using TRUE as default.
   # we have not seen any issue on 'auto' on weekly.seasonality, but are not using it for now just to be careful.
+  # Update on 2021/03 - We have been using Analytics View with "auto" for yearly as well as weekly, set by JS command generator layer,
+  # but haven't seen any obvious issues. Setting them back to auto, since now we rather see problem with yearly seasonality enabled
+  # for less than 2 years of data.
 
   loadNamespace("dplyr")
   # For some reason this needs to be library() instead of loadNamespace() to avoid error.

--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -59,11 +59,11 @@ test_that("do_prophet test mode with minute as time units", {
   # verify that the last forecasted_value is not NA to test #9211
   expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
   # verify that daily, weekly is enabled to test #9361.
-  expect_equal(c("daily","weekly") %in% colnames(ret),c(T,T))
+  expect_equal(c("daily","weekly") %in% colnames(ret),c(T,F))
 })
 
 test_that("do_prophet test mode with hour as time units", {
-  ts <- seq(as.POSIXct("2010-01-01:00:00:00"), as.POSIXct("2010-01-15:00:00"), by="hour")
+  ts <- seq(as.POSIXct("2010-01-01:00:00:00"), as.POSIXct("2010-01-16:00:00"), by="hour") # Make it a little longer than 2 weeks to automatically enable weekly seasonality.
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
   raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
   ret <- raw_data %>%


### PR DESCRIPTION
# Description
Set weekly/yearly seasonality default to auto.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
