### PR TITLE
Handle unused target category levels in xgboost with group_by

### DIFF
--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -888,7 +888,8 @@ partial_dependence.xgboost <- function(fit, vars = colnames(data),
 
   attr(pd, "class") = c("pd", "data.frame")
   attr(pd, "interaction") = interaction == TRUE
-  attr(pd, "target") = if (!classification) target else levels(fit$y_levels)
+  # Since levels(fit$y_levels) returns unused levels, it has to be as.character(fit$y_levels).
+  attr(pd, "target") = if (!classification) target else as.character(fit$y_levels)
   attr(pd, "vars") = vars
   attr(pd, "points") = points
   pd

--- a/R/partial_dependence.R
+++ b/R/partial_dependence.R
@@ -78,6 +78,9 @@ calc_firm_from_pd <- function(..., weight, class) {
 # References:
 #   https://arxiv.org/abs/1805.04755
 #   https://arxiv.org/abs/1904.03959
+# pdp_data - data.frame of partial dependence data.
+# target - character vector. For regression, name of the target column. For classification, vector of names of classes, which are column names of pdp_data.
+# vars - character vector of names of predictor variables, which are also column names of pdp_data.
 importance_firm <- function(pdp_data, target, vars) {
   points <- attr(pdp_data, "points")
   # Replace the grid values with the type of the column, e.g. "numeric", or "character".


### PR DESCRIPTION

# Description
Handle unused target category levels in xgboost with group_by.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
