### PR TITLE
Logistic/GLM Binomial: Rename predicted_response to predicted_probability

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -311,6 +311,10 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
   colnames(ret)[colnames(ret) == ".fitted"] <- avoid_conflict(colnames(ret), "predicted_value")
   colnames(ret)[colnames(ret) == ".se.fit"] <- avoid_conflict(colnames(ret), "standard_error")
   colnames(ret)[colnames(ret) == ".resid"] <- avoid_conflict(colnames(ret), "residual")
+  # For Analytics View for GLM binomial (including logistic regression), rename predicted_response to predicted_probability.
+  if ("glm_exploratory" %in% class(model_df$model[[1]]) && model_df$model[[1]]$family$family == "binomial") {
+    colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "predicted_probability")
+  }
 
   ret
 }

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -312,6 +312,10 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
   colnames(ret)[colnames(ret) == ".se.fit"] <- avoid_conflict(colnames(ret), "standard_error")
   colnames(ret)[colnames(ret) == ".resid"] <- avoid_conflict(colnames(ret), "residual")
   # For Analytics View for GLM binomial (including logistic regression), rename predicted_response to predicted_probability.
+  # Since we keep the output column name from augment predicted_response and adjust the column name in prediction_binary for training/test,
+  # we do the same kind of layering here for new data prediction too, and do the renaming here at the caller of the augment function,
+  # rather than inside the augment function.
+  # For prediction by Analytics Step, we also use prediction_binary, and the column renaming is done there.
   if ("glm_exploratory" %in% class(model_df$model[[1]]) && model_df$model[[1]]$family$family == "binomial") {
     colnames(ret)[colnames(ret) == "predicted_response"] <- avoid_conflict(colnames(ret), "predicted_probability")
   }

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -655,7 +655,7 @@ test_that("add_prediction with logistic regression", {
                                      predictor_funs=list(ARR_TIME="log", DELAY_TIME="none", "Carrier Name"="none"),
                                      model_type = "glm")
   ret <- test_data %>% select(-`CANCELLED X`) %>% add_prediction(model_df=model_df)
-  expect_true(all(c("predicted_value","predicted_label") %in% colnames(ret)))
+  expect_true(all(c("predicted_probability", "predicted_value","predicted_label") %in% colnames(ret)))
 })
 
 test_that("Logistic Regression with test_rate", {


### PR DESCRIPTION
# Description
For Logistic Regression and GLM Binomial, rename predicted_response to predicted_probability.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
