### PR TITLE
Parameter: Handle empty vector with class such as as.character(c()) correctly

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -339,7 +339,7 @@ js_glue_transformer <- function(expr, envir) {
     }
   }
 
-  if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
+  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done my length().
     val <- ""
   }
   else if (is.numeric(val)) {
@@ -469,7 +469,8 @@ sql_glue_transformer_internal <- function(expr, envir, bigquery=FALSE) {
     }
   }
 
-  if (is.null(val)) { # NULL in R is same as empty vector. Print empty string.
+  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done my length().
+    # Print "NULL" string.
     val <- "NULL" # With PostgreSQL, "IN (NULL)" is valid while "IN ()" is syntax error. TODO: Test other databases.
   }
   else if (is.numeric(val)) {

--- a/R/system.R
+++ b/R/system.R
@@ -339,7 +339,7 @@ js_glue_transformer <- function(expr, envir) {
     }
   }
 
-  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done my length().
+  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done by length().
     val <- ""
   }
   else if (is.numeric(val)) {
@@ -469,7 +469,7 @@ sql_glue_transformer_internal <- function(expr, envir, bigquery=FALSE) {
     }
   }
 
-  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done my length().
+  if (length(val) == 0) { # Empty vector case. NULL in R is same as empty vector, but since is.null(as.character(c(0))) returns FALSE, this has to be done by length().
     # Print "NULL" string.
     val <- "NULL" # With PostgreSQL, "IN (NULL)" is valid while "IN ()" is syntax error. TODO: Test other databases.
   }

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -154,6 +154,11 @@ test_that("js_glue_transformer", {
   res <- exploratory:::glue_exploratory("@{v}", .transformer=exploratory:::js_glue_transformer)
   expect_equal(as.character(res), "true, false, null")
 
+  # Empty vector case.
+  exploratory_env$v <- as.character(c())
+  res <- exploratory:::glue_exploratory("@{v}", .transformer=exploratory:::js_glue_transformer)
+  expect_equal(as.character(res), "")
+
   exploratory_env$v <- 1
   exploratory_env$w <- 2
   exploratory_env$x <- 1000000
@@ -194,7 +199,7 @@ test_that("sql_glue_transformer", {
   res <- exploratory:::glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=exploratory:::sql_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO''s secretary', 'Data Science\\Statistics') and empid > 1100")
 
-  exploratory_env$dept_names <- c()
+  exploratory_env$dept_names <- as.character(c())
   res <- exploratory:::glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=exploratory:::sql_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in (NULL) and empid > 1100")
 
@@ -222,7 +227,7 @@ test_that("bigquery_glue_transformer", {
   res <- exploratory:::glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=exploratory:::bigquery_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in ('Sales', 'HR', 'CEO\\'s secretary', 'Data Science\\\\Statistics') and empid > 1100")
 
-  exploratory_env$dept_names <- c()
+  exploratory_env$dept_names <- as.character(c())
   res <- exploratory:::glue_exploratory("select * from emp where deptname in (@{dept_names}) and empid > @{empid_above}", .transformer=exploratory:::bigquery_glue_transformer)
   expect_equal(as.character(res), "select * from emp where deptname in (NULL) and empid > 1100")
 


### PR DESCRIPTION
# Description
Handle empty vector with class such as as.character(c()) correctly as a parameter value in generating SQL/MongoDB query.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
