### PR TITLE
Fix Google BigQuery query ends up with Error in the HTTP2 framing layer

### DIFF
--- a/R/oauth.R
+++ b/R/oauth.R
@@ -199,6 +199,9 @@ refreshTwitterToken <- function(tokenFileId){
 #' @export
 getGoogleTokenForBigQuery <- function(tokenFileId="", useCache=TRUE){
   if(!requireNamespace("bigrquery")){stop("package bigrquery must be installed.")}
+  # To workaround Error in the HTTP2 framing layer
+  # set below config (see https://github.com/jeroen/curl/issues/156)
+  httr::set_config(httr::config(http_version = 0))
 
   appName = "google"
   # retrieve token info from environment


### PR DESCRIPTION
# Description

When executing a Google BigQuery query, it sometimes fails with 

```r
Error in curl::curl_fetch_memory(x$url$url, handle = x$url$handle) :
Error in the HTTP2 framing layer
```

And according to https://github.com/jeroen/curl/issues/156, setting below fixes the issue so added the workaround.

```r
httr::set_config(httr::config(http_version = 0))
```

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
