### PR TITLE
K-means / PCA: Remove list, difftime, etc. as preprocessing to avoid error

### DIFF
--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -52,6 +52,14 @@ exp_kmeans <- function(df, ...,
     sampled_nrow <- max_nrow
     df <- df %>% sample_rows(max_nrow)
   }
+  # list and difftime etc. causes error in tidy_rowwise(model, type="biplot").
+  # For now, we are removing them upfront.
+  df <- df %>% dplyr::select(-where(is.list),
+                             -where(lubridate::is.difftime),
+                             -where(lubridate::is.duration),
+                             -where(lubridate::is.interval),
+                             -where(lubridate::is.period))
+
   if (!elbow_method_mode) {
     kmeans_model_df <- df %>% build_kmeans.cols(...,
                                                 centers=centers,

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -14,6 +14,14 @@ do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_singl
     stop("Repeat-By column cannot be used as a variable column.")
   }
 
+  # list and difftime etc. causes error in tidy_rowwise(model, type="biplot").
+  # For now, we are removing them upfront.
+  df <- df %>% dplyr::select(-where(is.list),
+                             -where(lubridate::is.difftime),
+                             -where(lubridate::is.duration),
+                             -where(lubridate::is.interval),
+                             -where(lubridate::is.period))
+
   if(!is.null(seed)) { # Set seed before starting to call sample_n.
     set.seed(seed)
   }

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -20,6 +20,17 @@ test_that("exp_kmeans with strange column name", {
   df <- mtcars %>%
     rename(`Cy l` = cyl) %>%
     mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+
+  # Add list column and difftime column etc. which used to cause error until we removed it as preprocessing.
+  df <- df %>% mutate(posix1=lubridate::ymd_hm("2021-01-01 00:00"),
+                      posix2=lubridate::ymd_hm("2021-01-02 00:00"),
+                      difftime = posix2-posix1, dur = as.duration(difftime),
+                      intv = as.interval(posix1, posix2),
+                      period = as.period(intv),
+                      str="a,b,c",
+                      list=stringr::str_split(str,","))
+  df <- df %>% select(-posix1, -posix2, -str) # Remove POSIXct column and character column we used to create those special columns.
+
   model_df <- exp_kmeans(df, `Cy l`, mpg, hp)
   model_df %>% tidy_rowwise(model, type="variances")
   model_df %>% tidy_rowwise(model, type="loadings")


### PR DESCRIPTION
# Description
Remove list column, difftime column, etc. as preprocessing to avoid error.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
