### PR TITLE
Correlation: Convert logical to numeric explicitly

### DIFF
--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -183,7 +183,10 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
         stop("More than 1 row are required to calculate correlations.")
       }
     }
-    mat <- dplyr::select(df, !!!select_dots) %>%  as.matrix()
+    mat <- dplyr::select(df, !!!select_dots) %>%
+      # Convert logical to numeric explicitly, since implicit conversion by as.matrix does not happen if all the columns are logical.
+      dplyr::mutate(across(where(is.logical), as.numeric)) %>%
+      as.matrix()
     # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
     # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
     sorted_colnames <- sort(colnames(mat))

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -78,6 +78,14 @@ test_that("do_cor with only lower triangle", {
   expect_equal(nrow(res), 6) # Lower triangle elements with diagonal elements.
 })
 
+test_that("do_cor with only logical columns", {
+  # Steps to produce the output
+  df <- data.frame(x=c(T,T,F,F),y=c(T,F,T,F),z=c(T,T,F,F))
+  model_df <- df %>% do_cor(`x`, `y`, `z`, method = "pearson", distinct = TRUE, diag = TRUE, return_type = "model")
+  res <- model_df %>% tidy_rowwise(model, type='cor')
+  expect_equal(nrow(res), 6) # Lower triangle elements with diagonal elements.
+})
+
 test_that("do_cor should skip group with only one row.", {
   df <- data.frame(x=c(1,1,0,0),y=c(1,0,1,0),z=c(T,T,T,F))
   model_df <- df %>% group_by(z) %>% do_cor(`x`, `y`, method = "pearson", distinct = FALSE, diag = TRUE, return_type = "model")


### PR DESCRIPTION

# Description
Convert logical column to numeric explicitly in do_cor().
Implicit conversion did not happen when all the columns were logical.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
