### PR TITLE
Set mean as the default aggregation function of summarize_row

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2268,7 +2268,7 @@ summarize_group <- function(.data, group_cols = NULL, group_funs = NULL, ...) {
 #' @param x - data frame
 #' @param f - function
 #' @export
-summarize_row <- function(x, f, ...) {
+summarize_row <- function(x, f = mean, ...) {
   apply(x, 1, f, ...)
 }
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -930,6 +930,9 @@ test_that("summarize_group", {
 test_that("summarize_row", {
  df <- airquality %>% mutate(total = summarize_row(across(where(is.numeric)), mean, na.rm=TRUE))
  expect_equal(colnames(df), c("Ozone", "Solar.R", "Wind", "Temp", "Month", "Day", "total"))
+ # Test the default function (mean).
+ df <- airquality %>% mutate(total = summarize_row(across(where(is.numeric))))
+ expect_equal(colnames(df), c("Ozone", "Solar.R", "Wind", "Temp", "Month", "Day", "total"))
 })
 
 test_that("revert_factor_cols_to_logical", {


### PR DESCRIPTION
# Description
Set mean as the default aggregation function of summarize_row.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
