### PR TITLE
Test: Add test to detect arrow::read_parquet regression in arrow3.

### DIFF
--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -276,7 +276,7 @@ test_that("read_parquet_file", {
   expect_equal(TRUE, is.data.frame(df))
 })
 
-test_that("read_parquet_file can read the parquet file that arrow3 cannot read.", {
+test_that("read_parquet_file can read the parquet file that arrow v3 fails to read.", {
   df <- read_parquet_file("https://dl.dropbox.com/s/5v4xhjhunl7v58g/21331_Source1.parquet")
   expect_equal(TRUE, is.data.frame(df))
 })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -276,6 +276,11 @@ test_that("read_parquet_file", {
   expect_equal(TRUE, is.data.frame(df))
 })
 
+test_that("read_parquet_file can read the parquet that arrow3 cannot read.", {
+  df <- read_parquet_file("https://dl.dropbox.com/s/5v4xhjhunl7v58g/21331_Source1.parquet")
+  expect_equal(TRUE, is.data.frame(df))
+})
+
 test_that("test filter_cascade",{
   library(stringr)
   df <- readRDS(url("https://www.dropbox.com/s/p2vmd79ly1zugh9/airbnb_nyc_filter_7.rds?dl=1"))

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -276,7 +276,7 @@ test_that("read_parquet_file", {
   expect_equal(TRUE, is.data.frame(df))
 })
 
-test_that("read_parquet_file can read the parquet that arrow3 cannot read.", {
+test_that("read_parquet_file can read the parquet file that arrow3 cannot read.", {
   df <- read_parquet_file("https://dl.dropbox.com/s/5v4xhjhunl7v58g/21331_Source1.parquet")
   expect_equal(TRUE, is.data.frame(df))
 })


### PR DESCRIPTION
# Description
Add test to detect arrow::read_parquet regression in arrow3. 

# Checklist

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
