### PR TITLE
Make unixtime_to_datetime and excel_numeri_to_datetime work with character columns.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -736,7 +736,7 @@ move_col <- function(df, cname, position) {
 #' @export
 unixtime_to_datetime <- function(data){
   # referred from http://stackoverflow.com/questions/27408131/convert-unix-timestamp-into-datetime-in-r
-  as.POSIXct(data, origin="1970-01-01", tz='GMT')
+  as.POSIXct(as.numeric(data), origin="1970-01-01", tz='GMT')
 }
 
 # get binary prediction scores
@@ -1753,7 +1753,7 @@ excel_numeric_to_date <- function(date_num, date_system = "modern",
 
 #' @export
 excel_numeric_to_datetime <- function(datetime_num, tz = "", ...) {
-  res <- openxlsx::convertToDateTime(datetime_num, tz = tz, ...)
+  res <- openxlsx::convertToDateTime(as.numeric(datetime_num), tz = tz, ...)
   # Convert output timezone to the specified tz, in addition to reading the number with the tz.
   res <- lubridate::with_tz(res, tz = tz)
   res

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -552,6 +552,13 @@ test_that("unixtime_to_datetime", {
   unix_ans <- as.POSIXct(data, origin="1970-01-01", tz = "GMT")
   expect_equal(unix_ret, unix_ans)
 
+  data <- c("300", "900", NA)
+
+  unix_ret <- unixtime_to_datetime(data)
+  unix_ans <- as.POSIXct(as.numeric(data), origin="1970-01-01", tz = "GMT")
+  expect_equal(unix_ret, unix_ans)
+
+
 })
 
 test_that("append_colnames", {
@@ -855,6 +862,9 @@ test_that("excel_numeric_to_date", {
 test_that("excel_numeric_to_datetime", {
   res <- exploratory::excel_numeric_to_datetime(42370.5, tz = "GMT")
   expect_equal(res, as.POSIXct("2016-01-01 12:00:00",tz = "GMT"))
+  res <- exploratory::excel_numeric_to_datetime("42370.5", tz = "GMT")
+  expect_equal(res, as.POSIXct("2016-01-01 12:00:00",tz = "GMT"))
+
 })
 
 test_that("one_hot", {
@@ -951,7 +961,7 @@ test_that("is_integer", {
 })
 
 test_that("week", {
-  dates <- lubridate::ymd(c(20190101,20190107,20190108,20190131,20190201,20190207,20190208,20190701,20190707,20190708,20190731,20191201,20191207,20191208,20191231)) 
+  dates <- lubridate::ymd(c(20190101,20190107,20190108,20190131,20190201,20190207,20190208,20190701,20190707,20190708,20190731,20191201,20191207,20191208,20191231))
   expect_equal(exploratory::week(dates), c(1,1,2,5,5,6,6,26,27,27,31,48,49,49,53))
   expect_equal(exploratory::week(dates, unit="quarter"), c(1,1,2,5,5,6,6,1,1,2,5,9,10,10,14))
   expect_equal(exploratory::week(dates, unit="month"), c(1,1,2,5,1,1,2,1,1,2,5,1,1,2,5))


### PR DESCRIPTION
# Description

Supported character column for below APIs.

- unixtime_to_datetime
- excel_numeri_to_datetime 

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
