### PR TITLE
When try to re-select folder for existing Google Drive Data Frame, it didn't show files under the folder.

### DIFF
--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -60,8 +60,8 @@ getGoogleDriveFolderDetails <- function(teamDriveId = NULL , path = NULL) {
     if (teamDriveId != "" && !is.null(teamDriveId)) {
       teamDriveId = googledrive::as_id(teamDriveId)
     }
-    googledrive::drive_get(team_drive = teamDriveId, id = path)
-    dfdetails <- NULL
+    df <- googledrive::drive_get(team_drive = teamDriveId, id = path)
+    details <- NULL
     if (nrow(df) == 1) {
       dfdetails <- df %>% googledrive::drive_reveal("path")
     }

--- a/R/google_drive.R
+++ b/R/google_drive.R
@@ -61,7 +61,7 @@ getGoogleDriveFolderDetails <- function(teamDriveId = NULL , path = NULL) {
       teamDriveId = googledrive::as_id(teamDriveId)
     }
     df <- googledrive::drive_get(team_drive = teamDriveId, id = path)
-    details <- NULL
+    dfdetails <- NULL
     if (nrow(df) == 1) {
       dfdetails <- df %>% googledrive::drive_reveal("path")
     }


### PR DESCRIPTION
# Description

Fix variable names inside getGoogleDriveFolderDetails.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
