### PR TITLE
For Amazon Athena Data Source, change it to use odbc package instead of RODBC package.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1360,6 +1360,10 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   if(!requireNamespace("odbc")){stop("package RODBC must be installed.")}
   conn <- getAmazonAthenaConnection(driver = driver, region = region, authenticationType = authenticationType, s3OutputLocation = s3OutputLocation, user = user, password = password, additionalParams = additionalParams)
   tryCatch({
+    # For backwawrd compatibility, if 0 is passed as numOfRows, change it to -1.
+    if (numOfRows == 0) {
+      numOfRows = -1;
+    }
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
     query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())

--- a/R/system.R
+++ b/R/system.R
@@ -1361,6 +1361,7 @@ queryAmazonAthena <- function(driver = "", region = "", authenticationType = "IA
   conn <- getAmazonAthenaConnection(driver = driver, region = region, authenticationType = authenticationType, s3OutputLocation = s3OutputLocation, user = user, password = password, additionalParams = additionalParams)
   tryCatch({
     # For backwawrd compatibility, if 0 is passed as numOfRows, change it to -1.
+    # Previously with RODBC package, passing 0 means getting all rows. With odbc package, it needs to be -1 to get all rows.
     if (numOfRows == 0) {
       numOfRows = -1;
     }

--- a/R/system.R
+++ b/R/system.R
@@ -671,7 +671,6 @@ getAmazonAthenaConnection <- function(driver = "", region = "", authenticationTy
     conn <- connection_pool[[connectionString]]
   }
   if (is.null(conn)) {
-    #
     conn <- DBI::dbConnect(
       odbc::odbc(),
       Driver             = driver,


### PR DESCRIPTION
# Description

For Amazon Athena Data Source, change it to use odbc package instead of RODBC package.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
