### PR TITLE
Fix issue that filter_cascade fails with "quo" must be quosure error.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -2780,6 +2780,7 @@ read_raw_lines <- function(file, locale = readr::default_locale(), na = characte
 #
 #'@export
 filter_cascade <- function(.data, ...){
+  # ref: https://github.com/tidyverse/dplyr/blob/5d23cb8d87111ead96a09deb43154610263e7854/R/filter.R#L119
   dots <- dplyr:::dplyr_quosures(...)
   dplyr:::check_filter(dots)
   df <- .data

--- a/R/system.R
+++ b/R/system.R
@@ -2780,7 +2780,8 @@ read_raw_lines <- function(file, locale = readr::default_locale(), na = characte
 #
 #'@export
 filter_cascade <- function(.data, ...){
-  dots <- dplyr:::check_filter(enquos(...))
+  dots <- dplyr:::dplyr_quosures(...)
+  dplyr:::check_filter(dots)
   df <- .data
   for(i in 1:length(dots)) {
     expr <- rlang::quo_get_expr(dots[[i]])


### PR DESCRIPTION
# Description

Fix issue that filter_cascade fails with "quo" must be quosure error.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
