### PR TITLE
Improve NA preprocessing for factor analysis and PCA

### DIFF
--- a/R/factanal.R
+++ b/R/factanal.R
@@ -1,5 +1,5 @@
 
-# Simplified preprocess_regression_data_before_sample for factanal. TODO: Consider using it for PCA and k-means too.
+# Simplified preprocess_regression_data_before_sample for factor analysis (exp_factanal) PCA (do_prcomp). TODO: Consider using it for k-means too.
 preprocess_factanal_data_before_sample <- function(df, predictor_cols) {
   # Remove all-NA-or-Inf columns.
   # NOTE: This has to be done bofore filtering predictor numeric NAs. Otherwise, all the rows could be filtered out.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -1,6 +1,6 @@
 #' Function for Factor Analysis Analytics View
 #' @export
-exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = NULL) {
+exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1) {
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
 

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -22,7 +22,7 @@ preprocess_factanal_data_before_sample <- function(df, predictor_cols) {
     df <- df %>% dplyr::filter(!is.na(!!rlang::sym(col)) & !is.infinite(!!rlang::sym(col)))
   }
   if (nrow(df) == 0) {
-    stop("No row is left after removing NA/Inf from numeric, Date, or POSIXct columns.")
+    stop("No row is left after removing rows with NA/Inf.")
   }
   attr(df, 'predictors') <- cols
   df

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -27,10 +27,8 @@ do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_singl
   }
 
   each_func <- function(df) {
-    filtered_df <- df %>% tidyr::drop_na(!!!rlang::syms(selected_cols)) # TODO: take care of the case where values of a column are mostly NA
-    if (nrow(filtered_df) == 0) { # skip this group if no row is left.
-      return(NULL)
-    }
+    filtered_df <- preprocess_factanal_data_before_sample(df, selected_cols)
+    selected_cols <- attr(filtered_df, 'predictors') # predictors are updated (removed) in preprocess_factanal_data_before_sample. Sync with it.
     # sample the data for quicker turn around on UI,
     # if data size is larger than specified max_nrow.
     sampled_nrow <- NULL

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -1,7 +1,7 @@
 #' do PCA
 #' allow_single_column - Do not throw error and go ahead with PCA even if only one column is left after preprocessing. For K-means.
 #' @export
-do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_single_column = FALSE, seed = NULL) {
+do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_single_column = FALSE, seed = 1) {
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
 

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -22,11 +22,12 @@ test_that("exp_factanal", {
                c("mpg","cyl","disp","hp","drat","wt","qsec","vs","am","gear","carb","new_col","Factor 1","Factor 2"))
 })
 
-test_that("exp_factanal with strange column name", {
+test_that("exp_factanal with strange column name and all-NA column", {
   df <- mtcars %>%
     rename(`Cy l` = cyl) %>%
-    mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
-  model_df <- exp_factanal(df, `Cy l`, mpg, hp)
+    mutate(new_col = c(rep("A", n() - 10), rep("B", 10))) %>%
+    mutate(na_col = NA)
+  model_df <- exp_factanal(df, `Cy l`, mpg, hp, na_col)
   res <- model_df %>% tidy_rowwise(model, type="variances")
   expect_equal(colnames(res),
                c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))


### PR DESCRIPTION
# Description
- To avoid filtering out all rows, remove all-NA or all-Inf columns first, before filtering NA rows.
- Add default seed of 1 to factor analysis and PCA.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
