### PR TITLE
Handle numeric column/row name case in mat_to_df

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -321,11 +321,11 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     colnames(df) <- cnames
   }
 
-  if(is.factor(df[,1])){
+  if (!is.character(df[,1])) { # Can be a factor. Also can be integer if the origin column name was number.
     df[,1] <- as.character(df[,1])
   }
 
-  if(is.factor(df[,2])){
+  if (!is.character(df[,2])) { # Can be a factor. Also can be integer if the origin column name was number.
     df[,2] <- as.character(df[,2])
   }
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -345,6 +345,21 @@ test_that("test mat_to_df", {
   expect_true(!is.unsorted(ret[,1]))
 })
 
+test_that("test mat_to_df with column names with numeric characters only", {
+  nc <- 4
+  nr <- 5
+  mat <- matrix(seq(nc*nr), ncol=nc, nrow=nr)
+
+  # Set numeric-character-only column names for test.
+  colnames(mat) <- as.character(seq(nc))
+  rownames(mat) <- as.character(seq(nr))
+
+  ret <- mat_to_df(mat, c("aa", "bb", "value"))
+  expect_true(is.character(ret[,1]))
+  expect_true(is.character(ret[,2]))
+  expect_true(!is.unsorted(ret[,1]))
+})
+
 test_that("test %nin%", {
   ret <- c(1,3,NA,2) %nin% c(3, NA)
   expect_equal(ret, c(T,F,F,T))


### PR DESCRIPTION
# Description
In mat_to_df, making sure to return character column/row names in the long-style output data frame even when the input matrix has numeric column/row names.

# Checklist
Make sure you have performed following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
