### PR TITLE
Tokenize specified compound word so that user does not need to separate words in it

### DIFF
--- a/tests/testthat/test_textanal.R
+++ b/tests/testthat/test_textanal.R
@@ -9,10 +9,11 @@ test_that("exp_textanal", {
     "Jack fell down and broke his crown",
     "And Jill came tumbling after"))
 
-  # lang_res <- guess_lang_for_stopwords(df$text) #TODO: revive test after cld3 is added to the test docker image.
+  lang_res <- guess_lang_for_stopwords(df$text) #TODO: revive test after cld3 is added to the test docker image.
 
-  model_df <- df %>% exp_textanal(text, stopwords_lang = "english")
+  model_df <- df %>% exp_textanal(text, stopwords_lang = "english", compound_tokens=c("Jack and jill")) # Testing both lower and upper case for compound_token.
   res <- model_df %>% tidy_rowwise(model, type="word_count")
+  expect_true("Jack And Jill" %in% res$word)
   res <- model_df %>% tidy_rowwise(model, type="word_pairs")
 
   # Test for plotting


### PR DESCRIPTION
# Description
Tokenize specified compound word so that user does not need to separate words in it.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
