### PR TITLE
Delete if "Centroid <number>" is within the groups of input data

### DIFF
--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -108,6 +108,14 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
       df <- df %>% dplyr::select(time, value, category)
       # Pivot wider
       df <- df %>% tidyr::pivot_wider(names_from="category", values_from="value")
+
+      if (any(str_detect(colnames(df),"^Centroid [0-9]+$"))) {
+        # In case we want to show more info on this case.
+        # matches <- str_match(colnames(df),"^Centroid [0-9]+$")
+        # first_match <- matches[!is.na(matches)][1]
+        stop("EXP-ANA-4 :: [] :: Please remove or rename groups named \"Centroid <Number>\".")
+      }
+
       # Complete the time column.
       df <- df %>% complete_date("time", time_unit = time_unit)
       # Drop columns (represents category) that has more NAs than max_category_na_ratio, considering them to have not enough data.

--- a/R/ts_cluster.R
+++ b/R/ts_cluster.R
@@ -109,12 +109,9 @@ exp_ts_cluster <- function(df, time, value, category, time_unit = "day", fun.agg
       # Pivot wider
       df <- df %>% tidyr::pivot_wider(names_from="category", values_from="value")
 
-      if (any(str_detect(colnames(df),"^Centroid [0-9]+$"))) {
-        # In case we want to show more info on this case.
-        # matches <- str_match(colnames(df),"^Centroid [0-9]+$")
-        # first_match <- matches[!is.na(matches)][1]
-        stop("EXP-ANA-4 :: [] :: Please remove or rename groups named \"Centroid <Number>\".")
-      }
+      # If there is columns like "Centroid 1" in the input, which would mess up the process from here, silently delete them.
+      # TODO: When we have the ability to show warning without stopping the entire process, show this.
+      df <- df %>% dplyr::select(-matches("^Centroid [0-9]+$"))
 
       # Complete the time column.
       df <- df %>% complete_date("time", time_unit = time_unit)


### PR DESCRIPTION
# Description
Delete if "Centroid <number>" is within the groups of input data, since they would get mixed up with real centroid we are going to calculate.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
