### PR TITLE
Google Analytics: V4 API error handling for getting Accounts API.

### DIFF
--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -22,16 +22,19 @@ getGoogleProfile <- function(tokenFileId = ""){
     df <- df %>% dplyr::left_join(newdf, by = c("accountId" = "accountId", "webPropertyId" = "webPropertyId", "viewId" = "id")) %>% dplyr::select(accountId, accountName, webPropertyId, webPropertyName, viewId, viewName, timezone)
   }
   # get V4 Account
-  v4df <- googleAnalyticsR::ga_account_list("ga4")
-  if (nrow(v4df) > 0) {
-    v4newdf <- purrr::map_dfr(v4df$accountId, function(id){
-      # account looks like accounts/123456 so get rid of accounts/ to get account ID part. As for property, it looks like properties/123345 so remove properties/ to get property id.
-      getGoogleAnalyticsV4Property(id) %>% dplyr::mutate(accountId = stringr::str_replace(parent, "accounts/", ""), webPropertyId = stringr::str_replace(name, "properties/", ""))
-    })
-    v4newdf <- v4newdf %>% dplyr::distinct(accountId, name, .keep_all = T)
-    v4df <- v4df %>% dplyr::left_join(v4newdf, by = c("accountId" = "accountId", "propertyId" = "webPropertyId")) %>% dplyr::select(accountId, account_name, propertyId, property_name, timeZone) %>% dplyr::rename(webPropertyId = propertyId, webPropertyName = property_name, accountName = account_name, timezone = timeZone)
-    df <- df %>% dplyr::bind_rows(v4df)
-  }
+  # googleAnalyticsR::ga_account_list("ga4") throws an error if the google account only has access to V3 accounts so surround it with tryCatch
+  tryCatch({
+    v4df <- googleAnalyticsR::ga_account_list("ga4")
+    if (nrow(v4df) > 0) {
+      v4newdf <- purrr::map_dfr(v4df$accountId, function(id){
+        # account looks like accounts/123456 so get rid of accounts/ to get account ID part. As for property, it looks like properties/123345 so remove properties/ to get property id.
+        getGoogleAnalyticsV4Property(id) %>% dplyr::mutate(accountId = stringr::str_replace(parent, "accounts/", ""), webPropertyId = stringr::str_replace(name, "properties/", ""))
+      })
+      v4newdf <- v4newdf %>% dplyr::distinct(accountId, name, .keep_all = T)
+      v4df <- v4df %>% dplyr::left_join(v4newdf, by = c("accountId" = "accountId", "propertyId" = "webPropertyId")) %>% dplyr::select(accountId, account_name, propertyId, property_name, timeZone) %>% dplyr::rename(webPropertyId = propertyId, webPropertyName = property_name, accountName = account_name, timezone = timeZone)
+      df <- df %>% dplyr::bind_rows(v4df)
+    }
+  })
   df
 }
 #' Helper API to get properites from response.

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -27,7 +27,12 @@ getGoogleProfile <- function(tokenFileId = ""){
     # googleAnalyticsR::ga_account_list("ga4") throws an error if the google account only has access to V3 accounts so surround it with tryCatch
     v4df <- googleAnalyticsR::ga_account_list("ga4")
   }, error = function(err) {
-    # do nothing.
+    # if we detect "API Data failed to parse" message, we can ignore it.
+    if (stringr::str_detect(err$message, 'Error : API Data failed to parse')){
+      # do nothing.
+    } else {
+      stop(err)
+    }
   })
   if (nrow(v4df) > 0) {
     v4newdf <- purrr::map_dfr(v4df$accountId, function(id){


### PR DESCRIPTION
# Description

Added error handling for the case  `googleAnalyticsR::ga_account_list("ga4")` throws an error when the google account only has access to V3 accounts


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
