### PR TITLE
Enable yearly seasonality automatically a little more leniently for aggregated data

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -482,6 +482,33 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       if (nrow(training_data) < 2) {
         stop("The aggregated training data has less than 2 rows.")
       }
+
+      # Since we aggregate input time series data with time unit, duration for 2 years worth of training data
+      # is a little shorter than 2 years, which makes "auto" yearly seasonality of prophet to decide to turn off yearly seasonality.
+      # For this reason, we enable yearly seasonality a little more leniently.
+      if (yearly.seasonality == "auto") {
+        training_days <- as.numeric(difftime(max(training_data$ds), min(training_data$ds), unit="days"))
+        if (time_unit %in% c("quarter")) {
+          if (training_days + 31*3 >= 365*2) {
+            yearly.seasonality <- TRUE
+          }
+        }
+        else if (time_unit %in% c("month")) {
+          if (training_days + 31 >= 365*2) {
+            yearly.seasonality <- TRUE
+          }
+        }
+        else if (time_unit %in% c("week")) {
+          if (training_days + 7 >= 365*2) {
+            yearly.seasonality <- TRUE
+          }
+        }
+        else if (time_unit %in% c("day")) {
+          if (training_days + 1 >= 365*2) {
+            yearly.seasonality <- TRUE
+          }
+        }
+      }
   
       if (!is.null(cap) && is.data.frame(cap)) {
         # in this case, cap is the future data frame with cap, specified by user.

--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -84,6 +84,16 @@ test_that("do_prophet test mode with month as time units", {
   expect_true(!is.na(ret$forecasted_value[[length(ret$forecasted_value)]]))
 })
 
+test_that("do_prophet with 2 year worth of monthly data with auto yearly seasonality", {
+  ts <- seq.Date(as.Date("2010-01-01"), as.Date("2011-12-01"), by="month")
+  raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
+  ret <- raw_data %>%
+    do_prophet(`time stamp`, `da ta`, 10, time_unit = "month", yearly.seasonality="auto")
+  # Verify that yearly seasonality was enabled by "auto" for 2 years worth of monthly data,
+  # even though its duration is a little shorter than 2 years.
+  expect_true(!is.null(ret$yearly))
+})
+
 test_that("do_prophet test mode with quarter as time units", {
   ts <- seq.Date(as.Date("2010-01-01"), as.Date("2030-01-01"), by="quarter")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)


### PR DESCRIPTION
# Description
Enable yearly seasonality automatically a little more leniently for aggregated data.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
