### PR TITLE
ARIMA: Apply na.rm=TRUE on aggregation function when appropriate

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -154,15 +154,17 @@ exp_arima <- function(df, time, valueColumn,
     }
 
     aggregated_data <- if (!is.null(value_col)){
-      # remove rows with NA value_col
-      df <- df[!is.na(df[[value_col]]), ]
-
-      df %>% dplyr::select(ds=time_col, value=value_col, unname(regressors)) %>% # unname is necessary to avoid error when regressors is named vector.
-
+      grouped_df <- df %>% dplyr::select(ds=time_col, value=value_col, unname(regressors)) %>% # unname is necessary to avoid error when regressors is named vector.
         dplyr::arrange(ds) %>%
-        dplyr::filter(!is.na(value)) %>% # remove NA so that we do not pass data with NA, NaN, or 0 to arima
-        dplyr::group_by(ds) %>%
-        dplyr::summarise(y = fun.aggregate(value), !!!summarise_args)
+        dplyr::group_by(ds)
+      if (is_na_rm_func(fun.aggregate)) {
+        grouped_df %>%
+          dplyr::summarise(y = fun.aggregate(value, na.rm=TRUE), !!!summarise_args)
+      }
+      else {
+        grouped_df %>%
+          dplyr::summarise(y = fun.aggregate(value), !!!summarise_args)
+      }
     } else {
       grouped_df <- df %>% dplyr::select(ds=time_col, unname(regressors)) %>% dplyr::arrange(ds) %>% dplyr::group_by(ds)
 

--- a/R/arima.R
+++ b/R/arima.R
@@ -153,7 +153,7 @@ exp_arima <- function(df, time, valueColumn,
       df <- df[, !colnames(df) %in% grouped_col]
     }
 
-    aggregated_data <- if (!is.null(value_col)){
+    aggregated_data <- if (!is.null(value_col)){ # TODO: Make aggregation logic a common function among time series analysis functions.
       grouped_df <- df %>% dplyr::select(ds=time_col, value=value_col, unname(regressors)) %>% # unname is necessary to avoid error when regressors is named vector.
         dplyr::arrange(ds) %>%
         dplyr::group_by(ds)

--- a/tests/testthat/test_arima_1.R
+++ b/tests/testthat/test_arima_1.R
@@ -332,3 +332,13 @@ test_that("exp_arima without value_col", {
   # verify that the last forecasted_value is not NA to test #9211
   expect_true(!is.na(ret$data[[1]]$forecasted_value[[length(ret$data[[1]]$forecasted_value)]]))
 })
+
+test_that("exp_arima with all-NA value col", {
+  data("raw_data", package = "AnomalyDetection")
+  raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
+  data <- raw_data %>% mutate(count=NA) # Make the count column all-NA.
+  ret <- data %>%
+    exp_arima(timestamp, count, 10)
+  # verify that the last forecasted_value is at least not NA.
+  expect_true(!is.na(ret$data[[1]]$forecasted_value[[length(ret$data[[1]]$forecasted_value)]]))
+})


### PR DESCRIPTION
# Description
Apply na.rm=TRUE on aggregation function when appropriate. This allows, for example, sum() to work with all-NA data.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
