### PR TITLE
Add cor.test statistic to correlation (do_cor) output

### DIFF
--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -101,7 +101,7 @@ do_cor.kv_ <- function(df,
   # column names are "{subject}.x", "{subject}.y", "value"
   output_cols <- avoid_conflict(grouped_col,
                                 c(paste0(col, c(".x", ".y")), # We use paste0 since str_c garbles multibyte column names here for some reason.
-                                  "correlation", "p_value"))
+                                  "correlation", "p_value", "statistic"))
 
   do_cor_each <- function(df){
     mat <- simple_cast(

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -70,6 +70,14 @@ test_that("do_cor with zero correlations", {
   expect_equal(nrow(res), 9) # Make sure rows for all 9 combinations are there even though some have 0 correlation values.
 })
 
+test_that("do_cor with Spearman method", {
+  # Steps to produce the output
+  df <- data.frame(x=c(1,1,0,0),y=c(1,0,1,0),z=c(T,T,F,F))
+  model_df <- df %>% do_cor(`x`, `y`, `z`, method = "spearman", distinct = FALSE, diag = TRUE, return_type = "model")
+  res <- model_df %>% tidy_rowwise(model, type='cor')
+  expect_equal(nrow(res), 9) # Make sure rows for all 9 combinations are there even though some have 0 correlation values.
+})
+
 test_that("do_cor with only lower triangle", {
   # Steps to produce the output
   df <- data.frame(x=c(1,1,0,0),y=c(1,0,1,0),z=c(T,T,F,F))

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -224,7 +224,7 @@ test_that("test do_cor.cols for grouped df", {
     test_df
     %>%  dplyr::group_by(group)
     %>%  do_cor.cols(dplyr::starts_with("var")))
-  expect_equal(dim(result), c(4, 5))
+  expect_equal(dim(result), c(4, 6))
 })
 
 test_that("test do_cor.cols for grouped df with model output", {
@@ -239,14 +239,14 @@ test_that("test do_cor.cols for grouped df with model output", {
     %>%  do_cor.cols(dplyr::starts_with("var"), return_type = "model"))
 
   result_cor <- result %>% tidy_rowwise(model)
-  expect_equal(dim(result_cor), c(4, 5))
+  expect_equal(dim(result_cor), c(4, 6))
   result_data <- result %>% tidy_rowwise(model, type = "data")
   expect_equal(colnames(result_data), c("group", "var1", "var2"))
 })
 
 test_that("test do_cor.kv for duplicated pair", {
   result <- tidy_test_df %>%  do_cor.kv(cat, dim, val)
-  expect_equal(ncol(result), 4)
+  expect_equal(ncol(result), 5)
   expect_equal(result[["cat.x"]], c("cat1", "cat2"))
   expect_equal(result[["cat.y"]], c("cat2", "cat1"))
   expect_equal(result[["correlation"]], replicate(2, 1))
@@ -256,7 +256,7 @@ test_that("test do_cor.kv for duplicated pair", {
 test_that("test do_cor.kv with model output", {
   result <- tidy_test_df %>%  do_cor.kv(cat, dim, val, return_type = "model")
   result_cor <- result %>% tidy_rowwise(model, type = "cor")
-  expect_equal(ncol(result_cor), 4)
+  expect_equal(ncol(result_cor), 5)
   expect_equal(result_cor[["cat.x"]], c("cat1", "cat2"))
   expect_equal(result_cor[["cat.y"]], c("cat2", "cat1"))
   expect_equal(result_cor[["correlation"]], replicate(2, 1))
@@ -268,7 +268,7 @@ test_that("test do_cor.kv with model output", {
 test_that("test do_cor.kv with group_by with model output", {
   result <- tidy_group_test_df %>% group_by(grp) %>% do_cor.kv(cat, dim, val, return_type = "model")
   result_cor <- result %>% tidy_rowwise(model, type = "cor")
-  expect_equal(ncol(result_cor), 5)
+  expect_equal(ncol(result_cor), 6)
   expect_equal(result_cor[["grp"]], c("A", "A", "B", "B"))
   expect_equal(result_cor[["cat.x"]], c("cat1", "cat2", "cat1", "cat2"))
   expect_equal(result_cor[["cat.y"]], c("cat2", "cat1", "cat2", "cat1"))


### PR DESCRIPTION
# Description
Add cor.test statistic to correlation (do_cor) output.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
