### PR TITLE
Use stringr::str_sort instead of base sort in do_dist and do_cor for consistency on Windows

### DIFF
--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -344,6 +344,7 @@ do_dist.cols <- function(df,
 
     # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
     # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
+    # We use stringr::str_sort() as opposed to base sort() so that the result is consistent on Windows too.
     sortedNames <- stringr::str_sort(colnames(mat))
     mat <- t(mat)
     mat <- mat[sortedNames, ]

--- a/R/pairwise.R
+++ b/R/pairwise.R
@@ -344,7 +344,7 @@ do_dist.cols <- function(df,
 
     # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
     # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
-    sortedNames <- sort(colnames(mat))
+    sortedNames <- stringr::str_sort(colnames(mat))
     mat <- t(mat)
     mat <- mat[sortedNames, ]
 

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -198,8 +198,9 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
       dplyr::mutate(across(where(is.logical), as.numeric)) %>%
       as.matrix()
     # sort the column name so that the output of pair.name.1 and pair.name.2 will be sorted
-    # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE
-    sorted_colnames <- sort(colnames(mat))
+    # it's better to be sorted so that heatmap in exploratory can be triangle if distinct is TRUE.
+    # We use stringr::str_sort() as opposed to base sort() so that the result is consistent on Windows too.
+    sorted_colnames <- stringr::str_sort(colnames(mat))
     mat <- mat[,sorted_colnames]
 
     ret <- do_cor_internal(mat, use, method, distinct, diag, output_cols, sorted_colnames, na.rm=TRUE)


### PR DESCRIPTION

# Description
Use stringr::str_sort instead of base sort in do_dist and do_cor for consistency on Windows.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
