### PR TITLE
Remove variation selectors and zero-width joiner as well when removing emojis

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -859,6 +859,8 @@ get_emoji_regex <- function() {
   regexp = stringr::str_c(regexp, "|\U0001f6f9|\U0001f9f3|\U0001f9e8|\U0001f9e7|\U0001f94e|\U0001f94f|\U0001f94d|\U0001f9ff|\U0001f9e9|\U0001f9f8|\U0001f9f5|\U0001f9f6|\U0001f9ee", sep = "")
   regexp = stringr::str_c(regexp, "|\U0001f9fe|\U0001f9f0|\U0001f9f2|\U0001f9ea|\U0001f9eb|\U0001f9ec|\U0001f9f4|\U0001f9f7|\U0001f9f9|\U0001f9fa|\U0001f9fb|\U0001f9fc|\U0001f9fd", sep = "")
   regexp = stringr::str_c(regexp, "|\U0001f9ef|\u267e",  sep = "")
+  # Add variation selectors for emoji too. https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)
+  regexp = stringr::str_c(regexp, "|\ufe0e|\ufe0f",  sep = "")
   regexp
 }
 

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -860,19 +860,17 @@ get_emoji_regex <- function() {
   regexp = stringr::str_c(regexp, "|\U0001f9fe|\U0001f9f0|\U0001f9f2|\U0001f9ea|\U0001f9eb|\U0001f9ec|\U0001f9f4|\U0001f9f7|\U0001f9f9|\U0001f9fa|\U0001f9fb|\U0001f9fc|\U0001f9fd", sep = "")
   regexp = stringr::str_c(regexp, "|\U0001f9ef|\u267e",  sep = "")
   # Add variation selectors for emoji too. https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)
-  regexp = stringr::str_c(regexp, "|\ufe0e|\ufe0f",  sep = "")
+  regexp = stringr::str_c("\u200d?(", regexp, ")(\ufe0e|\ufe0f)?",  sep = "")
   regexp
 }
 
 #'Function to remove emoji from a list of characters.
 str_remove_emoji <- function(column, position = "any"){
   regexp <- get_emoji_regex()
-  if(position == "any") {
-    regexp = stringr::str_c("(", regexp, ")", sep = "")
-  } else if(position == "start") {
-    regexp = stringr::str_c("^(", regexp, ")", sep = "")
+  if (position == "start") {
+    regexp = stringr::str_c("^(", regexp, ")+", sep = "")
   } else if (position == "end") {
-    regexp = stringr::str_c("(", regexp, ")$", sep = "")
+    regexp = stringr::str_c("(", regexp, ")+$", sep = "")
   }
   stringi::stri_replace_all(column, regex = regexp, "")
 }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -859,7 +859,8 @@ get_emoji_regex <- function() {
   regexp = stringr::str_c(regexp, "|\U0001f6f9|\U0001f9f3|\U0001f9e8|\U0001f9e7|\U0001f94e|\U0001f94f|\U0001f94d|\U0001f9ff|\U0001f9e9|\U0001f9f8|\U0001f9f5|\U0001f9f6|\U0001f9ee", sep = "")
   regexp = stringr::str_c(regexp, "|\U0001f9fe|\U0001f9f0|\U0001f9f2|\U0001f9ea|\U0001f9eb|\U0001f9ec|\U0001f9f4|\U0001f9f7|\U0001f9f9|\U0001f9fa|\U0001f9fb|\U0001f9fc|\U0001f9fd", sep = "")
   regexp = stringr::str_c(regexp, "|\U0001f9ef|\u267e",  sep = "")
-  # Add variation selectors for emoji too. https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)
+  # Handle zero-width joiner (\u200d) prefixing another emoji. https://en.wikipedia.org/wiki/Zero-width_joiner
+  # Also handle variation selector (\ufe0e, \ufe0f) suffixing emoji. https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)
   regexp = stringr::str_c("\u200d?(", regexp, ")(\ufe0e|\ufe0f)?",  sep = "")
   regexp
 }

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -652,10 +652,13 @@ test_that("str_replace_inside", {
 })
 
 test_that("str_remove_emoji", {
-  # Smile Face, Thumbs Up, and exclamation mark with variation selector (\ufe0f).
-  text = c("Hello\uD83D\uDE00", "Hello\uD83D\uDC4D", "Hello\u2757\ufe0f")
+  text = c("Hello\uD83D\uDE00", # Smile Face
+           "Hello\uD83D\uDC4D", # Thumbs Up
+           "Hello\u2757\ufe0f", # exclamation mark with variation selector (\ufe0f).
+           "Hello\ud83c\udf99\ufe0f", # 2-character emoji (studio microphone) with variation selector
+           "Hello\U0001f481\u200d\u2640\ufe0f") # Female greeting
   ret <- exploratory::str_remove_emoji(text)
-  expect_equal(ret, c("Hello", "Hello", "Hello"))
+  expect_equal(ret, c("Hello", "Hello", "Hello", "Hello", "Hello"))
 })
 
 test_that("str_remove_word", {

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -652,10 +652,10 @@ test_that("str_replace_inside", {
 })
 
 test_that("str_remove_emoji", {
-  # Smile Face and Thumbs Up.
-  text = c("\uD83D\uDE00", "\uD83D\uDC4D")
+  # Smile Face, Thumbs Up, and exclamation mark with variation selector (\ufe0f).
+  text = c("Hello\uD83D\uDE00", "Hello\uD83D\uDC4D", "Hello\u2757\ufe0f")
   ret <- exploratory::str_remove_emoji(text)
-  expect_equal(ret, c("",""))
+  expect_equal(ret, c("Hello", "Hello", "Hello"))
 })
 
 test_that("str_remove_word", {


### PR DESCRIPTION
# Description
Remove variation selectors and zero-width joiner as well when removing emojis

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
