### PR TITLE
Check if the class has augment method or not in add_prediction

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -238,7 +238,7 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
     # because ... can't be passed to a function inside mutate directly.
     model_class_name <- class(model_df$model[[1]])[1]
     if (!exists(paste0('augment.', model_class_name))) {
-      stop("The model is not of a type that can make predictions.")
+      stop("This is not a prediction model.")
     }
     aug_fml <- if(aug_args == ""){
       "broom::augment(m, newdata = df)"

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -238,7 +238,7 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
     # because ... can't be passed to a function inside mutate directly.
     model_class_name <- class(model_df$model[[1]])[1]
     if (!exists(paste0('augment.', model_class_name))) {
-      stop("This is not a prediction model.")
+      stop("EXP-ANA-4 :: [] :: This is not a prediction model.")
     }
     aug_fml <- if(aug_args == ""){
       "broom::augment(m, newdata = df)"

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -236,6 +236,10 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
   get_result <- function(model_df, df, aug_args, with_response){
     # Use formula to support expanded aug_args (especially for type.predict for logistic regression)
     # because ... can't be passed to a function inside mutate directly.
+    model_class_name <- class(model_df$model[[1]])[1]
+    if (!exists(paste0('augment.', model_class_name))) {
+      stop("The model is not of a type that can make predictions.")
+    }
     aug_fml <- if(aug_args == ""){
       "broom::augment(m, newdata = df)"
     } else {

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -70,6 +70,13 @@ test_that("do_cor with zero correlations", {
   expect_equal(nrow(res), 9) # Make sure rows for all 9 combinations are there even though some have 0 correlation values.
 })
 
+test_that("add_prediction with do_cor should throw error", {
+  # Steps to produce the output
+  df <- data.frame(x=c(1,1,0,0),y=c(1,0,1,0),z=c(T,T,F,F))
+  model_df <- df %>% do_cor(`x`, `y`, `z`, method = "pearson", distinct = FALSE, diag = TRUE, return_type = "model")
+  expect_error({ret <- df %>% add_prediction(model_df=model_df)}, "EXP\\-ANA\\-4 :: \\[\\] :: This is not a prediction model.")
+})
+
 test_that("do_cor with Spearman method", {
   # Steps to produce the output
   df <- data.frame(x=c(1,1,0,0),y=c(1,0,1,0),z=c(T,T,F,F))


### PR DESCRIPTION
# Description
Check if the class has augment method or not in add_prediction.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
