### PR TITLE
fix str_remove_word fails when a word contains special characters.

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -837,26 +837,26 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
     if(end == 1) { # It means the first word.
       if (rep == "") { # for remove case
         x[1] = rep # replace first word with the replace text.
-        if (len > 1) { # trim the white space of the second element's left side
+        if (len > 1) { # trim the white space of the second word's left side
           x[2] = stringr::str_trim(x[2], side = "left")
         }
-        # join back the string using the normalized separator.
+        # join back the words using the normalized separator.
         stringr::str_c(x[-1], collapse = sep_)
       } else {
-        x[1] = rep
+        x[1] = rep # replace the first word with the replace text.
         stringr::str_c(x, collapse = sep_)
       }
     } else if (end == -1){ # It means the last word.
       if (rep == "") { # for Remove Case
-        if (len > 1) {# trim the white space of the second element from the end
+        if (len > 1) {# Trim the white space of the second word from the end.
           x[len - 1] = stringr::str_trim(x[len - 1], side = "right")
         }
-        # drop the last element from list then collapse with the separator.
+        # drop the last word from list then collapse with the separator.
         stringr::str_c(x[-1 * len], collapse = sep_)
       } else {
-        # replace the last element with the replace string.
+        # replace the last word with the replace string.
         x[len] = rep
-        # join back the string using the normalized separator.
+        # join back the words using the normalized separator.
         stringr::str_c(x, collapse = sep_)
       }
     } else {

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -855,7 +855,11 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
         stringr::str_c(x[-1 * len], collapse = sep_)
       } else {
         # replace the last word with the replace string.
-        x[len] = rep
+        if (sep_ == ",") { # if the separator is "," add " " as a prefix it to make it look better.
+          x[len] = stringr::str_c(" ", rep)
+        } else {
+          x[len] = rep
+        }
         # join back the words using the normalized separator.
         stringr::str_c(x, collapse = sep_)
       }

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -836,14 +836,14 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
     len <- length(x) # get number of words
     if (end == 1) { # It means the first word.
       if (rep == "") { # for remove case
-        x[1] = rep # replace first word with the replace text.
         if (len > 1) { # trim the white space of the second word's left side
           x[2] = stringr::str_trim(x[2], side = "left")
         }
-        # join back the words using the normalized separator.
+        # remove the first word and join back the words using the normalized separator.
         stringr::str_c(x[-1], collapse = sep_)
       } else {
         x[1] = rep # replace the first word with the replace text.
+        # join back the words using the normalized separator.
         stringr::str_c(x, collapse = sep_)
       }
     } else if (end == -1) { # It means the last word.
@@ -851,7 +851,7 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
         if (len > 1) {# Trim the white space of the second word from the end.
           x[len - 1] = stringr::str_trim(x[len - 1], side = "right")
         }
-        # drop the last word from list then collapse with the separator.
+        # remove the last word from list then collapse with the separator.
         stringr::str_c(x[-1 * len], collapse = sep_)
       } else {
         # replace the last word with the replace string.

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -834,7 +834,7 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
   ret <- stringr::str_split(string, pattern = sep_)
   sapply(ret, function(x){
     len <- length(x) # get number of words
-    if(end == 1) { # It means the first word.
+    if (end == 1) { # It means the first word.
       if (rep == "") { # for remove case
         x[1] = rep # replace first word with the replace text.
         if (len > 1) { # trim the white space of the second word's left side
@@ -846,7 +846,7 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
         x[1] = rep # replace the first word with the replace text.
         stringr::str_c(x, collapse = sep_)
       }
-    } else if (end == -1){ # It means the last word.
+    } else if (end == -1) { # It means the last word.
       if (rep == "") { # for Remove Case
         if (len > 1) {# Trim the white space of the second word from the end.
           x[len - 1] = stringr::str_trim(x[len - 1], side = "right")

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -288,8 +288,8 @@ do_tokenize_icu <- function(df, text_col, token = "word", keep_cols = FALSE,
 #' @param stopwords_lang Language for the stopwords that need to be excluded from the result.
 #' @param remove_punct Whether it should remove punctuations.
 #' @param remove_numbers Whether it should remove numbers.
-#' @param remove_url Whether it should remove URLs. 
-#' @param remove_twitter Whether it should remove Twitter social tags. 
+#' @param remove_url Whether it should remove URLs.
+#' @param remove_twitter Whether it should remove Twitter social tags.
 #' @param stopwords Additional stopwords.
 #' @param stopwords_to_remove Words to be removed from the set of stopwords.
 #' @param hiragana_word_length_to_remove Length of a Hiragana word that needs to be excluded from the result.
@@ -323,7 +323,7 @@ do_tokenize <- function(df, text, token = "words", keep_cols = FALSE,
     sentences_list <- tokenizers::tokenize_sentences(text_v)
     # Create a data.frame, where one row represents one sentence. document_id is the document the sentence belongs (row number in the original df.)
     # .sentence is the text of the sentence.
-    # To avoid expensive unnest_longer call, we use base R functions like unlist() instead here. 
+    # To avoid expensive unnest_longer call, we use base R functions like unlist() instead here.
     # as.integer() is there to convert the matrix unlist() returns there into an integer vector.
     # unname() is there to unname the named vector unlist returns.
     res <- tibble::tibble(document_id = as.integer(unlist(mapply(function(tokens,index) {rep(index,length(tokens))},
@@ -836,13 +836,15 @@ str_replace_word <- function(string, start = 1L, end = start, sep = fixed(" "), 
     if(rep != "") {
       rep <- stringr::str_c(rep, sep_, sep="")
     }
-    stringr::str_replace(string, stringr::str_c("^", ret, sep, ""), rep)
+    # Placing characters between \\Q and \\E makes the regular expression engine treat them literally rather than as regular expressions.
+    stringr::str_replace(string, stringr::str_c("^", "\\Q", ret, "\\E", sep, ""), rep)
   } else if (end == -1){
     ret <- stringr::word(string, start = start, end = end, sep = sep)
     if(rep != "") {
       rep <- stringr::str_c(sep_, rep, sep="")
     }
-    stringr::str_replace(string, stringr::str_c(sep, ret, "$"), rep)
+    # Placing characters between \\Q and \\E makes the regular expression engine treat them literally rather than as regular expressions.
+    stringr::str_replace(string, stringr::str_c(sep, "\\Q", ret, "\\E$"), rep)
   } else {
     ## TODO: Implement other cases
     string

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -666,6 +666,9 @@ test_that("str_remove_word", {
   expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners"))
   ret <- exploratory::str_remove_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*")
   expect_equal(ret, c("Qiming Venture Partners, Tencent Holdings"))
+  ret <- exploratory::str_remove_word("Sequoia Capital (China Space), Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*")
+  expect_equal(ret, c("Qiming Venture Partners, Tencent Holdings"))
+
 })
 
 test_that("str_replace_word", {

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -673,7 +673,7 @@ test_that("str_remove_word", {
 
 test_that("str_replace_word", {
   ret <- exploratory::str_replace_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", -1, sep = "\\s*\\,\\s*", rep = "Last One")
-  expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners,Last One"))
+  expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners, Last One"))
   ret <- exploratory::str_replace_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*", rep = "First One")
   expect_equal(ret, c("First One, Qiming Venture Partners, Tencent Holdings"))
 })

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -666,14 +666,14 @@ test_that("str_remove_word", {
   expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners"))
   ret <- exploratory::str_remove_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*")
   expect_equal(ret, c("Qiming Venture Partners, Tencent Holdings"))
-  ret <- exploratory::str_remove_word("Sequoia Capital (China Space), Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*")
-  expect_equal(ret, c("Qiming Venture Partners, Tencent Holdings"))
+  ret <- exploratory::str_remove_word("Sequoia Capital, Qiming Venture Partners, Tencent Holdings (China Space)", -1, sep = "\\s+")
+  expect_equal(ret, c("Sequoia Capital, Qiming Venture Partners, Tencent Holdings (China"))
 
 })
 
 test_that("str_replace_word", {
   ret <- exploratory::str_replace_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", -1, sep = "\\s*\\,\\s*", rep = "Last One")
-  expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners, Last One"))
+  expect_equal(ret, c("Sequoia Capital China, Qiming Venture Partners,Last One"))
   ret <- exploratory::str_replace_word("Sequoia Capital China, Qiming Venture Partners, Tencent Holdings", 1, sep = "\\s*\\,\\s*", rep = "First One")
   expect_equal(ret, c("First One, Qiming Venture Partners, Tencent Holdings"))
 })


### PR DESCRIPTION
# Description

str_remove_word fails if the text is something like `"Great White Multi-Use Recycled Paper (20Lb. and 84 Bright)` and word is created with space as a separator.

This is because it ended up doing below incorrect reg exp operation.

```r
stringr::str_replace("Great White Multi-Use Recycled Paper (20Lb. and 84 Bright)", stringr::str_c(" ", "Bright)", "$"), "")
```

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
