### PR TITLE
Set random seed before random sampling for Text Analysis Analytics View

### DIFF
--- a/R/textanal.R
+++ b/R/textanal.R
@@ -142,12 +142,16 @@ exp_textanal <- function(df, text,
                          cooccurrence_window = 1, # 5 is the quanteda's default, but narrowing it for speed of default run. 
                          cooccurrence_network_num_words = 50,
                          max_nrow = 5000,
+                         seed = 1,
                          ...) {
   text_col <- tidyselect::vars_pull(names(df), !! rlang::enquo(text))
   each_func <- function(df) {
     # Filter out NAs before sampling. We keep empty string, since we will anyway have to work with the case where no token was found in a doc.
     df <- df %>% dplyr::filter(!is.na(!!rlang::sym(text_col)))
 
+    if (!is.null(seed)) {
+      set.seed(seed)
+    }
     # sample the data for performance if data size is too large.
     sampled_nrow <- NULL
     if (!is.null(max_nrow) && nrow(df) > max_nrow) {


### PR DESCRIPTION
# Description
Set random seed before random sampling for Text Analysis Analytics View.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
