### PR TITLE
clean_data_frame should remove row names.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -2266,6 +2266,8 @@ clean_data_frame <- function(x) {
   # Remove tab, new line, carriage return, and backslash from column names
   clean_names <- original_names  %>% gsub("[\r\n\t\\]", "", .)
   names(df) <- clean_names
+  # Remove row names.
+  row.names(df) <- NULL
   df
 }
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -16,13 +16,15 @@ test_that("test clean_data_frame",{
   expect_equal(colnames(result2), c("country  year"))
 
   # Make sure clean_data_frame drops row names.
-  # mtcars has row names.
+  # Use mtcars for the test because it has row names.
   df3a <- mtcars
-  df3b <- mtcars
   df3a <- clean_data_frame(df3a)
+  df3b <- mtcars
   row.names(df3b) <- NULL
+  # Compare the row names between data frames. 
+  # One data frame is processed by clean_data_frame.
+  # The other one is processed manually.
   expect_equal(row.names(df3a), row.names(df3b))
-
 })
 
 test_that("test parse_html_tables",{

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -14,6 +14,15 @@ test_that("test clean_data_frame",{
   colnames(df2)<-c("country \\ year")
   result2 <- clean_data_frame(df2)
   expect_equal(colnames(result2), c("country  year"))
+
+  # Make sure clean_data_frame drops row names.
+  # mtcars has row names.
+  df3a <- mtcars
+  df3b <- mtcars
+  df3a <- clean_data_frame(df3a)
+  row.names(df3b) <- NULL
+  expect_equal(row.names(df3a), row.names(df3b))
+
 })
 
 test_that("test parse_html_tables",{


### PR DESCRIPTION
# Description

Now `clean_data_frame` removes row names from the given data frame.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
