### PR TITLE
Analytics: Topic Model: Tag words with topic in order of appearance for less mistaken match and performance

### DIFF
--- a/R/textanal.R
+++ b/R/textanal.R
@@ -689,7 +689,8 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
   }
   else if (type == "doc_topics_tagged") {
     words_to_tag_df <- x$doc_word_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
-    #words_to_tag_df <- words_to_tag_df %>% dplyr::group_by(document) %>% dplyr::slice_max(topic_max, prop=0.3) %>% dplyr::ungroup() # Filter per document.
+    # Filter per document at 70 percentile. Use filter rather than slice_max to preserve the row order.
+    words_to_tag_df <- words_to_tag_df %>% dplyr::group_by(document) %>% dplyr::filter(topic_max >= quantile(topic_max, probs=0.7)) %>% dplyr::ungroup()
     tag_df <- words_to_tag_df %>% dplyr::nest_by(document) %>% dplyr::ungroup()
     res <- x$doc_df %>% dplyr::rename(text=!!x$text_col) %>% dplyr::mutate(doc_id=row_number()) %>% left_join(tag_df, by=c("doc_id"="document"))
     res <- res %>% dplyr::mutate(tagged_text=purrr::flatten_chr(purrr::map2(text, data, function(txt,dat) {
@@ -706,7 +707,8 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
             pre_regex <- '^(.*?)(\\Q'
             post_regex <- '\\E)(.*)$'
           }
-          matches <- stringr::str_match(txt_remaining, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE))
+          # dotall = TRUE is necessary to process entire multiline text.
+          matches <- stringr::str_match(txt_remaining, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE, dotall = TRUE))
           if (!is.na(matches[1])) {
             res_str <- stringr::str_c(res_str, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
             txt_remaining <- matches[4]

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -695,7 +695,7 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
     res <- x$doc_df %>% dplyr::rename(text=!!x$text_col) %>% dplyr::mutate(doc_id=row_number()) %>% left_join(tag_df, by=c("doc_id"="document"))
     res <- res %>% dplyr::mutate(tagged_text=purrr::flatten_chr(purrr::map2(text, data, function(txt,dat) {
       if (!is.null(dat)) {
-        res_str <- ''
+        txt_out <- ''
         txt_remaining <- txt
         for (i in 1:nrow(dat)) {
           if (stringr::str_detect(dat$word[i], '[a-zA-Z]')) { # For alphabet word, char before/after should not be alphabet, to avoid matches within other words.
@@ -710,12 +710,12 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
           # dotall = TRUE is necessary to process entire multiline text.
           matches <- stringr::str_match(txt_remaining, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE, dotall = TRUE))
           if (!is.na(matches[1])) {
-            res_str <- stringr::str_c(res_str, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
+            txt_out <- stringr::str_c(txt_out, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
             txt_remaining <- matches[4]
           }
         }
-        res_str <- stringr::str_c(res_str, txt_remaining)
-        res_str
+        txt_out <- stringr::str_c(txt_out, txt_remaining)
+        txt_out
       }
       else {
         txt

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -690,11 +690,14 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
   else if (type == "doc_topics_tagged") {
     words_to_tag_df <- x$doc_word_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
     # Filter per document at 70 percentile. Use filter rather than slice_max to preserve the row order.
-    words_to_tag_df <- words_to_tag_df %>% dplyr::group_by(document) %>% dplyr::filter(topic_max >= quantile(topic_max, probs=0.7)) %>% dplyr::ungroup()
+    # na.rm seems to be necessary to avoid error. Not very sure of the condition for it to become NA at this point though.
+    words_to_tag_df <- words_to_tag_df %>% dplyr::group_by(document) %>% dplyr::filter(topic_max >= quantile(topic_max, probs=0.7, na.rm=TRUE)) %>% dplyr::ungroup()
     tag_df <- words_to_tag_df %>% dplyr::nest_by(document) %>% dplyr::ungroup()
     res <- x$doc_df %>% dplyr::rename(text=!!x$text_col) %>% dplyr::mutate(doc_id=row_number()) %>% left_join(tag_df, by=c("doc_id"="document"))
     res <- res %>% dplyr::mutate(tagged_text=purrr::flatten_chr(purrr::map2(text, data, function(txt,dat) {
       if (!is.null(dat)) {
+        # dat is a data frame of words to surround with tags. The words in dat are in the order of appearance in the text.
+        # We will find and tag them one by one from the beginning of the text to the end of the text.
         txt_out <- ''
         txt_remaining <- txt
         for (i in 1:nrow(dat)) {
@@ -704,12 +707,12 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
             post_regex <- '\\E)([^a-zA-Z].*)$'
           }
           else {
-            pre_regex <- '^(.*?)(\\Q'
+            pre_regex <- '^(.*?)(\\Q' # .*? is for the shortest match, since we want to match with the first appearance of the word.
             post_regex <- '\\E)(.*)$'
           }
           # dotall = TRUE is necessary to process entire multiline text.
           matches <- stringr::str_match(txt_remaining, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE, dotall = TRUE))
-          if (!is.na(matches[1])) {
+          if (!is.na(matches[1])) { # There always should be a match, but if there is no match, we just move on to the next word without proceeding on the text.
             txt_out <- stringr::str_c(txt_out, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
             txt_remaining <- matches[4]
           }

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -688,8 +688,7 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
     res <- x$doc_df
   }
   else if (type == "doc_topics_tagged") {
-    words_to_tag_df <- x$doc_word_df %>% dplyr::distinct(document, word, .keep_all = TRUE)
-    words_to_tag_df <- words_to_tag_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
+    words_to_tag_df <- x$doc_word_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
     words_to_tag_df <- words_to_tag_df %>% dplyr::group_by(document) %>% dplyr::slice_max(topic_max, prop=0.3) %>% dplyr::ungroup() # Filter per document.
     tag_df <- words_to_tag_df %>% dplyr::nest_by(document) %>% dplyr::ungroup()
     res <- x$doc_df %>% dplyr::rename(text=!!x$text_col) %>% dplyr::mutate(doc_id=row_number()) %>% left_join(tag_df, by=c("doc_id"="document"))

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -707,8 +707,10 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
             post_regex <- '\\E)(.*)$'
           }
           matches <- stringr::str_match(txt_remaining, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE))
-          res_str <- stringr::str_c(res_str, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
-          txt_remaining <- matches[4]
+          if (!is.na(matches[1])) {
+            res_str <- stringr::str_c(res_str, matches[2], '<span topic="', dat$max_topic[i], '">', matches[3], '</span>')
+            txt_remaining <- matches[4]
+          }
         }
         res_str <- stringr::str_c(res_str, txt_remaining)
         res_str

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -698,12 +698,12 @@ tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words
         for (i in 1:nrow(dat)) {
           if (stringr::str_detect(dat$word[i], '[a-zA-Z]')) { # For alphabet word, char before/after should not be alphabet, to avoid matches within other words.
             # \\Q, \\E are to match literally even if regex special characters like . or - are in the word.
-            pre_regex <- '(?<![a-zA-Z])\\Q'
-            post_regex <- '\\E(?![a-zA-Z])'
+            pre_regex <- '^(.*?[^a-zA-Z])(\\Q'
+            post_regex <- '\\E)([^a-zA-Z].*)$'
           }
           else {
-            pre_regex <- '\\Q'
-            post_regex <- '\\E'
+            pre_regex <- '^(.*?)\\Q'
+            post_regex <- '\\E(.*)$'
           }
           orig_strs_ <- stringr::str_extract_all(txt, stringr::regex(stringr::str_c(pre_regex, dat$word[i], post_regex), ignore_case = TRUE))
           orig_strs[[i]] <- orig_strs_[[1]]


### PR DESCRIPTION
# Description
Tag words with topic in order of appearance for less mistaken match and performance.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
