### PR TITLE
Rename factor IDs so that they are in the order of importance

### DIFF
--- a/R/factanal.R
+++ b/R/factanal.R
@@ -150,7 +150,8 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)
   }
   else if (type == "variances") {
-    res <- tibble::as_tibble(t(x$Vaccounted)) %>% dplyr::mutate(Factor=as.factor(1:n()), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
+    res <- tibble::as_tibble(t(x$Vaccounted)) %>%
+      dplyr::mutate(Factor=forcats::fct_inorder(stringr::str_replace(colnames(x$Vaccounted),paste0("^", factor_score_prefix), "")), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
   }
   else if (type == "loadings") {
     res <- broom:::tidy.factanal(x) # TODO: This just happens to work. Revisit.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -109,7 +109,8 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
 glance.fa_exploratory <- function(x, pretty.name = FALSE, ...) {
   # glance.factanal works on psych::fa due to compatibility kept to some degree. TODO: Extract and output more info from psych::fa
   res <- broom:::glance.factanal(x) %>% dplyr::select(-n, -converged, -method) # But converged is NULL.
-  res <- res %>% dplyr::rename(`Number of Factors`=n.factors, `Total Variance`=total.variance, `Chi-Square`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Number of Rows`=nobs)
+  res <- res %>% dplyr::mutate(variance=total.variance*length(x$communality), pct_variance=100*total.variance)
+  res <- res %>% dplyr::select(`Number of Factors`=n.factors, `% Variance`=pct_variance, Variance=variance, `Chi-Square`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Number of Rows`=nobs)
   res
 }
 

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -177,7 +177,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     scores_df <- broom:::augment.factanal(x)
     scores_df <- scores_df %>% select(-.rownames) # augment.factanal seems to always return row names in .rownames column.
     # Rename the IDs of the factors so that IDs correspond with the order of importance, which is the order in the augment.factanal output.
-    colnames(scores_df) <- stringr::str_c(factor_loading_prefix, 1:n_factor)
+    colnames(scores_df) <- stringr::str_c(factor_score_prefix, 1:n_factor)
     loadings_df <- broom:::tidy.factanal(x)
     # Rename the IDs of the factors so that IDs correspond with the order of importance, which is the order in the tidy.factanal output.
     colnames(loadings_df) <-c("variable", "uniqueness", stringr::str_c(factor_loading_prefix, 1:n_factor))
@@ -237,7 +237,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     scores_df <- broom:::augment.factanal(x) # This happens to work. Revisit.
     scores_df <- scores_df %>% select(-.rownames) # augment.factanal seems to always return row names in .rownames column.
     # Rename the IDs of the factors so that IDs correspond with the order of importance, which is the order in the augment.factanal output.
-    colnames(scores_df) <-stringr::str_c(factor_loading_prefix, 1:n_factor)
+    colnames(scores_df) <-stringr::str_c(factor_score_prefix, 1:n_factor)
     scores_df <- scores_df %>% rename_with(function(x){stringr::str_replace(x,paste0("^", factor_score_prefix), "Factor ")}, starts_with(factor_score_prefix)) #TODO: Make string match condition stricter.
 
     # table of observations. bind original data so that color can be used later.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -110,7 +110,7 @@ glance.fa_exploratory <- function(x, pretty.name = FALSE, ...) {
   # glance.factanal works on psych::fa due to compatibility kept to some degree. TODO: Extract and output more info from psych::fa
   res <- broom:::glance.factanal(x) %>% dplyr::select(-n, -converged, -method) # But converged is NULL.
   res <- res %>% dplyr::mutate(variance=total.variance*length(x$communality), pct_variance=100*total.variance)
-  res <- res %>% dplyr::select(`Number of Factors`=n.factors, `% Variance`=pct_variance, Variance=variance, `Chi-Square`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Number of Rows`=nobs)
+  res <- res %>% dplyr::select(`Number of Factors`=n.factors, `Explained Variance (%)`=pct_variance, `Explained Variance`=variance, `Chi-Square`=statistic, `P Value`=p.value, `Degree of Freedom`=df, `Number of Rows`=nobs)
   res
 }
 

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -172,7 +172,6 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- res %>% dplyr::mutate(factor = forcats::fct_inorder(factor)) # fct_inorder is to make order on chart right, e.g. Factor 2 before Factor 10
   }
   else if (type == "biplot") {
-    browser()
     factor_1_loading_col <- paste0(factor_loading_prefix, "1")
     factor_2_loading_col <- paste0(factor_loading_prefix, "2")
     factor_1_score_col <- paste0(factor_score_prefix, "1")
@@ -232,12 +231,12 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- res %>% dplyr::bind_rows(loadings_df)
     # fill group_by column so that Repeat By on chart works fine. loadings_df does not have values for the group_by column.
     res <- res %>% tidyr::fill(x$grouped_cols)
-    browser()
     res
   }
   else { # should be data
     scores_df <- broom:::augment.factanal(x) # This happens to work. Revisit.
     scores_df <- scores_df %>% select(-.rownames) # augment.factanal seems to always return row names in .rownames column.
+    colnames(scores_df) <-stringr::str_c(factor_loading_prefix, 1:n_factor)
     scores_df <- scores_df %>% rename_with(function(x){stringr::str_replace(x,paste0("^", factor_score_prefix), "Factor ")}, starts_with(factor_score_prefix)) #TODO: Make string match condition stricter.
 
     # table of observations. bind original data so that color can be used later.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -172,13 +172,16 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- res %>% dplyr::mutate(factor = forcats::fct_inorder(factor)) # fct_inorder is to make order on chart right, e.g. Factor 2 before Factor 10
   }
   else if (type == "biplot") {
+    browser()
     factor_1_loading_col <- paste0(factor_loading_prefix, "1")
     factor_2_loading_col <- paste0(factor_loading_prefix, "2")
     factor_1_score_col <- paste0(factor_score_prefix, "1")
     factor_2_score_col <- paste0(factor_score_prefix, "2")
     scores_df <- broom:::augment.factanal(x)
     scores_df <- scores_df %>% select(-.rownames) # augment.factanal seems to always return row names in .rownames column.
+    colnames(scores_df) <-stringr::str_c(factor_loading_prefix, 1:n_factor)
     loadings_df <- broom:::tidy.factanal(x)
+    colnames(loadings_df) <-c("variable", "uniqueness", stringr::str_c(factor_loading_prefix, 1:n_factor))
 
     if (is.null(n_sample)) { # set default of 5000 for biplot case.
       n_sample = 5000
@@ -229,6 +232,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- res %>% dplyr::bind_rows(loadings_df)
     # fill group_by column so that Repeat By on chart works fine. loadings_df does not have values for the group_by column.
     res <- res %>% tidyr::fill(x$grouped_cols)
+    browser()
     res
   }
   else { # should be data

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -149,8 +149,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)
   }
   else if (type == "variances") {
-    res <- tibble::as_tibble(t(x$Vaccounted)) %>%
-      dplyr::mutate(Factor=forcats::fct_inorder(stringr::str_replace(colnames(x$Vaccounted),paste0("^", factor_score_prefix), "")), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
+    res <- tibble::as_tibble(t(x$Vaccounted)) %>% dplyr::mutate(Factor=as.factor(1:n()), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
   }
   else if (type == "loadings") {
     res <- broom:::tidy.factanal(x) # TODO: This just happens to work. Revisit.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -93,7 +93,6 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
         return(NULL)
       }
     }
-    # "scale." is an argument name. There is no such operator like ".=". 
     fit <- psych::fa(cleaned_df, nfactors = nfactors, fm = fm, scores = scores, rotate = rotate)
     fit$correlation <- cor(cleaned_df) # For creating scree plot later.
     fit$df <- filtered_df # add filtered df to model so that we can bind_col it for output. It needs to be the filtered one to match row number.

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -8,7 +8,7 @@ test_that("exp_factanal", {
   check_output <- function(model_df) {
     res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(colnames(res),
-                 c("Number of Factors", "% Variance", "Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
+                 c("Number of Factors", "Explained Variance (%)", "Explained Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
     res <- model_df %>% tidy_rowwise(model, type="variances")
     expect_equal(colnames(res),
                  c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))
@@ -55,7 +55,7 @@ test_that("exp_factanal with strange column name and all-NA column", {
   model_df <- exp_factanal(df, `Cy l`, mpg, hp, na_col)
   res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
   expect_equal(colnames(res),
-               c("Number of Factors", "% Variance", "Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
+               c("Number of Factors", "Explained Variance (%)", "Explained Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
   res <- model_df %>% tidy_rowwise(model, type="variances")
   expect_equal(colnames(res),
                c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -8,7 +8,7 @@ test_that("exp_factanal", {
   check_output <- function(model_df) {
     res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(colnames(res),
-                 c("Number of Factors", "Total Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
+                 c("Number of Factors", "% Variance", "Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
     res <- model_df %>% tidy_rowwise(model, type="variances")
     expect_equal(colnames(res),
                  c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))
@@ -55,7 +55,7 @@ test_that("exp_factanal with strange column name and all-NA column", {
   model_df <- exp_factanal(df, `Cy l`, mpg, hp, na_col)
   res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
   expect_equal(colnames(res),
-               c("Number of Factors", "Total Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
+               c("Number of Factors", "% Variance", "Variance", "Chi-Square", "P Value", "Degree of Freedom", "Number of Rows"))
   res <- model_df %>% tidy_rowwise(model, type="variances")
   expect_equal(colnames(res),
                c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))


### PR DESCRIPTION
# Description
- Rename factor IDs so that they are in the order of importance.
- Add % Variance and Variance to factanal glance output

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
