### PR TITLE
make sure to pass name and value pair when calling readr::read_log

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -2937,10 +2937,10 @@ read_log_file <- function(file, col_names = FALSE, col_types = NULL,
       stringr::str_detect(file, "^http://") ||
       stringr::str_detect(file, "^ftp://")) {
     tmp <- download_data_file(file, "log")
-    readr::read_log(tmp, col_names, col_types, skip, n_max, progress)
+    readr::read_log(tmp, col_names = col_names, col_types = col_types, skip = skip, n_max = n_max, progress = progress)
   } else {
     # if it's local file simply call readr::read_log
-    readr::read_log(file, col_names, col_types, skip, n_max, progress)
+    readr::read_log(file, col_names = col_names, col_types = col_types, skip = skip, n_max = n_max, progress = progress)
   }
 }
 


### PR DESCRIPTION
# Description

To prepare the `readr` v2.0 uptake, make sure to pass name and value pair as an argument to call reader::read_log.


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
