### PR TITLE
Survival Curve: row number in the summary was larger than actual row number by 1

### DIFF
--- a/R/survival.R
+++ b/R/survival.R
@@ -220,7 +220,7 @@ tidy.survdiff_exploratory <- function(x, ...) {
 glance.survdiff_exploratory <- function(x, ...) {
   if (is.null(x$error)) {
     ret <- broom:::glance.survdiff(x, ...)
-    ret <- ret %>% dplyr::mutate(n = !!sum(x$n, rm.na=TRUE), nevent = !!sum(x$obs, rm.na=TRUE))
+    ret <- ret %>% dplyr::mutate(n = !!sum(x$n, na.rm = TRUE), nevent = !!sum(x$obs, na.rm = TRUE))
     if ("df" %in% colnames(ret) && "p.value" %in% colnames(ret)) {
       ret <- ret %>% dplyr::relocate(df, .after=p.value) # Adjust order just to be consistent with other Analytics Views.
     }

--- a/tests/testthat/test_exp_survival.R
+++ b/tests/testthat/test_exp_survival.R
@@ -37,6 +37,8 @@ test_that("test exp_survival", {
   ret1 <- ret %>% tidy_rowwise(model1)
   ret2 <- ret %>% tidy_rowwise(model2)
   ret3 <- ret %>% glance_rowwise(model2)
+  expect_equal(ret3$`Number of Rows`, nrow(data))
+  expect_equal(ret3$`Number of Events`,sum(data$`is churned`))
 
   # No cohort case
   ret <- data %>% exp_survival(`weeks on service`, `is churned`)


### PR DESCRIPTION
# Description
Fixed the issue that the row number in the summary was larger than actual row number by 1.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
