### PR TITLE
Pass logistic regression test that failed due to readr upgrade

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     qlcMatrix,
     purrr,
     httr,
-    text2vec,
     quanteda,
     Matrix,
     rvest,

--- a/tests/testthat/test_logistic_negative_1.R
+++ b/tests/testthat/test_logistic_negative_1.R
@@ -11,13 +11,13 @@ test_that("logistic regression can handle failed model building", {
   df1 <- df %>% slice_sample(n=50000)
 
   filtered <- df1 %>%  filter(CARRIER %in% c("9E", "AA", "AS"))
-  model_df <- filtered %>% dplyr::group_by(`CARRIER`) %>% build_lm.fast(`delayed`, `YEAR`, `MONTH`, `DAY_OF_MONTH`, `FL_DATE`, `FL_NUM`, `ORIGIN`, `ORIGIN_CITY_NAME`, `ORIGIN_STATE_ABR`, `DEST`, `DEST_CITY_NAME`, `DEST_STATE_ABR`, `DEP_TIME`, `DEP_DELAY`, `ARR_TIME`, `CANCELLED`, `CANCELLATION_CODE`, `AIR_TIME`, `DISTANCE`, `WEATHER_DELAY`, `X23`, model_type = "glm", smote = TRUE, variable_metric = "ame", with_marginal_effects_confint = FALSE, test_rate = 0.3)
+  model_df <- filtered %>% dplyr::group_by(`CARRIER`) %>% build_lm.fast(`delayed`, `YEAR`, `MONTH`, `DAY_OF_MONTH`, `FL_DATE`, `FL_NUM`, `ORIGIN`, `ORIGIN_CITY_NAME`, `ORIGIN_STATE_ABR`, `DEST`, `DEST_CITY_NAME`, `DEST_STATE_ABR`, `DEP_TIME`, `DEP_DELAY`, `ARR_TIME`, `CANCELLED`, `CANCELLATION_CODE`, `AIR_TIME`, `DISTANCE`, `WEATHER_DELAY`, model_type = "glm", smote = TRUE, variable_metric = "ame", with_marginal_effects_confint = FALSE, test_rate = 0.3)
   res <- model_df %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
 
   set.seed(1) # In this case, the first model happens to be NULL, but 2nd model is not, which is another case we should handle.
   df1 <- df %>% slice_sample(n=50000)
 
   filtered <- df1 %>%  filter(CARRIER %in% c("9E", "AA", "AS"))
-  model_df <- filtered %>% dplyr::group_by(`CARRIER`) %>% build_lm.fast(`delayed`, `YEAR`, `MONTH`, `DAY_OF_MONTH`, `FL_DATE`, `FL_NUM`, `ORIGIN`, `ORIGIN_CITY_NAME`, `ORIGIN_STATE_ABR`, `DEST`, `DEST_CITY_NAME`, `DEST_STATE_ABR`, `DEP_TIME`, `DEP_DELAY`, `ARR_TIME`, `CANCELLED`, `CANCELLATION_CODE`, `AIR_TIME`, `DISTANCE`, `WEATHER_DELAY`, `X23`, model_type = "glm", smote = TRUE, variable_metric = "ame", with_marginal_effects_confint = FALSE, test_rate = 0.3)
+  model_df <- filtered %>% dplyr::group_by(`CARRIER`) %>% build_lm.fast(`delayed`, `YEAR`, `MONTH`, `DAY_OF_MONTH`, `FL_DATE`, `FL_NUM`, `ORIGIN`, `ORIGIN_CITY_NAME`, `ORIGIN_STATE_ABR`, `DEST`, `DEST_CITY_NAME`, `DEST_STATE_ABR`, `DEP_TIME`, `DEP_DELAY`, `ARR_TIME`, `CANCELLED`, `CANCELLATION_CODE`, `AIR_TIME`, `DISTANCE`, `WEATHER_DELAY`, model_type = "glm", smote = TRUE, variable_metric = "ame", with_marginal_effects_confint = FALSE, test_rate = 0.3)
   res <- model_df %>% prediction_training_and_test(prediction_type = 'conf_mat', threshold = 0.5)
 })


### PR DESCRIPTION
# Description
Pass logistic regression test that failed due to readr upgrade.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
