### PR TITLE
Use tempdir instead of ~/.exploratory to pass test

### DIFF
--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -3,7 +3,7 @@
 
 context("test lm/glm prediction with training/test data")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_build_lm_2.R
+++ b/tests/testthat/test_build_lm_2.R
@@ -5,7 +5,7 @@ context("test lm/glm prediction with training/test data")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_build_lm_3.R
+++ b/tests/testthat/test_build_lm_3.R
@@ -3,7 +3,7 @@
 
 context("test lm/glm prediction with training/test data")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_build_lm_3.R
+++ b/tests/testthat/test_build_lm_3.R
@@ -5,7 +5,7 @@ context("test lm/glm prediction with training/test data")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_build_lm_4.R
+++ b/tests/testthat/test_build_lm_4.R
@@ -5,7 +5,7 @@ context("lm/glm negative test")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_build_lm_4.R
+++ b/tests/testthat/test_build_lm_4.R
@@ -3,7 +3,7 @@
 
 context("lm/glm negative test")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_randomForest_tidiers_1.R
+++ b/tests/testthat/test_randomForest_tidiers_1.R
@@ -3,7 +3,7 @@
 
 context("test tidiers for randomForest")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_randomForest_tidiers_1.R
+++ b/tests/testthat/test_randomForest_tidiers_1.R
@@ -5,7 +5,7 @@ context("test tidiers for randomForest")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -1,6 +1,6 @@
 context("test tidiers for ranger randomForest")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_randomForest_tidiers_2.R
+++ b/tests/testthat/test_randomForest_tidiers_2.R
@@ -2,7 +2,7 @@ context("test tidiers for ranger randomForest")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -5,7 +5,7 @@ context("test tidiers for randomForest 3 (training and test data)")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -3,7 +3,7 @@
 
 context("test tidiers for randomForest 3 (training and test data)")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_randomForest_tidiers_4.R
+++ b/tests/testthat/test_randomForest_tidiers_4.R
@@ -6,7 +6,7 @@ context("test tidiers for randomForest 4 (training and test data with group_by)"
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_randomForest_tidiers_4.R
+++ b/tests/testthat/test_randomForest_tidiers_4.R
@@ -4,7 +4,7 @@
 
 context("test tidiers for randomForest 4 (training and test data with group_by)")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -3,7 +3,7 @@
 
 context("test rpart prediction with training/test data")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -5,7 +5,7 @@ context("test rpart prediction with training/test data")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_rpart_3.R
+++ b/tests/testthat/test_rpart_3.R
@@ -4,9 +4,9 @@
 
 context("test tidiers for rpart. (trainig/test with group_by)")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_sampling.R
+++ b/tests/testthat/test_sampling.R
@@ -3,9 +3,9 @@
 
 context("test sampling down to default 50000 rows in preprocessing of various Analytics View functions.")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_test_wrapper_4.R
+++ b/tests/testthat/test_test_wrapper_4.R
@@ -1,8 +1,8 @@
 context("T-Test/ANOVA with groups with only single category")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_ts_cluster.R
+++ b/tests/testthat/test_ts_cluster.R
@@ -3,9 +3,9 @@
 
 context("test time series clustering")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_xgboost_1.R
+++ b/tests/testthat/test_xgboost_1.R
@@ -5,7 +5,7 @@ context("test tidiers for randomForest 3 (training and test data)")
 
 testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
-testdata_file_path <- paste0(testdata_dir, testdata_filename)
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
 
 filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
   "https://www.dropbox.com/s/f47baw5f3v0xoll/airline_2013_10_tricky_v3.csv?dl=1"

--- a/tests/testthat/test_xgboost_1.R
+++ b/tests/testthat/test_xgboost_1.R
@@ -3,7 +3,7 @@
 
 context("test tidiers for randomForest 3 (training and test data)")
 
-testdata_dir <- "~/.exploratory/"
+testdata_dir <- tempdir()
 testdata_filename <- "airline_2013_10_tricky_v3_5k.csv" 
 testdata_file_path <- paste0(testdata_dir, testdata_filename)
 


### PR DESCRIPTION
# Description
Use tempdir instead of ~/.exploratory to pass test. (Test-only change)

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
