### PR TITLE
Improved reorder_cols to handle columns that do not exist.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1739,7 +1739,8 @@ mase <- function(actual, predicted, is_test_data, period = 1) {
 #' Column reorder function we use from Reorder steps of Exploratory.
 #' @export
 reorder_cols <- function(df, ...) {
-  dplyr::select(df, !!!rlang::quos(...), dplyr::everything())
+  # use any_of to make it work even if the columns in the arguments do not exist.
+  dplyr::select(df, dplyr::any_of(!!purrr::flatten_chr(purrr::map(rlang::quos(...),rlang::as_name))), dplyr::everything())
 }
 
 #' @export

--- a/R/util.R
+++ b/R/util.R
@@ -1740,7 +1740,7 @@ mase <- function(actual, predicted, is_test_data, period = 1) {
 #' @export
 reorder_cols <- function(df, ...) {
   # use any_of to make it work even if the columns in the arguments do not exist.
-  dplyr::select(df, dplyr::any_of(!!purrr::flatten_chr(purrr::map(rlang::quos(...),rlang::as_name))), dplyr::everything())
+  dplyr::select(df, dplyr::any_of(!!purrr::flatten_chr(purrr::map(rlang::quos(...), rlang::as_name))), dplyr::everything())
 }
 
 #' @export


### PR DESCRIPTION
# Description

Improved reorder_cols to handle columns that do not exist.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
