### PR TITLE
Make sure to not pass ssl.ca parameter to RMariaDB::dbConnect API if path is empty.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -884,11 +884,21 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       # To avoid integer64 handling issues in charts, etc., use numeric as the R type to receive bigint data rather than default integer64 by specifying bigint argument.
       if (timezone != "") {# if Timezone is set use it for timezone and timezone_out
-        conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
-                                   password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
+        if (sslCA != "") {
+          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
+                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
+        } else {
+          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
+                                     password = password, host = host, port = port, bigint = "numeric")
+        }
       } else {
-        conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
-                                   password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
+        if (sslCA != "") {
+          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
+                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
+        } else {
+          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
+                                     password = password, host = host, port = port, bigint = "numeric")
+        }
       }
       connection_pool[[key]] <- conn
     }
@@ -1416,7 +1426,7 @@ getListOfTablesWithODBC <- function(conn){
 #' @export
 getListOfTables <- function(type, host, port, databaseName = NULL, username, password, catalog = "", schema = "", sslCA = ""){
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
-  conn <- getDBConnection(type, host, port, databaseName, username, password, catalog, schema, sslCA)
+  conn <- getDBConnection(type, host, port, databaseName, username, password, catalog, schema, sslCA = sslCA)
 
   tryCatch({
     tables <- DBI::dbListTables(conn)

--- a/R/system.R
+++ b/R/system.R
@@ -884,18 +884,18 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       # To avoid integer64 handling issues in charts, etc., use numeric as the R type to receive bigint data rather than default integer64 by specifying bigint argument.
       if (timezone != "") {# if Timezone is set use it for timezone and timezone_out
-        if (sslCA != "") {
+        if (sslCA != "") { # if sslCA is set, pass it as ssl.ca
           conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
                                      password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else {
+        } else { # if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
           conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
                                      password = password, host = host, port = port, bigint = "numeric")
         }
-      } else {
+      } else {# if sslCA is set, pass it as ssl.ca
         if (sslCA != "") {
           conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
                                      password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else {
+        } else {# if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
           conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
                                      password = password, host = host, port = port, bigint = "numeric")
         }


### PR DESCRIPTION
# Description

When connecting to Amazon Aurora, passing an empty path to `RMariaDB::dbConnect` causes an 

"Error : Failed to connect: SSL connection error: No such file or directory"

So do not pass `ssl.ca` parameter when the path is empty.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
