### PR TITLE
Handle vector index in the parameter notations like @{param[1]}

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -464,6 +464,11 @@ sql_glue_transformer_internal <- function(expr, envir, bigquery=FALSE, salesforc
   # Trim white spaces.
   name <- trimws(name)
 
+  # Extract the vector index from name[index] expression if it exists.
+  name_index <- stringr::str_split(name,'[\\[\\]]')[[1]]
+  name <- name_index[1]
+  index <- name_index[2]
+
   # Strip quote by ``.
   should_strip <- grepl("^`.+`$", name)
   if (should_strip) {
@@ -472,6 +477,9 @@ sql_glue_transformer_internal <- function(expr, envir, bigquery=FALSE, salesforc
   }
 
   code <- paste0("exploratory_env$`", name, "`")
+  if (!is.na(index)) { # Apply the vector index if it is specified.
+    code <- paste0(code, '[', index, ']')
+  }
 
   val <- eval(parse(text = code), envir)
 

--- a/R/system.R
+++ b/R/system.R
@@ -330,6 +330,11 @@ js_glue_transformer <- function(expr, envir) {
   # Trim white spaces.
   name <- trimws(name)
 
+  # Extract the vector index from name[index] expression if it exists.
+  name_index <- stringr::str_split(name,'[\\[\\]]')[[1]]
+  name <- name_index[1]
+  index <- name_index[2]
+
   # Strip quote by ``.
   should_strip <- grepl("^`.+`$", name)
   if (should_strip) {
@@ -337,6 +342,9 @@ js_glue_transformer <- function(expr, envir) {
     name <- sub("`$", "", name)
   }
   code <- paste0("exploratory_env$`", name, "`")
+  if (!is.na(index)) { # Apply the vector index if it is specified.
+    code <- paste0(code, '[', index, ']')
+  }
 
   val <- eval(parse(text = code), envir)
 

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -183,6 +183,10 @@ test_that("js_glue_transformer", {
   exploratory_env$stock_symbols <- c()
   res <- exploratory:::glue_exploratory("{stock:{$in:[@{stock_symbols}]}}", .transformer=exploratory:::js_glue_transformer)
   expect_equal(as.character(res), "{stock:{$in:[]}}", "message")
+
+  exploratory_env$number_range <- c(-10, 20)
+  res <- exploratory:::glue_exploratory("{salary:{$gte:@{number_range[1]}, $lt:@{number_range[2]}}}", .transformer=exploratory:::js_glue_transformer)
+  expect_equal(as.character(res), "{salary:{$gte:-10, $lt:20}}")
 })
 
 test_that("sql_glue_transformer", {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -217,6 +217,10 @@ test_that("sql_glue_transformer", {
   exploratory_env$number_limit <- 1000000
   res <- exploratory:::glue_exploratory("select top @{number_limit} * from emp", .transformer=exploratory:::sql_glue_transformer)
   expect_equal(as.character(res), "select top 1000000 * from emp")
+
+  exploratory_env$number_range <- c(-10, 20)
+  res <- exploratory:::glue_exploratory("select * from emp where salary between @{number_range[1]} and @{number_range[2]}", .transformer=exploratory:::sql_glue_transformer)
+  expect_equal(as.character(res), "select * from emp where salary between -10 and 20")
 })
 
 test_that("bigquery_glue_transformer", {


### PR DESCRIPTION
# Description
Handle vector index in the parameter notations like `@{param[1]}`.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
