### PR TITLE
Add bind_rows_safe to avoid removing ...1 from column names

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -660,7 +660,7 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
         dplyr::mutate(source.data = purrr::map2(source.data.training, source.data.test, function(df1, df2){
           df1 <- df1 %>% dplyr::mutate(is_test_data=FALSE)
           df2 <- df2 %>% dplyr::mutate(is_test_data=TRUE)
-          dplyr::bind_rows(df1, df2)
+          bind_rows_safe(df1, df2)
         })) %>%
         dplyr::select(-source.data.training, -source.data.test) %>%
         dplyr::ungroup()
@@ -777,7 +777,7 @@ prediction2 <- function(df, data_frame = NULL, conf_int = 0.95, pretty.name=FALS
     dplyr::mutate(source.data = purrr::map2(source.data.training, source.data.test, function(df1, df2){
       df1 <- df1 %>% dplyr::mutate(is_test_data=FALSE)
       df2 <- df2 %>% dplyr::mutate(is_test_data=TRUE)
-      res <- dplyr::bind_rows(df1, df2)
+      res <- bind_rows_safe(df1, df2)
       res[grouping_cols]<-NULL # A dirty hack to avoid column name conflict at unnest. TODO: Maybe group column should not be there inside do_on_each_group in the first place.
       res
     })) %>%
@@ -882,7 +882,7 @@ evaluation <- function(df, ...){
       if (nrow(df2) > 0) {
         df1 <- df1 %>% dplyr::mutate(is_test_data=FALSE)
         df2 <- df2 %>% dplyr::mutate(is_test_data=TRUE)
-        dplyr::bind_rows(df1, df2)
+        bind_rows_safe(df1, df2)
       }
       else {
         df1

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -415,7 +415,9 @@ kmeans_info <- function(df){
   ret
 }
 
-#' augment using source data and test index
+#' augment using source data (source.data column) and test index (.test_index column).
+#' The data frames in source.data are in the safe column names (e.g. c1, c2, ...).
+#' The augmenter for each type of models is expected to map the column names back to the original.
 #' @param df Data frame that has model and .test_index.
 #' @param data "training" or "test" or "newdata". Which source data should be used.
 #' @param ... Additional argument to be passed to broom::augment

--- a/R/util.R
+++ b/R/util.R
@@ -1908,6 +1908,20 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   }
 }
 
+bind_rows_safe <- function(df1, df2) {
+  colnames1 <- colnames(df1)
+  colnames2 <- colnames(df2)
+  colnames_unique <- unique(c(colnames1, colnames2))
+  safe_names <- paste('c', 1:length(colnames_unique), sep = '')
+  names(colnames_unique) <- safe_names
+  names(safe_names) <- colnames_unique
+  names(df1) <- safe_names[colnames1]
+  names(df2) <- safe_names[colnames2]
+  ret <- dplyr::bind_rows(df1, df2)
+  names(ret) <- colnames_unique[names(ret)]
+  ret
+}
+
 #'Wrapper function for dplyr's set operations to support ignoring data type difference.
 set_operation_with_force_character <- function(func, x, y, ...) {
   x <- dplyr::mutate_all(x, funs(as.character))

--- a/R/util.R
+++ b/R/util.R
@@ -1908,6 +1908,8 @@ bind_rows <- function(..., id_column_name = NULL, current_df_name = '', force_da
   }
 }
 
+# bind_rows wrapper to avoid the issue that column names like "a...1" is reduced to "a".
+# We use this internally in functions like prediction() to avoid such an issue.
 bind_rows_safe <- function(df1, df2) {
   colnames1 <- colnames(df1)
   colnames2 <- colnames(df2)

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -3,8 +3,8 @@ test_that("bind_rows_safe", {
   df1 <- tibble::tibble(a...1=1, b=1)
   df2 <- tibble::tibble(a...1=2, c=2)
   res <- dplyr::bind_rows(df1, df2)
-  expect_equal(colnames(res), c("a", "b", "c"))
-  res <- bind_rows_safe(df1, df2)
+  expect_equal(colnames(res), c("a", "b", "c")) # To check if this fix is still necessary when dplyr is upgraded in future.
+  res <- exploratory:::bind_rows_safe(df1, df2) # This is an internal function.
   expect_equal(colnames(res), c("a...1", "b", "c"))
 })
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1,4 +1,13 @@
 context("check util functions")
+test_that("bind_rows_safe", {
+  df1 <- tibble::tibble(a...1=1, b=1)
+  df2 <- tibble::tibble(a...1=2, c=2)
+  res <- dplyr::bind_rows(df1, df2)
+  expect_equal(colnames(res), c("a", "b", "c"))
+  res <- bind_rows_safe(df1, df2)
+  expect_equal(colnames(res), c("a...1", "b", "c"))
+})
+
 test_that("bind_rows", {
   library(dplyr)
   res <- mtcars %>% exploratory::bind_rows(list(acars = mtcars, bcars = mtcars), id_column_name="dataf", current_df_name="firstMtcars")


### PR DESCRIPTION
# Description
Add bind_rows_safe to avoid removing ...1 from column names.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
