### PR TITLE
Reimplement mat_to_df with pivot_longer instead of reshape2::melt

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -304,7 +304,10 @@ grouped_by <- function(df){
 #' @param diag If diagonal values should be returned
 #' @export
 mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
-  df <- as.data.frame(mat) %>% tibble::rownames_to_column("Var2") %>% tidyr::pivot_longer(-Var2, "Var1","value", values_drop_na = na.rm)
+  df <- as.data.frame(mat) %>%
+    tibble::rownames_to_column(".Var2.temp") %>% # The column name .Var2.temp is to avoid name conflict as much as possible.
+    tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
+    dplyr::rename(Var2 = .Var2.temp)
 
   if(zero.rm){
     df <- df[is.na(df[[3]]) | df[[3]] != 0, ]

--- a/R/util.R
+++ b/R/util.R
@@ -304,8 +304,6 @@ grouped_by <- function(df){
 #' @param diag If diagonal values should be returned
 #' @export
 mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
-  # loadNamespace("reshape2")
-  # df <- reshape2::melt(t(mat), na.rm=na.rm)
   df <- as.data.frame(mat) %>% tibble::rownames_to_column("Var2") %>% tidyr::pivot_longer(-Var2, "Var1","value", values_drop_na = na.rm)
 
   if(zero.rm){
@@ -316,8 +314,6 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     df <- df[df[[1]]!=df[[2]],]
   }
 
-  # make the first column to be sorted
-  #df <- df[,c(2,1,3)]
   if(!is.null(cnames)){
     colnames(df) <- cnames
   }

--- a/R/util.R
+++ b/R/util.R
@@ -308,6 +308,7 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     tibble::rownames_to_column(".Var2.temp") %>% # The column name .Var2.temp is to avoid name conflict as much as possible.
     tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
     dplyr::rename(Var2 = .Var2.temp)
+  # Remove V from names like V1, V2 to align the output to the previous implementation that used reshape2::melt.
   df <- df %>% dplyr::mutate(Var1 = str_replace(Var1, "^V", ""))
 
   if(zero.rm){

--- a/R/util.R
+++ b/R/util.R
@@ -308,6 +308,7 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     tibble::rownames_to_column(".Var2.temp") %>% # The column name .Var2.temp is to avoid name conflict as much as possible.
     tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
     dplyr::rename(Var2 = .Var2.temp)
+  df <- df %>% dplyr::mutate(Var1 = str_replace(Var1, "^V", ""))
 
   if(zero.rm){
     df <- df[is.na(df[[3]]) | df[[3]] != 0, ]

--- a/R/util.R
+++ b/R/util.R
@@ -309,7 +309,7 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
     dplyr::rename(Var2 = .Var2.temp)
   # Remove V from names like V1, V2 to align the output to the previous implementation that used reshape2::melt.
-  df <- df %>% dplyr::mutate(Var1 = str_replace(Var1, "^V", ""))
+  df <- df %>% dplyr::mutate(Var1 = stringr::str_replace(Var1, "^V", ""))
 
   if(zero.rm){
     df <- df[is.na(df[[3]]) | df[[3]] != 0, ]

--- a/R/util.R
+++ b/R/util.R
@@ -304,8 +304,9 @@ grouped_by <- function(df){
 #' @param diag If diagonal values should be returned
 #' @export
 mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
-  loadNamespace("reshape2")
-  df <- reshape2::melt(t(mat), na.rm=na.rm)
+  # loadNamespace("reshape2")
+  # df <- reshape2::melt(t(mat), na.rm=na.rm)
+  df <- as.data.frame(mat) %>% tibble::rownames_to_column("Var2") %>% tidyr::pivot_longer(-Var2, "Var1","value", values_drop_na = na.rm)
 
   if(zero.rm){
     df <- df[is.na(df[[3]]) | df[[3]] != 0, ]
@@ -316,17 +317,17 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
   }
 
   # make the first column to be sorted
-  df <- df[,c(2,1,3)]
-  if(!is.null(colnames)){
+  #df <- df[,c(2,1,3)]
+  if(!is.null(cnames)){
     colnames(df) <- cnames
   }
 
-  if (!is.character(df[,1])) { # Can be a factor. Also can be integer if the origin column name was number.
-    df[,1] <- as.character(df[,1])
+  if (!is.character(df[[1]])) { # Can be a factor. Also can be integer if the origin column name was number.
+    df[[1]] <- as.character(df[[1]])
   }
 
   if (!is.character(df[,2])) { # Can be a factor. Also can be integer if the origin column name was number.
-    df[,2] <- as.character(df[,2])
+    df[[2]] <- as.character(df[[2]])
   }
 
   df

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -157,11 +157,11 @@ test_that("test upper_gather with vector", {
   names <- paste("entity", seq(4))
   result <- upper_gather(mat,names)
   expect_equal(result$Var1, sort(result$Var1))
-  expect_equal(result[result[,1]=="entity 1" & result[,2]=="entity 3",3], 2)
-  expect_equal(result[result[,1]=="entity 1" & result[,2]=="entity 4",3], 3)
-  expect_equal(result[result[,1]=="entity 2" & result[,2]=="entity 3",3], 4)
-  expect_equal(result[result[,1]=="entity 2" & result[,2]=="entity 4",3], 5)
-  expect_equal(result[result[,1]=="entity 3" & result[,2]=="entity 4",3], 6)
+  expect_equal(as.numeric(result[result[[1]]=="entity 1" & result[[2]]=="entity 3",3]), 2)
+  expect_equal(as.numeric(result[result[[1]]=="entity 1" & result[[2]]=="entity 4",3]), 3)
+  expect_equal(as.numeric(result[result[[1]]=="entity 2" & result[[2]]=="entity 3",3]), 4)
+  expect_equal(as.numeric(result[result[[1]]=="entity 2" & result[[2]]=="entity 4",3]), 5)
+  expect_equal(as.numeric(result[result[[1]]=="entity 3" & result[[2]]=="entity 4",3]), 6)
   expect_equal(nrow(result), 6)
 })
 
@@ -340,9 +340,9 @@ test_that("test mat_to_df", {
   colnames(mat) <- paste("cname", seq(nc))
   rownames(mat) <- paste("rname", seq(nr))
   ret <- mat_to_df(mat, c("aa", "bb", "value"))
-  expect_true(is.character(ret[,1]))
-  expect_true(is.character(ret[,2]))
-  expect_true(!is.unsorted(ret[,1]))
+  expect_true(is.character(ret$aa))
+  expect_true(is.character(ret$bb))
+  expect_true(!is.unsorted(ret$aa))
 })
 
 test_that("test mat_to_df with column names with numeric characters only", {
@@ -355,9 +355,9 @@ test_that("test mat_to_df with column names with numeric characters only", {
   rownames(mat) <- as.character(seq(nr))
 
   ret <- mat_to_df(mat, c("aa", "bb", "value"))
-  expect_true(is.character(ret[,1]))
-  expect_true(is.character(ret[,2]))
-  expect_true(!is.unsorted(ret[,1]))
+  expect_true(is.character(ret$aa))
+  expect_true(is.character(ret$bb))
+  expect_true(!is.unsorted(ret$aa))
 })
 
 test_that("test %nin%", {


### PR DESCRIPTION
# Description
Reimplement mat_to_df with pivot_longer instead of reshape2::melt to avoid error from handling full-width number characters.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
