### PR TITLE
Fix column name handling for separate_japanese_address

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2778,8 +2778,10 @@ merge_sds <- function(sds, means, sizes) {
 #' @param address - column that contains address text data
 #' @export
 separate_japanese_address <- function(df, address){
-  # create a new column with a dummy column name.
-  df <- df %>% dplyr::mutate(.exploratory_dummy_column_for_japanese_address = zipangu::separate_address(address))
+  # get column name from address.
+  address_col <- tidyselect::vars_pull(names(df), !! rlang::enquo(address))
+  # create a new column with a dummy column name and store the separated address elements.
+  df <- df %>% dplyr::mutate(.exploratory_dummy_column_for_japanese_address = zipangu::separate_address(!!rlang::sym(address_col)))
   # since the .exploratory_dummy_column_for_japanese_address column is a list that contains address elements,
   # call tidyr::unnest_wider so that each element becomes dedicated column like prefecture, city, and street.
   df %>% tidyr::unnest_wider(.exploratory_dummy_column_for_japanese_address, names_repair = "unique")

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1227,12 +1227,12 @@ test_that("mutate_group", {
 test_that("separate_japanese_address", {
   #  Address 1. Tokyo-To Shinjuku-ku Hyakunin-cho 1-2
   #  Address 2. Tokyo-To Shibuya-ku Shoto 2-3
-  df <- data.frame(address = c("\u6771\u4EAC\u90FD\u65B0\u5BBF\u533A\u767E\u4EBA\u753A\u0031\u002D\u0032", "\u6771\u4EAC\u90FD\u6E0B\u8C37\u533A\u677E\u6FE4\u0032\u002D\u0033"))
-  df2 <- exploratory::separate_japanese_address(df, address)
+  df <- data.frame(address2 = c("\u6771\u4EAC\u90FD\u65B0\u5BBF\u533A\u767E\u4EBA\u753A\u0031\u002D\u0032", "\u6771\u4EAC\u90FD\u6E0B\u8C37\u533A\u677E\u6FE4\u0032\u002D\u0033"))
+  df2 <- exploratory::separate_japanese_address(df, address2)
   # The prefecure is Tokyo for both first line and second line.
   # The city for the first line is Shinjuku-ku and the city for the second line is Shibuya-ku
   # The street for the fist line is Hyakunin-cho 1-2 and the street for the second line is Shoto 2-3.
-  check <- df2 %>% dplyr::select(-address)
+  check <- df2 %>% dplyr::select(-address2)
   answer <- tibble::tibble(prefecture = c("\u6771\u4EAC\u90FD", "\u6771\u4EAC\u90FD"),  city = c("\u65B0\u5BBF\u533A", "\u6E0B\u8C37\u533A"), street = c("\u767E\u4EBA\u753A\u0031\u002D\u0032", "\u677E\u6FE4\u0032\u002D\u0033"))
   expect_true(isTRUE(all.equal(check, answer)), TRUE)
 })


### PR DESCRIPTION
# Description

Fix column name handling for separate_japanese_address, before the fix it didn't work if the passed column name is not "address"

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
