### PR TITLE
is_japanese_holiday: Workaround for NA

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1634,8 +1634,8 @@ is_japanese_holiday <- function(date) {
     date <-
       lubridate::as_date(date)
       # make sure to exclude NA otherwise, lubridate::as_date(unlist(zipangu::jholiday(yr, "en")))
-      yr <-
-        unique(lubridate::year(date[!is.na(date)]))
+    yr <-
+      unique(lubridate::year(date[!is.na(date)]))
     jholidays <-
       unique(c(
         zipangu:::jholiday_df$date,            # Holidays from https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv

--- a/R/util.R
+++ b/R/util.R
@@ -1631,7 +1631,7 @@ is_japanese_holiday <- function(date) {
     date <-
       lubridate::as_date(date)
     na_index <- which(sapply(date, is.na))
-    # make sure to exclude NA otherwise, lubridate::year fails.
+    # make sure to exclude NA otherwise, lubridate::as_date(unlist(zipangu::jholiday(yr, "en")))
     if (length(na_index) == 0) {
       yr <- unique(lubridate::year(date))
     } else {

--- a/R/util.R
+++ b/R/util.R
@@ -1625,7 +1625,16 @@ is_japanese_holiday <- function(date) {
   current_option <- getOption("lubridate.week.start")
   result <- tryCatch({
     options(lubridate.week.start = 7)
-    zipangu::is_jholiday(date)
+    # When NA is pass to zipangu::is_joholiday, it throws an error.
+    # As an workaround, use a date which is not Japanese Holiday (e.g. 2020-02-01)
+    # so that it returns FALSE for NA.
+    if (is.character(date)) {
+      zipangu::is_jholiday(tidyr::replace_na(date, "2020-02-01"))
+    } else if (lubridate::is.Date(date)) {
+      zipangu::is_jholiday(tidyr::replace_na(date, as.Date("2020-02-01")))
+    } else if (lubridate::is.POSIXct(date)) {
+      zipangu::is_jholiday(tidyr::replace_na(date, as.POSIXCt("2020-02-01")))
+    }
   }, error=function(cond) {
     stop(cond)
   }, finally = {

--- a/R/util.R
+++ b/R/util.R
@@ -1624,10 +1624,8 @@ weekend <- function(x){
 is_japanese_holiday <- function(date) {
   current_option <- getOption("lubridate.week.start")
   result <- tryCatch({
+    # Make sure to set 7 as the week start date to make the result stable.
     options(lubridate.week.start = 7)
-    # When NA is pass to zipangu::is_joholiday, it throws an error.
-    # As an workaround, use a date which is not Japanese Holiday (e.g. 2020-02-01)
-    # so that it returns FALSE for NA.
     date <-
       lubridate::as_date(date)
     na_index <- which(sapply(date, is.na))

--- a/R/util.R
+++ b/R/util.R
@@ -1633,7 +1633,7 @@ is_japanese_holiday <- function(date) {
     } else if (lubridate::is.Date(date)) {
       zipangu::is_jholiday(tidyr::replace_na(date, as.Date("2020-02-01")))
     } else if (lubridate::is.POSIXct(date)) {
-      zipangu::is_jholiday(tidyr::replace_na(date, as.POSIXCt("2020-02-01")))
+      zipangu::is_jholiday(tidyr::replace_na(date, as.POSIXCt("2020-02-01 00:00:00")))
     }
   }, error=function(cond) {
     stop(cond)

--- a/R/util.R
+++ b/R/util.R
@@ -1631,9 +1631,9 @@ is_japanese_holiday <- function(date) {
     if (is.character(date)) {
       zipangu::is_jholiday(tidyr::replace_na(date, "2020-02-01"))
     } else if (lubridate::is.Date(date)) {
-      zipangu::is_jholiday(tidyr::replace_na(date, as.Date("2020-02-01")))
+      zipangu::is_jholiday(tidyr::replace_na(date, lubridate::as_date("2020-02-01")))
     } else if (lubridate::is.POSIXct(date)) {
-      zipangu::is_jholiday(tidyr::replace_na(date, as.POSIXCt("2020-02-01 00:00:00")))
+      zipangu::is_jholiday(tidyr::replace_na(date, lubridate::as_datetime("2020-02-01 00:00:00")))
     }
   }, error=function(cond) {
     stop(cond)

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1222,6 +1222,8 @@ test_that("is_japanese_holiday", {
   options(lubridate.week.start = 1)
   expect_equal(exploratory::is_japanese_holiday("2019-10-14"), TRUE)
   expect_equal(exploratory::is_japanese_holiday("2019-10-08"), FALSE)
+  expect_equal(exploratory::is_japanese_holiday(c("2019-10-14", "2019-10-08", NA)), c(TRUE, FALSE, FALSE))
+
   # Make sure the option is not reset by exploratory::is_japanese_holiday
   expect_equal(getOption("lubridate.week.start"),1)
   # reset


### PR DESCRIPTION
# Description

Added a workaround for is_japanse_holiday fails when NA is passed.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
