### PR TITLE
Add test about PDP facet order for rpart, ranger, xgboost, linear regression, logistic regression, cox regression, and survival forest

### DIFF
--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -68,8 +68,11 @@ test_that("build_coxph.fast with start_time and end_time", {
   ret <- model_df %>% evaluation(pretty.name=TRUE)
   expect_false("Data Type" %in% colnames(ret))
   ret <- model_df %>% tidy_rowwise(model, type='permutation_importance')
-  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence')
-  expect_true(all(c("estimate", "p.value") %in% colnames(ret))) # Make sure that estimate and p.value are joined to the result for hover on Prediction tab.
+  ret2 <- model_df %>% tidy_rowwise(model, type='partial_dependence')
+  variables <- (ret %>% arrange(desc(importance)))$term
+  names(variables) <- NULL
+  expect_equal(unique(ret2$variable), variables) # Factor order of the PDP should be the same as the importance.
+  expect_true(all(c("estimate", "p.value") %in% colnames(ret2))) # Make sure that estimate and p.value are joined to the result for hover on Prediction tab.
   ret <- model_df %>% tidy_rowwise(model, type='partial_dependence_survival_curve')
   ret <- model_df %>% tidy_rowwise(model, type='vif')
   ret <- model_df %>% tidy_rowwise(model)

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -164,7 +164,10 @@ test_that("Linear Regression with test rate", {
 
     res <- ret %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(res$`Number of Rows`, 17)
+    variables <- (ret %>% tidy_rowwise(model, type="importance") %>% arrange(desc(importance)))$variable
+    names(variables) <- NULL
     res <- ret %>% lm_partial_dependence()
+    expect_equal(levels(res$x_name), variables) # Factor order of the PDP should be the same as the importance.
     expect_true(all(c("conf_high", "conf_low", "bin_sample_size") %in% colnames(res)))
    })
 })
@@ -670,6 +673,11 @@ test_that("Logistic Regression with test_rate", {
   expect_equal(colnames(ret), c("model", ".test_index", "source.data"))
   test_rownum <- length(ret$.test_index[[1]])
   training_rownum <- nrow(test_data) - test_rownum
+
+  variables <- (ret %>% tidy_rowwise(model, type="importance") %>% arrange(desc(importance)))$variable
+  names(variables) <- NULL
+  res <- ret %>% lm_partial_dependence()
+  expect_equal(levels(res$x_name), variables) # Factor order of the PDP should be the same as the importance.
 
   suppressWarnings({
     pred_new <- prediction(ret, data = "newdata", data_frame=test_data)

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -32,6 +32,10 @@ test_that("calc_feature_imp(regression) evaluate training and test with FIRM imp
   # Check variable importance output.
   ret <- model_df %>% tidy_rowwise(model, type="importance")
   expect_equal(colnames(ret), c("variable", "importance"))
+  ret2 <- model_df %>% rf_partial_dependence()
+  variables <- ret$variable
+  names(variables) <- NULL
+  expect_equal(levels(ret2$x_name), variables) # Factor order of the PDP should be the same as the importance.
 
   ret <- flight %>% select(-`ARR DELAY`) %>% add_prediction(model_df=model_df)
   ret <- model_df %>% prediction(data="newdata", data_frame=flight)

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -29,7 +29,6 @@ test_that("exp_rpart(regression) evaluate training and test with permutation imp
   ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
   ret <- flight %>% select(-`FL NUM`) %>% add_prediction(model_df=model_df)
   ret <- model_df %>% prediction(data="newdata", data_frame = flight)
-  ret <-  model_df %>% rf_partial_dependence()
 
   ret <- model_df %>% prediction(data="training_and_test")
   test_ret <- ret %>% filter(is_test_data==TRUE)
@@ -47,6 +46,8 @@ test_that("exp_rpart(regression) evaluate training and test with permutation imp
   # Check order of result of variable importance.
   ret <- model_df %>% tidy_rowwise(model, type="importance") %>% arrange(-importance)
   expect_equal(as.character(ret$variable), c("DIS TANCE", "DEP TIME"))
+  ret <- model_df %>% rf_partial_dependence()
+  expect_equal(levels(ret$x_name), c("DIS TANCE", "DEP TIME")) # Factor order should be the same as the importance.
 
   # Training only case
   model_df <- flight %>%

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -53,8 +53,11 @@ test_that("exp_survival_forest basic with start_time and end_time", {
 
   ret <- model_df %>% tidy_rowwise(model, type='partial_dependence_survival_curve')
   expect_equal(class(model_df$model[[1]]), c("ranger_survival_exploratory", "ranger"))
-  ret <- model_df %>% tidy_rowwise(model, type='partial_dependence')
   ret <- model_df %>% tidy_rowwise(model, type='importance')
+  ret2 <- model_df %>% tidy_rowwise(model, type='partial_dependence')
+  variables <- (ret %>% arrange(desc(importance)))$variable
+  names(variables) <- NULL
+  expect_equal(unique(ret2$variable), variables) # Factor order of the PDP should be the same as the importance.
 })
 
 test_that("exp_survival_forest with group-by", {

--- a/tests/testthat/test_xgboost_1.R
+++ b/tests/testthat/test_xgboost_1.R
@@ -95,6 +95,10 @@ test_that("exp_xgboost(regression) evaluate training and test with permutation i
   # Check result of variable importance 
   ret <- model_df %>% tidy_rowwise(model, type="importance")
   expect_equal(as.character(ret$variable[[1]]), "DEP DELAY") # Most important should be dep delay.
+  ret2 <- model_df %>% rf_partial_dependence()
+  variables <- ret$variable
+  names(variables) <- NULL
+  expect_equal(levels(ret2$x_name), variables) # Factor order of the PDP should be the same as the importance.
 
   ret <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
   expect_equal(nrow(ret), 2) # 2 for train and test


### PR DESCRIPTION
# Description
Add test about PDP facet order for rpart, ranger, xgboost, linear regression, logistic regression, cox regression, and survival forest.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
