### PR TITLE
Improve mat_to_df behavior on column name starting with V

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -28,7 +28,6 @@ simple_cast <- function(data, row, col, val=NULL, fun.aggregate=mean, fill=0, ti
   loadNamespace("reshape2")
   loadNamespace("tidyr")
 
-
   if (!row %in% colnames(data)) {
     stop(paste0(row, " is not in column names"))
   }
@@ -309,7 +308,7 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
     tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
     dplyr::rename(Var2 = .Var2.temp)
   # Remove V from names like V1, V2 to align the output to the previous implementation that used reshape2::melt.
-  df <- df %>% dplyr::mutate(Var1 = stringr::str_replace(Var1, "^V", ""))
+  df <- df %>% dplyr::mutate(Var1 = stringr::str_replace(Var1, "^V(?=[0-9]+$)", ""))
 
   if(zero.rm){
     df <- df[is.na(df[[3]]) | df[[3]] != 0, ]

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -354,6 +354,19 @@ test_that("test mat_to_df", {
   expect_true(!is.unsorted(ret$aa))
 })
 
+test_that("test mat_to_df handling V at the beginning of the name", { #TODO: revisit this behavior.
+  nc <- 4
+  nr <- 5
+  mat <- matrix(seq(nc*nr), ncol=nc, nrow=nr)
+  colnames(mat) <- paste0("V", seq(nc))
+  rownames(mat) <- paste0("V", seq(nr))
+  ret <- mat_to_df(mat, c("aa", "bb", "value"))
+  expect_true(all(stringr::str_detect(ret$aa,"^V"))) # V from row names are kept.
+  expect_true(all(!stringr::str_detect(ret$bb,"^V"))) # V from col names are dropped.
+  expect_true(is.character(ret$bb))
+  expect_true(!is.unsorted(ret$aa))
+})
+
 test_that("test mat_to_df with column names with numeric characters only", {
   nc <- 4
   nr <- 5


### PR DESCRIPTION
# Description
Improve mat_to_df behavior on column name starting with V.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
