### PR TITLE
When data type override with date is specifically set, make sure to convert POSIXct to Date.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.9.5.3
+Version: 6.9.5.4
 Date: 2022-03-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -2824,7 +2824,13 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
     }
     if(!is.null(tzone)) { # if timezone is specified, apply the timezeon to POSIXct columns
       df <- df %>% dplyr::mutate_if(lubridate::is.POSIXct, funs(lubridate::force_tz(., tzone=tzone)))
+      # make sure to convert POSIXct to Date if the col_types are set as Date specifically
+      df <- df %>% dplyr::mutate_at(vars(colnames(df)[col_types == "date"]), funs(as.Date(.,tz=tzone)))
+    } else {
+      # make sure to convert POSIXct to Date if the col_types are set as Date specifically
+      df <- df %>% dplyr::mutate_at(vars(colnames(df)[col_types == "date"]), funs(as.Date))
     }
+
     # When this API is called from getExcelFilesFromS3, getExcelFilesFromGoogleDrive, and read_excel_files,
     # by default the convertDataTypeToChar is set as TRUE to covert the resulting data frame columns' data type as character.
     # This is required to make sure that merging the Excel based data frames doesn't error out due to column data types mismatch.


### PR DESCRIPTION
# Description

When data type override with date is specifically set, make sure to convert POSIXct to Date.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
