### PR TITLE
Add data_text argument to read_delim_file to support Text Input as a data source

### DIFF
--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -125,7 +125,9 @@ get_stopwords <- function(lang = "english", include = c(), exclude = c(), is_twi
     # tidystopwords required language name with Title Case so make sure it's title case.
     stopwords <- append(stopwords, tidystopwords::generate_stoplist(stringr::str_to_title(lang)))
   }
-  ret <- c(stopwords[!stopwords %in% exclude], include)
+  # include first and then exclude, so that we can exclude words in the include, which we use for custom dictionary too.
+  stopwords <- c(stopwords, include)
+  ret <- stopwords[!stopwords %in% exclude]
   ret
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -3017,9 +3017,9 @@ read_delim_file <- function(file, delim, quote = '"',
     if(!is_free_text && stringi::stri_enc_mark(file) != "ASCII"){
       file_path <- file(file)
     }
-    # For Windows and Free Text, use CP932 as encoding.
+    # For Windows and Free Text, it's most likely not Unicode so guess encoding.
     if (is_free_text && Sys.info()["sysname"]=="Windows") {
-      locale$encoding <- "CP932"
+      locale$encoding <- utils::head((readr::guess_encoding(file, n_max = -1, threshold = 0.3))$encoding,1)
     }
     tryCatch({ # try to close connection and ignore error
       readr::read_delim(file_path, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,

--- a/R/system.R
+++ b/R/system.R
@@ -3017,7 +3017,7 @@ read_delim_file <- function(file, delim, quote = '"',
     if (is_free_input_text) { # for free input text
       # For Windows, make sure to convert text to UTF-8
       if (Sys.info()["sysname"] == "Windows") {
-        data_text <- exploratory::convertUserInputToUtf8(data_text)
+        data_text <- exploratory:::convertUserInputToUtf8(data_text)
         locale$encoding <- "UTF-8"
       }
       # call I() to data_text so that readr::read_delimit can hand the text data.

--- a/R/system.R
+++ b/R/system.R
@@ -3017,10 +3017,6 @@ read_delim_file <- function(file, delim, quote = '"',
     if(!is_free_text && stringi::stri_enc_mark(file) != "ASCII"){
       file_path <- file(file)
     }
-    # For Windows and Free Text, it's most likely not Unicode so guess encoding.
-    if (is_free_text && Sys.info()["sysname"]=="Windows") {
-      locale$encoding <- utils::head((readr::guess_encoding(file, n_max = -1, threshold = 0.3))$encoding,1)
-    }
     tryCatch({ # try to close connection and ignore error
       readr::read_delim(file_path, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
                         locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)

--- a/R/system.R
+++ b/R/system.R
@@ -3017,6 +3017,10 @@ read_delim_file <- function(file, delim, quote = '"',
     if(!is_free_text && stringi::stri_enc_mark(file) != "ASCII"){
       file_path <- file(file)
     }
+    # For Windows and Free Text, use CP932 as encoding.
+    if (is_free_text && Sys.info()["sysname"]=="Windows") {
+      locale$encoding <- "CP932"
+    }
     tryCatch({ # try to close connection and ignore error
       readr::read_delim(file_path, delim, quote = quote, escape_backslash = escape_backslash, escape_double = escape_double, col_names = col_names, col_types = col_types,
                         locale = locale, na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max, progress = progress)

--- a/R/system.R
+++ b/R/system.R
@@ -2964,7 +2964,7 @@ read_delim_file <- function(file, delim, quote = '"',
                             na = c("", "NA"), quoted_na = TRUE,
                             comment = "", trim_ws = FALSE,
                             skip = 0, n_max = Inf, guess_max = min(1000, n_max),
-                            progress = interactive(), with_api_key = FALSE){
+                            progress = interactive(), with_api_key = FALSE, is_free_text = FALSE){
   loadNamespace("readr")
   loadNamespace("stringr")
   if (stringr::str_detect(file, "^https://") ||
@@ -3013,7 +3013,8 @@ read_delim_file <- function(file, delim, quote = '"',
     # reading through file() is to be able to read files with path that includes multibyte chars.
     # without it, error is thrown from inside read_delim.
     file_path <- file
-    if(stringi::stri_enc_mark(file) != "ASCII"){
+    # for Free Text case (i.e. is_free_text = TRUE), file is actually a data so do not call file()
+    if(!is_free_text && stringi::stri_enc_mark(file) != "ASCII"){
       file_path <- file(file)
     }
     tryCatch({ # try to close connection and ignore error

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -464,6 +464,12 @@ test_that("read_delim_file open local file failed error message", {
   })
 })
 
+test_that("read_delim_file with text data", {
+  df <- exploratory::read_delim_file(data_text = "a,b\n1,2", delim=",")
+  expect_equal(nrow(df),1)
+  expect_equal(ncol(df),2)
+})
+
 # TODO: For now the below test fails on Linux so skip it for Linux.
 if (Sys.info()["sysname"] !="Linux") {
   test_that("case_when mixed data types error message", {


### PR DESCRIPTION
# Description

Add data_text argument to read_delim_file to support Free Text as a data source

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
