### PR TITLE
Fix issue that pivot calculation result becomes invalid when there is a "value" column in the source data frame.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -993,8 +993,6 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
   value_col_name = avoid_conflict(colnames(df), c("value"))
   pivot_each <- function(df) {
     res <- if(is.null(value_col)) {
-      # make a count matrix if value_col is NULL
-      value_col_name <- avoid_conflict(colnames(df), c("value"))
       # use glue for custom result name ref: https://www.tidyverse.org/blog/2020/02/glue-strings-and-tidy-eval/#custom-result-names
       df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, "{value_col_name}" := dplyr::n())
     } else {

--- a/R/util.R
+++ b/R/util.R
@@ -989,11 +989,14 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
     # fill must be a numeric type of NA for data type consistency
     fill <- NA_real_
   }
-
+  # make sure the value column name is unique and does not conflict existing columns in the source data frame.
+  value_col_name = avoid_conflict(colnames(df), c("value"))
   pivot_each <- function(df) {
     res <- if(is.null(value_col)) {
       # make a count matrix if value_col is NULL
-      df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, value=dplyr::n())
+      value_col_name <- avoid_conflict(colnames(df), c("value"))
+      # use glue for custom result name ref: https://www.tidyverse.org/blog/2020/02/glue-strings-and-tidy-eval/#custom-result-names
+      df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, "{value_col_name}" := dplyr::n())
     } else {
       if(na.rm &&
          !identical(na_ratio, fun.aggregate) &&
@@ -1005,10 +1008,11 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
         # remove NA, unless fun.aggregate function is one of the above NA related ones.
         df <- df %>% dplyr::filter(!is.na(!!rlang::sym(value_col)))
       }
-      df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, value=fun.aggregate(!!rlang::sym(value_col)))
+      # use glue for custom result name ref: https://www.tidyverse.org/blog/2020/02/glue-strings-and-tidy-eval/#custom-result-names
+      df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, "{value_col_name}" := fun.aggregate(!!rlang::sym(value_col)))
     }
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_col_cols)) # arrange before pivot_wider, so that the create columns are sorted.
-    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=value, values_fill=list(value=!!fill), names_sep=cols_sep)
+    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=!!rlang::sym(value_col_name), values_fill=list(value_col_name=!!fill), names_sep=cols_sep)
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_row_cols)) # arrange grouping rows.
     res
   }

--- a/R/util.R
+++ b/R/util.R
@@ -1012,7 +1012,8 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
       df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, "{value_col_name}" := fun.aggregate(!!rlang::sym(value_col)))
     }
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_col_cols)) # arrange before pivot_wider, so that the create columns are sorted.
-    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=!!rlang::sym(value_col_name), values_fill=list(value_col_name=!!fill), names_sep=cols_sep)
+    # Dynamically set value column name to list passed to value_fill argument.
+    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=!!rlang::sym(value_col_name), values_fill=setNames(list(!!fill), value_col_name), names_sep=cols_sep)
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_row_cols)) # arrange grouping rows.
     res
   }

--- a/R/util.R
+++ b/R/util.R
@@ -993,6 +993,7 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
   value_col_name = avoid_conflict(colnames(df), c("value"))
   pivot_each <- function(df) {
     res <- if(is.null(value_col)) {
+      # make a count matrix if value_col is NULL
       # use glue for custom result name ref: https://www.tidyverse.org/blog/2020/02/glue-strings-and-tidy-eval/#custom-result-names
       df %>% summarize_group(group_cols = group_cols_arg, group_funs = all_funs, "{value_col_name}" := dplyr::n())
     } else {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -631,6 +631,7 @@ test_that("test pivot", {
     cat1 = c(letters[round(runif(100)*5)+1], NA),
     cat2 = c(letters[round(runif(100)*3)+1], "a"),
     cat3 = c(letters[round(runif(100)*3)+1], "a"),
+    value = c(letters[round(runif(100)*3)+1], "a"),
     num3 = c(NA, seq(100))
   )
 
@@ -650,6 +651,9 @@ test_that("test pivot", {
 
   pivoted_with_na_ratio <- pivot(test_df, row_cols=c("cat1"), col_cols=c("cat2") , value = num3, fun.aggregate=na_ratio, na.rm = TRUE)
   expect_true(any(pivoted_with_na_ratio %>% select(a,b,c,d) !=0)) # Verify that NA is detected.
+
+  pivoted_with_na <- pivot(test_df, row_cols=c("cat1"), col_cols=c("value"),fun.aggregate=mean, na.rm = FALSE) # test for the case where original df has value column
+  expect_true(ncol(pivoted_with_na)>1) # make sure resulting column is not the only one row.
 
 })
 


### PR DESCRIPTION
# Description

fix the issue that the Pivot calculation result is incorrect if the source data frame has the "value" column.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
