### PR TITLE
Support multi-expression, expression out of the context of pipe (%>%) in dependency detection

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3410,15 +3410,18 @@ get_refs_in_call <- function(call,
 # Returns names that references outside objects (most likely data frames) from the script.
 # priv_step_df - The data frame of the previous step. Refs to the columns of it are not considered outside refs.
 get_refs_in_script <- function(script) {
-  call <- NULL
+  calls <- NULL
   tryCatch({
-    call <- rlang::parse_expr(script)
+    calls <- rlang::parse_exprs(script)
   }, error = function(e) { # Ignore parse error and return NULL.
   })
-  if (is.null(call)) {
+  if (is.null(calls)) {
     NULL
   }
   else {
-    get_refs_in_call(call)
+    res <- purrr::reduce(calls, function(names, call) {
+      c(names, get_refs_in_call(call))
+    }, .init = c())
+    res
   }
 }

--- a/R/system.R
+++ b/R/system.R
@@ -3330,8 +3330,7 @@ select_and_friends <- c('arrange', 'select', 'rename', 'relocate', 'reorder_cols
   'do_tokenize',
   'do_ngram',
   'do_tf_idf',
-  'pair_count',
-  'library') # library() is a little different, but the name inside it should be a package name and not a ref to an object.
+  'pair_count')
 # Names of functions that uses column specifications or reference with the column names, and could also reference outside data frames, such as mutate.
 # Collected from the doc of dplyr, and our command menu.
 mutate_and_friends <- c('mutate_group', 'mutate', 'mutate_at', 'mutate_all', 'mutate_if', 'transmute', 'summarize_group',

--- a/R/system.R
+++ b/R/system.R
@@ -3448,13 +3448,13 @@ get_refs_in_call <- function(call,
                                             inside_bang_bang = inside_bang_bang)
   }
   else if (call_name_str == '%>%') {
-    res1 <- get_refs_in_call_args_basic(call_name_str, args[[1]])
-    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[[-1]])
+    res1 <- get_refs_in_call_args_basic(call_name_str, args[1])
+    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[-1])
     res <- c(res1, res2)
   }
   else if (call_name_str %in% c(select_and_friends, mutate_and_friends)) {
-    res1 <- get_refs_in_call_args_basic(call_name_str, args[[1]])
-    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[[-1]])
+    res1 <- get_refs_in_call_args_basic(call_name_str, args[1])
+    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[-1])
     res <- c(res1, res2)
   }
   else {

--- a/R/system.R
+++ b/R/system.R
@@ -3397,7 +3397,9 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
         }
       }
       else if (class(arg) == 'call') {
-        c(names, get_refs_in_call(arg, inside_mutate_and_friends, inside_bang, inside_bang_bang))
+        c(names, get_refs_in_call(arg, inside_mutate_and_friends, inside_bang, inside_bang_bang,
+                                  TRUE) # after_pipe
+        )
       }
       else {
         names
@@ -3434,13 +3436,26 @@ get_refs_in_call_args_basic <- function(call_name_str, args) {
 get_refs_in_call <- function(call,
                              inside_mutate_and_friends = FALSE,
                              inside_bang = FALSE, # Passes down the state of inside a single bang.
-                             inside_bang_bang = FALSE) { # Passes down the state of inside a consecutive bang bang.
+                             inside_bang_bang = FALSE, # Passes down the state of inside a consecutive bang bang.
+                             after_pipe = FALSE 
+                             ) {
   args <- rlang::call_args(call)
   call_name_str <- rlang::call_name(call)
-  res <- get_refs_in_call_args_after_pipe(call_name_str, args,
-                               inside_mutate_and_friends = inside_mutate_and_friends,
-                               inside_bang = inside_bang,
-                               inside_bang_bang = inside_bang_bang)
+  if (after_pipe) {
+    res <- get_refs_in_call_args_after_pipe(call_name_str, args,
+                                            inside_mutate_and_friends = inside_mutate_and_friends,
+                                            inside_bang = inside_bang,
+                                            inside_bang_bang = inside_bang_bang)
+  }
+  else if (call_name_str == '%>%') {
+    # TODO
+  }
+  else if (call_name_str %in% c(select_and_friends, mutate_and_friends)) {
+    # TODO
+  }
+  else {
+    res <- get_refs_in_call_args_basic(call_name_str, args)
+  }
   res
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -3338,7 +3338,7 @@ mutate_and_friends <- c('mutate_group', 'mutate', 'mutate_at', 'mutate_all', 'mu
   'summarize', 'summarize_at', 'summarize_all', 'summarize_if', 'summarise', 'summarise_at', 'summarise_all', 'summarise_if', 'filter',
   'do_prophet') # do_prophet is here to handle reference to holiday data frame.
 
-get_refs_in_call_args <- function(call_name_str,
+get_refs_in_call_args_after_pipe <- function(call_name_str,
                                   args,
                                   inside_mutate_and_friends = FALSE,
                                   inside_bang = FALSE, # Passes down the state of inside a single bang.
@@ -3414,7 +3414,7 @@ get_refs_in_call <- function(call,
                              inside_bang_bang = FALSE) { # Passes down the state of inside a consecutive bang bang.
   args <- rlang::call_args(call)
   call_name_str <- rlang::call_name(call)
-  res <- get_refs_in_call_args(call_name_str, args,
+  res <- get_refs_in_call_args_after_pipe(call_name_str, args,
                                inside_mutate_and_friends = inside_mutate_and_friends,
                                inside_bang = inside_bang,
                                inside_bang_bang = inside_bang_bang)

--- a/R/system.R
+++ b/R/system.R
@@ -3373,6 +3373,11 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
       args <- args[1]
     }
 
+    if (call_name_str == '<-') { # Assignment should not count as a reference.
+      args <- args[-1]
+    }
+
+
     args <- purrr::discard(args, function(arg) { # Remove empty names that are formed by empty arg. e.g. func(a, ,b). It leads purr::reduce to throw error.
       class(arg) == 'name' && as.character(arg) == ''
     })
@@ -3412,6 +3417,10 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
 get_refs_in_call_args_basic <- function(call_name_str, args) {
   if (call_name_str == '$') { # Ignore after $ since it should be a name inside the first arg.
     args <- args[1]
+  }
+
+  if (call_name_str == '<-') { # Assignment should not count as a reference.
+    args <- args[-1]
   }
 
   args <- purrr::discard(args, function(arg) { # Remove empty names that are formed by empty arg. e.g. func(a, ,b). It leads purr::reduce to throw error.

--- a/R/system.R
+++ b/R/system.R
@@ -3448,10 +3448,14 @@ get_refs_in_call <- function(call,
                                             inside_bang_bang = inside_bang_bang)
   }
   else if (call_name_str == '%>%') {
-    # TODO
+    res1 <- get_refs_in_call_args_basic(call_name_str, args[[1]])
+    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[[-1]])
+    res <- c(res1, res2)
   }
   else if (call_name_str %in% c(select_and_friends, mutate_and_friends)) {
-    # TODO
+    res1 <- get_refs_in_call_args_basic(call_name_str, args[[1]])
+    res2 <- get_refs_in_call_args_after_pipe(call_name_str, args[[-1]])
+    res <- c(res1, res2)
   }
   else {
     res <- get_refs_in_call_args_basic(call_name_str, args)
@@ -3461,7 +3465,7 @@ get_refs_in_call <- function(call,
 
 # Returns names that references outside objects (most likely data frames) from the script.
 # priv_step_df - The data frame of the previous step. Refs to the columns of it are not considered outside refs.
-get_refs_in_script <- function(script) {
+get_refs_in_script <- function(script, after_pipe = TRUE) {
   calls <- NULL
   tryCatch({
     calls <- rlang::parse_exprs(script)
@@ -3472,7 +3476,7 @@ get_refs_in_script <- function(script) {
   }
   else {
     res <- purrr::reduce(calls, function(names, call) {
-      c(names, get_refs_in_call(call))
+      c(names, get_refs_in_call(call, after_pipe = after_pipe))
     }, .init = c())
     res
   }

--- a/R/system.R
+++ b/R/system.R
@@ -3407,6 +3407,29 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
   res
 }
 
+get_refs_in_call_args_basic <- function(call_name_str, args) {
+  if (call_name_str == '$') { # Ignore after $ since it should be a name inside the first arg.
+    args <- args[1]
+  }
+
+  args <- purrr::discard(args, function(arg) { # Remove empty names that are formed by empty arg. e.g. func(a, ,b). It leads purr::reduce to throw error.
+    class(arg) == 'name' && as.character(arg) == ''
+  })
+
+  res <- purrr::reduce2(args, names(args), function(names, arg, arg_name) {
+    if (class(arg) == 'name') {
+      c(names, as.character(arg)) 
+    }
+    else if (class(arg) == 'call') {
+      c(names, get_refs_in_call(arg))
+    }
+    else {
+      names
+    }
+  }, .init = c())
+  res
+}
+
 # Returns names that references outside objects (most likely data frames) from the call.
 get_refs_in_call <- function(call,
                              inside_mutate_and_friends = FALSE,

--- a/R/system.R
+++ b/R/system.R
@@ -3373,7 +3373,7 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
       args <- args[1]
     }
 
-    if (call_name_str == '<-') { # Assignment should not count as a reference.
+    if (call_name_str %in% c('<-', '=')) { # Assignment should not count as a reference.
       args <- args[-1]
     }
 
@@ -3419,7 +3419,7 @@ get_refs_in_call_args_basic <- function(call_name_str, args) {
     args <- args[1]
   }
 
-  if (call_name_str == '<-') { # Assignment should not count as a reference.
+  if (call_name_str %in% c('<-', '=')) { # Assignment should not count as a reference.
     args <- args[-1]
   }
 

--- a/R/system.R
+++ b/R/system.R
@@ -3369,6 +3369,10 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
       inside_mutate_and_friends <- TRUE
     }
 
+    if (call_name_str == 'library') { # Ignore symbol inside library() since it is a library name.
+      return(c())
+    }
+
     if (call_name_str == '$') { # Ignore after $ since it should be a name inside the first arg.
       args <- args[1]
     }
@@ -3415,6 +3419,10 @@ get_refs_in_call_args_after_pipe <- function(call_name_str,
 }
 
 get_refs_in_call_args_basic <- function(call_name_str, args) {
+  if (call_name_str == 'library') { # Ignore symbol inside library() since it is a library name.
+    return(c())
+  }
+
   if (call_name_str == '$') { # Ignore after $ since it should be a name inside the first arg.
     args <- args[1]
   }

--- a/R/system.R
+++ b/R/system.R
@@ -3330,7 +3330,8 @@ select_and_friends <- c('arrange', 'select', 'rename', 'relocate', 'reorder_cols
   'do_tokenize',
   'do_ngram',
   'do_tf_idf',
-  'pair_count')
+  'pair_count',
+  'library') # library() is a little different, but the name inside it should be a package name and not a ref to an object.
 # Names of functions that uses column specifications or reference with the column names, and could also reference outside data frames, such as mutate.
 # Collected from the doc of dplyr, and our command menu.
 mutate_and_friends <- c('mutate_group', 'mutate', 'mutate_at', 'mutate_all', 'mutate_if', 'transmute', 'summarize_group',

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -11,7 +11,7 @@ test_that("get_refs_in_script", {
   refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
   expect_equal(refs, c('external'))
   refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
-  expect_equal(refs, c('cyl1', 'external1', 'cyl2', 'external2'))
+  expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
   refs <- get_refs_in_script("df1 %>% mutate(a1 = x1)\ndf2 %>% select(a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 2.
   expect_equal(refs, c('df1', 'df2'))
   refs <- get_refs_in_script("mutate(cyl2 = \u5916\u90e8$cyl)") # "external" in Japanese.

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -6,6 +6,8 @@ test_that("get_refs_in_script", {
   expect_equal(refs, NULL)
   refs <- get_refs_in_script('mutate(cyl2 = !!external[["cyl"]])')
   expect_equal(refs, c('external'))
+  refs <- get_refs_in_script("library(MASS)") # library()
+  expect_equal(refs, NULL)
   refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
   expect_equal(refs, c('external'))
   refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2") # multi-expressions

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -14,6 +14,8 @@ test_that("get_refs_in_script", {
   expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
   refs <- get_refs_in_script("df1 %>% mutate(a1 = x1)\ndf2 %>% select(a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 2.
   expect_equal(refs, c('df1', 'df2'))
+  refs <- get_refs_in_script("mutate(df1, a1 = x1)\nselect(df2, a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 3.
+  expect_equal(refs, c('df1', 'df2'))
   refs <- get_refs_in_script("mutate(cyl2 = \u5916\u90e8$cyl)") # "external" in Japanese.
   expect_equal(refs, c('\u5916\u90e8'))
   refs <- get_refs_in_script("mutate(cyl2 = `\u5916\u90e8`$cyl)") # With backticks.

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -10,8 +10,10 @@ test_that("get_refs_in_script", {
   expect_equal(refs, NULL)
   refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
   expect_equal(refs, c('external'))
-  refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2") # multi-expressions
+  refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
   expect_equal(refs, c('cyl1', 'external1', 'cyl2', 'external2'))
+  refs <- get_refs_in_script("df1 %>% mutate(a1 = x1)\ndf2 %>% select(a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 2.
+  expect_equal(refs, c('df1', 'df2'))
   refs <- get_refs_in_script("mutate(cyl2 = \u5916\u90e8$cyl)") # "external" in Japanese.
   expect_equal(refs, c('\u5916\u90e8'))
   refs <- get_refs_in_script("mutate(cyl2 = `\u5916\u90e8`$cyl)") # With backticks.

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -6,7 +6,9 @@ test_that("get_refs_in_script", {
   expect_equal(refs, NULL)
   refs <- get_refs_in_script('mutate(cyl2 = !!external[["cyl"]])')
   expect_equal(refs, c('external'))
-  refs <- get_refs_in_script("library(MASS)") # library()
+  refs <- get_refs_in_script("library(MASS)", after_pipe = FALSE) # library()
+  expect_equal(refs, NULL)
+  refs <- get_refs_in_script("library(MASS)", after_pipe = TRUE) # library() in after-pipe expression.
   expect_equal(refs, NULL)
   refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
   expect_equal(refs, c('external'))

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -1,5 +1,7 @@
 context("test R parser")
 test_that("get_refs_in_script", {
+  refs <- get_refs_in_script("df1") # Just a name.
+  expect_equal(refs, c('df1'))
   refs <- get_refs_in_script("select(cyl)")
   expect_equal(refs, NULL)
   refs <- get_refs_in_script("mutate(cyl2 = cyl)")
@@ -10,12 +12,12 @@ test_that("get_refs_in_script", {
   expect_equal(refs, NULL)
   refs <- get_refs_in_script("library(MASS)", after_pipe = TRUE) # library() in after-pipe expression.
   expect_equal(refs, NULL)
-  refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
-  expect_equal(refs, c('external'))
   refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
   expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
   refs <- get_refs_in_script("cyl1 = external1\ncyl2 = external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
   expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
+  refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
+  expect_equal(refs, c('external'))
   refs <- get_refs_in_script("df1 %>% mutate(a1 = x1)\ndf2 %>% select(a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 2.
   expect_equal(refs, c('df1', 'df2'))
   refs <- get_refs_in_script("mutate(df1, a1 = x1)\nselect(df2, a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 3.

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -12,6 +12,8 @@ test_that("get_refs_in_script", {
   expect_equal(refs, c('external'))
   refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
   expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
+  refs <- get_refs_in_script("cyl1 = external1\ncyl2 = external2", after_pipe = FALSE) # multi-expressions, non-after-pipe.
+  expect_equal(refs, c('external1', 'external2')) # cyl1, cyl2 should not be picked up as references.
   refs <- get_refs_in_script("df1 %>% mutate(a1 = x1)\ndf2 %>% select(a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 2.
   expect_equal(refs, c('df1', 'df2'))
   refs <- get_refs_in_script("mutate(df1, a1 = x1)\nselect(df2, a2)", after_pipe = FALSE) # multi-expressions, non-after-pipe case 3.

--- a/tests/testthat/test_r_parser.R
+++ b/tests/testthat/test_r_parser.R
@@ -6,8 +6,10 @@ test_that("get_refs_in_script", {
   expect_equal(refs, NULL)
   refs <- get_refs_in_script('mutate(cyl2 = !!external[["cyl"]])')
   expect_equal(refs, c('external'))
-  refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)")
+  refs <- get_refs_in_script("mutate(cyl2 = \nexternal$cyl)") # multi-line
   expect_equal(refs, c('external'))
+  refs <- get_refs_in_script("cyl1 <- external1\ncyl2 <- external2") # multi-expressions
+  expect_equal(refs, c('cyl1', 'external1', 'cyl2', 'external2'))
   refs <- get_refs_in_script("mutate(cyl2 = \u5916\u90e8$cyl)") # "external" in Japanese.
   expect_equal(refs, c('\u5916\u90e8'))
   refs <- get_refs_in_script("mutate(cyl2 = `\u5916\u90e8`$cyl)") # With backticks.


### PR DESCRIPTION
# Description
Support multi-expression, expression out of the context of pipe (%>%) in dependency detection.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
