### PR TITLE
Changed to pass noActl to fetch more than 200 buckets.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1866,6 +1866,8 @@ listGoogleCloudStorageBuckets <- function(project, tokenFileId){
   if(!requireNamespace("googleAuthR")){stop("package googleAuthR must be installed.")}
   token <- getGoogleTokenForBigQuery(tokenFileId)
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
+  # make sure to pass "noAcl" as projection so that Google won't limit maxResults as 200.
+  # ref: https://cloud.google.com/storage/docs/json_api/v1/buckets/list
   googleCloudStorageR::gcs_list_buckets(projectId = project, maxResults = 1000, projection = c("noAcl"))
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -1866,7 +1866,7 @@ listGoogleCloudStorageBuckets <- function(project, tokenFileId){
   if(!requireNamespace("googleAuthR")){stop("package googleAuthR must be installed.")}
   token <- getGoogleTokenForBigQuery(tokenFileId)
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
-  googleCloudStorageR::gcs_list_buckets(projectId = project, projection = c("full"))
+  googleCloudStorageR::gcs_list_buckets(projectId = project, maxResults = 1000, projection = c("noAcl"))
 }
 
 #' API to get a data from google BigQuery table


### PR DESCRIPTION
# Description

Updated `listGoogleCloudStorageBuckets` to show more than 200 buckets.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
