### PR TITLE
kmeans: Limit the numbers of centers to search up to nrow(df) - 1

### DIFF
--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -7,7 +7,9 @@ iterate_kmeans <- function(df, max_centers = 10,
                            normalize_data = TRUE,
                            seed = NULL
                            ) {
-  n_centers <- seq(max_centers)
+  # Limit the numbers of centers to search up to nrow(df) - 1.
+  # Otherwise we will get "Centers should be less than rows" error.
+  n_centers <- seq(min(max_centers, nrow(df) - 1))
   ret <- data.frame(center = n_centers)
   ret <- ret %>% dplyr::mutate(model = purrr::map(center, function(x) {
     model_df <- df %>% build_kmeans.cols(everything(),

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -61,6 +61,12 @@ test_that("exp_kmeans elbow method mode", {
   model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode=TRUE)
   res <- model_df %>% tidyr::unnest(model)
   expect_equal(colnames(res), c("center","totss","tot.withinss","betweenss","iter"))
+  # Test the case the rows are fewer and we have to limit the search.
+  df <- df %>% head(9)
+  model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode=TRUE)
+  res <- model_df %>% tidyr::unnest(model)
+  # Search should be limited up to 8 (9 - 1).
+  expect_equal(nrow(res), 8)
 })
 
 # group_by for elbow method is not currently supported. Revive this test when it is.


### PR DESCRIPTION
# Description

kmeans: Limit the numbers of centers to search up to nrow(df) - 1

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
