### PR TITLE
fix Google BigQuery Data Source: Data became NA when columns data types are INT64

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1811,7 +1811,7 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
     token <- getGoogleTokenForBigQuery(tokenFileId)
     bigrquery::set_access_cred(token)
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
-    # Treat int64 as numeric by passing bigint = "numeric"
+    # Treat int64 as numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
     bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
@@ -1959,7 +1959,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       # set envir = parent.frame() to get variables from users environment, not papckage environment
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
-      # Treat int64 as numeric by passing bigint = "numeric"
+      # Treat int64 as numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
       df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
     }
     df

--- a/R/system.R
+++ b/R/system.R
@@ -1811,7 +1811,8 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
     token <- getGoogleTokenForBigQuery(tokenFileId)
     bigrquery::set_access_cred(token)
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
-    bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, quiet = TRUE, max_connections = max_connections)
+    # Treat int64 as numeric by passing bigint = c("numeric")
+    bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = c("numeric"), quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
     options(scipen = original_scipen)
@@ -1958,7 +1959,8 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       # set envir = parent.frame() to get variables from users environment, not papckage environment
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
-      df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, max_connections = max_connections, quiet = TRUE)
+      # Treat int64 as numeric by passing bigint = c("numeric")
+      df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint=c("numeric"), max_connections = max_connections, quiet = TRUE)
     }
     df
   }, finally = {

--- a/R/system.R
+++ b/R/system.R
@@ -1811,7 +1811,7 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
     token <- getGoogleTokenForBigQuery(tokenFileId)
     bigrquery::set_access_cred(token)
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
-    # Treat int64 as numeric by passing bigint = c("numeric")
+    # Treat int64 as numeric by passing bigint = "numeric"
     bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
@@ -1959,7 +1959,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       # set envir = parent.frame() to get variables from users environment, not papckage environment
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
-      # Treat int64 as numeric by passing bigint = c("numeric")
+      # Treat int64 as numeric by passing bigint = "numeric"
       df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
     }
     df

--- a/R/system.R
+++ b/R/system.R
@@ -1811,7 +1811,7 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
     token <- getGoogleTokenForBigQuery(tokenFileId)
     bigrquery::set_access_cred(token)
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
-    # Treat int64 as numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
+    # Since Exploratory Desktop does not handle int64, convert int64 to numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
     bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
@@ -1959,7 +1959,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       # set envir = parent.frame() to get variables from users environment, not papckage environment
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
-      # Treat int64 as numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
+      # Since Exploratory Desktop does not handle int64, convert int64 to numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
       df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
     }
     df

--- a/R/system.R
+++ b/R/system.R
@@ -1812,7 +1812,7 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
     bigrquery::set_access_cred(token)
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
     # Treat int64 as numeric by passing bigint = c("numeric")
-    bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = c("numeric"), quiet = TRUE, max_connections = max_connections)
+    bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
     options(scipen = original_scipen)
@@ -1960,7 +1960,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
       # Treat int64 as numeric by passing bigint = c("numeric")
-      df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint=c("numeric"), max_connections = max_connections, quiet = TRUE)
+      df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
     }
     df
   }, finally = {


### PR DESCRIPTION
# Description

This PR fixes the issue that Google BigQuery Data Source: Data became NA when columns data types are INT64

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
