### PR TITLE
Google Sheets Data Source: 404 not found error message improvement.

### DIFF
--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -107,7 +107,7 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NUL
     # When a worksheet is missing, Google returns "`range` doesn't appear to be a range in A1 notation" error so detect it.
     if (stringr::str_detect(e$message, "`range` doesn't appear to be a range in A1 notation, a named range")) {
       stop(paste0('EXP-DATASRC-16 :: ', jsonlite::toJSON(c(title, sheetName)), ' :: There is no such work sheet in the Google Sheets.'))
-    } else if (stringr::str_detect(e$message, "Client error: \\(404\\) (Not Found|NOT_FOUND)")) { # When a sheet does not exist, Google Returns (404) Not Found (or NOT_FOUDN) so detect it.
+    } else if (stringr::str_detect(e$message, "Client error: \\(404\\) (Not Found|NOT_FOUND)")) { # When a sheet does not exist, Google Returns (404) Not Found (or NOT_FOUND) so detect it.
       stop(paste0('EXP-DATASRC-17 :: ', jsonlite::toJSON(c(title, sheetName)), ' :: There is no such sheet in the Google Sheets.'))
     } else {
       stop(e)

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -107,7 +107,7 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NUL
     # When a worksheet is missing, Google returns "`range` doesn't appear to be a range in A1 notation" error so detect it.
     if (stringr::str_detect(e$message, "`range` doesn't appear to be a range in A1 notation, a named range")) {
       stop(paste0('EXP-DATASRC-16 :: ', jsonlite::toJSON(c(title, sheetName)), ' :: There is no such work sheet in the Google Sheets.'))
-    } else if (stringr::str_detect(e$message, "Client error: \\(404\\) Not Found")) { # When a sheet does not exist, Google Returns (404) Not Found so detect it.
+    } else if (stringr::str_detect(e$message, "Client error: \\(404\\) (Not Found|NOT_FOUND)")) { # When a sheet does not exist, Google Returns (404) Not Found (or NOT_FOUDN) so detect it.
       stop(paste0('EXP-DATASRC-17 :: ', jsonlite::toJSON(c(title, sheetName)), ' :: There is no such sheet in the Google Sheets.'))
     } else {
       stop(e)


### PR DESCRIPTION
# Description

We found that Google Sheets return the below error message when the specified Google Sheet does not exist.

```
Error: Error : Client error: (404) NOT_FOUND
• A specified resource is not found, or the request is rejected by undisclosed
  reasons, such as whitelisting.
• Requested entity was not found.
```

So show a user-friendly message for this csae.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
