### PR TITLE
Fix issue that NA fill parameter value is not reflected for the Pivot result.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1012,7 +1012,7 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
     }
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_col_cols)) # arrange before pivot_wider, so that the create columns are sorted.
     # Dynamically set value column name to list passed to value_fill argument.
-    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=!!rlang::sym(value_col_name), values_fill=setNames(list(!!fill), value_col_name), names_sep=cols_sep)
+    res <- res %>% tidyr::pivot_wider(names_from = !!new_col_cols, values_from=!!rlang::sym(value_col_name), values_fill=setNames(list(fill), value_col_name), names_sep=cols_sep)
     res <- res %>% dplyr::arrange(!!!rlang::syms(new_row_cols)) # arrange grouping rows.
     res
   }

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -643,6 +643,11 @@ test_that("test pivot", {
   pivoted_with_val <- pivot(test_df, row_cols=c("cat1"), col_cols=c("cat2","cat3"), value = num3, fun.aggregate=mean, fill = 0)
   expect_true(all(!is.na(pivoted_with_val)))
 
+  # add test case for fill argument is not 0 or 1.
+  pivoted_with_val2 <- pivot(test_df, row_cols=c("cat1"), col_cols=c("cat2","cat3"), value = num3, fun.aggregate=mean, fill = 10)
+  expect_equal(sum(pivoted_with_val2$a_a), 152)
+
+
   pivoted_with_na <- pivot(test_df, row_cols=c("cat1"), col_cols=c("cat2", "cat3"), value = num3, fun.aggregate=mean, na.rm = FALSE)
   expect_true(any(is.na(pivoted_with_na)))
 


### PR DESCRIPTION
# Description

fixed issue that NA fill parameter value is not reflected for the Pivot result.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
