### PR TITLE
Fix Pivot does not work when non-numeric value column is set.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -978,13 +978,13 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
       # NA is regarded as logical
       fill <- NA
     } else if (class(df[[value_col]]) %in% c("numeric", "integer")) {
-      # NA is regarded as numeric
+      # NA_real is regarded as numeric
       fill <- NA_real_
     } else if (class(df[[value_col]]) %in% c("character", "factor")) {
-      # NA is regarded as character
+      # NA_character_ is regarded as character
       fill <- NA_character_
     } else {
-      # NA for all the other data types.
+      # NA is regarded as logical for all the other data types.
       fill <- NA
     }
   } else if (is.null(fill)) {

--- a/R/util.R
+++ b/R/util.R
@@ -977,9 +977,15 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
     if (identical(fun.aggregate, all) || identical(fun.aggregate, any) ) {
       # NA is regarded as logical
       fill <- NA
-    } else {
-      # NA_real_ is regarded as numeric
+    } else if (class(df[[value_col]]) %in% c("numeric", "integer")) {
+      # NA is regarded as numeric
       fill <- NA_real_
+    } else if (class(df[[value_col]]) %in% c("character", "factor"))
+      # NA is regarded as character
+      fill <- NA_character_
+    } else {
+      # NA for all the other data types.
+      fill <- NA
     }
   } else if (is.null(fill)) {
     # this case is counting row col pairs and default is 0

--- a/R/util.R
+++ b/R/util.R
@@ -977,10 +977,10 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
     if (identical(fun.aggregate, all) || identical(fun.aggregate, any) ) {
       # NA is regarded as logical
       fill <- NA
-    } else if (class(df[[value_col]]) %in% c("numeric", "integer")) {
+    } else if (any(class(df[[value_col]]) %in% c("numeric", "integer"))) {
       # NA_real is regarded as numeric
       fill <- NA_real_
-    } else if (class(df[[value_col]]) %in% c("character", "factor")) {
+    } else if (any(class(df[[value_col]]) %in% c("character", "factor"))) {
       # NA_character_ is regarded as character
       fill <- NA_character_
     } else {

--- a/R/util.R
+++ b/R/util.R
@@ -980,7 +980,7 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
     } else if (class(df[[value_col]]) %in% c("numeric", "integer")) {
       # NA is regarded as numeric
       fill <- NA_real_
-    } else if (class(df[[value_col]]) %in% c("character", "factor"))
+    } else if (class(df[[value_col]]) %in% c("character", "factor")) {
       # NA is regarded as character
       fill <- NA_character_
     } else {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -632,8 +632,12 @@ test_that("test pivot", {
     cat2 = c(letters[round(runif(100)*3)+1], "a"),
     cat3 = c(letters[round(runif(100)*3)+1], "a"),
     value = c(letters[round(runif(100)*3)+1], "a"),
+    dateCol = c(rep(lubridate::ymd("2022-01-01"),101)),
+    posixctCol = c(rep(lubridate::ymd_hms("2022-01-01 00:00:00"),101)),
     num3 = c(NA, seq(100))
   )
+  test_df <- test_df %>% dplyr::mutate(dateCol = dplyr::case_when(cat2 == "a" ~ as.Date(NA), TRUE ~ dateCol))
+  test_df <- test_df %>% dplyr::mutate(posixctCol = dplyr::case_when(cat2 == "b" ~ as.POSIXct(NA), TRUE ~ posixctCol))
 
   pivoted <- pivot(test_df, row_cols=c("cat1","cat3"), col_cols=c("cat2"))
   #pivoted <- pivot(test_df, cat1+cat3 ~ cat2)
@@ -659,6 +663,18 @@ test_that("test pivot", {
 
   pivoted_with_na <- pivot(test_df, row_cols=c("cat1"), col_cols=c("value"),fun.aggregate=mean, na.rm = FALSE) # test for the case where original df has value column
   expect_true(ncol(pivoted_with_na)>1) # make sure resulting column is not the only one row.
+
+  # test with value column with categorical column
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = get_mode, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # test with value column with Date column
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = get_mode, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # test with value column with POSIXct column
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = get_mode, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
 
 })
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -634,10 +634,12 @@ test_that("test pivot", {
     value = c(letters[round(runif(100)*3)+1], "a"),
     dateCol = c(rep(lubridate::ymd("2022-01-01"),101)),
     posixctCol = c(rep(lubridate::ymd_hms("2022-01-01 00:00:00"),101)),
+    intCol = as.integer(1:101),
     num3 = c(NA, seq(100))
   )
   test_df <- test_df %>% dplyr::mutate(dateCol = dplyr::case_when(cat2 == "a" ~ as.Date(NA), TRUE ~ dateCol))
   test_df <- test_df %>% dplyr::mutate(posixctCol = dplyr::case_when(cat2 == "b" ~ as.POSIXct(NA), TRUE ~ posixctCol))
+  test_df <- test_df %>% dplyr::mutate(intCol = dplyr::case_when(cat2 == "b" ~ NA_integer_, TRUE ~ intCol))
 
   pivoted <- pivot(test_df, row_cols=c("cat1","cat3"), col_cols=c("cat2"))
   #pivoted <- pivot(test_df, cat1+cat3 ~ cat2)
@@ -664,17 +666,21 @@ test_that("test pivot", {
   pivoted_with_na <- pivot(test_df, row_cols=c("cat1"), col_cols=c("value"),fun.aggregate=mean, na.rm = FALSE) # test for the case where original df has value column
   expect_true(ncol(pivoted_with_na)>1) # make sure resulting column is not the only one row.
 
-  # test with value column with categorical column
+  # value column as categorical column
   pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = get_mode, na.rm = TRUE)
   expect_true(nrow(pivoted_with_categorical)>1)
 
-  # test with value column with Date column
+  # value column as Date column
   pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = get_mode, na.rm = TRUE)
   expect_true(nrow(pivoted_with_date)>1)
 
-  # test with value column with POSIXct column
+  # value column as POSIXct column
   pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = get_mode, na.rm = TRUE)
   expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as integer column
+  pivoted_with_int <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = intCol, fun.aggregate = sum, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_int)>1)
 
 })
 


### PR DESCRIPTION
# Description

Fix Pivot does not work when non-numeric value column is set.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
