### PR TITLE
After closing the Exploratory Desktop, lock file is not removed.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1720,7 +1720,10 @@ queryODBC <- function(dsn="", username, password, additionalParams="", numOfRows
     DBI::dbClearResult(resultSet)
   }
   if (type == "access") { # clear access connection so that lock file is removed.
-    DBI::dbDisconnect(conn)
+    tryCatch({
+      clearDBConnection(type, NULL, NULL, NULL, username, dsn = dsn, additionalParams = additionalParams)
+      DBI::dbDisconnect(conn)
+    })
   }
   df
 }

--- a/R/system.R
+++ b/R/system.R
@@ -1719,6 +1719,9 @@ queryODBC <- function(dsn="", username, password, additionalParams="", numOfRows
   if (type == "mssqlserver" || type == "dbiodbc" || type == "snowflake" || type == "teradata" || type == "access") {
     DBI::dbClearResult(resultSet)
   }
+  if (type == "access") { # clear access connection so that lock file is removed.
+    DBI::dbDisconnect(conn)
+  }
   df
 }
 

--- a/R/system.R
+++ b/R/system.R
@@ -1722,7 +1722,7 @@ queryODBC <- function(dsn="", username, password, additionalParams="", numOfRows
   if (type == "access") { # clear access connection so that lock file is removed.
     tryCatch({
       clearDBConnection(type, NULL, NULL, NULL, username, dsn = dsn, additionalParams = additionalParams)
-      DBI::dbDisconnect(conn)
+      odbc::dbDisconnect(conn)
     })
   }
   df


### PR DESCRIPTION
# Description

fix issue that  After closing the Exploratory Desktop, lock file is not removed.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
