### PR TITLE
Backport: Pivot: When a character column is selected for value and aggregation function that returns numeric value is selected, it fails.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -981,8 +981,29 @@ pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_fun
       # NA_real is regarded as numeric
       fill <- NA_real_
     } else if (any(class(df[[value_col]]) %in% c("character", "factor"))) {
-      # NA_character_ is regarded as character
-      fill <- NA_character_
+      # when aggregate function is min, max, or get_mode, resulting data is character
+      if (identical(fun.aggregate, min) || identical(fun.aggregate, max) ||
+          identical(fun.aggregate, first) || identical(fun.aggregate, last) || identical(fun.aggregate, get_mode)) {
+        # NA_character_ is regarded as character
+        fill <- NA_character_
+      } else { # for other cases such as na_count, na_ratio etc, resulting data is numeric.
+        fill <- NA_real_
+      }
+    } else if (any(class(df[[value_col]]) %in% c("Date", "POSIXct"))) {
+      if (identical(fun.aggregate, min) || identical(fun.aggregate, max) || identical(fun.aggregate, median) ||
+          identical(fun.aggregate, first) || identical(fun.aggregate, last) || identical(fun.aggregate, get_mode)) {
+        # Returned value is Date/POSIXct.
+        fill <- NA
+      } else { # for other cases such as na_count, na_ratio etc, resulting data is numeric.
+        fill <- NA_real_
+      }
+    } else if (any(class(df[[value_col]]) %in% c("logical"))) {
+      if (identical(fun.aggregate, first) || identical(fun.aggregate, last) || identical(fun.aggregate, get_mode)) {
+        # Returned value is logical.
+        fill <- NA
+      } else { # for other cases such as na_count, na_ratio etc, resulting data is numeric.
+        fill <- NA_real_
+      }
     } else {
       # NA is regarded as logical for all the other data types.
       fill <- NA

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -666,16 +666,116 @@ test_that("test pivot", {
   pivoted_with_na <- pivot(test_df, row_cols=c("cat1"), col_cols=c("value"),fun.aggregate=mean, na.rm = FALSE) # test for the case where original df has value column
   expect_true(ncol(pivoted_with_na)>1) # make sure resulting column is not the only one row.
 
-  # value column as categorical column
+  # value column as categorical column: mode
   pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = get_mode, na.rm = TRUE)
   expect_true(nrow(pivoted_with_categorical)>1)
 
-  # value column as Date column
+  # value column as categorical column: n_distinct
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = n_distinct, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: min
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = min, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: max
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = max, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: na_count
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: na_ratio
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = na_ratio, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: non_na_count
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = non_na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as categorical column: non_na_ratio
+  pivoted_with_categorical <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = cat3, fun.aggregate = non_na_ratio, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_categorical)>1)
+
+  # value column as Date column: mode
   pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = get_mode, na.rm = TRUE)
   expect_true(nrow(pivoted_with_date)>1)
 
-  # value column as POSIXct column
+  # value column as Date column:median
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = median, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column:min
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = min, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column:max
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = max, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column: n_distinct
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = n_distinct, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column: na_count
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column: na_ratio
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = na_ratio, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column: non_na_count
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = non_na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as Date column: non_na_ratio
+  pivoted_with_date <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = dateCol, fun.aggregate = non_na_ratio, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_date)>1)
+
+  # value column as POSIXct column: mode
   pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = get_mode, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: median
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = median, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: min
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = min, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: max
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = max, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: first
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = first, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: last
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = last, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: n_distinct
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = n_distinct, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: na_count
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: na_ratio
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = na_ratio, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: non_na_count
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = non_na_count, na.rm = TRUE)
+  expect_true(nrow(pivoted_with_posixct)>1)
+
+  # value column as POSIXct column: non_na_ratio
+  pivoted_with_posixct <- pivot(test_df, row_cols = c("cat1"), col_cols = c("cat2"), value = posixctCol, fun.aggregate = non_na_ratio, na.rm = TRUE)
   expect_true(nrow(pivoted_with_posixct)>1)
 
   # value column as integer column


### PR DESCRIPTION
# Description

Backport https://github.com/exploratory-io/exploratory_func/pull/1221 for a one-off patch.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
