### PR TITLE
Work around an error from tidy.anova with broom 1.0.0 that happens when heading attribute of the anova model is there.

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -1510,7 +1510,8 @@ model_anova <- function(df, pretty.name = FALSE){
   ret <- suppressWarnings({
     # this causes warning for Deviance, Resid..Df, Resid..Dev in glm model. TODO: Is this still true?
     df %>% dplyr::ungroup() %>%
-      dplyr::mutate(output=purrr::map(model,function(m){broom::tidy(anova(m))})) %>%
+      # Work around an error from tidy.anova with broom 1.0.0 that happens when heading attribute of the anova model is there.
+      dplyr::mutate(output=purrr::map(model,function(m){am<-anova(m);attr(am,'heading')<-NULL;broom::tidy(am)})) %>%
       dplyr::select(-source.data, -.test_index, -model, -.model_metadata) %>%
       tidyr::unnest(output)
   })


### PR DESCRIPTION

# Description
Work around an error from tidy.anova with broom 1.0.0 that happens when heading attribute of the anova model is there.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement - Already covered.
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
