### PR TITLE
Support target_columns arguments for join to support column selection as preprocess

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -24,9 +24,11 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
 #' Wrapper function for dplyr's inner_join to support case insensitive join.
 #' @export
 inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  # Limit source columns to use for join when source_columns are set.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }
+  # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
   }
@@ -40,9 +42,11 @@ inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 #' @export
 #' Wrapper function for dplyr's left_join to support case insensitive join.
 left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  # Limit source columns to use for join when source_columns are set.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }
+  # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
   }
@@ -56,9 +60,11 @@ left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 #' @export
 #' Wrapper function for dplyr's right_join to support case insensitive join.
 right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  # Limit source columns to use for join when source_columns are set.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }
+  # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
   }
@@ -72,9 +78,11 @@ right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 #' @export
 #' Wrapper function for dplyr's full_join to support case insensitive join.
 full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...) {
+  # Limit source columns to use for join when source_columns are set.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }
+  # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
   }
@@ -88,6 +96,8 @@ full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 #' @export
 #' Wrapper function for dplyr's semi_join to support case insensitive join.
 semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
+  # Limit source columns to use for join when source_columns are set.
+  # For semi_join, it does not bring target columns so it only supports source_columns argument.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }
@@ -101,6 +111,8 @@ semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_
 #' @export
 #' Wrapper function for dplyr's anti_join to support case insensitive join.
 anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
+  # Limit source columns to use for join when source_columns are set.
+  # For anit_join, it does not bring target columns so it only supports source_columns argument.
   if (!is.null(source_columns)) {
     x <- x %>% dplyr::select(source_columns)
   }

--- a/R/join.R
+++ b/R/join.R
@@ -23,11 +23,7 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
 
 #' Wrapper function for dplyr's inner_join to support case insensitive join.
 #' @export
-inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
-  # Limit source columns to use for join when source_columns are set.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
@@ -41,11 +37,7 @@ inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's left_join to support case insensitive join.
-left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
-  # Limit source columns to use for join when source_columns are set.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
@@ -59,11 +51,7 @@ left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 
 #' @export
 #' Wrapper function for dplyr's right_join to support case insensitive join.
-right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
-  # Limit source columns to use for join when source_columns are set.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
@@ -77,11 +65,7 @@ right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's full_join to support case insensitive join.
-full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...) {
-  # Limit source columns to use for join when source_columns are set.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...) {
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     y <- y %>% dplyr::select(target_columns)
@@ -95,12 +79,7 @@ full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 
 #' @export
 #' Wrapper function for dplyr's semi_join to support case insensitive join.
-semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
-  # Limit source columns to use for join when source_columns are set.
-  # For semi_join, it does not bring target columns so it only supports source_columns argument.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
   if(ignorecase) {
     insensitive_join(dplyr::semi_join)(x = x, y = y, by = by, copy = copy)
   } else {
@@ -110,12 +89,7 @@ semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_
 
 #' @export
 #' Wrapper function for dplyr's anti_join to support case insensitive join.
-anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
-  # Limit source columns to use for join when source_columns are set.
-  # For anit_join, it does not bring target columns so it only supports source_columns argument.
-  if (!is.null(source_columns)) {
-    x <- x %>% dplyr::select(source_columns)
-  }
+anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
   if(ignorecase) {
     insensitive_join(dplyr::anti_join)(x = x, y = y, by = by, copy = copy)
   } else {

--- a/R/join.R
+++ b/R/join.R
@@ -1,10 +1,10 @@
 #' @ref{https://gist.github.com/jimhester/a060323a05b40c6ada34}
 #' @export
-insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
+insensitive_join <- function(fun = dplyr::left_join, type = "LEFT", suffix =  c(".x", ".y")) {
   new_fun <- fun
   body(new_fun) <- substitute({
     by <- dplyr:::common_by(by, x, y)
-    
+
     tmp_by_x <- paste0("_", by$x, "_")
     tmp_by_y <- paste0("_", by$y, "_")
     for (i in seq_along(by$x)) {
@@ -12,10 +12,10 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
       y[[tmp_by_y[[i]]]] <- tolower(y[[by$y[[i]]]])
       y[[by$y[[i]]]] <- NULL
     }
-    
-    res <- fun(x, y, list(x = tmp_by_x, y = tmp_by_y))
+
+    res <- fun(x, y, list(x = tmp_by_x, y = tmp_by_y), suffix = suffix)
     res[tmp_by_x] <- list(NULL)
-    
+
     res
   })
   new_fun
@@ -23,7 +23,13 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
 
 #' Wrapper function for dplyr's inner_join to support case insensitive join.
 #' @export
-inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, ...){
+inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
+  if (!is.null(target_columns)) {
+    y <- y %>% dplyr::select(target_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::inner_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)
   } else {
@@ -33,7 +39,13 @@ inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's left_join to support case insensitive join.
-left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, ...){
+left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
+  if (!is.null(target_columns)) {
+    y <- y %>% dplyr::select(target_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::left_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)
   } else {
@@ -43,7 +55,13 @@ left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 
 #' @export
 #' Wrapper function for dplyr's right_join to support case insensitive join.
-right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, ...){
+right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...){
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
+  if (!is.null(target_columns)) {
+    y <- y %>% dplyr::select(target_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::right_join, "RIGHT")(x, y, by = by, copy = copy, suffix = suffix)
   } else {
@@ -53,7 +71,13 @@ right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's full_join to support case insensitive join.
-full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, ...) {
+full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, source_columns = NULL, target_columns = NULL, ...) {
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
+  if (!is.null(target_columns)) {
+    y <- y %>% dplyr::select(target_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::full_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)
   } else {
@@ -63,7 +87,10 @@ full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 
 #' @export
 #' Wrapper function for dplyr's semi_join to support case insensitive join.
-semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ......) {
+semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::semi_join)(x = x, y = y, by = by, copy = copy)
   } else {
@@ -73,7 +100,10 @@ semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ......)
 
 #' @export
 #' Wrapper function for dplyr's anti_join to support case insensitive join.
-anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ......) {
+anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, source_columns = NULL, ...) {
+  if (!is.null(source_columns)) {
+    x <- x %>% dplyr::select(source_columns)
+  }
   if(ignorecase) {
     insensitive_join(dplyr::anti_join)(x = x, y = y, by = by, copy = copy)
   } else {

--- a/R/join.R
+++ b/R/join.R
@@ -1,6 +1,6 @@
 #' @ref{https://gist.github.com/jimhester/a060323a05b40c6ada34}
 #' @export
-insensitive_join <- function(fun = dplyr::left_join, type = "LEFT", suffix =  c(".x", ".y")) {
+insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
   new_fun <- fun
   body(new_fun) <- substitute({
     by <- dplyr:::common_by(by, x, y)

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -178,3 +178,8 @@ test_that("anti_join with case sensitive", {
   # 6       f1c               6
   expect_equal(unlist(df12 %>% filter(lower_col == "d1a") %>% select(value_lower_col))[[1]], 4)
 })
+
+test_that("column suffix argument with case sensitive", {
+  df13 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("1", "2"), ignorecase = TRUE)
+  expect_equal(df13 %>% dplyr::filter(mpg1 > 21) %>% nrow(), 71)
+})

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -179,7 +179,7 @@ test_that("anti_join with case sensitive", {
   expect_equal(unlist(df12 %>% filter(lower_col == "d1a") %>% select(value_lower_col))[[1]], 4)
 })
 
-test_that("column suffix argument with case sensitive", {
+test_that("column suffix argument with case insensitive", {
   df13 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("1", "2"), ignorecase = TRUE)
   expect_equal(df13 %>% dplyr::filter(mpg1 > 21) %>% nrow(), 71)
 })

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -5,14 +5,20 @@ lower_col <- c("a","b","c", "d1a", "1eb","f1c")
 upper_col <- c("A","B","C", "D1a", "1EB", "F1C", "G", "H")
 value_lower_col <- c(1,2,3,4,5,6)
 value_upper_col <- c(8,7,6,5,4,3,2,1)
-lower_df <- data.frame(lower_col, value_lower_col)
-upper_df <- data.frame(upper_col, value_upper_col)
+other_lower_col <- c('aa','bb','cc','dd','ee', 'ff')
+other_upper_col <- c('AA','BB','CC','DD','EE', 'FF', "GG", "HH")
+
+lower_df <- data.frame(lower_col, value_lower_col, other_lower_col)
+upper_df <- data.frame(upper_col, value_upper_col, other_upper_col)
 
 
 context("test case insensitive join functions")
 
 test_that("left_join with case insensitive", {
-  df1 <- lower_df %>% left_join(upper_df, by = c("lower_col" = "upper_col"), ignorecase = TRUE)
+  df1 <- lower_df %>% left_join(upper_df, by = c("lower_col" = "upper_col"),
+                                ignorecase = TRUE,
+                                source_columns = c("lower_col","value_lower_col"),
+                                target_columns = c("upper_col","value_upper_col"))
   # > df1
   # lower_col value_lower_col value_upper_col
   # 1         a               1               8
@@ -26,14 +32,13 @@ test_that("left_join with case insensitive", {
 
 test_that("left_join with case sensitive", {
   df2 <- lower_df %>% left_join(upper_df, by = c("lower_col" = "upper_col"))
-  # > df2
-  #   lower_col value_lower_col value_upper_col
-  # 1         a               1              NA
-  # 2         b               2              NA
-  # 3         c               3              NA
-  # 4       d1a               4              NA
-  # 5       1eb               5              NA
-  # 6       f1c               6              NA
+  #lower_col value_lower_col other_lower_col value_upper_col other_upper_col
+  # 1         a               1              aa              NA            <NA>
+  # 2         b               2              bb              NA            <NA>
+  # 3         c               3              cc              NA            <NA>
+  # 4       d1a               4              dd              NA            <NA>
+  # 5       1eb               5              ee              NA            <NA>
+  # 6       f1c               6              ff              NA            <NA>
   result <- df2 %>% filter(lower_col == "d1a") %>% select(value_upper_col)
   expect_equal(is.na(result$value_upper_col),TRUE)
 })
@@ -104,7 +109,7 @@ test_that("full_join with case sensitive", {
   # 11       1EB              NA               4
   # 12       F1C              NA               3
   # 13         G              NA               2
-  # 14         H              NA               1 
+  # 14         H              NA               1
   expect_equal(unlist(df6 %>% filter(lower_col == "D1a") %>% select(value_upper_col))[[1]], 5)
   result <- df6 %>% filter(lower_col == "D1a") %>% select(value_lower_col)
   expect_equal(is.na(result$value_lower_col),TRUE)

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -17,16 +17,14 @@ context("test case insensitive join functions")
 test_that("left_join with case insensitive", {
   df1 <- lower_df %>% left_join(upper_df, by = c("lower_col" = "upper_col"),
                                 ignorecase = TRUE,
-                                source_columns = c("lower_col","value_lower_col"),
                                 target_columns = c("upper_col","value_upper_col"))
-  # > df1
-  # lower_col value_lower_col value_upper_col
-  # 1         a               1               8
-  # 2         b               2               7
-  # 3         c               3               6
-  # 4       d1a               4               5
-  # 5       1eb               5               4
-  # 6       f1c               6               3
+  # lower_col value_lower_col other_lower_col value_upper_col
+  # 1         a               1              aa               8
+  # 2         b               2              bb               7
+  # 3         c               3              cc               6
+  # 4       d1a               4              dd               5
+  # 5       1eb               5              ee               4
+  # 6       f1c               6              ff               3
   expect_equal(unlist(df1 %>% filter(lower_col == "d1a") %>% select(value_upper_col))[[1]], 5)
 })
 


### PR DESCRIPTION
# Description

a) Supported source_column, target_columns argument for join command.

- When source_columns are provided, it first only selects the columns from the source data frame and then joins data frames.
- When target_columns are provided, it first only selects the columns from the target data frame and then joins data frames.

b) Fixed suffix does not work for insensitve_join

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
