### PR TITLE
Join: supported option to exclude columns from target data frame.

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -13,7 +13,7 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
       y[[by$y[[i]]]] <- NULL
     }
 
-    res <- fun(x, y, list(x = tmp_by_x, y = tmp_by_y), suffix = suffix)
+    res <- fun(x, y, list(x = tmp_by_x, y = tmp_by_y), suffix = suffix, copy = copy)
     res[tmp_by_x] <- list(NULL)
 
     res
@@ -23,10 +23,14 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
 
 #' Wrapper function for dplyr's inner_join to support case insensitive join.
 #' @export
-inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
+inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
-    y <- y %>% dplyr::select(target_columns)
+    if (exclude_target_columns) {
+      y <- y %>% dplyr::select(-dplyr::one_of(target_columns))
+    } else {
+      y <- y %>% dplyr::select(dplyr::one_of(target_columns))
+    }
   }
   if(ignorecase) {
     insensitive_join(dplyr::inner_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)
@@ -37,10 +41,14 @@ inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's left_join to support case insensitive join.
-left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
+left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
-    y <- y %>% dplyr::select(target_columns)
+    if (exclude_target_columns) {
+      y <- y %>% dplyr::select(-dplyr::one_of(target_columns))
+    } else {
+      y <- y %>% dplyr::select(dplyr::one_of(target_columns))
+    }
   }
   if(ignorecase) {
     insensitive_join(dplyr::left_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)
@@ -51,10 +59,14 @@ left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 
 #' @export
 #' Wrapper function for dplyr's right_join to support case insensitive join.
-right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...){
+right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, ...){
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
-    y <- y %>% dplyr::select(target_columns)
+    if (exclude_target_columns) {
+      y <- y %>% dplyr::select(-dplyr::one_of(target_columns))
+    } else {
+      y <- y %>% dplyr::select(dplyr::one_of(target_columns))
+    }
   }
   if(ignorecase) {
     insensitive_join(dplyr::right_join, "RIGHT")(x, y, by = by, copy = copy, suffix = suffix)
@@ -65,10 +77,14 @@ right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 
 #' @export
 #' Wrapper function for dplyr's full_join to support case insensitive join.
-full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, ...) {
+full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, ...) {
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
-    y <- y %>% dplyr::select(target_columns)
+    if (exclude_target_columns) {
+      y <- y %>% dplyr::select(-dplyr::one_of(target_columns))
+    } else {
+      y <- y %>% dplyr::select(dplyr::one_of(target_columns))
+    }
   }
   if(ignorecase) {
     insensitive_join(dplyr::full_join)(x = x, y = y, by = by, copy = copy, suffix = suffix)

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -179,15 +179,18 @@ test_that("anti_join with case sensitive", {
 
 test_that("column suffix argument with case insensitive", {
   df13 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("1", "2"), ignorecase = TRUE)
-  expect_equal(df13 %>% dplyr::filter(mpg1 > 21) %>% nrow(), 71)
+  expect_equal("mpg1" %in% colnames(df13) , TRUE)
+  expect_equal("mpg2" %in% colnames(df13) , TRUE)
 })
 
 test_that("column suffix argument with case insensitive and empty source suffix", {
   df14 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE)
-  expect_equal(df14 %>% dplyr::filter(mpg > 21) %>% nrow(), 71)
+  expect_equal("mpg" %in% colnames(df14) , TRUE)
+  expect_equal("mpg_1" %in% colnames(df14) , TRUE)
 })
 
 test_that("column suffix argument with case insensitive and empty source suffix and exclude_selected_columns", {
   df15 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE, target_columns = c("mpg", "am", "vs"), exclude_target_columns = TRUE)
+  expect_equal("carb" %in% colnames(df15) , TRUE)
   expect_equal("carb_1" %in% colnames(df15) , TRUE)
 })

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -189,5 +189,5 @@ test_that("column suffix argument with case insensitive and empty source suffix"
 
 test_that("column suffix argument with case insensitive and empty source suffix and exclude_selected_columns", {
   df15 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE, target_columns = c("mpg", "am", "vs"), exclude_target_columns = TRUE)
-  expect_equal(df15 %>% dplyr::filter(carb_1 > 4) %>% nrow(), 3)
+  expect_equal("carb_1" %in% colnames(df15) , TRUE)
 })

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -181,3 +181,8 @@ test_that("column suffix argument with case insensitive", {
   df13 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("1", "2"), ignorecase = TRUE)
   expect_equal(df13 %>% dplyr::filter(mpg1 > 21) %>% nrow(), 71)
 })
+
+test_that("column suffix argument with case insensitive and empty source suffix", {
+  df14 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE)
+  expect_equal(df14 %>% dplyr::filter(mpg > 21) %>% nrow(), 71)
+})

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -186,3 +186,8 @@ test_that("column suffix argument with case insensitive and empty source suffix"
   df14 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE)
   expect_equal(df14 %>% dplyr::filter(mpg > 21) %>% nrow(), 71)
 })
+
+test_that("column suffix argument with case insensitive and empty source suffix and exclude_selected_columns", {
+  df15 <- mtcars %>% left_join(mtcars, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE, target_columns = c("mpg", "am", "vs"), exclude_target_columns = TRUE)
+  expect_equal(df15 %>% dplyr::filter(carb_1 > 4) %>% nrow(), 3)
+})


### PR DESCRIPTION
# Description

supported option to exclude columns from target data frame.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
