### PR TITLE
Rename .fitted to linear_predictor for glm for the models from analytics view in add_prediction

### DIFF
--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -321,7 +321,13 @@ add_prediction <- function(df, model_df, conf_int = 0.95, ...){
     }
   })
   ret <- add_confint(ret, conf_int)
-  colnames(ret)[colnames(ret) == ".fitted"] <- avoid_conflict(colnames(ret), "predicted_value")
+  # For Analytics View for GLM (including logistic regression), rename .fitted to linear_predictor.
+  if ("glm_exploratory" %in% class(model_df$model[[1]])) {
+    colnames(ret)[colnames(ret) == ".fitted"] <- avoid_conflict(colnames(ret), "linear_predictor")
+  }
+  else {
+    colnames(ret)[colnames(ret) == ".fitted"] <- avoid_conflict(colnames(ret), "predicted_value")
+  }
   colnames(ret)[colnames(ret) == ".se.fit"] <- avoid_conflict(colnames(ret), "standard_error")
   colnames(ret)[colnames(ret) == ".resid"] <- avoid_conflict(colnames(ret), "residual")
   # For Analytics View for GLM binomial (including logistic regression), rename predicted_response to predicted_probability.

--- a/tests/testthat/test_build_lm_1.R
+++ b/tests/testthat/test_build_lm_1.R
@@ -659,7 +659,7 @@ test_that("add_prediction with logistic regression", {
                                      model_type = "glm",
                                      importance_measure="firm")
   ret <- test_data %>% select(-`CANCELLED X`) %>% add_prediction(model_df=model_df)
-  expect_true(all(c("predicted_probability", "predicted_value","predicted_label") %in% colnames(ret)))
+  expect_true(all(c("predicted_probability", "linear_predictor","predicted_label") %in% colnames(ret)))
 })
 
 test_that("Logistic Regression with test_rate", {


### PR DESCRIPTION
# Description
Rename .fitted to linear_predictor for glm for the models from analytics view in add_prediction

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
