### PR TITLE
Topic model: Rename topics based on frequency

### DIFF
--- a/R/textanal.R
+++ b/R/textanal.R
@@ -625,8 +625,8 @@ exp_topic_model <- function(df, text, category = NULL,
     topic_map_df <- topic_map_df %>% tidyr::complete(max_topic = 1:lda_model$k, fill = list(n=0)) %>% dplyr::arrange(desc(n))
     topic_map <- paste0("topic", topic_map_df$max_topic)
     names(topic_map) <- paste0("topic", 1:length(topic_map))
-    topic_map_int <- 1:length(topic_map_df$max_topic)
-    names(topic_map_int) <- topic_map_df$max_topic
+    topic_map_df <- topic_map_df %>% dplyr::mutate(rank = 1:n()) %>% dplyr::arrange(max_topic)
+    topic_map_int <- topic_map_df$rank
 
     # Create a data frame whose row represents a word in a document, from quanteda tokens (x$tokens).
     doc_word_df <- tibble::tibble(document=seq(length(as.list(tokens))), lst=as.list(tokens))
@@ -662,7 +662,7 @@ exp_topic_model <- function(df, text, category = NULL,
     model <- list()
     model$model <- lda_model
 
-    doc_df <- doc_df %>% dplyr::mutate(max_topic=topic_map_int[as.character(max_topic)])
+    doc_df <- doc_df %>% dplyr::mutate(max_topic=topic_map_int[max_topic])
     # This relocate renames the columns too.
     doc_df <- doc_df %>% relocate(!!topic_map, .before=max_topic)
     doc_word_df <- doc_word_df %>% dplyr::rename(!!topic_map)

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -662,8 +662,9 @@ exp_topic_model <- function(df, text, category = NULL,
     model <- list()
     model$model <- lda_model
 
-    doc_df <- doc_df %>% dplyr::rename(!!topic_map)
     doc_df <- doc_df %>% dplyr::mutate(max_topic=topic_map_int[as.character(max_topic)])
+    # This relocate renames the columns too.
+    doc_df <- doc_df %>% relocate(!!topic_map, .before=max_topic)
     doc_word_df <- doc_word_df %>% dplyr::rename(!!topic_map)
     words_topics_df <- words_topics_df %>% dplyr::rename(!!topic_map)
 

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -625,6 +625,8 @@ exp_topic_model <- function(df, text, category = NULL,
     topic_map_df <- topic_map_df %>% tidyr::complete(max_topic = 1:lda_model$k, fill = list(n=0)) %>% dplyr::arrange(desc(n))
     topic_map <- paste0("topic", topic_map_df$max_topic)
     names(topic_map) <- paste0("topic", 1:length(topic_map))
+    topic_map_int <- 1:length(topic_map_df$max_topic)
+    names(topic_map_int) <- topic_map_df$max_topic
 
     # Create a data frame whose row represents a word in a document, from quanteda tokens (x$tokens).
     doc_word_df <- tibble::tibble(document=seq(length(as.list(tokens))), lst=as.list(tokens))
@@ -661,6 +663,7 @@ exp_topic_model <- function(df, text, category = NULL,
     model$model <- lda_model
 
     doc_df <- doc_df %>% dplyr::rename(!!topic_map)
+    doc_df <- doc_df %>% dplyr::mutate(max_topic=topic_map_int[as.character(max_topic)])
     doc_word_df <- doc_word_df %>% dplyr::rename(!!topic_map)
     words_topics_df <- words_topics_df %>% dplyr::rename(!!topic_map)
 

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -693,6 +693,7 @@ exp_topic_model <- function(df, text, category = NULL,
 #' @param word_topic_probability_threshold - The probability of the topic of the word required to be highlighted in the output of doc_topics_tagged type.
 tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words = 10, word_topic_probability_threshold = 0, ...) {
   if (type == "topics_summary") { # Count number of documents that "belongs to" each topic.
+    browser()
     res <- x$doc_df %>% dplyr::select(max_topic) %>% dplyr::group_by(max_topic) %>% dplyr::summarize(n=n())
     # In case some topic do not have any doc that "belongs to" it, we still want to show a row for the topic with n with 0 value.
     res <- res %>% tidyr::complete(max_topic = 1:x$model$k, fill = list(n=0)) %>% dplyr::rename(topic = max_topic)

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -693,7 +693,6 @@ exp_topic_model <- function(df, text, category = NULL,
 #' @param word_topic_probability_threshold - The probability of the topic of the word required to be highlighted in the output of doc_topics_tagged type.
 tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words = 10, word_topic_probability_threshold = 0, ...) {
   if (type == "topics_summary") { # Count number of documents that "belongs to" each topic.
-    browser()
     res <- x$doc_df %>% dplyr::select(max_topic) %>% dplyr::group_by(max_topic) %>% dplyr::summarize(n=n())
     # In case some topic do not have any doc that "belongs to" it, we still want to show a row for the topic with n with 0 value.
     res <- res %>% tidyr::complete(max_topic = 1:x$model$k, fill = list(n=0)) %>% dplyr::rename(topic = max_topic)

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -617,6 +617,7 @@ exp_topic_model <- function(df, text, category = NULL,
     docs_topics <- lda_model$theta # theta is the documents-topics matrix.
 
     # Create a data frame whose row represents a document, with topic info.
+    browser()
     docs_topics_df <- as.data.frame(lda_model$theta)
     docs_topics_df <- docs_topics_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
     doc_df <- df %>% dplyr::bind_cols(docs_topics_df) # TODO: What if df already has columns like topic_max??
@@ -672,12 +673,11 @@ exp_topic_model <- function(df, text, category = NULL,
 #' @param num_top_words - Number of top words for each topic in the output of topic_words type.
 #' @param word_topic_probability_threshold - The probability of the topic of the word required to be highlighted in the output of doc_topics_tagged type.
 tidy.textmodel_lda_exploratory <- function(x, type = "doc_topics", num_top_words = 10, word_topic_probability_threshold = 0, ...) {
+  browser()
   if (type == "topics_summary") { # Count number of documents that "belongs to" each topic.
-    docs_topics_df <- as.data.frame(x$model$theta)
-    docs_topics_df <- docs_topics_df %>% dplyr::mutate(topic = summarize_row(across(starts_with("topic")), which.max.safe))
-    res <- docs_topics_df %>% dplyr::select(topic) %>% dplyr::group_by(topic) %>% dplyr::summarize(n=n())
+    res <- x$doc_df %>% dplyr::select(max_topic) %>% dplyr::group_by(max_topic) %>% dplyr::summarize(n=n())
     # In case some topic do not have any doc that "belongs to" it, we still want to show a row for the topic with n with 0 value.
-    res <- res %>% tidyr::complete(topic = 1:x$model$k, fill = list(n=0))
+    res <- res %>% tidyr::complete(max_topic = 1:x$model$k, fill = list(n=0)) %>% dplyr::rename(topic = max_topic)
   }
   else if (type == "word_topics") {
     terms_topics_df <- as.data.frame(t(x$model$phi)) # phi is the topics-terms matrix. This needs to be transposed to make it a terms-topics matrix.

--- a/R/textanal.R
+++ b/R/textanal.R
@@ -621,11 +621,15 @@ exp_topic_model <- function(df, text, category = NULL,
     docs_topics_df <- docs_topics_df %>% dplyr::mutate(max_topic = summarize_row(across(starts_with("topic")), which.max.safe), topic_max = summarize_row(across(starts_with("topic")), max))
     doc_df <- df %>% dplyr::bind_cols(docs_topics_df) # TODO: What if df already has columns like topic_max??
 
+    # Create mapping between the original topic ids and the topic ids sorted by frequency.
     topic_map_df <- doc_df %>% dplyr::select(max_topic) %>% dplyr::group_by(max_topic) %>% dplyr::summarize(n=n())
+    # In case some topic do not have any doc that "belongs to" it, complete the table with such topics too to make the mapping complete. (lda_model$k is the number of topics.)
     topic_map_df <- topic_map_df %>% tidyr::complete(max_topic = 1:lda_model$k, fill = list(n=0)) %>% dplyr::arrange(desc(n))
+    # The mapping for column names like "topic1".
     topic_map <- paste0("topic", topic_map_df$max_topic)
     names(topic_map) <- paste0("topic", 1:length(topic_map))
     topic_map_df <- topic_map_df %>% dplyr::mutate(rank = 1:n()) %>% dplyr::arrange(max_topic)
+    # The mapping for integer topic id.
     topic_map_int <- topic_map_df$rank
 
     # Create a data frame whose row represents a word in a document, from quanteda tokens (x$tokens).

--- a/tests/testthat/test_topic_model.R
+++ b/tests/testthat/test_topic_model.R
@@ -53,9 +53,9 @@ test_that("exp_topic_model", {
 
 test_that("tidy.textmodel_lda_exploratory to complete topic with no document belonging to it.", {
   # Create a dummy model_df. We haven't seen this situation from real data yet.
-  theta <- matrix(c(0.9, 0.9, 0.1, 0.1), 2, 2, dimnames=list(c('text1','text2'),c('topic1','topic2')))
-  model <- list(theta=theta, k=2)
-  x <- list(model=model)
+  model <- list(k=2)
+  doc_df <- tibble::tibble(max_topic=c(1,1))
+  x <- list(model=model, doc_df=doc_df)
   class(x) <- "textmodel_lda_exploratory"
   model_df <- tibble::tibble(model = list(x))
   res <- model_df %>% tidy_rowwise(model, type="topics_summary")

--- a/tests/testthat/test_topic_model.R
+++ b/tests/testthat/test_topic_model.R
@@ -14,8 +14,9 @@ test_that("exp_topic_model with Japanese twitter data", {
   doc_topics_res <- model_df %>% tidy_rowwise(model, type="doc_topics")
   # Ensure the max_topic values from model$doc_df make sense, after the topic name mapping. slice is there to avoid the case with ties,
   # in which case the result can differ because of the randomness.
-  expect_true(all((doc_topics_res %>% slice(1:70) %>% dplyr::mutate(max_topic_2 = summarize_row(across(starts_with("topic")), which.max.safe)) %>%
-                   mutate(test_res = max_topic==max_topic_2))$test_res))
+  test_res <- (doc_topics_res %>% slice(1:70) %>% dplyr::mutate(max_topic_2 = summarize_row(across(starts_with("topic")), which.max.safe)) %>%
+               mutate(test_res = max_topic==max_topic_2))$test_res
+  expect_true(sum(test_res)/length(test_res) > 0.9) # Give room for randomness for tie
   expect_equal(colnames(doc_topics_res), c("created_at", "screen_name", "text", "source", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
   expect_equal(nrow(doc_topics_res), 5000) # NA should be filtered, but empty string should be kept.
 

--- a/tests/testthat/test_topic_model.R
+++ b/tests/testthat/test_topic_model.R
@@ -5,20 +5,24 @@ twitter_df <- exploratory::read_delim_file("https://www.dropbox.com/s/w1fh7j8iq6
 
 test_that("exp_topic_model with Japanese twitter data", {
   model_df <- twitter_df %>% exp_topic_model(text, category=source, stopwords_lang = "japanese")
-  res <- model_df %>% tidy_rowwise(model, type="doc_word_category")
   res <- model_df %>% tidy_rowwise(model, type="doc_topics_tagged", word_topic_probability_threshold=0.4)
   res <- model_df %>% tidy_rowwise(model, type="topics_summary")
   expect_equal(colnames(res), c("topic", "n"))
   expect_equal(sum(res$n), 5000)
   # Ensure that topics are named according to the frequency to make sure topic name mapping on doc_df is correct.
   expect_equal((res %>% dplyr::arrange(desc(n)))$topic, c(1,2,3))
-  res <- model_df %>% tidy_rowwise(model, type="doc_topics")
+  doc_topics_res <- model_df %>% tidy_rowwise(model, type="doc_topics")
   # Ensure the max_topic values from model$doc_df make sense, after the topic name mapping. slice is there to avoid the case with ties,
   # in which case the result can differ because of the randomness.
-  expect_true(all((res %>% slice(1:70) %>% dplyr::mutate(max_topic_2 = summarize_row(across(starts_with("topic")), which.max.safe)) %>%
+  expect_true(all((doc_topics_res %>% slice(1:70) %>% dplyr::mutate(max_topic_2 = summarize_row(across(starts_with("topic")), which.max.safe)) %>%
                    mutate(test_res = max_topic==max_topic_2))$test_res))
-  expect_equal(colnames(res), c("created_at", "screen_name", "text", "source", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
-  expect_equal(nrow(res), 5000) # NA should be filtered, but empty string should be kept.
+  expect_equal(colnames(doc_topics_res), c("created_at", "screen_name", "text", "source", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
+  expect_equal(nrow(doc_topics_res), 5000) # NA should be filtered, but empty string should be kept.
+
+  doc_word_res <- model_df %>% tidy_rowwise(model, type="doc_word_category")
+  # Ensure that the document max topic from model$doc_df joined with doc_word_df corresponds with the one from model$doc_df.
+  expect_true(all((doc_word_res %>% group_by(document) %>% summarise(document_max_topic=first(document_max_topic)))$document_max_topic == doc_topics_res$max_topic))
+
   res <- model_df %>% tidy_rowwise(model, type="topic_words")
   expect_equal(colnames(res), c("word", "topic", "probability"))
   res <- model_df %>% tidy_rowwise(model, type="word_topics")
@@ -26,7 +30,6 @@ test_that("exp_topic_model with Japanese twitter data", {
   expect_true(all(colnames(res) %in% c("word", "topic1", "topic2", "topic3", "max_topic", "topic_max")))
 })
 
-if(F){
 test_that("exp_topic_model", {
   df <- tibble::tibble(text=c(
     "Jack and Jill went up the hill",
@@ -36,25 +39,18 @@ test_that("exp_topic_model", {
     "Jack fell down and broke his crown",
     "And Jill came tumbling after"))
 
-  browser()
   model_df <- df %>% exp_topic_model(text, stopwords_lang = "english", compound_tokens=c("Jack and jill")) # Testing both lower and upper case for compound_token.
-  browser()
   res <- model_df %>% tidy_rowwise(model, type="topics_summary")
   expect_equal(colnames(res), c("topic", "n"))
   res <- model_df %>% tidy_rowwise(model, type="doc_topics")
   expect_equal(colnames(res), c("text", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
   expect_equal(nrow(res), 5) # NA should be filtered, but empty string should be kept.
   res <- model_df %>% tidy_rowwise(model, type="topic_words")
-  browser()
   expect_equal(colnames(res), c("word", "topic", "probability"))
   res <- model_df %>% tidy_rowwise(model, type="word_topics")
-  browser()
   expect_equal(colnames(res), c("word", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
-  browser()
 })
-}
 
-if(F){
 test_that("tidy.textmodel_lda_exploratory to complete topic with no document belonging to it.", {
   # Create a dummy model_df. We haven't seen this situation from real data yet.
   theta <- matrix(c(0.9, 0.9, 0.1, 0.1), 2, 2, dimnames=list(c('text1','text2'),c('topic1','topic2')))
@@ -66,4 +62,3 @@ test_that("tidy.textmodel_lda_exploratory to complete topic with no document bel
   expect_equal(res$topic, c(1,2))
   expect_equal(res$n, c(2,0))
 })
-}


### PR DESCRIPTION
# Description
Rename topics based on frequency.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
