### PR TITLE
Survival Forest: Add time 0 if times does not start with 0 in Survival curve PDP

### DIFF
--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -86,9 +86,20 @@ partial_dependence.ranger_survival_exploratory <- function(fit, time_col, vars =
   n = c(min(nrow(unique(data[, vars, drop = FALSE])), 25L), nrow(data)), # Keeping same default of 25 as edarf::partial_dependence, although we usually overwrite from callers.
   interaction = FALSE, uniform = TRUE, data, ...) {
   times <- sort(unique(data[[time_col]])) # Keep vector of actual times to map time index to actual time later.
+  # Add time 0 if times does not start with 0.
+  time_zero_added <- FALSE
+  if (times[1] != 0) {
+    times <- c(0, times)
+    time_zero_added <- TRUE
+  }
 
   predict.fun <- function(object, newdata) {
-    predict(object, data=newdata)$survival
+    res <- predict(object, data=newdata)$survival
+    # If time 0 is added, add the column of 100% survival.
+    if (time_zero_added) {
+      res <- cbind(rep(1,nrow(res)),res)
+    }
+    res
   }
 
   aggregate.fun <- function(x) {

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -65,6 +65,8 @@ test_that("exp_survival_forest basic with start_time and end_time", {
   ret <- model_df %>% augment_rowwise(model)
 
   ret <- model_df %>% tidy_rowwise(model, type='partial_dependence_survival_curve')
+  # Verify that period starts with 0. (If the input data does not, we add a data point for time 0.)
+  expect_equal(ret$period[1], 0)
   expect_equal(class(model_df$model[[1]]), c("ranger_survival_exploratory", "ranger"))
   ret <- model_df %>% tidy_rowwise(model, type='importance')
   ret2 <- model_df %>% tidy_rowwise(model, type='partial_dependence')
@@ -72,7 +74,6 @@ test_that("exp_survival_forest basic with start_time and end_time", {
   names(variables) <- NULL
   expect_equal(unique(ret2$variable), variables) # Factor order of the PDP should be the same as the importance.
 })
-
 test_that("exp_survival_forest with group-by", {
   df <- survival::lung # this data has NAs.
   df <- df %>% mutate(status = status==2)


### PR DESCRIPTION
# Description
Add time 0 if times does not start with 0 in Survival curve PDP

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
