### PR TITLE
Cox Regression / Survival Forest: Pick integer value as the auto-selected prediction time for PDP

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -467,8 +467,10 @@ build_coxph.fast <- function(df,
     # By default, use mean of observations with event.
     # median gave a point where survival rate was still predicted 100% in one of our test case.
     pred_survival_time <- mean((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
-    # Pick maximum of existing values equal or less than the actual mean.
-    pred_survival_time <- max((df %>% dplyr::filter(!!rlang::sym(time_col) <= !!pred_survival_time))[[time_col]], na.rm=TRUE)
+    # Pick the integer value equal or less than the actual mean.
+    pred_survival_time <- floor(pred_survival_time)
+    # Since 0 is most likely meaningless as a prediction time, pick 1 if the above gives 0.
+    if (pred_survival_time == 0) pred_survival_time <- 1
   }
 
   # cols will be filtered to remove invalid columns

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -303,6 +303,8 @@ exp_survival_forest <- function(df,
     pred_survival_time <- mean((df %>% dplyr::filter(!!rlang::sym(status_col)))[[time_col]], na.rm=TRUE)
     # Pick maximum of existing values equal or less than the actual mean.
     pred_survival_time <- max((df %>% dplyr::filter(!!rlang::sym(time_col) <= !!pred_survival_time))[[time_col]], na.rm=TRUE)
+    # Since 0 is most likely meaningless as a prediction time, pick 1 if the above gives 0.
+    if (pred_survival_time == 0) pred_survival_time <- 1
   }
 
   # cols will be filtered to remove invalid columns

--- a/tests/testthat/test_build_coxph.R
+++ b/tests/testthat/test_build_coxph.R
@@ -16,6 +16,8 @@ test_that("build_coxph.fast with start_time and end_time", {
     df <- df %>% mutate(`se-x` = `se-x`==1) # test handling of logical
     model_df <- df %>% build_coxph.fast(NULL, `sta tus`, `a ge`, `se-x`, ph.ecog, ph.karno, pat.karno, meal.cal, wt.loss, start_time=start, end_time=end, time_unit="auto", predictor_funs=list(`a ge`="none", `se-x`="none", ph.ecog="none", ph.karno="none", pat.karno="none", meal.cal="none", wt.loss="none"), predictor_n = 2)
     expect_equal(class(model_df$model[[1]]), c("coxph_exploratory","coxph"))
+    # Make sure the auto-picked prediction survival time is an integer.
+    expect_equal(model_df$model[[1]]$pred_survival_time, floor(model_df$model[[1]]$pred_survival_time))
 
     # Survival-time-based prediction. Still used in the Analytics View, for example, for ROC chart.
     df2 <- df %>% select(-`ti me`, -`sta tus`)


### PR DESCRIPTION
# Description
Pick integer value as the auto-selected prediction time for PDP.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
