### PR TITLE
Handle NAs in conf.low/conf.high before calling approxfun

### DIFF
--- a/R/build_coxph.R
+++ b/R/build_coxph.R
@@ -122,8 +122,15 @@ partial_dependence.coxph_exploratory <- function(fit, time_col, vars = colnames(
     res0 <- res %>% select(starts_with('conf.high.'))
     res1 <- tibble::tibble(time = times)
     for (i in 1:length(res0)) {
-      afun <- approxfun(res$time, res0[[i]])
-      res1[[paste0('conf.high.', i)]] <- afun(times)
+      # conf.high values can be NA, and if at least 2 non-NA values are not there, approxfun fails.
+      # Handle such case by outputting NAs.
+      if (sum(!is.na(res0[[i]])) > 2) {
+        afun <- approxfun(res$time, res0[[i]])
+        res1[[paste0('conf.high.', i)]] <- afun(times)
+      }
+      else {
+        res1[[paste0('conf.high.', i)]] <- rep(NA, length(times))
+      }
     }
     high <- as.data.frame(t(res1 %>% dplyr::select(-time)))
     high <- high %>% dplyr::rename_with(~stringr::str_replace(., 'V', 'H'), starts_with('V'))
@@ -132,8 +139,15 @@ partial_dependence.coxph_exploratory <- function(fit, time_col, vars = colnames(
     res0 <- res %>% select(starts_with('conf.low.'))
     res1 <- tibble::tibble(time = times)
     for (i in 1:length(res0)) {
-      afun <- approxfun(res$time, res0[[i]])
-      res1[[paste0('conf.low.', i)]] <- afun(times)
+      # conf.low values can be NA, and if at least 2 non-NA values are not there, approxfun fails.
+      # Handle such case by outputting NAs.
+      if (sum(!is.na(res0[[i]])) > 2) {
+        afun <- approxfun(res$time, res0[[i]])
+        res1[[paste0('conf.low.', i)]] <- afun(times)
+      }
+      else {
+        res1[[paste0('conf.low.', i)]] <- rep(NA, length(times))
+      }
     }
     low <- as.data.frame(t(res1 %>% dplyr::select(-time)))
     low <- low %>% dplyr::rename_with(~stringr::str_replace(., 'V', 'L'), starts_with('V'))

--- a/R/survival_forest.R
+++ b/R/survival_forest.R
@@ -74,7 +74,9 @@ calc_survival_curves_with_strata <- function(df, time_col, status_col, vars) {
     ret <- broom:::tidy.survfit(fit)
     ret
   })
-  ret <- data.table::rbindlist(curve_dfs_list)
+  # Bind the data frames in the list. fill=TRUE is needed because it is possible that strata column is missing for some of the data frames
+  # if var has only one value for all the rows.
+  ret <- data.table::rbindlist(curve_dfs_list, fill=TRUE)
   ret <- ret %>% tidyr::separate(strata, into = c('variable','value'), sep='=') %>% rename(survival=estimate, period=time)
   ret <- ret %>% dplyr::mutate(chart_type = chart_type_map[variable])
   ret <- ret %>% dplyr::mutate(x_type = x_type_map[variable])


### PR DESCRIPTION
# Description
Fixes around Cox regression.
- Handle NAs in conf.low/conf.high before calling approxfun to avoid error.
- Avoid error from rbindlist that happens when strata column is missing for some of the PDP data frames.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
