### PR TITLE
Fix the issue of wrong topic tag colors by sorting the column order of topicX columns

### DIFF
--- a/R/textanal.R
+++ b/R/textanal.R
@@ -667,10 +667,11 @@ exp_topic_model <- function(df, text, category = NULL,
     model$model <- lda_model
 
     doc_df <- doc_df %>% dplyr::mutate(max_topic=topic_map_int[max_topic])
-    # This relocate renames the columns too.
-    doc_df <- doc_df %>% relocate(!!topic_map, .before=max_topic)
-    doc_word_df <- doc_word_df %>% dplyr::rename(!!topic_map)
-    words_topics_df <- words_topics_df %>% dplyr::rename(!!topic_map)
+    # These relocate renames the columns as well as sorting the column order.
+    # Especially, for doc_topics_tagged tidier to work, column order of topics in doc_word_df must be sorted.
+    doc_df <- doc_df %>% dplyr::relocate(!!topic_map, .before=max_topic)
+    doc_word_df <- doc_word_df %>% dplyr::relocate(!!topic_map, .after=word)
+    words_topics_df <- words_topics_df %>% dplyr::relocate(!!topic_map, .after=word)
 
     # model$docs_coordinates <- docs_coordinates # MDS result for scatter plot
     # model$docs_sample_index <- docs_sample_index

--- a/tests/testthat/test_topic_model.R
+++ b/tests/testthat/test_topic_model.R
@@ -5,6 +5,9 @@ twitter_df <- exploratory::read_delim_file("https://www.dropbox.com/s/w1fh7j8iq6
 
 test_that("exp_topic_model with Japanese twitter data", {
   model_df <- twitter_df %>% exp_topic_model(text, category=source, stopwords_lang = "japanese")
+  # For doc_topics_tagged tidier to work, column order of topics must be sorted.
+  expect_equal(colnames(model_df$model[[1]]$doc_word_df), c("document","word","topic1","topic2","topic3"))
+  expect_equal(colnames(model_df$model[[1]]$words_topics_df), c("word","topic1","topic2","topic3"))
   res <- model_df %>% tidy_rowwise(model, type="doc_topics_tagged", word_topic_probability_threshold=0.4)
   res <- model_df %>% tidy_rowwise(model, type="topics_summary")
   expect_equal(colnames(res), c("topic", "n"))
@@ -27,8 +30,7 @@ test_that("exp_topic_model with Japanese twitter data", {
   res <- model_df %>% tidy_rowwise(model, type="topic_words")
   expect_equal(colnames(res), c("word", "topic", "probability"))
   res <- model_df %>% tidy_rowwise(model, type="word_topics")
-  # Ingnoring order since column order is expected to be messed up here because of topic name mapping.
-  expect_true(all(colnames(res) %in% c("word", "topic1", "topic2", "topic3", "max_topic", "topic_max")))
+  expect_equal(colnames(res), c("word", "topic1", "topic2", "topic3", "max_topic", "topic_max"))
 })
 
 test_that("exp_topic_model", {


### PR DESCRIPTION
# Description
Fix the issue of wrong topic tag colors by sorting the column order of topicX columns

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
