### PR TITLE
sample_df_index should return NULL (empty vector) if rate is 0 in ordered split

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -635,6 +635,8 @@ expand_args <- function(call, exclude = c()) {
 #' get sampled indice from data frame
 #' @export
 sample_df_index <- function(df, rate, seed = NULL, ordered = FALSE) {
+  # Return NULL (empty vector) for rate 0 case. If we go on, ordered case would return the index for the last row.
+  if (rate == 0) return(NULL)
   if (!ordered) {
     if(!is.null(seed)){
       set.seed(seed)

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -109,6 +109,18 @@ test_that("calc_feature_imp(regression) evaluate training and test with permutat
   expect_equal(nrow(ret), 1) # 1 for train
 })
 
+test_that("calc_feature_imp() with test_split_type = ordered and test_rate = 0, which used to have an issue of creating test data set of 1 row.", {
+  set.seed(1) # For stability of result.
+  model_df <- flight %>%
+                calc_feature_imp(`ARR DELAY`, `CAR RIER`, `ORI GIN`, `DEP DELAY`, `AIR TIME`,
+                                 test_rate = 0,
+                                 importance_measure = "firm",
+                                 test_split_type = "ordered", pd_with_bin_means = TRUE) # testing ordered split too.
+
+  ret <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
+  expect_equal(nrow(ret), 1) # Should be 1 only for trainning set. Test set should not be created.
+})
+
 test_that("calc_feature_imp(binary) evaluate training and test with FIRM importance", {
   set.seed(1) # For stability of result.
   # `is delayed` is not logical for some reason.

--- a/tests/testthat/test_randomForest_tidiers_3.R
+++ b/tests/testthat/test_randomForest_tidiers_3.R
@@ -118,7 +118,7 @@ test_that("calc_feature_imp() with test_split_type = ordered and test_rate = 0, 
                                  test_split_type = "ordered", pd_with_bin_means = TRUE) # testing ordered split too.
 
   ret <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
-  expect_equal(nrow(ret), 1) # Should be 1 only for trainning set. Test set should not be created.
+  expect_equal(nrow(ret), 1) # Should be 1 only for training set. Test set should not be created.
 })
 
 test_that("calc_feature_imp(binary) evaluate training and test with FIRM importance", {


### PR DESCRIPTION

# Description
sample_df_index should return NULL (empty vector) if rate is 0 in ordered split

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
