### PR TITLE
Remove validate_empty_data from exploratory::pivot function

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -935,7 +935,6 @@ pivot_ <- function(df, row_cols, col_cols, row_funs = NULL, col_funs = NULL, val
 #' @param cols_sep - If na should be removed from values
 #' @export
 pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_funs = NULL, value = NULL, fun.aggregate = mean, fill = NA, na.rm = TRUE, cols_sep = "_") {
-  validate_empty_data(df)
 
   value_col <- if(!missing(value)){
     tidyselect::vars_select(names(df), !! rlang::enquo(value))

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -123,13 +123,6 @@ test_that("setdiff", {
   expect_equal(nrow(res), 2)
 })
 
-test_that("test pivot with empty data frame", {
-  df <- data.frame()
-  expect_error({
-    pivot(df, row_cols=c("row"), col_cols=c("col"))
-  }, "Input data frame is empty.")
-})
-
 test_that("test upper_gather", {
   mat <- matrix(seq(20),nrow=5, ncol=4)
   mat[[15]] <- NA # inject NA

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -123,6 +123,18 @@ test_that("setdiff", {
   expect_equal(nrow(res), 2)
 })
 
+test_that("test pivot with empty data frame", {
+  # Create an empty data frame
+  df <- mtcars %>% filter(gear > 100)
+  df <- pivot(df, row_cols=c("gear"), col_cols=c("cyl"))
+  # it should return below 0 row df.
+  # > df
+  # A tibble: 0 × 1
+  # … with 1 variable: gear <dbl>
+  expect_equal(nrow(df), 0)
+  expect_equal(ncol(df), 1)
+})
+
 test_that("test upper_gather", {
   mat <- matrix(seq(20),nrow=5, ncol=4)
   mat[[15]] <- NA # inject NA


### PR DESCRIPTION
# Description

Remove validate_empty_data from exploratory::pivot function

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
