### PR TITLE
likert_sigma: Make it work when input does not start with 1 too.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -3121,18 +3121,19 @@ format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.ma
 # Input - Discrete values which can work as ranking but may not have contiguous meaning.
 # Output - Likert sigma values.
 likert_sigma <- function(x) {
+  # Convert the input into a factor, so that the actual numeric input values would not matter
+  # when mapping them into the output sigma values. Note that factor() assigns the levels to the distinct values in ascending sorted order.
+  x0 <- factor(x)
   # Remove NA before calculating the mapping.
-  x1 <- x[!is.na(x)]
-  ratios <- table(x1)/length(x1)
+  x1 <- x[!is.na(x0)]
+  ratios <- as.numeric(table(x1))/length(x1) # as.numeric is to convert table class object to numeric.
   p1 <- cumsum(ratios)
   p0 <- lag(p1)
   p0[is.na(p0)] <- 0
   # Reference: https://stats.stackexchange.com/questions/237828/how-did-likert-calculate-sigma-values-in-his-original-1932-paper
   # Note that weighted mean of x in each segment can be calculated this way since integral of x*dnorm(x) is -dnorm(x), 
   mapping <- (dnorm(qnorm(p0)) - dnorm(qnorm(p1)))/ratios
-  res <- mapping[x]
-  # Convert table class object to numeric.
-  res <- as.numeric(res)
+  res <- mapping[x0] # Note that factor levels of x0 rather than the face value of x is used for the mapping here.
   res
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -3123,7 +3123,12 @@ format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.ma
 likert_sigma <- function(x) {
   # Convert the input into a factor, so that the actual numeric input values would not matter
   # when mapping them into the output sigma values. Note that factor() assigns the levels to the distinct values in ascending sorted order.
-  x0 <- factor(x)
+  if (!is.factor(x)) {
+    x0 <- factor(x)
+  }
+  else {
+    x0 <- x
+  }
   # Remove NA before calculating the mapping.
   x1 <- x[!is.na(x0)]
   ratios <- as.numeric(table(x1))/length(x1) # as.numeric is to convert table class object to numeric.

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1775,4 +1775,9 @@ test_that("likert_sigma", {
   # Values from the original 1932 paper - https://stats.stackexchange.com/questions/237828/how-did-likert-calculate-sigma-values-in-his-original-1932-paper
   expected <- c(rep(-1.6272701,13),rep(-0.4252946,43),rep(0.4322558,21),rep(0.9857673,13),rep(1.7549833,10),rep(NA_real_, 5))
   expect_equal(res, expected, tolerance=1e-7)
+
+  # Case where input does not start with 1.
+  res <- likert_sigma(c(5, 4, 3, 5))
+  expected <- c(0.7978846, -0.3246628, -1.2711063, 0.7978846)
+  expect_equal(res, expected, tolerance=1e-7)
 })

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1780,4 +1780,15 @@ test_that("likert_sigma", {
   res <- likert_sigma(c(5, 4, 3, 5))
   expected <- c(0.7978846, -0.3246628, -1.2711063, 0.7978846)
   expect_equal(res, expected, tolerance=1e-7)
+
+  # Work with factor.
+  res <- likert_sigma(factor(c("e","d","c","e"), levels=c("a","b","c","d","e")))
+  expected <- c(0.7978846, -0.3246628, -1.2711063, 0.7978846)
+  expect_equal(res, expected, tolerance=1e-7)
+
+  # Work with logical
+  res <- likert_sigma(c(TRUE, FALSE, TRUE))
+  expected <- c(0.5453997, -1.0907993, 0.5453997)
+  expect_equal(res, expected, tolerance=1e-7)
+
 })


### PR DESCRIPTION
# Description
- Make it work when input does not start with 1 too.
- Make it work with factor or logical input too.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
