### PR TITLE
GA: Fix issue Can't subset columns that don't exist. ✖ Column `viewId` doesn't exist when there is no V3 accounts.

### DIFF
--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -6,15 +6,13 @@ getGoogleProfile <- function(tokenFileId = ""){
 
   token <- getGoogleTokenForAnalytics(tokenFileId);
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
+  # Get V3 account list.
   df <- googleAnalyticsR::ga_account_list()
-  if (nrow(df) > 0) {
+  if (nrow(df) > 0) { # only select below columns.
     df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
   } else {
-    # It means v3 accounts are empty, so create an empty data frame with below column names since the response from
-    # googleAnalyticsR::ga_account_list does not include all required columns when there is no record.
-    columns = c("accountId","accountName","viewId", "viewName", "webPropertyId", "webPropertyName")
-    df = data.frame(matrix(nrow = 0, ncol = length(columns)))
-    colnames(df) = columns
+    # It means v3 accounts are empty, so create an empty data frame and bind this to a v4 account data frame.
+    df <- tibble::tibble()
   }
   # get V4 Account
   v4df <- data.frame()

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -8,7 +8,7 @@ getGoogleProfile <- function(tokenFileId = ""){
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
   # Get V3 account list.
   df <- googleAnalyticsR::ga_account_list()
-  if (nrow(df) > 0) { # only select below columns.
+  if (nrow(df) > 0) { # if there are V3 accounts, only select below columns.
     df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
   } else {
     # It means v3 accounts are empty, so create an empty data frame and bind this to a v4 account data frame.

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -7,7 +7,13 @@ getGoogleProfile <- function(tokenFileId = ""){
   token <- getGoogleTokenForAnalytics(tokenFileId);
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
   df <- googleAnalyticsR::ga_account_list()
-  df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
+  if (nrow(df) > 0) {
+    df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
+  } else { # it means v3 accounts are empty, so create an empty data frame with below column names since the response does not include all required columns
+    columns = c("accountId","accountName","viewId", "viewName", "webPropertyId", "webPropertyName")
+    df = data.frame(matrix(nrow = 0, ncol = length(columns)))
+    colnames(df) = columns
+  }
   # get V4 Account
   v4df <- data.frame()
   tryCatch({

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -11,7 +11,7 @@ getGoogleProfile <- function(tokenFileId = ""){
   if (nrow(df) > 0) { # if there are V3 accounts, only select below columns.
     df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
   } else {
-    # It means v3 accounts are empty, so create an empty data frame and bind this to a v4 account data frame.
+    # It means there are no v3 accounts, so create an empty data frame without columns and bind this to a v4 account data frame.
     df <- tibble::tibble()
   }
   # get V4 Account

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -9,7 +9,9 @@ getGoogleProfile <- function(tokenFileId = ""){
   df <- googleAnalyticsR::ga_account_list()
   if (nrow(df) > 0) {
     df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
-  } else { # it means v3 accounts are empty, so create an empty data frame with below column names since the response does not include all required columns
+  } else {
+    # It means v3 accounts are empty, so create an empty data frame with below column names since the response from
+    # googleAnalyticsR::ga_account_list does not include all required columns when there is no record.
     columns = c("accountId","accountName","viewId", "viewName", "webPropertyId", "webPropertyName")
     df = data.frame(matrix(nrow = 0, ncol = length(columns)))
     colnames(df) = columns


### PR DESCRIPTION
# Description

it fixes the issue that the below error raised when there is no V3 accounts.

Error in dplyr::select(., accountId, accountName, viewId, viewName, webPropertyId, : Can't subset columns that don't exist. ✖ Column `viewId` doesn't exist.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
