### PR TITLE
Add apiType argument to querySalesforceDataWithQuery

### DIFF
--- a/R/salesforce.R
+++ b/R/salesforce.R
@@ -72,7 +72,8 @@ querySalesforceTableDetails <- function(server = NULL, username, password, secur
 #' @param password - Salesforce login password
 #' @param securityToken - (optional) security token to login
 #' @param query - SOQL query.
-querySalesforceDataWithQuery <- function(server = NULL, username, password, securityToken = NULL, query = "", guessType = TRUE){
+#' @param apiType - it could be either REST, SOAP, Bulk 1.0, or Bulk 2.0. By default it's REST.
+querySalesforceDataWithQuery <- function(server = NULL, username, password, securityToken = NULL, query = "", guessType = TRUE, apiType = "REST"){
   if (!requireNamespace("salesforcer")) {
     stop("package salesforcer must be installed.")
   }
@@ -80,7 +81,7 @@ querySalesforceDataWithQuery <- function(server = NULL, username, password, secu
   queryControl <- salesforcer::sf_control(QueryOptions = list(batchSize = 2000))
   loginToSalesforce(server = server, username = username, password = password, securityToken = securityToken)
   query <- glue_exploratory(query, .transformer=salesforce_glue_transformer, .envir = parent.frame())
-  salesforcer::sf_query(soql = query, control = queryControl, guess_types = guessType)
+  salesforcer::sf_query(soql = query, control = queryControl, guess_types = guessType, api_type = apiType)
 }
 
 #' API to execute Salesforce Object Query Language (SOQL)

--- a/R/salesforce.R
+++ b/R/salesforce.R
@@ -73,6 +73,7 @@ querySalesforceTableDetails <- function(server = NULL, username, password, secur
 #' @param securityToken - (optional) security token to login
 #' @param query - SOQL query.
 #' @param apiType - it could be either REST, SOAP, Bulk 1.0, or Bulk 2.0. By default it's REST.
+#' Bulk can handle a large data set but it has limitation (ref: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_concepts_limits.htm)
 querySalesforceDataWithQuery <- function(server = NULL, username, password, securityToken = NULL, query = "", guessType = TRUE, apiType = "REST"){
   if (!requireNamespace("salesforcer")) {
     stop("package salesforcer must be installed.")


### PR DESCRIPTION
# Description

Add `apiType` argument to querySalesforceDataWithQuery

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
