### PR TITLE
Rtweet: getTwitter: fixed name conflict when includes_rts is TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.12.1.1
+Version: 6.12.1.2
 Date: 2023-01-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -2036,6 +2036,13 @@ getTwitter <- function(n=10000, lang=NULL,  lastNDays=7, searchString, tokenFile
     tidyr::unnest_wider(place_place, names_sep = "_", names_repair = "unique") %>%
     # It's possible that place_cols are not available in the query result, so use any_of to avoid column does not exist error.
     dplyr::rename(dplyr::any_of(place_cols))
+    # When Include Retweets are set as TRUE, make sure to make below column names unique
+    if (includeRts) {
+      conflictNames <- c(created_at_users = "created_at",
+                         withheld_in_countries_users = "withheld_in_countries",
+                         withheld_scope_users = "withheld_scope")
+      users <- users %>% dplyr::rename(dplyr::any_of(conflictNames))
+    }
     # combine tweet data and user information.
     tweetList <- cbind(tweetList, users)
 


### PR DESCRIPTION
# Description

 fixed name conflict when includes_rts is TRUE for getTwitter


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
