### PR TITLE
Presto / Treasure Data: Explicitly set bigint argument as numeric when getting a connection.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1034,10 +1034,10 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
       )
       if (timezone != "") { #if timezone is set, use it for session.timezone.
         conn <- RPresto::dbConnect(drv, user = username,
-                                   password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = timezone)
+                                   password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = timezone, bigint = "numeric")
       } else {
         conn <- RPresto::dbConnect(drv, user = username,
-                                   password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = Sys.timezone(location = TRUE))
+                                   password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = Sys.timezone(location = TRUE), bigint = "numeric")
       }
       connection_pool[[key]] <- conn
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1033,9 +1033,11 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         httr::add_headers("X-Presto-User"=username)
       )
       if (timezone != "") { #if timezone is set, use it for session.timezone.
+        # As described https://github.com/prestodb/RPresto#bigint-handling, make sure to pass numeric for the bigint argument to avoid the bigint column is treated as integer otherwise values are imported as NA.
         conn <- RPresto::dbConnect(drv, user = username,
                                    password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = timezone, bigint = "numeric")
       } else {
+        # As described https://github.com/prestodb/RPresto#bigint-handling, make sure to pass numeric for the bigint argument to avoid the bigint column is treated as integer otherwise values are imported as NA.
         conn <- RPresto::dbConnect(drv, user = username,
                                    password = password, host = host, port = port, schema = schema, catalog = catalog, session.timezone = Sys.timezone(location = TRUE), bigint = "numeric")
       }


### PR DESCRIPTION
# Description

As described https://github.com/prestodb/RPresto#bigint-handling, make sure to pass `numeric` for the `bigint` argument to avoid the bigint column is treated as integer otherwise values are imported as NA.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
