### PR TITLE
Set TZ env var for arima, prophet, coxph, and survival forest  test to avoid instability on Windows

### DIFF
--- a/tests/testthat/test_arima_1.R
+++ b/tests/testthat/test_arima_1.R
@@ -1,5 +1,6 @@
 context("test ARIMA functions")
 test_that("exp_arima with aggregation", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   data("raw_data", package = "AnomalyDetection")
   raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
   raw_data <- raw_data %>% rename(`time stamp`=timestamp, `cou nt`=count)
@@ -42,6 +43,7 @@ test_that("exp_arima with aggregation", {
 })
 
 test_that("exp_arima with minutes", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   data("raw_data", package = "AnomalyDetection")
   raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
   raw_data <- raw_data %>% rename(`time stamp`=timestamp, `cou nt`=count)
@@ -54,6 +56,7 @@ test_that("exp_arima with minutes", {
 
 # This test is too slow. TODO: make it faster and enable.
 test_that("exp_arima test mode with second as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   ts <- seq(as.POSIXct("2010-01-01 00:00:00"), as.POSIXct("2010-01-01 00:01:00"), by="sec")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
   raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
@@ -65,6 +68,7 @@ test_that("exp_arima test mode with second as time units", {
 
 # This test is slow. TODO: make it faster.
 test_that("exp_arima test mode with minute as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   # cannot be much longer than this on win 32bit to avoid memory error.
   ts <- seq(as.POSIXct("2010-01-01 00:00:00"), as.POSIXct("2010-01-08 00:00:00"), by="min")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
@@ -76,6 +80,7 @@ test_that("exp_arima test mode with minute as time units", {
 })
 
 test_that("exp_arima test mode with hour as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   ts <- seq(as.POSIXct("2010-01-01:00:00:00"), as.POSIXct("2010-01-15:00:00"), by="hour")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
   raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211

--- a/tests/testthat/test_build_coxph_1.R
+++ b/tests/testthat/test_build_coxph_1.R
@@ -1,6 +1,7 @@
 context("test build_coxph")
 
 test_that("build_coxph.fast with start_time and end_time", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   # Repeat the same test for Date input and POSIXct input. We do not support units like hour, min, sec, but still it should work with POSIXct type time input.
   for (type in c("Date", "POSIXct")) {
     df <- survival::lung # this data has NAs.

--- a/tests/testthat/test_prophet_1.R
+++ b/tests/testthat/test_prophet_1.R
@@ -1,5 +1,6 @@
 context("test prophet functions")
 test_that("do_prophet with aggregation", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   data("raw_data", package = "AnomalyDetection")
   raw_data$timestamp <- as.POSIXct(raw_data$timestamp)
   raw_data <- raw_data %>% rename(`time stamp`=timestamp, `cou nt`=count)
@@ -36,6 +37,7 @@ test_that("do_prophet with aggregation", {
 })
 
 test_that("do_prophet test mode with second as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   ts <- seq(as.POSIXct("2010-01-01 00:00:00"), as.POSIXct("2010-01-01 00:01:00"), by="sec")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
   raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211
@@ -50,6 +52,7 @@ test_that("do_prophet test mode with second as time units", {
 
 # This test is slow. TODO: make it faster.
 test_that("do_prophet test mode with minute as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   # cannot be much longer than this on win 32bit to avoid memory error.
   ts <- seq(as.POSIXct("2010-01-01 00:00:00"), as.POSIXct("2010-01-08 00:00:00"), by="min")
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
@@ -63,6 +66,7 @@ test_that("do_prophet test mode with minute as time units", {
 })
 
 test_that("do_prophet test mode with hour as time units", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   ts <- seq(as.POSIXct("2010-01-01:00:00:00"), as.POSIXct("2010-01-16:00:00"), by="hour") # Make it a little longer than 2 weeks to automatically enable weekly seasonality.
   raw_data <- data.frame(timestamp=ts, data=runif(length(ts))) %>% dplyr::rename(`time stamp`=timestamp, `da ta`=data)
   raw_data$`da ta`[[length(ts) - 2]] <- NA # inject NA near the end to test #9211

--- a/tests/testthat/test_survival_forest.R
+++ b/tests/testthat/test_survival_forest.R
@@ -1,6 +1,7 @@
 context("test exp_survival_forest")
 
 test_that("exp_survival_forest basic with start_time and end_time", {
+  Sys.setenv(TZ="UTC") # set time zone for test stability for tests with time unit smaller than day.
   # Repeat the same test for Date input and POSIXct input. We do not support units like hour, min, sec, but still it should work with POSIXct type time input.
   for (type in c("Date", "POSIXct")) {
     df <- survival::lung # this data has NAs.


### PR DESCRIPTION
# Description
Set TZ env var for arima, prophet, coxph, and survival forest  test to avoid instability on Windows.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
