### PR TITLE
Support type argument in queryPostgres.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1848,11 +1848,11 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
 }
 
 #' @export
-queryPostgres <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslMode = '', sslCA = '', ...){
+queryPostgres <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslMode = '', sslCA = '', type = "postgres", ...){
   if(!requireNamespace("RPostgres")){stop("package RPostgres must be installed.")}
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
 
-  conn <- getDBConnection(type = "postgres", host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslMode = sslMode, sslCA = sslCA)
+  conn <- getDBConnection(type = type, host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslMode = sslMode, sslCA = sslCA)
 
   tryCatch({
     query <- convertUserInputToUtf8(query)

--- a/R/system.R
+++ b/R/system.R
@@ -1848,6 +1848,7 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
 }
 
 #' @export
+# When querying Redshift, be sure to pass "redshift" as the type parameter so that correct sslCA handling is done for Linux case.
 queryPostgres <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslMode = '', sslCA = '', type = "postgres", ...){
   if(!requireNamespace("RPostgres")){stop("package RPostgres must be installed.")}
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}

--- a/R/system.R
+++ b/R/system.R
@@ -1848,7 +1848,18 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
 }
 
 #' @export
-# When querying Redshift, be sure to pass "redshift" as the type parameter so that correct sslCA handling is done for Linux case.
+#' @param host
+#' @param port
+#' @param databaseName
+#' @param username
+#' @param password
+#' @param numOfRows default is -1, which means all rows
+#' @param query
+#' @param timezone
+#' @param sslMode
+#' @param sslCA
+#' @param type (optional) Default is postgres. Set either postgres or redshift for now. When querying against Redshift, be sure to pass "redshift" as the type parameter so that correct sslCA handling is done for Linux case.
+#'
 queryPostgres <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslMode = '', sslCA = '', type = "postgres", ...){
   if(!requireNamespace("RPostgres")){stop("package RPostgres must be installed.")}
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}


### PR DESCRIPTION
# Description

To make Redshift SSL handling work, supported "type" argument to queryPostgres.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
