### PR TITLE
WIP: Update the small.mark default for cut output formatter.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.12.3.4
-Date: 2023-02-12
+Version: 6.12.3.5
+Date: 2023-03-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.12.3.5
-Date: 2023-03-01
+Version: 6.12.3.4
+Date: 2023-02-12
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/util.R
+++ b/R/util.R
@@ -3017,7 +3017,7 @@ construct_new_labels <- function(base.labels, new.labels) {
 # Example
 # Input: "(0.996,2.33]", "(2.33,3.67]", "(3.67,5]"
 # Output: "0.996 - 2.33", "2.33 - 3.67", "3.67 - 5"
-format_cut_output <- function(x, decimal.digits=2, big.mark=",", small.mark=".", new.labels=NULL, prefix="", suffix="", right=TRUE) {
+format_cut_output <- function(x, decimal.digits=2, big.mark=",", small.mark="", new.labels=NULL, prefix="", suffix="", right=TRUE) {
   # Exit if the length is 0.
   if (length(x) == 0 || all(is.na(x))) {
     return (x)
@@ -3045,7 +3045,7 @@ format_cut_output <- function(x, decimal.digits=2, big.mark=",", small.mark=".",
 # Input: [1] "(0.996,2.333333333]"       "(2.333333333,3.666666667]" "(3.666666667,5.004]"
 # Output: [1] "1.00 - 2.33" "2.33 - 3.67" "3.67 - 5.00"
 #
-format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.mark=".", prefix="", suffix="", right=TRUE) {
+format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.mark="", prefix="", suffix="", right=TRUE) {
   # Split the text by ",". It will breaks the vector like this.
   # [[1]]
   # [1] "(0.996"       "2.333333333]"

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1746,6 +1746,12 @@ test_that("format_cut_output function", {
   formatted <- format_cut_output(x)
   expect_equal(formatted, factor(c("1.00 - 2.33","1.00 - 2.33","2.33 - 3.67","3.67 - 5.00","3.67 - 5.00")))
 
+  # decimal.digits is more than 6 case. 
+  # It shouldn't show the small mark "." between 6th and 7th decimal digit
+  # like "0.996000.00". #27137.
+  formatted <- `_tam_format_cut_output`(x, decimal.digits=8)
+  expect_equal(formatted, factor(c("0.99600000 - 2.33333333", "0.99600000 - 2.33333333", "2.33333333 - 3.66666667", "3.66666667 - 5.00400000","3.66666667 - 5.00400000")))
+
   # Negative test
   expect_equal(c(NA,NA,NA), format_cut_output(c(NA,NA,NA), decimal.digits=2))
   expect_equal(NULL, format_cut_output(c(), decimal.digits=2))


### PR DESCRIPTION
# Description
Update the small.mark default to "" for cut output formatted.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
