### PR TITLE
Avoid error from new na_if from dplyr 1.1.0 in align_predictor_factor_levels

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -812,7 +812,7 @@ align_predictor_factor_levels <- function(newdata, model_df, predictor_cols) {
       # In case model does not know (Missing) level, do fct_other again. (Missing) will be absorbed in Other.
       ret <- forcats::fct_other(ret, keep=training_predictor_levels)
       # If "Other" is not included in the model levels, replace them with NA. They will be handled as NA rows.
-      if ("Other" %nin% training_predictor_levels) {
+      if ("Other" %nin% training_predictor_levels && "Other" %in% levels(ret)) {
         ret <- dplyr::na_if(ret, "Other")
       }
       if (is.factor(training_predictor)) { # Set the same levels as the training data including the level order.


### PR DESCRIPTION
# Description
Avoid error from new na_if from dplyr 1.1.0 in align_predictor_factor_levels, which caused the following diffs.
```
[test_build_coxph_1.R] build_coxph.fast with start_time and end_time
[test_build_lm_1.R] GLM - Gamma Destribution with test_rate
[test_build_lm_1.R] GLM - Inverse Gaussian Destribution with test_rate
[test_build_lm_1.R] GLM - Negative Binomial Destribution with test_rate
[test_build_lm_1.R] GLM - Normal Destribution with test_rate
[test_build_lm_1.R] GLM - poisson Destribution with test_rate
[test_build_lm_1.R] Logistic Regression with test_rate
[test_build_lm_1.R] add_prediction with linear regression
[test_build_lm_1.R] add_prediction with logistic regression
[test_build_lm_1.R] add_prediction with poisson regression
```

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
