### PR TITLE
For recode type_convert handling, change it to use tibble instead of data.frame.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2089,7 +2089,7 @@ recode <- function(x, type_convert = FALSE, ...) {
   if (type_convert && is.character(ret)) {
     # try to guess the data type for recoded value.
     tryCatch({
-      ret <- readr::type_convert(data.frame(x = ret))$x
+      ret <- readr::type_convert(tibble::tibble(x = ret))$x
     })
   }
   ret


### PR DESCRIPTION
# Description

Af for recode type_convert handling, change it to use` tibble` instead of `data.frame`.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
