### PR TITLE
KW test summary tab fix

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2266,7 +2266,7 @@ tidy.kruskal_exploratory <- function(x, type="model", conf_level=0.95) {
       ret <- ret %>% dplyr::mutate(Note=!!note)
     }
   }
-  if (type == "pairs") {
+  else if (type == "pairs") {
     ret <- tibble::as_tibble(x$dunn.test)
     ret <- ret %>% dplyr::select(-chi2, -P)
     ret <- ret %>% dplyr::relocate(comparisons, .before = Z)


### PR DESCRIPTION
# Description
KW test "summary" tab was showing the content of "data" tab.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
