### PR TITLE
Handle ordered factor target column in predictive models data preprocessing

### DIFF
--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -486,6 +486,7 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
                                                     predictor_n = 12, # so that at least months can fit in it.
                                                     name_map = NULL, 
                                                     other_level = "Other") {
+                                                    browser()
   c_cols <- predictor_cols
   for(col in predictor_cols){
     if(lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {
@@ -571,7 +572,10 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
       df[[col]] <- as.numeric(df[[col]])
     }
   }
-
+  # If target is factor, turn it into unordered factor if it is not already.
+  if (is.factor(df[[target_col]])) {
+    df[[target_col]] <- factor(df[[target_col]], ordered=FALSE)
+  }
   # remove columns with only one unique value
   cols_copy <- c_cols
   for (col in cols_copy) {

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -486,7 +486,6 @@ preprocess_regression_data_after_sample <- function(df, target_col, predictor_co
                                                     predictor_n = 12, # so that at least months can fit in it.
                                                     name_map = NULL, 
                                                     other_level = "Other") {
-                                                    browser()
   c_cols <- predictor_cols
   for(col in predictor_cols){
     if(lubridate::is.Date(df[[col]]) || lubridate::is.POSIXct(df[[col]])) {

--- a/tests/testthat/test_rpart_2.R
+++ b/tests/testthat/test_rpart_2.R
@@ -273,8 +273,8 @@ test_that("exp_rpart evaluate training and test with impurity importance - logic
   expect_equal(nrow(ret), 1) # 1 for train
 })
 
-test_that("exp_rpart(character(A,B)) evaluate training and test", { # This should be treated as multi-class
-  data <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B"))
+test_that("exp_rpart(factor(A,B)) evaluate training and test", { # This should be treated as multi-class
+  data <- flight %>% dplyr::mutate(is_delayed = factor(if_else(as.logical(`is delayed`), "A", "B"), ordered=TRUE))
   model_df <- data %>% exp_rpart(is_delayed, `DIS TANCE`, `DEP DELAY`, test_rate = 0.3, binary_classification_threshold=0.5)
 
   ret <- model_df %>% prediction(data="training_and_test", pretty.name=TRUE)
@@ -295,9 +295,12 @@ test_that("exp_rpart(character(A,B)) evaluate training and test", { # This shoul
   expect_gt(nrow(train_ret), 3300)
 
   ret <- model_df %>% rf_evaluation_training_and_test()
-  expect_equal(nrow(ret), 2) # 2 for train and test
+  expect_equal(nrow(ret), 2) # 2 for train/test
   ret <- model_df %>% rf_evaluation_training_and_test(type="evaluation_by_class")
-  expect_equal(nrow(ret), 4) # 2 for train and test times A/B.
+  expect_equal(nrow(ret), 4) # 4 for train/test times A/B.
+  ret <- model_df %>% rf_evaluation_training_and_test(type='conf_mat')
+  expect_equal(nrow(ret), 8) # 8 for train/test times A/B (actual) times A/B (predicted).
+  expect_equal(colnames(ret), c("actual_value", "predicted_value", "count", "is_test_data"))
 
   # Training only case
   model_df <- flight %>% dplyr::mutate(is_delayed = if_else(as.logical(`is delayed`), "A", "B")) %>%


### PR DESCRIPTION
# Description
Handle ordered factor target column in predictive models data preprocessing. We are making them regular factor.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
