### PR TITLE
Data Source: Make MS SQL Server ODBC driver configurable for Collaboration Server.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -1426,7 +1426,10 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     # If the platform is Linux, set the below predefined driver installed on Collaboration Server
     # so that this data soure can be scheduled.
     if(Sys.info()["sysname"]=="Linux"){
-      driver <-  "ODBC Driver 18 for SQL Server";
+      driver <- Sys.getenv("MS_SQL_SERVER_DRIVER_FILE")
+      if (driver == "") { # if environment variable is not set, fallback to default one.
+        driver <-  "ODBC Driver 18 for SQL Server";
+      }
     }
     # mssqlserver uses odbc package instead of RODBC for two reasons:
     # 1) The "ODBC Driver 17 for SQL Server" driver does not work on Mac with RODBC.


### PR DESCRIPTION
# Description

Make MS SQL Server ODBC driver configurable for Collaboration Server.
Now you can configure the MS SQL Server ODBC driver with the `MS_SQL_SERVER_DRIVER_FILE` environment variable for Collaboration Server.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
