### PR TITLE
Recode fails to replace a single dot (".") to something else and shows an error " Argument 2 must be named."

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.13.0.19
-Date: 2023-04-20
+Version: 6.13.0.20
+Date: 2023-04-21
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/util.R
+++ b/R/util.R
@@ -2075,7 +2075,7 @@ setdiff <- function(x, y, force_data_type = FALSE, ...) {
 
 #'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
-recode <- function(x, ..., type_convert = FALSE) {
+recode <- function(x, type_convert = FALSE, ...) {
   # Recreate the dynamic dots for recoding "." characters.
   map <- list(...)
   ret <- dplyr::recode(x, !!!map)

--- a/R/util.R
+++ b/R/util.R
@@ -2130,7 +2130,6 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
 
   # Recreate the dynamic dots for recoding a single dot (".") problem.
   map <- list(...)
-  ret <- dplyr::recode(x, !!!map)
   # check if all the unique values are recoded
   if (argumentLength == num_of_unique_value) { # if all the values are recoded, just call recode_factor so that level is automatically adjusted.
       ret <- dplyr::recode_factor(x, !!!map, .default = .default, .missing = .missing, .ordered = .ordered)

--- a/R/util.R
+++ b/R/util.R
@@ -2075,8 +2075,10 @@ setdiff <- function(x, y, force_data_type = FALSE, ...) {
 
 #'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
-recode <- function(x, type_convert = FALSE, ...) {
-  ret <- dplyr::recode(x, ...)
+recode <- function(x, ..., type_convert = FALSE) {
+  # Recreate the dynamic dots for recoding "." characters.
+  map <- list(...)
+  ret <- dplyr::recode(x, !!!map)
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.
   # Such values are displayed fine on the spot, but later if bind_row is applied,
   # they get garbled. Working it around by converting to UTF-8.

--- a/R/util.R
+++ b/R/util.R
@@ -2076,7 +2076,7 @@ setdiff <- function(x, y, force_data_type = FALSE, ...) {
 #'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
 recode <- function(x, type_convert = FALSE, ...) {
-  # Recreate the dynamic dots for recoding "." characters.
+  # Recreate the dynamic dots for recoding a single dot (".") problem.
   map <- list(...)
   ret <- dplyr::recode(x, !!!map)
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.

--- a/R/util.R
+++ b/R/util.R
@@ -2076,7 +2076,7 @@ setdiff <- function(x, y, force_data_type = FALSE, ...) {
 #'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
 recode <- function(x, type_convert = FALSE, ...) {
-  # Recreate the dynamic dots for recoding a single dot (".") problem.
+  # Recreate the dynamic dots. Without it recoding a single dot (".") leads to an error when called from inside mutate().
   map <- list(...)
   ret <- dplyr::recode(x, !!!map)
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.
@@ -2128,7 +2128,7 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
   replacements <- dplyr:::dplyr_quosures(...)
   argumentLength = length(replacements)
 
-  # Recreate the dynamic dots for recoding a single dot (".") problem.
+  # Recreate the dynamic dots. Without it recoding a single dot (".") leads to an error when called from inside mutate().
   map <- list(...)
   # check if all the unique values are recoded
   if (argumentLength == num_of_unique_value) { # if all the values are recoded, just call recode_factor so that level is automatically adjusted.

--- a/R/util.R
+++ b/R/util.R
@@ -2127,9 +2127,13 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
   }
   replacements <- dplyr:::dplyr_quosures(...)
   argumentLength = length(replacements)
+
+  # Recreate the dynamic dots for recoding a single dot (".") problem.
+  map <- list(...)
+  ret <- dplyr::recode(x, !!!map)
   # check if all the unique values are recoded
   if (argumentLength == num_of_unique_value) { # if all the values are recoded, just call recode_factor so that level is automatically adjusted.
-      ret <- dplyr::recode_factor(x, ..., .default = .default, .missing = .missing, .ordered = .ordered)
+      ret <- dplyr::recode_factor(x, !!!map, .default = .default, .missing = .missing, .ordered = .ordered)
   } else { # if not all the unique values are recoded, need to adjust ordering manually.
     if (!is.factor(x)) { # check if input is factor.
       if (!is.character(x)) {
@@ -2139,7 +2143,7 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
       x <- forcats::fct_relevel(x, current_levels)
     }
     # pass current_levels to .default argument to keep the levels in the input.
-    ret <- dplyr::recode(x, ..., .default = current_levels, .missing = .missing)
+    ret <- dplyr::recode(x, !!!map, .default = current_levels, .missing = .missing)
   }
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.
   # Such values are displayed fine on the spot, but later if bind_row is applied,

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1804,6 +1804,11 @@ test_that("recode and recode_factor", {
   # type covert is set as TRUE so the result should be Date 2023-01-01,2023-01-02,2023-01-03 instead of character "2023-01-01","2023-01-02", "2023-01-03".
   result6 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "2023-01-01", "なし" = "2023-01-02", "頻繁" = "2023-01-03", type_convert = TRUE))
   expect_equal(exploratory:::get_unique_values(result6$business_travel, 100), c(lubridate::ymd("2023-01-01"),lubridate::ymd("2023-01-02"),lubridate::ymd("2023-01-03")))
+
+  # Recoding "." to something else. 
+  test.df <- tibble(text=c("a", "b", ".", "."), value=1:4)
+  test.df.result <- test.df %>% dplyr::mutate(text= recode(text, `.` = "abc", a="xyz"))
+  expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
 })
 
 test_that("separate_japanese_address", {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1805,11 +1805,12 @@ test_that("recode and recode_factor", {
   result6 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "2023-01-01", "なし" = "2023-01-02", "頻繁" = "2023-01-03", type_convert = TRUE))
   expect_equal(exploratory:::get_unique_values(result6$business_travel, 100), c(lubridate::ymd("2023-01-01"),lubridate::ymd("2023-01-02"),lubridate::ymd("2023-01-03")))
   # Test recoding "." to something else. 
+    # Test recoding "." to something else. 
   test.df <- tibble(text=c("a", "b", ".", "."), value=1:4)
-  test.df.result <- test.df %>% dplyr::mutate(text= recode(text, `.` = "abc", a="xyz"))
+  test.df.result <- test.df %>% dplyr::mutate(text = recode(text, `.` = "abc", a="xyz"))
   expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
-  test.df.result <- test.df %>% dplyr::mutate(text= recode_factor(text, `.` = "abc", a="xyz"))
-  expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
+  test.df.result <- test.df %>% dplyr::mutate(text = recode_factor(text, `.` = "abc", a="xyz"))
+  expect_equal(levels(test.df.result$text), c("abc", "xyz", "b"))
 })
 
 test_that("separate_japanese_address", {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1808,6 +1808,8 @@ test_that("recode and recode_factor", {
   test.df <- tibble(text=c("a", "b", ".", "."), value=1:4)
   test.df.result <- test.df %>% dplyr::mutate(text= recode(text, `.` = "abc", a="xyz"))
   expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
+  test.df.result <- test.df %>% dplyr::mutate(text= recode_factor(text, `.` = "abc", a="xyz"))
+  expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
 })
 
 test_that("separate_japanese_address", {

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1804,8 +1804,7 @@ test_that("recode and recode_factor", {
   # type covert is set as TRUE so the result should be Date 2023-01-01,2023-01-02,2023-01-03 instead of character "2023-01-01","2023-01-02", "2023-01-03".
   result6 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "2023-01-01", "なし" = "2023-01-02", "頻繁" = "2023-01-03", type_convert = TRUE))
   expect_equal(exploratory:::get_unique_values(result6$business_travel, 100), c(lubridate::ymd("2023-01-01"),lubridate::ymd("2023-01-02"),lubridate::ymd("2023-01-03")))
-
-  # Recoding "." to something else. 
+  # Test recoding "." to something else. 
   test.df <- tibble(text=c("a", "b", ".", "."), value=1:4)
   test.df.result <- test.df %>% dplyr::mutate(text= recode(text, `.` = "abc", a="xyz"))
   expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))


### PR DESCRIPTION
# Description

The `recode` function has a problem if you try to recode a dot (".") to something else. It happens only for a single dot. 

```R
> df <- tibble(text=c("a", "b", " ", "."), value=1:4)
> df %>%  dplyr::mutate(c1= dplyr::recode(text, `.` = "abc"))

Error in `dplyr::mutate()`:
  :information_source: In argument: `c1 = dplyr::recode(text, . = "abc")`.
Caused by error in `dplyr::recode()`:
  ! Argument 2 must be named.

```

It fixes this issue.


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
