### PR TITLE
Data Wrangling: Recoding numeric values with "Preserve Order as Factor" option fails.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2122,6 +2122,9 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
     current_levels <- levels(x)
     num_of_unique_value <- length(current_levels)
   } else { # if input is not factor, get unique values sorted by count and remember it as current level.
+    if (!is.character(x)) {
+      x <- as.character(x) # to make forcats::fct_relevel works, convert it to character.
+    }
     current_levels <- get_unique_values(x, length(x))
     num_of_unique_value <- length(current_levels)
   }
@@ -2135,9 +2138,6 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
       ret <- dplyr::recode_factor(x, !!!map, .default = .default, .missing = .missing, .ordered = .ordered)
   } else { # if not all the unique values are recoded, need to adjust ordering manually.
     if (!is.factor(x)) { # check if input is factor.
-      if (!is.character(x)) {
-        x <- as.character(x) # to make forcats::fct_relevel works, convert it to character.
-      }
       # make sure to apply current_levels before doing recode, so that current levels is honored.
       x <- forcats::fct_relevel(x, current_levels)
     }

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1804,12 +1804,15 @@ test_that("recode and recode_factor", {
   # type covert is set as TRUE so the result should be Date 2023-01-01,2023-01-02,2023-01-03 instead of character "2023-01-01","2023-01-02", "2023-01-03".
   result6 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "2023-01-01", "なし" = "2023-01-02", "頻繁" = "2023-01-03", type_convert = TRUE))
   expect_equal(exploratory:::get_unique_values(result6$business_travel, 100), c(lubridate::ymd("2023-01-01"),lubridate::ymd("2023-01-02"),lubridate::ymd("2023-01-03")))
-  # Test recoding "." to something else. 
-    # Test recoding "." to something else. 
+  result7 <- empDF %>% mutate(job_level = exploratory::recode_factor(job_level, `1` = "10", `4` = "40"))
+  expect_equal(levels(result7$job_level), c("10", "2", "3", "40", "5"))
+
+  # Test recoding "." to something else.
+    # Test recoding "." to something else.
   test.df <- tibble(text=c("a", "b", ".", "."), value=1:4)
-  test.df.result <- test.df %>% dplyr::mutate(text = recode(text, `.` = "abc", a="xyz"))
+  test.df.result <- test.df %>% dplyr::mutate(text = exploratory::recode(text, `.` = "abc", a="xyz"))
   expect_equal(test.df.result$text, c("xyz", "b", "abc", "abc"))
-  test.df.result <- test.df %>% dplyr::mutate(text = recode_factor(text, `.` = "abc", a="xyz"))
+  test.df.result <- test.df %>% dplyr::mutate(text = exploratory::recode_factor(text, `.` = "abc", a="xyz"))
   expect_equal(levels(test.df.result$text), c("abc", "xyz", "b"))
 })
 


### PR DESCRIPTION
# Description

This fixes the issue that the numeric column case does not work well with `recode_factor`.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
