### PR TITLE
mat_to_df: Changed it to use names_to/values_to in pivot_longer call to make it work with tidyr 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 6.13.0.21
-Date: 2023-04-24
+Version: 6.13.0.22
+Date: 2023-04-25
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/util.R
+++ b/R/util.R
@@ -310,7 +310,7 @@ mat_to_df <- function(mat, cnames=NULL, na.rm=TRUE, zero.rm = TRUE, diag=TRUE) {
   }
   df <- as.data.frame(mat) %>%
     tibble::rownames_to_column(".Var2.temp") %>% # The column name .Var2.temp is to avoid name conflict as much as possible.
-    tidyr::pivot_longer(-.Var2.temp, "Var1","value", values_drop_na = na.rm) %>%
+    tidyr::pivot_longer(-.Var2.temp, names_to="Var1", values_to="value", values_drop_na = na.rm) %>%
     dplyr::rename(Var2 = .Var2.temp)
 
   if(zero.rm){


### PR DESCRIPTION
# Description
Describe your fix here

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
