### PR TITLE
Recode / Recode Factor: Fix  issue that passing the .default argument does not work

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -2141,8 +2141,12 @@ recode_factor <- function(x, ..., reverse_order = FALSE, .default = NULL, .missi
       # make sure to apply current_levels before doing recode, so that current levels is honored.
       x <- forcats::fct_relevel(x, current_levels)
     }
-    # pass current_levels to .default argument to keep the levels in the input.
-    ret <- dplyr::recode(x, !!!map, .default = current_levels, .missing = .missing)
+    if (is.null(.default)) {
+      # pass current_levels to .default argument to keep the levels in the input.
+      ret <- dplyr::recode(x, !!!map, .default = current_levels, .missing = .missing)
+    } else {
+      ret <- dplyr::recode(x, !!!map, .default = .default, .missing = .missing)
+    }
   }
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.
   # Such values are displayed fine on the spot, but later if bind_row is applied,

--- a/R/util.R
+++ b/R/util.R
@@ -2075,10 +2075,10 @@ setdiff <- function(x, y, force_data_type = FALSE, ...) {
 
 #'Wrapper function for dplyr::recode to workaround encoding info getting lost.
 #'@export
-recode <- function(x, type_convert = FALSE, ...) {
+recode <- function(x, ..., type_convert = FALSE, .default = NULL, .missing = NULL) {
   # Recreate the dynamic dots. Without it recoding a single dot (".") leads to an error when called from inside mutate().
   map <- list(...)
-  ret <- dplyr::recode(x, !!!map)
+  ret <- dplyr::recode(x, !!!map, .default = .default, .missing = .missing)
   # Workaround for the issue that Encoding of recoded values becomes 'unknown' on Windows.
   # Such values are displayed fine on the spot, but later if bind_row is applied,
   # they get garbled. Working it around by converting to UTF-8.

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1809,6 +1809,8 @@ test_that("recode and recode_factor", {
   # type covert is set as TRUE so the result should be numeric 1,2,3 instead of character "1","2","3".
   result8 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "1", "なし" = "2", .default = "0", type_convert = TRUE))
   expect_equal(exploratory:::get_unique_values(result8$business_travel, 100), c(0,1,2))
+  result9 <- empDF %>% mutate(job_level = exploratory::recode_factor(job_level, `1` = "10", `4` = "40", .default = "99"))
+  expect_equal(levels(result9$job_level), c("10", "99", "40"))
 
 
   # Test recoding "." to something else.

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1806,6 +1806,10 @@ test_that("recode and recode_factor", {
   expect_equal(exploratory:::get_unique_values(result6$business_travel, 100), c(lubridate::ymd("2023-01-01"),lubridate::ymd("2023-01-02"),lubridate::ymd("2023-01-03")))
   result7 <- empDF %>% mutate(job_level = exploratory::recode_factor(job_level, `1` = "10", `4` = "40"))
   expect_equal(levels(result7$job_level), c("10", "2", "3", "40", "5"))
+  # type covert is set as TRUE so the result should be numeric 1,2,3 instead of character "1","2","3".
+  result8 <- empDF %>% mutate(business_travel = exploratory::recode(business_travel, "たまに" = "1", "なし" = "2", .default = "0", type_convert = TRUE))
+  expect_equal(exploratory:::get_unique_values(result8$business_travel, 100), c(0,1,2))
+
 
   # Test recoding "." to something else.
     # Test recoding "." to something else.


### PR DESCRIPTION
# Description

This fixes an issue that passing .default argument to recode and recode_factor does not work.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
