### PR TITLE
Add effect size in Kruskal-Wallis output. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 man
+# Exclude intermediate testcases for the development purpose.
+tests/testthat/test-dev*.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 7.0.0.4
-Date: 2023-05-09
+Version: 7.0.0.5
+Date: 2023-05-10
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 7.0.0.5
+Version: 7.0.5
 Date: 2023-05-10
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/broom_wrapper.R
+++ b/R/broom_wrapper.R
@@ -748,13 +748,21 @@ prediction <- function(df, data = "training", data_frame = NULL, conf_int = 0.95
     colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
     colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
     colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
-    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Residual Standard Deviation")
+    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Estimated Residual SD")
     colnames(ret)[colnames(ret) == "cooks_distance"] <- avoid_conflict(colnames(ret), "Cook's Distance")
     colnames(ret)[colnames(ret) == "standardised_residuals"] <- avoid_conflict(colnames(ret), "Standardised Residuals")
     colnames(ret)[colnames(ret) == "conf_low"] <- avoid_conflict(colnames(ret), "Conf Low")
     colnames(ret)[colnames(ret) == "conf_high"] <- avoid_conflict(colnames(ret), "Conf High")
     colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
     ret <- ret %>% dplyr::rename_with(function(x){gsub("predicted_probability_","Predicted Probability for ", x)}, starts_with("predicted_probability_")) # For multiclass classification.
+
+    # Show Residuals, Standardized Residuals, Estimated Residual SD next to each other.
+    if (all(c("Residuals", "Estimated Residual SD") %in% colnames(ret))) {
+      ret <- ret %>% dplyr::relocate(`Estimated Residual SD`, .after=`Residuals`)
+    }
+    if (all(c("Residuals", "Standardised Residuals") %in% colnames(ret))) {
+      ret <- ret %>% dplyr::relocate(`Standardised Residuals`, .after=`Residuals`)
+    }
   }
 
   dplyr::group_by(ret, !!!rlang::syms(grouping_cols))
@@ -1152,12 +1160,19 @@ prediction_binary <- function(df, threshold = 0.5, pretty.name = FALSE, ...){
     colnames(ret)[colnames(ret) == "standard_error"] <- avoid_conflict(colnames(ret), "Standard Error")
     colnames(ret)[colnames(ret) == "residuals"] <- avoid_conflict(colnames(ret), "Residuals")
     colnames(ret)[colnames(ret) == "hat"] <- avoid_conflict(colnames(ret), "Hat")
-    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Residual Standard Deviation")
+    colnames(ret)[colnames(ret) == "residual_standard_deviation"] <- avoid_conflict(colnames(ret), "Estimated Residual SD")
     colnames(ret)[colnames(ret) == "cooks_distance"] <- avoid_conflict(colnames(ret), "Cook's Distance")
     colnames(ret)[colnames(ret) == "standardised_residuals"] <- avoid_conflict(colnames(ret), "Standardised Residuals")
     colnames(ret)[colnames(ret) == "conf_low"] <- avoid_conflict(colnames(ret), "Conf Low")
     colnames(ret)[colnames(ret) == "conf_high"] <- avoid_conflict(colnames(ret), "Conf High")
     colnames(ret)[colnames(ret) == "is_test_data"] <- avoid_conflict(colnames(ret), "Test Data")
+    # Show Residuals, Standardized Residuals, Estimated Residual SD next to each other.
+    if (all(c("Residuals", "Estimated Residual SD") %in% colnames(ret))) {
+      ret <- ret %>% dplyr::relocate(`Estimated Residual SD`, .after=`Residuals`)
+    }
+    if (all(c("Residuals", "Standardised Residuals") %in% colnames(ret))) {
+      ret <- ret %>% dplyr::relocate(`Standardised Residuals`, .after=`Residuals`)
+    }
   }
   ret
 }

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2589,6 +2589,13 @@ exp_kruskal <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05, pai
       model$data <- df
       model$epsilon_squared <- epsilon_squared
       model$test_sig_level <- test_sig_level
+      # Calculate effect size: eta2[H] = (H - k + 1)/(n - k)
+      # H: Value obtained in the Kruskal-Wallis test 
+      # k: Number of groups 
+      # n: Total number of observation
+      K <- n_distinct(df[[var2_col]])
+      H <- model$statistic
+      model$effsize <- (H - K + 1)/(N - K)
       model
     }, error = function(e){
       if(length(grouped_cols) > 0) {
@@ -2614,11 +2621,12 @@ tidy.kruskal_exploratory <- function(x, type="model", conf_level=0.95) {
     note <- NULL
     ret <- broom:::tidy.htest(x)
     ret <- ret %>% dplyr::select(statistic, p.value) # Removed method since it is always "Kruskal-Wallis rank sum test" here.
-    ret <- ret %>% dplyr::mutate(df=!!x$parameter, epsilon_squared=!!x$epsilon_squared, n=!!tot_n_rows)
+    ret <- ret %>% dplyr::mutate(df=!!x$parameter, effsize=!!x$effsize, epsilon_squared=!!x$epsilon_squared, n=!!tot_n_rows)
     ret <- ret %>% dplyr::rename(`H Value` = statistic,
                                  `P Value`=p.value,
                                  `DF`=df,
                                  `Epsilon Squared`=epsilon_squared,
+                                 `Eta Squared`=effsize,
                                  `Rows`=n)
     if (!is.null(note)) { # Add Note column, if there was an error from pwr function.
       ret <- ret %>% dplyr::mutate(Note=!!note)

--- a/tests/testthat/test_test_wrapper_3.R
+++ b/tests/testthat/test_test_wrapper_3.R
@@ -9,7 +9,8 @@ test_that("test exp_kruskal", {
 
   ret <- model_df %>% tidy_rowwise(model, type="model")
   expect_true("Eta Squared" %in% colnames(ret))
-  expect_equal(ret$`Eta Squared`, 0.424, tolerance=1e-3)
+  expect_true(ret$`Eta Squared` > 0.424)
+  expect_true(ret$`Eta Squared` < 0.425)
   
   ret <- model_df %>% tidy_rowwise(model, type="data_summary")
   expect_equal(colnames(ret),

--- a/tests/testthat/test_test_wrapper_3.R
+++ b/tests/testthat/test_test_wrapper_3.R
@@ -8,6 +8,9 @@ test_that("test exp_kruskal", {
   expect_true("p.value" %in% colnames(ret))
 
   ret <- model_df %>% tidy_rowwise(model, type="model")
+  expect_equal("Eta Squared" %in% colnames(ret))
+  expect_equal(ret$`Eta Squared`, 0.424, tolerance=1e-3)
+  
   ret <- model_df %>% tidy_rowwise(model, type="data_summary")
   expect_equal(colnames(ret),
                c("gear","Rows","Mean","Conf Low","Conf High","Std Error of Mean","Std Deviation",

--- a/tests/testthat/test_test_wrapper_3.R
+++ b/tests/testthat/test_test_wrapper_3.R
@@ -8,7 +8,7 @@ test_that("test exp_kruskal", {
   expect_true("p.value" %in% colnames(ret))
 
   ret <- model_df %>% tidy_rowwise(model, type="model")
-  expect_equal("Eta Squared" %in% colnames(ret))
+  expect_true("Eta Squared" %in% colnames(ret))
   expect_equal(ret$`Eta Squared`, 0.424, tolerance=1e-3)
   
   ret <- model_df %>% tidy_rowwise(model, type="data_summary")


### PR DESCRIPTION
# Description

* Add effect size in Kruskal-Wallis output.
* Update the residual column order.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
