### PR TITLE
Weather Data: Only show online stations and handle start_date parameter.

### DIFF
--- a/R/data_source_extension.R
+++ b/R/data_source_extension.R
@@ -2,10 +2,17 @@
 #' This was initially treated as an extension, but we had to include it in this package to make it run on the server,
 #' which effectively makes it not really an extension.
 #' @export
-get_riem_measures <- function(station = "SFO", date_start = "2020-01-01", date_end = NULL, full_columns = "Yes", tzone = ""){
+get_riem_measures <- function(station = "SFO", date_start = NULL, date_end = NULL, full_columns = "Yes", tzone = ""){
   loadNamespace("riem")
   if(is.null(date_end)){
     date_end <- as.character(Sys.Date())
+  }
+  if (date_start == "" || is.null(date_start)) {
+    if (tzone != "") {
+      date_start <- as.character(lubridate::today(tzone = tzone) %m-% months(3))
+    } else {
+      date_start <- as.character(lubridate::today() %m-% months(3))
+    }
   }
   # Since we cannot use POSIXct for start_date and end_date
   # We give little bit of buffers for start and end date and use filter to get the exact date range.
@@ -60,7 +67,8 @@ get_riem_measures <- function(station = "SFO", date_start = "2020-01-01", date_e
 #' Wrapper API for riem_stations
 #' @export
 riem_stations_exp <- function(network = NULL) {
-  df <- riem::riem_stations(network)
+  # make sure only return "online" status stations.
+  df <- riem::riem_stations(network) %>% filter(online)
   df <- df %>% dplyr::mutate(name = dplyr::case_when(
     id == "RJOA" ~ "Hiroshima-shi",
     id == "RJOO" ~ "Osaka (Itami)",

--- a/R/data_source_extension.R
+++ b/R/data_source_extension.R
@@ -7,7 +7,8 @@ get_riem_measures <- function(station = "SFO", date_start = NULL, date_end = NUL
   if(is.null(date_end)){
     date_end <- as.character(Sys.Date())
   }
-  if (date_start == "" || is.null(date_start)) {
+  if (is.null(date_start) || date_start == "") {
+    # if date_start is not set, use 3 months ago as the date_start.
     if (tzone != "") {
       date_start <- as.character(lubridate::today(tzone = tzone) %m-% months(3))
     } else {

--- a/R/data_source_extension.R
+++ b/R/data_source_extension.R
@@ -100,7 +100,7 @@ execute_tidyquant <- function(stocks = NULL, from = NULL, to = NULL) {
     to <- lubridate::today()
   }
 
-  if (is.null(stocks) || stocks == "") {
+  if (is.null(stocks) || all(stocks == "")) {
     # If no stocks identified, return all SP500
     ret <- tidyquant::tq_index("SP500") %>%
       select(1) %>%


### PR DESCRIPTION
# Description

- Updated `riem_stations_exp`
- Updated `get_riem_measures` for `date_start` parameter default handling.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
