### PR TITLE
Fix the column order: show xxx_low then xxx_high.

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -343,8 +343,8 @@ exp_arima <- function(df, time, valueColumn,
 
     forecast_rows <- tibble(ds=forecasted_df$ds,
                             forecasted_value=mean(forecasted_df$y), # Note that y is a distribution object.
-                            forecasted_value_high=quantile(forecasted_df$y, conf_level),
-                            forecasted_value_low=quantile(forecasted_df$y, 1 - conf_level))
+                            forecasted_value_low=quantile(forecasted_df$y, 1 - conf_level),
+                            forecasted_value_high=quantile(forecasted_df$y, conf_level))
 
     if (test_mode){
       fitted_training_df$is_test_data <- FALSE

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -723,7 +723,7 @@ do_prophet_ <- function(df, time_col, value_col = NULL, periods = 10, time_unit 
       }
   
       # adjust order of output columns
-      ret <- ret %>% dplyr::select(ds, y, yhat, yhat_upper, yhat_lower, trend, trend_upper, trend_lower,
+      ret <- ret %>% dplyr::select(ds, y, yhat, yhat_lower, yhat_upper, trend, trend_lower, trend_upper, 
                                    matches('^yearly$'), matches('^yearly_lower$'), matches('^yearly_upper$'),
                                    matches('^quarterly$'), matches('^quarterly_lower$'), matches('^quarterly_upper$'),
                                    matches('^monthly$'), matches('^monthly_lower$'), matches('^monthly_upper$'),

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -842,6 +842,12 @@ test_that("test exp_anova with logical group column", {
   res <- model_df %>% tidy_rowwise(model, type="data", sort_factor_levels=TRUE)
 })
 
+test_that("test exp_anova with factor group column", {
+  mtcars2 <- mtcars %>% mutate(`a m`=factor(am), `w t`=wt, `q sec`=qsec)
+  model_df <- exp_anova(mtcars2, mpg, `a m`)
+  res <- model_df %>% tidy_rowwise(model, type="data", sort_factor_levels=TRUE)
+})
+
 test_that("test exp_anova with group-level error (lack of unique values)", {
   df <- tibble::tibble(group=c(1,1,2,2),category=c("a","a","b","b"),value=c(1,2,1,2))
   model_df <- df %>% dplyr::group_by(`group`) %>% exp_anova(`value`, `category`)

--- a/tests/testthat/test_test_wrapper_3.R
+++ b/tests/testthat/test_test_wrapper_3.R
@@ -39,3 +39,28 @@ test_that("test exp_kruskal with group-level error", {
   ret <- model_df %>% tidy_rowwise(model, type='prob_dist')
   expect_equal(nrow(ret), 0)
 })
+
+
+test_that("test exp_kruskal with pairs_adjust types.", {
+  model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "bonferroni")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 3) # for cyl=4, 6, 8.
+
+  model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "sidak")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 3)
+
+  model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "holm")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 3)
+
+  model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "hochberg")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 3)
+
+  model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "none")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 3)
+})
+
+


### PR DESCRIPTION
# Description
Fix the column order (show xxx_low then xxx_high).

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
