### PR TITLE
Local Files: fix for startsWith condition handling for file match cases.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3167,7 +3167,7 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
   }
   if (stringr::str_starts(pattern, "\\^")) {
-    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))

--- a/R/system.R
+++ b/R/system.R
@@ -3169,6 +3169,9 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
+  } else if (pattern != "") {
+    # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
+    pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {
@@ -3405,6 +3408,9 @@ searchAndReadDelimFiles <- function(folder, pattern = "", forPreview = FALSE, de
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
+  } else if (pattern != "") {
+    # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
+    pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {
@@ -3647,6 +3653,9 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
+  } else if (pattern != "") {
+    # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
+    pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {

--- a/R/system.R
+++ b/R/system.R
@@ -3166,6 +3166,10 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
   if (!dir.exists(folder)) {
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
   }
+  if (stringr::str_starts(pattern, "\\^")) {
+    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
+  }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {
     stop(paste0('EXP-DATASRC-3 :: ', jsonlite::toJSON(folder), ' :: There is no file in the folder that matches with the specified condition.')) # TODO: escape folder name.
@@ -3397,6 +3401,10 @@ searchAndReadDelimFiles <- function(folder, pattern = "", forPreview = FALSE, de
   # search condition is case insensitive. (ref: https://www.regular-expressions.info/modifiers.html, https://stackoverflow.com/questions/5671719/case-insensitive-search-of-a-list-in-r)
   if (!dir.exists(folder)) {
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
+  }
+  if (stringr::str_starts(pattern, "\\^")) {
+    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {
@@ -3635,6 +3643,10 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
   # search condition is case insensitive. (ref: https://www.regular-expressions.info/modifiers.html, https://stackoverflow.com/questions/5671719/case-insensitive-search-of-a-list-in-r)
   if (!dir.exists(folder)) {
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
+  }
+  if (stringr::str_starts(pattern, "\\^")) {
+    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
   if (length(files) == 0) {

--- a/R/system.R
+++ b/R/system.R
@@ -3403,7 +3403,7 @@ searchAndReadDelimFiles <- function(folder, pattern = "", forPreview = FALSE, de
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
   }
   if (stringr::str_starts(pattern, "\\^")) {
-    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
@@ -3645,7 +3645,7 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
   }
   if (stringr::str_starts(pattern, "\\^")) {
-    # if pattern starts with "^", it needs to replace the "^" with folder since patter match is done with full path
+    # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))


### PR DESCRIPTION
# Description

This addresses the issue that the "startsWith" search condition for local files does not work.

- searchAndReadExcelFiles
- searchAndReadDelimFiles
- searchAndReadParquetFiles

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
