### PR TITLE
Make sure to exclude excel temporary files whose name starts with "~$".

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3174,6 +3174,10 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
     pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
   files <- fs::dir_ls(path = folder, regexp = stringr::str_c("(?i)", pattern))
+  if (length(files) > 0) {
+    # Exclude Excel temporary files whose name starts with ~$ (e.g. ~$test.xlsx)
+    files <- files[!grepl("/\\~\\$", files)]
+  }
   if (length(files) == 0) {
     stop(paste0('EXP-DATASRC-3 :: ', jsonlite::toJSON(folder), ' :: There is no file in the folder that matches with the specified condition.')) # TODO: escape folder name.
   }

--- a/R/system.R
+++ b/R/system.R
@@ -3169,7 +3169,7 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
-  } else if (pattern != "") {
+  } else if (pattern != "" && !stringr::str_starts(pattern, "\\*")) { # For the "all files" case, the pattern starts with *
     # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
     pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
@@ -3412,7 +3412,7 @@ searchAndReadDelimFiles <- function(folder, pattern = "", forPreview = FALSE, de
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
-  } else if (pattern != "") {
+  } else if (pattern != "" && !stringr::str_starts(pattern, "\\*")) { # For the "all files" case, the pattern starts with *
     # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
     pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }
@@ -3657,7 +3657,7 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
   if (stringr::str_starts(pattern, "\\^")) {
     # If the pattern starts with "^", it needs to replace the "^" with a folder since the pattern match is done with the full path
     pattern <- paste0(fs::fs_path(folder), "/", stringr::str_sub(pattern, start = 2,))
-  } else if (pattern != "") {
+  } else if (pattern != "" && !stringr::str_starts(pattern, "\\*")) { # For the "all files" case, the pattern starts with *
     # For the "contains" and "ends with" cases, make sure to set the folder so that it only matches with file names.
     pattern <- paste0(fs::fs_path(folder), "/.*", pattern)
   }


### PR DESCRIPTION
# Description

Changed searchAndReadExcelFiles to exclude Excel Temporary Files (whose file name starts with ~$)

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
