### PR TITLE
Add monthname_with_year date grouping function.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1611,6 +1611,9 @@ extract_from_date <- function(x, type = "fltoyear") {
     monnamelong = {
       ret <- lubridate::month(x, label=TRUE, abbr=FALSE)
     },
+    monthname_with_year = {
+      ret <- format(x, "%Y-%m")
+    },
     week = {
       ret <- lubridate::week(x)
     },
@@ -2522,6 +2525,7 @@ column_mutate_quosure <- function(func, cname) {
       "monname",
       "monthnamelong",
       "monnamelong",
+      "monthname_with_year",
       "week",
       "week_of_month",
       "week_of_quarter",

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1780,6 +1780,11 @@ test_that("mutate_group", {
   expect_equal(as.character(head(df16)$hired_date_monnamelong[[2]]), "January")
   expect_equal(head(df16)$salary_cumsum[[1]], 2426)
 
+  # group by Date - extract month name (year and month)
+  df16b <- empDF %>% exploratory::mutate_group(group_cols = c(`hired_date_monthname_with_year` = "hired_date"),group_funs = c("monthname_with_year"),salary_cumsum = cumsum(salary))
+  expect_equal(as.character(head(df16b)$hired_date_monthname_with_year[[2]]), "1977-06")
+  expect_equal(head(df16b)$salary_cumsum[[1]], 19246)
+
   # group by Date - extract week
   df17 <- empDF %>% exploratory::mutate_group(group_cols = c(`hired_date_week` = "hired_date"),group_funs = c("week"),salary_cumsum = cumsum(salary))
   expect_equal(head(df17)$hired_date_week[[2]], 1)


### PR DESCRIPTION
# Description

Add monthname_with_year date grouping function.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
