### PR TITLE
Kruskal–Wallis: Fix separating comparisons column into groups.

### DIFF
--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2579,7 +2579,30 @@ exp_kruskal <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05, pai
         }
       }
       model <- kruskal.test(formula, data = df, ...)
-      model$dunn.test <- dunn.test::dunn.test(df[[var1_col]],df[[var2_col]], method=pairs_adjust, alpha=test_sig_level)
+
+      # dunn.test pre-processing.
+      # Escape " - " string in the variable since dunn.test concatenates
+      # the variable names with " - ".
+      df.dunn <- df
+      if (is.character(df.dunn[[var2_col]]) || is.factor(df.dunn[[var2_col]])) {
+        df.dunn[[var2_col]] <- stringr::str_replace_all(df.dunn[[var2_col]], " - ", "__SeP__")
+      }
+
+      # Run dunn.test.
+      res.dunn <- tibble::as.tibble(dunn.test::dunn.test(df.dunn[[var1_col]],df.dunn[[var2_col]], method=pairs_adjust, alpha=test_sig_level))
+
+      # dunn.test post-processing.
+      # Restore " - " string in the "comparisons" variable.
+      if (is.character(res.dunn[["comparisons"]]) || is.factor(res.dunn[["comparisons"]])) {
+        res.dunn <- res.dunn %>%
+          # Separate comparisons values like "Cat 1 - Cat 2" into "Cat 1" and "Cat 2".
+          tidyr::separate(comparisons, into = c("Group 1", "Group 2"), sep = " - ", extra = "merge") %>%
+          # Restore " - " string in the variable.
+          dplyr::mutate(`Group 1` = stringr::str_replace_all(`Group 1`, "__SeP__", " - "),
+                        `Group 2` = stringr::str_replace_all(`Group 2`, "__SeP__", " - "))
+      }
+
+      model$dunn.test <- res.dunn
       model$pairs_adjust <- pairs_adjust
       N <- nrow(df)
       epsilon_squared <- calculate_epsilon_squared(model, N)
@@ -2635,8 +2658,6 @@ tidy.kruskal_exploratory <- function(x, type="model", conf_level=0.95) {
   else if (type == "pairs") {
     ret <- tibble::as_tibble(x$dunn.test)
     ret <- ret %>% dplyr::select(-chi2, -P)
-    # Separate comparisons values like "Cat 1 - Cat 2" into "Cat 1" and "Cat 2".
-    ret <- ret %>% tidyr::separate(comparisons, into = c("Group 1", "Group 2"), sep = " - ", extra = "merge")
     ret <- ret %>% dplyr::select(`Group 1`, `Group 2`, everything())
     ret <- ret %>% dplyr::rename(`Z Value`=Z,
                                  `P Value`=P.adjusted)

--- a/tests/testthat/test_test_wrapper_3.R
+++ b/tests/testthat/test_test_wrapper_3.R
@@ -61,6 +61,18 @@ test_that("test exp_kruskal with pairs_adjust types.", {
   model_df <- mtcars %>% exp_kruskal(mpg, cyl, pairs_adjust = "none")
   ret <- model_df %>% tidy_rowwise(model, type="pairs")
   expect_equal(nrow(ret), 3)
+
+  # Test with bucketed data.
+  range.text <- c( rep("1 - 2", 8), rep("2 - 3", 8), rep("3 - 4", 8), rep("4 - 5", 8))
+  model_df <- mtcars %>% mutate(range= range.text) %>% exp_kruskal(mpg, range, pairs_adjust = "bonferroni")
+  ret <- model_df %>% tidy_rowwise(model, type="pairs")
+  expect_equal(nrow(ret), 6) # Combination of 4 range groups.
+  expect_equal(colnames(ret), c("Group 1", "Group 2", "Z Value", "P Value", "Method")) 
+  # Make sure it is in "1 - 2" format, not in "1" or "1 - 2 - 3".
+  expect_equal(ret$`Group 1`, c("1 - 2", "1 - 2", "2 - 3", "1 - 2", "2 - 3", "3 - 4")) 
+  # Make sure it is in "1 - 2" format, not in "1" or "1 - 2 - 3".
+  expect_equal(ret$`Group 2`, c("2 - 3", "3 - 4", "3 - 4", "4 - 5", "4 - 5", "4 - 5")) 
+
 })
 
 


### PR DESCRIPTION
# Description

Fix separating comparisons column into groups if the variable column contains the values including " - " like "1 - 2". 

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
