### PR TITLE
Update exp_cut behavior with zero.to.center and either upper or lower range is specified.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -4262,10 +4262,10 @@ exp_cut <- function(x, breaks=5, labels=NULL, dig.lab=3, zero.to.center=FALSE, i
           # If include.outside.range option is specified, add the -Inf and
           # Inf in the breaks. If it is already there, do nothing.
           if (include.outside.range) {
-            if (!is.infinite(minv) && !is.na(lower.range) && !any(breaks.with.inf == -Inf)) {
+            if (!is.infinite(minv) && !is.na(lower.range) && !any(break_points == -Inf)) {
               break_points <- c( -Inf, break_points)
             }
-            if (!is.infinite(maxv) && !is.na(upper.range) && !any(breaks.with.inf == Inf)) {
+            if (!is.infinite(maxv) && !is.na(upper.range) && !any(break_points == Inf)) {
               break_points <- c(break_points, Inf)
             }
           }

--- a/R/system.R
+++ b/R/system.R
@@ -4145,11 +4145,32 @@ exp_cut <- function(x, breaks=5, labels=NULL, dig.lab=3, zero.to.center=FALSE, i
 
           minv.no.inf <- min(x.no.inf, na.rm=TRUE)
           maxv.no.inf <- max(x.no.inf, na.rm=TRUE)
+
           if (zero.to.center) {
             # Reduce the bucket size to add infinite values on both ends.
             lenout <- lenout - 1
-            maxv.no.inf <- max(abs(maxv.no.inf), abs(minv.no.inf))
-            minv.no.inf <- -maxv.no.inf
+
+            minv.no.inf.org <- minv.no.inf
+            maxv.no.inf.org <- maxv.no.inf
+
+            # Set custom range if specified.
+            if (!is.na(upper.range)) {
+              maxv.no.inf <- upper.range
+              # If only upper range is specified, set lower range to 
+              # the smaller value of eigher -upper.range or minv.org.
+              if (is.na(lower.range)) {
+                minv.no.inf <- - max(abs(upper.range), abs(minv.no.inf.org))
+              }
+            }
+            if (!is.na(lower.range)) {
+              minv.no.inf <- lower.range
+              # If only lower range is specified, set upper range to 
+              # the larger value of eigher -lower.range or maxv.org.
+              if (is.na(upper.range)) {
+                maxv.no.inf <- max(abs(lower.range), abs(maxv.no.inf.org))
+              }
+            }
+
           } else {
             # If there's only 1 value available after taking off infinites, we add
             # another value to have 2 different values for cut. This is because
@@ -4164,14 +4185,14 @@ exp_cut <- function(x, breaks=5, labels=NULL, dig.lab=3, zero.to.center=FALSE, i
               # Reduce the bucket size to add infinite values on both ends.
               lenout <- lenout - 1
             }
-          }
 
-          # Set custom range if specified.
-          if (!is.na(upper.range)) {
-            maxv.no.inf <- upper.range
-          }
-          if (!is.na(lower.range)) {
-            minv.no.inf <- lower.range
+            # Set custom range if specified.
+            if (!is.na(upper.range)) {
+              maxv.no.inf <- upper.range
+            }
+            if (!is.na(lower.range)) {
+              minv.no.inf <- lower.range
+            }
           }
 
           breaks.with.inf <- seq(minv.no.inf, maxv.no.inf,  length.out=lenout)
@@ -4189,27 +4210,45 @@ exp_cut <- function(x, breaks=5, labels=NULL, dig.lab=3, zero.to.center=FALSE, i
           # If include.outside.range is TRUE and range value is specified,
           # add the -Inf and Inf in the breaks.
           if (include.outside.range) {
-            if (!is.infinite(minv) && !is.na(lower.range)) {
+            if (!is.infinite(minv) && !is.na(lower.range) && !any(breaks.with.inf == -Inf)) {
               breaks.with.inf <- c(-Inf, breaks.with.inf)
             }
-            if (!is.infinite(maxv) && !is.na(upper.range)) {
+            if (!is.infinite(maxv) && !is.na(upper.range) && !any(breaks.with.inf == Inf)) {
               breaks.with.inf <- c(breaks.with.inf, Inf)
             }
           }
 
           return (cut(x, breaks=breaks.with.inf, labels=labels, dig.lab=dig.lab, include.lowest=include.lowest, right=right))
         } else {
-          if (zero.to.center) {
-            maxv <- max(abs(maxv), abs(minv))
-            minv <- -maxv
-          }
 
-          # Set custom range if specified.
-          if (!is.na(upper.range)) {
-            maxv <- upper.range
-          }
-          if (!is.na(lower.range)) {
-            minv <- lower.range
+          if (zero.to.center) {
+            minv.org <- minv
+            maxv.org <- maxv
+            # Set custom range if specified.
+            if (!is.na(upper.range)) {
+              maxv <- upper.range
+              # If only upper range is specified, set lower range to 
+              # the smaller value of eigher -upper.range or minv.org.
+              if (is.na(lower.range)) {
+                minv <- - max(abs(upper.range), abs(minv.org))
+              }
+            }
+            if (!is.na(lower.range)) {
+              minv <- lower.range
+              # If only lower range is specified, set upper range to 
+              # the larger value of eigher -lower.range or maxv.org.
+              if (is.na(upper.range)) {
+                maxv <- max(abs(lower.range), abs(maxv.org))
+              }
+            }
+          } else {
+            # Set custom range if specified.
+            if (!is.na(upper.range)) {
+              maxv <- upper.range
+            }
+            if (!is.na(lower.range)) {
+              minv <- lower.range
+            }
           }
 
           break_points = seq(minv, maxv, length.out = breaks+1)
@@ -4223,10 +4262,10 @@ exp_cut <- function(x, breaks=5, labels=NULL, dig.lab=3, zero.to.center=FALSE, i
           # If include.outside.range option is specified, add the -Inf and
           # Inf in the breaks. If it is already there, do nothing.
           if (include.outside.range) {
-            if (!is.infinite(minv) && !is.na(lower.range)) {
+            if (!is.infinite(minv) && !is.na(lower.range) && !any(breaks.with.inf == -Inf)) {
               break_points <- c( -Inf, break_points)
             }
-            if (!is.infinite(maxv) && !is.na(upper.range)) {
+            if (!is.infinite(maxv) && !is.na(upper.range) && !any(breaks.with.inf == Inf)) {
               break_points <- c(break_points, Inf)
             }
           }

--- a/R/util.R
+++ b/R/util.R
@@ -3356,16 +3356,22 @@ format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.ma
       #
       # Both are finite: "[5, 20]" ->  "5.00 - 20.00"
       # Left is -Inf: "(-Inf, 20]" ->  "<= 20.00"
-      # Right is Inf: "(20, Inf]" ->  "20.00 <"
+      # Right is Inf: "(20, Inf]" ->  "> 20.00"
       # Both are infinite: "(-Inf, Inf]" ->  "-Inf - Inf"
       connect.str <- " - "
       if (is.infinite.on.one.side) {
         # Add prefix/suffix. Do not add prefix/suffix to infinites.
         sign.negative.inf <- "<"
-        sign.positive.inf <- "<="
+        sign.positive.inf <- ">="
         if (right) {
           sign.negative.inf <- "<="
-          sign.positive.inf <- "<"
+          sign.positive.inf <- ">"
+        }
+
+        if (range[1] == "Inf") {
+          # If the upper end is inf, we reverse the order to show the sign 
+          # on the left. E.g. (5, Inf) -> (Inf, 5) -> (>, 5) -> "> 5".
+          range <- rev(range)
         }
 
         range <- if_else(range == "-Inf", sign.negative.inf, if_else(range == "Inf", sign.positive.inf, paste0(prefix, range, suffix)))

--- a/R/util.R
+++ b/R/util.R
@@ -3368,7 +3368,7 @@ format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.ma
           sign.positive.inf <- ">"
         }
 
-        if (range[1] == "Inf") {
+        if (range[2] == "Inf") {
           # If the upper end is inf, we reverse the order to show the sign 
           # on the left. E.g. (5, Inf) -> (Inf, 5) -> (>, 5) -> "> 5".
           range <- rev(range)

--- a/R/util.R
+++ b/R/util.R
@@ -3356,22 +3356,16 @@ format_cut_output_levels <- function(x, decimal.digits=2, big.mark=",", small.ma
       #
       # Both are finite: "[5, 20]" ->  "5.00 - 20.00"
       # Left is -Inf: "(-Inf, 20]" ->  "<= 20.00"
-      # Right is Inf: "(20, Inf]" ->  "> 20.00"
+      # Right is Inf: "(20, Inf]" ->  "20.00 <"
       # Both are infinite: "(-Inf, Inf]" ->  "-Inf - Inf"
       connect.str <- " - "
       if (is.infinite.on.one.side) {
         # Add prefix/suffix. Do not add prefix/suffix to infinites.
         sign.negative.inf <- "<"
-        sign.positive.inf <- ">="
+        sign.positive.inf <- "<="
         if (right) {
           sign.negative.inf <- "<="
-          sign.positive.inf <- ">"
-        }
-
-        if (range[2] == "Inf") {
-          # If the upper end is inf, we reverse the order to show the sign 
-          # on the left. E.g. (5, Inf) -> (Inf, 5) -> (>, 5) -> "> 5".
-          range <- rev(range)
+          sign.positive.inf <- "<"
         }
 
         range <- if_else(range == "-Inf", sign.negative.inf, if_else(range == "Inf", sign.positive.inf, paste0(prefix, range, suffix)))

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -521,3 +521,44 @@ test_that("test filter_cascade",{
   df <- df %>% filter_cascade(detect_outlier(reviews_per_month, "iqr") == "Normal", cut(reviews_per_month, breaks = 5, dig.lab = 10) %in% c("(0.21,0.31]"))
   expect_equal(nrow(df), 2661)
 })
+
+
+test_that("Test exp_cut with zero.to.center is set and either upper.range or lower.range is set. ",{
+
+  v <- c(-25:40)
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=10)), c("[-25,-18]", "(-18,-11]","(-11,-4]" ,"(-4,3]"   ,"(3,10]"   ,"(10,Inf]" )) 
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=50)), c("[-25,-10]", "(-10,5]"  ,"(5,20]"   ,"(20,35]"  ,"(35,50]"  ,"(50,Inf]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=10)), c("[-25,-18]", "(-18,-11]","(-11,-4]" ,"(-4,3]"   ,"(3,10]"   ,"(10,Inf]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=50)), c("[-50,-30]", "(-30,-10]","(-10,10]" ,"(10,30]"  ,"(30,50]"  ,"(50,Inf]" ))
+
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-10)), c("[-Inf,-10]","(-10,0]"   ,"(0,10]"    ,"(10,20]"   ,"(20,30]"  , "(30,40]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-50)), c("[-Inf,-50]","(-50,-32]" ,"(-32,-14]" ,"(-14,4]"   ,"(4,22]"   , "(22,40]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-10)), c("[-Inf,-10]","(-10,0]"   ,"(0,10]"    ,"(10,20]"   ,"(20,30]"  , "(30,40]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-50)), c("[-Inf,-50]","(-50,-30]" ,"(-30,-10]" ,"(-10,10]"  ,"(10,30]"  , "(30,50]"   ))
+
+  v <- c(-25:40, Inf)
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=10)), c("[-25,-16.2]", "(-16.2,-7.5]","(-7.5,1.25]" ,"(1.25,10]"  , "(10,Inf]"))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=50)), c("[-25,-6.25]", "(-6.25,12.5]","(12.5,31.2]" ,"(31.2,50]"  , "(50,Inf]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=10)), c("[-Inf,-25]" ,  "(-25,-13.3]",  "(-13.3,-1.67]","(-1.67,10]",   "(10, Inf]"    ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=50)), c("[-Inf,-50]" , "(-50,-16.7]" ,"(-16.7,16.7]","(16.7,50]"   ,"(50, Inf]"  ))
+
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-10)), c("[-Inf,-10]","(-10,2.5]" ,"(2.5,15]"  ,"(15,27.5]" ,"(27.5,40]", "(40, Inf]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-50)), c("[-Inf,-50]", "(-50,-27.5]","(-27.5,-5]", "(-5,17.5]",  "(17.5,40]"  ,"(40, Inf]"  ))
+
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-10)), c("[-Inf,-10]", "(-10,6.67]", "(6.67,23.3]","(23.3,40]" , "(40, Inf]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-50)), c("[-Inf,-50]"  ,"(-50,-16.7]", "(-16.7,16.7]","(16.7,50]",   "(50, Inf]"  ))
+
+
+  v <- c(-25:40, -Inf)
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=10)), c("[-Inf,-25]", "(-25,-16.2]" ,"(-16.2,-7.5]","(-7.5,1.25]" ,"(1.25,10]"   ,"(10, Inf]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, upper.range=50)), c("[-Inf,-25]",  "(-25,-6.25]", "(-6.25,12.5]","(12.5,31.2]", "(31.2,50]"  , "(50, Inf]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=10)), c("[-Inf,-25]", "(-25,-13.3]" , "(-13.3,-1.67]","(-1.67,10]",   "(10, Inf]"   ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, upper.range=50)), c("[-Inf,-50]",  "(-50,-16.7]", "(-16.7,16.7]","(16.7,50]"  , "(50, Inf]"   ))
+
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-10)), c("[-Inf,-10]", "(-10,2.5]" ,"(2.5,15]"  ,"(15,27.5]" ,"(27.5,40]" ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=F, lower.range=-50)), c("[-Inf,-50]", "(-50,-27.5]","(-27.5,-5]" ,"(-5,17.5]",  "(17.5,40]"  ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-10)), c("[-Inf,-10]", "(-10,6.67]", "(6.67,23.3]","(23.3,40]"  ,"(40, Inf]"  ))
+  expect_equal(levels(exploratory::exp_cut(v, breaks=5, zero.to.center=T, lower.range=-50)), c("[-Inf,-50]",  "(-50,-16.7]", "(-16.7,16.7]","(16.7,50]",   "(50, Inf]"    ))
+
+})
+


### PR DESCRIPTION
# Description

Update `exp_cut` behavior with `zero.to.center` and either `upper.range` or `lower.range` is specified.



If you call `exp_cut` with `zero.to.center=TRUE`, `upper.range` to 2000, and no value for `lower.range`;

* If the data range is -5000 to 5000 (min value of the data is less than -2000)  ), it will create buckets between -5000 and 2000. 
* If the data range is -1000 to 5000 (min value of the data greater than -2000)  ), it will create buckets between -2000 and 2000. 



# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
