### PR TITLE
Fix issue that remote file with HTTPS protocol may not work inside intranet.

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3127,18 +3127,10 @@ download_data_file <- function(url, type){
     dir.create(tempdir(), showWarnings = FALSE)
 
     tryCatch({
-      # Get current timeout sec. Default is 60 sec.
-      originalTimeout <- options("timeout")
-      # Increase timeout to 10 minutes (600 sec)
-      options("timeout" = 600)
-      # Download file to tempoprary location
-      download.file(url, destfile = tmp, mode = "wb")
+      # Download file to temporary location
+      httr::GET(url, httr::write_disk(tmp, overwrite = TRUE), httr::timeout(600))
     }, error = function(cond){
        stop(cond)
-    }
-    ,finally = {
-      # Set the original timeout
-      options("timeout" = originalTimeout)
     })
     # cache file
     if(!is.null(shouldCacheFile) && isTRUE(shouldCacheFile)){

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -421,7 +421,7 @@ test_that("read_delim_file downlod failed error message", {
   tryCatch({
     df <- exploratory::read_delim_file("https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample.csv", delim = ",")
   }, error = function(cond) {
-    expect_equal(cond$message, c("EXP-DATASRC-15 :: [\"https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample.csv\",\"cannot open URL 'https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample.csv'\"] :: Failed to download from the URL."))
+    expect_equal(cond$message, c("EXP-DATASRC-15 :: [\"https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample.csv\",\"Could not resolve host: dummy.dropbox.com\"] :: Failed to download from the URL."))
   })
 })
 


### PR DESCRIPTION
# Description

- Switched to use `httr` instead of `download.file` 

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
