### PR TITLE
Switch to use httr for remote parquet file import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 8.3.1
-Date: 2023-09-25
+Version: 8.3.2
+Date: 2023-10-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -3696,7 +3696,6 @@ read_parquet_file <- function(file, col_select = NULL) {
     # Remove on exit.
     on.exit(unlink(tf))
     tryCatch({
-      # mode="wb" for binary download
       # Download file to temporary location
       httr::GET(file, httr::write_disk(tf, overwrite = TRUE), httr::timeout(600))
     }, error = function(e) {

--- a/R/system.R
+++ b/R/system.R
@@ -3697,7 +3697,8 @@ read_parquet_file <- function(file, col_select = NULL) {
     on.exit(unlink(tf))
     tryCatch({
       # mode="wb" for binary download
-      utils::download.file(file, tf, mode = "wb")
+      # Download file to temporary location
+      httr::GET(file, httr::write_disk(tf, overwrite = TRUE), httr::timeout(600))
     }, error = function(e) {
       stop(paste0('EXP-DATASRC-15 :: ', jsonlite::toJSON(c(file, e$message)), ' :: Failed to download from the URL.'))
     })

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -385,7 +385,7 @@ test_that("read_parquet_file downlod failed error message", {
   tryCatch({
     df <- exploratory::read_parquet_file("https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample2.parquet")
   }, error = function(cond) {
-    expect_equal(cond$message, c("EXP-DATASRC-15 :: [\"https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample2.parquet\",\"cannot open URL 'https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample2.parquet'\"] :: Failed to download from the URL."))
+    expect_equal(cond$message, c("EXP-DATASRC-15 :: [\"https://dummy.dropbox.com/s/sjkgk9gj0vemq36/sample2.parquet\",\"Could not resolve host: dummy.dropbox.com\"] :: Failed to download from the URL."))
   })
 })
 


### PR DESCRIPTION
# Description

Switch to use httr for remote parquet file import

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
