### PR TITLE
Fix confidence interval calculation in tidy.wilcox_exploratory.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 8.5.0
-Date: 2023-10-25
+Version: 8.5.1
+Date: 2023-10-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -1557,8 +1557,8 @@ tidy.wilcox_exploratory <- function(x, type="model", conf_level=0.95) {
                        `Std Error of Mean`=sd(!!rlang::sym(x$var1), na.rm=TRUE)/sqrt(sum(!is.na(!!rlang::sym(x$var1)))),
                        # Note: Use qt (t distribution) instead of qnorm (normal distribution) here.
                        # For more detail take a look at 10.5.1 A slight mistake in the formula of "Learning Statistics with R" 
-                       `Conf High` = Mean + `Std Error of Mean` * qt(p=conf_level, df=`Rows`-1),
-                       `Conf Low` = Mean - `Std Error of Mean` * qt(p=conf_level, df=`Rows`-1),
+                       `Conf High` = Mean + `Std Error of Mean` * qt(p=conf_threshold, df=`Rows`-1),
+                       `Conf Low` = Mean - `Std Error of Mean` * qt(p=conf_threshold, df=`Rows`-1),
                        `Minimum`=min(!!rlang::sym(x$var1), na.rm=TRUE),
                        `Maximum`=max(!!rlang::sym(x$var1), na.rm=TRUE)) %>%
       dplyr::select(!!rlang::sym(x$var2),

--- a/tests/testthat/test_test_wrapper_2.R
+++ b/tests/testthat/test_test_wrapper_2.R
@@ -71,6 +71,10 @@ test_that("test exp_wilcox with conf.int = TRUE", {
   expect_equal(colnames(ret),
                c("am","Rows","Mean","Conf Low","Conf High","Std Error of Mean","Std Deviation",
                  "Minimum","Maximum"))
+
+  # check confidence interval
+  expect_equal(round(ret$`Conf Low`, 3), c(15.299, 20.639))
+  expect_equal(round(ret$`Conf High`, 3), c(18.995, 28.711))
 })
 
 test_that("test exp_wilcox with paired = TRUE", {


### PR DESCRIPTION
# Description
Fix confidence interval calculation in `tidy.wilcox_exploratory`.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
