### PR TITLE
Data Wrangling: Join: When Target Data Frame is Grouped by, result gets weird

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 9.0.4
-Date: 2024-02-27
+Version: 9.0.5
+Date: 2024-03-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/join.R
+++ b/R/join.R
@@ -35,6 +35,7 @@ insensitive_join <- function(fun = dplyr::left_join, type = "LEFT") {
 #' Wrapper function for dplyr's inner_join to support case insensitive join.
 #' @export
 inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, na_matches = "never", ...){
+  y <- y %>% ungroup()
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     if (exclude_target_columns) {
@@ -53,6 +54,7 @@ inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 #' @export
 #' Wrapper function for dplyr's left_join to support case insensitive join.
 left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, na_matches = "never", ...){
+  y <- y %>% ungroup()
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     if (exclude_target_columns) {
@@ -71,6 +73,7 @@ left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 #' @export
 #' Wrapper function for dplyr's right_join to support case insensitive join.
 right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, na_matches = "never", ...){
+  y <- y %>% ungroup()
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     if (exclude_target_columns) {
@@ -89,6 +92,7 @@ right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ig
 #' @export
 #' Wrapper function for dplyr's full_join to support case insensitive join.
 full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ignorecase = FALSE, target_columns = NULL, exclude_target_columns = FALSE, na_matches = "never", ...) {
+  y <- y %>% ungroup()
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     if (exclude_target_columns) {
@@ -107,6 +111,7 @@ full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ign
 #' @export
 #' Wrapper function for dplyr's semi_join to support case insensitive join.
 semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
+  y <- y %>% ungroup()
   if(ignorecase) {
     insensitive_join(dplyr::semi_join)(x = x, y = y, by = by, copy = copy)
   } else {
@@ -117,6 +122,7 @@ semi_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
 #' @export
 #' Wrapper function for dplyr's anti_join to support case insensitive join.
 anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
+  y <- y %>% ungroup()
   if(ignorecase) {
     insensitive_join(dplyr::anti_join)(x = x, y = y, by = by, copy = copy)
   } else {
@@ -127,6 +133,7 @@ anti_join <- function(x, y, by = NULL, copy = FALSE, ignorecase = FALSE, ...) {
 #' @export
 #' Wrapper function for dplyr's cross_join to support case insensitive join.
 cross_join <- function(x, y, copy = FALSE, suffix = c(".x", ".y"), target_columns = NULL, exclude_target_columns = FALSE, ...) {
+  y <- y %>% ungroup()
   # Limit target columns to use for join when target_columns are set.
   if (!is.null(target_columns)) {
     if (exclude_target_columns) {

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -314,3 +314,10 @@ test_that("column suffix argument with case insensitive and empty source suffix 
   expect_equal("carb" %in% colnames(df15) , TRUE)
   expect_equal("carb_1" %in% colnames(df15) , TRUE)
 })
+
+test_that("group by target data frame case", {
+  target <- mtcars %>% group_by(mpg)
+  df16 <- mtcars %>% select(-mpg) %>% left_join(target, by = c("gear" = "gear", "cyl" = "cyl"), suffix = c("", "_1"), ignorecase = TRUE, target_columns = c("mpg", "am", "vs"), exclude_target_columns = TRUE)
+  expect_equal("mpg" %nin% colnames(df16) , TRUE)
+  expect_equal("mpg_1" %nin% colnames(df16) , TRUE)
+})


### PR DESCRIPTION
# Description

This PR fixes the issue that Join results get weird when the target data frame is grouped.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
