### PR TITLE
Fix t.test/wilcox formula for paired case for R4.4.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.0.1
-Date: 2024-05-08
+Version: 10.0.2
+Date: 2024-05-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory


### PR DESCRIPTION
# Description


It fixes t.test/wilcox formula for paired case for R4.4.

https://cran.r-project.org/doc/manuals/r-devel/NEWS.html

> The formula methods for t.test() and wilcox.test() now catch when paired is passed, addressing PR#14359; use Pair(x1, x2) ~ 1 for a paired test.



# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory
