### PR TITLE
Added mmap argument to read_parquet_file_internal to avoid resource lock issue.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.0.3
-Date: 2024-05-14
+Version: 10.0.4
+Date: 2024-05-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -3754,12 +3754,13 @@ read_parquet_file <- function(file, col_select = NULL) {
 
 # Wrapper around arrow::read_parquet to work around https://issues.apache.org/jira/browse/ARROW-13860 by applying group_by column stored in the parquet file
 # as one of the class names.
-read_parquet_file_internal <- function(filepath, col_select = NULL) {
+# To avoid the resource lock issue, set mmap as FALSE by default.
+read_parquet_file_internal <- function(filepath, col_select = NULL, mmap = FALSE) {
   res <- NULL
   if (is.null(col_select)) {
-    res <- arrow::read_parquet(filepath)
+    res <- arrow::read_parquet(filepath, mmap = mmap)
   } else {
-    res <- arrow::read_parquet(filepath, col_select = col_select)
+    res <- arrow::read_parquet(filepath, col_select = col_select, mmap = mmap)
   }
   if (stringr::str_starts(class(res)[1], '...grouped_by_')) {
     group_col <- stringr::str_remove(class(res)[1], '^\\.\\.\\.grouped_by_')


### PR DESCRIPTION
# Description

Added the `mmap` argument to read_parquet_file_internal API. The default value is FALSE to avoid resource lock issue.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
