### PR TITLE
Added allow_empty_pattern argument to exploratory::str_detect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.1.1
-Date: 2024-06-13
+Version: 10.1.2
+Date: 2024-06-24
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/string_operation.R
+++ b/R/string_operation.R
@@ -924,12 +924,15 @@ str_logical <- function(column, true_value = NULL) {
 #' @param pattern Pattern to look for.
 #' @param negate If TRUE, return non-matching elements.
 #' @param ignore_case If TRUE, detect the pattern with case insensitive way.
+#' @param allow_empty_pattern if TRUE, assumes it matches (i.e. return TRUE), if FALSE underlying stringr::str_detect raises an error.
 #' @export
-str_detect <- function(string, pattern, negate = FALSE, ignore_case = FALSE) {
+str_detect <- function(string, pattern, negate = FALSE, ignore_case = FALSE, allow_empty_pattern = TRUE) {
   # if pattern is not empty string and case insensitive is specified, use regex to handle the case insensitive match.
   # any() is necessary to avoid error when pattern is a vector.
   if (any(pattern != "") && ignore_case) {
     stringr::str_detect(string, stringr::regex(pattern, ignore_case = TRUE), negate = negate)
+  } else if (all(pattern == "") && allow_empty_pattern) {
+    rep(TRUE, length(string))
   } else { # if the pattern is empty string stringr::regexp throws warning, so simply use stringr::str_detect as is.
     stringr::str_detect(string, pattern, negate)
   }

--- a/tests/testthat/test_string_operation.R
+++ b/tests/testthat/test_string_operation.R
@@ -681,15 +681,19 @@ test_that("str_detect", {
   ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "Te", ignore_case = TRUE)
   expect_equal(ret, c(TRUE, TRUE, TRUE, FALSE))
   # When pattern is empty string, it used to always match, but since stringr 1.5.0, it returns error.
+  # so we introduce the allow_empty_pattern so that setting this to TRUE behaves as same as stringr::str_detect.
+  # If this allow_empty_pattern is TRUE, it behaves as same as pre-1.5.0
   expect_error({
-    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "")
+    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "", allow_empty_pattern = FALSE)
   })
   expect_error({
-    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "", ignore_case = TRUE)
+    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "", ignore_case = TRUE, allow_empty_pattern = FALSE)
   })
   expect_error({
-    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "", negate =TRUE, ignore_case = TRUE)
+    ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "", negate =TRUE, ignore_case = TRUE, allow_empty_pattern = FALSE)
   })
+  ret <- exploratory::str_detect(c("Test", "test", "tEST", "abc"), "")
+  expect_equal(ret, c(TRUE, TRUE, TRUE,TRUE))
   ret <- exploratory::str_detect(c("Aabc", "baadd", "dddd"), stringr::regex(stringr::str_c("AA"), ignore_case=TRUE))
   expect_equal(ret, c(TRUE, TRUE, FALSE))
 


### PR DESCRIPTION
# Description

I added the new argument `allow_empty_pattern` to exploratory::str_detect`. If this parameter is set as TRUE, it returns TRUE (i.e. matched) for any cases. This is the stringr::str_detect pre-1.5.0 behavior.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
