### PR TITLE
read_delim_file: Fix error handling for guess delimiter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.1.2
+Version: 10.1.3
 Date: 2024-06-24
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -3609,6 +3609,9 @@ read_delim_file <- function(file, delim, quote = '"',
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "does not exist")) {
         stop(paste0('EXP-DATASRC-14 :: ', jsonlite::toJSON(file), ' :: The file does not exist.'))
       } else {
+        if (is_free_input_text) {
+          stop(paste0('EXP-DATASRC-13 :: ', jsonlite::toJSON(c("", e$message)), ' :: Failed to import file.'))
+        }
         stop(paste0('EXP-DATASRC-13 :: ', jsonlite::toJSON(c(file, e$message)), ' :: Failed to import file.'))
       }
     })


### PR DESCRIPTION
# Description

Fixed error handling for guess delimiter

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
