### PR TITLE
Update google sheets writeback API for better error message handling.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.2.1
-Date: 2024-07-15
+Version: 10.2.2
+Date: 2024-08-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -37,27 +37,37 @@ uploadGoogleSheet <- function(filepath, title, overwrite = FALSE, sheetName= NUL
 #' @export
 #' @param filepath path of source CSV file that you want to update with
 #' @param id id of the existing sheet on Google Sheets.
-updateGoogleSheet <- function(filepath, id, overwrite = FALSE){
-  if(!requireNamespace("googlesheets4")){stop("package googlesheets4 must be installed.")}
-  if(!requireNamespace("googledrive")){stop("package googledrive must be installed.")}
-  currentConfig <- getOption("httr_config")
-  tryCatch({
-    # To workaround Error in the HTTP2 framing layer
-    # set below config (see https://github.com/jeroen/curl/issues/156)
-    httr::set_config(httr::config(http_version = 0))
+updateGoogleSheet <- function(filepath, id, overwrite = FALSE) {
+  if (!requireNamespace("googlesheets4", quietly = TRUE)) {
+    stop("The 'googlesheets4' package must be installed.")
+  }
+  if (!requireNamespace("googledrive", quietly = TRUE)) {
+    stop("The 'googledrive' package must be installed.")
+  }
 
-    token <- getGoogleTokenForSheet("")
-    googlesheets4::sheets_set_token(token)
-    googledrive::drive_set_token(token)
-    sheet <- googledrive::drive_update(file = googledrive::as_id(id), media = filepath)
-    sheet
-  },finally = function(){
+  currentConfig <- getOption("httr_config")
+
+  # Ensure that the HTTP configuration is reset upon function exit
+  on.exit({
     if (is.null(currentConfig)) {
       httr::reset_config()
     } else {
       httr::set_config(currentConfig)
     }
-  })
+  }, add = TRUE)
+
+  # Set HTTP configuration to workaround the HTTP2 framing layer error
+  httr::set_config(httr::config(http_version = 0))
+
+  # Obtain the Google token
+  token <- getGoogleTokenForSheet("")
+  googlesheets4::sheets_set_token(token)
+  googledrive::drive_set_token(token)
+
+  # Update the Google Sheet
+  sheet <- googledrive::drive_update(file = googledrive::as_id(id), media = filepath)
+
+  return(sheet)
 }
 
 #' API to upload data frame to Google Sheets.
@@ -70,34 +80,41 @@ updateGoogleSheet <- function(filepath, id, overwrite = FALSE){
 #' @param workSheet - name of the worksheet
 #'
 uploadDataToGoogleSheets <- function(df, type = "newSpreadSheet", spreadSheetName = "", workSheet = "") {
-  if(!requireNamespace("googlesheets4")){stop("package googlesheets4 must be installed.")}
-  currentConfig <- getOption("httr_config")
-  tryCatch({
-    # To workaround Error in the HTTP2 framing layer
-    # set below config (see https://github.com/jeroen/curl/issues/156)
-    httr::set_config(httr::config(http_version = 0))
+  if (!requireNamespace("googlesheets4", quietly = TRUE)) {
+    stop("The 'googlesheets4' package must be installed.")
+  }
 
-    token <- getGoogleTokenForSheet("")
-    googlesheets4::sheets_set_token(token)
-    if (type == "newSpreadSheet") {
-      sheetsList <- list(df)
-      names(sheetsList) <- c(workSheet)
-      googlesheets4::gs4_create(spreadSheetName, sheets = sheetsList)
-    } else if (type == "overrideSpreadSheet" || type == "newWorkSheet") {
-      googlesheets4::sheet_write(df, spreadSheetName, sheet = workSheet)
-    } else if (type == "appendToWorkSheet") {
-      googlesheets4::sheet_append(spreadSheetName, df, sheet = workSheet)
-    }
-  },
-  finally = function(){
+  currentConfig <- getOption("httr_config")
+
+  # Ensure that the HTTP configuration is reset upon function exit
+  on.exit({
     if (is.null(currentConfig)) {
       httr::reset_config()
     } else {
       httr::set_config(currentConfig)
     }
-  })
-}
+  }, add = TRUE)
 
+  # Set HTTP configuration to workaround the HTTP2 framing layer error
+  httr::set_config(httr::config(http_version = 0))
+
+  # Obtain the Google token
+  token <- getGoogleTokenForSheet("")
+  googlesheets4::sheets_set_token(token)
+
+  # Perform actions based on the 'type' parameter
+  if (type == "newSpreadSheet") {
+    sheetsList <- list(df)
+    names(sheetsList) <- c(workSheet)
+    googlesheets4::gs4_create(spreadSheetName, sheets = sheetsList)
+  } else if (type %in% c("overrideSpreadSheet", "newWorkSheet")) {
+    googlesheets4::sheet_write(df, spreadSheetName, sheet = workSheet)
+  } else if (type == "appendToWorkSheet") {
+    googlesheets4::sheet_append(spreadSheetName, df, sheet = workSheet)
+  } else {
+    stop("Invalid 'type' parameter provided.")
+  }
+}
 #' API to normalize data for Google Sheets Export
 #' @param df - data frame
 #


### PR DESCRIPTION
# Description

Change it to use `on.exit` instead of finally clause.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
