### PR TITLE
The broom::glance command for a survival curve model without a cohort should return the number of rows and events. 

### DIFF
--- a/tests/testthat/test_exp_survival.R
+++ b/tests/testthat/test_exp_survival.R
@@ -46,6 +46,10 @@ test_that("test exp_survival", {
   ret1 <- ret %>% tidy_rowwise(model1)
   ret2 <- ret %>% tidy_rowwise(model2)
   ret3 <- ret %>% glance_rowwise(model2)
+  # ret3 should return a data frame with "Rows" and "Rows (TRUE)" columns
+  expect_equal(colnames(ret3), c("Rows","Rows (TRUE)"))
+  expect_equal(ret3$`Rows`, nrow(data))
+  expect_equal(ret3$`Rows (TRUE)`,sum(data$`is churned`))
 
   data2 <- data %>% mutate(`o s` = "Windows") # test single value cohort case
   ret <- data2 %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)


### PR DESCRIPTION

# Description

The broom::glance command for a survival curve model without a cohort should return the number of rows and events. 


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
