### PR TITLE
Additional Fix for: broom::glance command for a survival curve model without a cohort should return the number of rows and events. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.2.4
+Version: 10.2.5
 Date: 2024-08-20
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/survival.R
+++ b/R/survival.R
@@ -122,9 +122,9 @@ exp_survival <- function(df, time, status, start_time, end_time, end_time_fill =
         class(ret) <- c("survdiff_exploratory", class(ret))
       }
     } else {
-      # If there is no cohort, return a list with n (the total number of rows) 
-      # and nevent (number of rows with event).
-      ret <- list(n = nrow(df), nevent = sum(df[[status_col]], na.rm = TRUE))
+      # If there is no cohort, return the number of data except NAs (n) 
+      # and number of TRUEs (nevent).
+      ret <- list(n = sum(!is.na(df[[status_col]]), na.rm = TRUE), nevent = sum(df[[status_col]], na.rm = TRUE))
       class(ret) <- c("survdiff_exploratory", class(ret))
     }
     ret

--- a/tests/testthat/test_exp_survival.R
+++ b/tests/testthat/test_exp_survival.R
@@ -3,7 +3,7 @@ context("test exp_survival")
 test_that("test exp_survival", {
   # log simulation data
   data <- tibble::tibble(weeks_on_service = c(18, 13, 1, 7, 1, 1, 2, 1, 1, 1),
-                         is_churned = c(TRUE, TRUE, FALSE, TRUE, FALSE, TRUE, TRUE, TRUE, FALSE, TRUE),
+                         is_churned = c(TRUE, TRUE, FALSE, TRUE, FALSE, TRUE, TRUE, NA, FALSE, TRUE),
                          os = structure(c(1L, 2L, 1L, 1L, 2L, 2L, 2L, 2L, 2L, 1L),
                                         .Label = c("Windows", "Mac"), class = "factor"),
                          country = structure(c(13L, 82L, 27L, 82L, 82L, 27L, 13L,
@@ -37,8 +37,10 @@ test_that("test exp_survival", {
   ret1 <- ret %>% tidy_rowwise(model1)
   ret2 <- ret %>% tidy_rowwise(model2)
   ret3 <- ret %>% glance_rowwise(model2)
-  expect_equal(ret3$`Rows`, nrow(data))
-  expect_equal(ret3$`Rows (TRUE)`,sum(data$`is churned`))
+  # Rows is the number of data except NAs.
+  expect_equal(ret3$`Rows`, sum(!is.na(data$`is churned`), na.rm=TRUE))
+  # Rows (TRUE) is the number of TRUEs.
+  expect_equal(ret3$`Rows (TRUE)`,sum(data$`is churned`, na.rm=TRUE))
 
   # No cohort case
   ret <- data %>% exp_survival(`weeks on service`, `is churned`)
@@ -48,8 +50,10 @@ test_that("test exp_survival", {
   ret3 <- ret %>% glance_rowwise(model2)
   # ret3 should return a data frame with "Rows" and "Rows (TRUE)" columns
   expect_equal(colnames(ret3), c("Rows","Rows (TRUE)"))
-  expect_equal(ret3$`Rows`, nrow(data))
-  expect_equal(ret3$`Rows (TRUE)`,sum(data$`is churned`))
+  # Rows is the number of data except NAs.
+  expect_equal(ret3$`Rows`, sum(!is.na(data$`is churned`), na.rm=TRUE))
+  # Rows (TRUE) is the number of TRUEs.
+  expect_equal(ret3$`Rows (TRUE)`,sum(data$`is churned`, na.rm=TRUE))
 
   data2 <- data %>% mutate(`o s` = "Windows") # test single value cohort case
   ret <- data2 %>% exp_survival(`weeks on service`, `is churned`, cohort=`o s`)


### PR DESCRIPTION
# Description

The "Rows" in the glance table should show # of data without NAs.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
