### PR TITLE
Data Wrangling: Pivot: If there is "group by" before the pivot step and row_columns are the same as group columns, it fails.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 11.0.1
-Date: 2024-12-10
+Version: 11.0.2
+Date: 2024-12-26
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/util.R
+++ b/R/util.R
@@ -935,7 +935,11 @@ pivot_ <- function(df, row_cols, col_cols, row_funs = NULL, col_funs = NULL, val
 #' @param cols_sep - If na should be removed from values
 #' @export
 pivot <- function(df, row_cols = NULL, col_cols = NULL, row_funs = NULL, col_funs = NULL, value = NULL, fun.aggregate = mean, fill = NA, na.rm = TRUE, cols_sep = "_") {
-
+  # make sure to ungroup the data frame first if the row_cols are same as grouped columns.
+  grouped_col <- grouped_by(df)
+  if (!is.null(row_cols) && any(grouped_col %in% row_cols)) {
+    df <- df %>% dplyr::ungroup()
+  }
   value_col <- if(!missing(value)){
     tidyselect::vars_select(names(df), !! rlang::enquo(value))
   }
@@ -2520,7 +2524,7 @@ get_row_numbers_from_index_vector <- function(index_vector) {
 
 # Calculates average moving range of a vector.
 get_average_moving_range <- function(x) {
-  # Remove NAs  
+  # Remove NAs
   x <- x[!is.na(x)]
   if (length(x) < 2) {
     return(NA)
@@ -3225,7 +3229,7 @@ ts_lag <- function(time, x, unit = "year", n = 1, na_fill_type = "previous") {
     time_unit_func <- lubridate::years
   }
 
-  # Use add_with_rollback to avoid null such as a month ago of 2024-03-31. 
+  # Use add_with_rollback to avoid null such as a month ago of 2024-03-31.
   base_time <- lubridate::add_with_rollback(time, time_unit_func(-n))
   tmp_df <- tibble::tibble(t=time, x=x)
   join_df <- tmp_df %>% tidyr::complete(t=base_time) %>% dplyr::arrange(t)
@@ -3531,10 +3535,10 @@ likert_sigma <- function(x) {
 
 #' cumsum wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cumsum <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- base::cumsum(x[!is.na(x)]) 
+    x[!is.na(x)] <- base::cumsum(x[!is.na(x)])
     x
   } else {
     base::cumsum(x)
@@ -3543,10 +3547,10 @@ cumsum <- function(x, skip.na = TRUE) {
 
 #' cummean wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cummean <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- dplyr::cummean(x[!is.na(x)]) 
+    x[!is.na(x)] <- dplyr::cummean(x[!is.na(x)])
     x
   } else {
     dplyr::cummean(x)
@@ -3555,10 +3559,10 @@ cummean <- function(x, skip.na = TRUE) {
 
 #' cummin wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cummin <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- base::cummin(x[!is.na(x)]) 
+    x[!is.na(x)] <- base::cummin(x[!is.na(x)])
     x
   } else {
     base::cummin(x)
@@ -3567,10 +3571,10 @@ cummin <- function(x, skip.na = TRUE) {
 
 #' cummax wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cummax <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- base::cummax(x[!is.na(x)]) 
+    x[!is.na(x)] <- base::cummax(x[!is.na(x)])
     x
   } else {
     base::cummax(x)
@@ -3579,10 +3583,10 @@ cummax <- function(x, skip.na = TRUE) {
 
 #' cumprod wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cumprod <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- base::cumprod(x[!is.na(x)]) 
+    x[!is.na(x)] <- base::cumprod(x[!is.na(x)])
     x
   } else {
     base::cumprod(x)
@@ -3591,24 +3595,24 @@ cumprod <- function(x, skip.na = TRUE) {
 
 #' cumall wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cumall <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- dplyr::cumall(x[!is.na(x)]) 
+    x[!is.na(x)] <- dplyr::cumall(x[!is.na(x)])
     x
   } else {
     dplyr::cumall(x)
   }
-} 
+}
 
 #' cumany wrapper function. It skips NA values in the calculation by default.
 #' @param x vector
-#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE. 
+#' @param skip.na logical. If TRUE, NA values are skipped. If FALSE, it respects NA values. Default is TRUE.
 cumany <- function(x, skip.na = TRUE) {
   if (skip.na) {
-    x[!is.na(x)] <- dplyr::cumany(x[!is.na(x)]) 
+    x[!is.na(x)] <- dplyr::cumany(x[!is.na(x)])
     x
   } else {
     dplyr::cumany(x)
   }
-} 
+}

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1051,6 +1051,23 @@ test_that("test pivot with group_by and dirty colum names", {
   expect_equal("group", grouped_by(grouped_pivoted))
 })
 
+test_that("test pivot with group_by and same group column as row column", {
+  test_df <- data.frame(
+    group = c(rep(letters[1:2], each = 50),"a"),
+    cat1 = c(letters[round(runif(100)*5)+1], NA),
+    cat2 = c(letters[round(runif(100)*3)+1], "a"),
+    cat3 = c(letters[round(runif(100)*3)+1], "a"),
+    num3 = c(NA, seq(100))
+  )
+  colnames(test_df) <- c("group", "cat 1", "cat-2", "cat 3", "Num 3")
+
+  grouped_pivoted <- test_df %>%
+    dplyr::group_by(group) %>%
+    pivot(row_cols=c("group"), col_cols=c("cat 3"))
+  expect_true("group" %in% colnames(grouped_pivoted))
+  expect_equal(0, length(grouped_by(grouped_pivoted)))
+})
+
 test_that("test to_same_type for factor", {
   original <- factor(c("bb", "bb", "aa"), levels = c("bb", "aa"))
 


### PR DESCRIPTION
# Description

This fixes the issue that If there is "group by" before the pivot step and row_columns are the same as group columns, it fails.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
