### PR TITLE
Data Source: After import & merge multiple Excel files, columns with duplicated names are created.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 10.2.5
-Date: 2024-08-20
+Version: 11.1.1
+Date: 2025-01-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 11.0.2
-Date: 2024-12-26
+Version: 11.1.1
+Date: 2025-01-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -3256,8 +3256,12 @@ read_excel_file_multi_sheets <- function(file, forPrevew = FALSE, sheets = c(1),
   id_col <- avoid_conflict(colnames(df), "id")
   # copy internal exp.sheet.id to the id column.
   df[[id_col]] <- df[["exp.sheet.id"]]
+
   # drop internal column and move the id column to the very beginning.
-  df %>% dplyr::select(!!rlang::sym(id_col), dplyr::everything(), -exp.sheet.id)
+  df <- df %>% dplyr::select(!!rlang::sym(id_col), dplyr::everything(), -exp.sheet.id)
+  # make the column names unique
+  colnames(df) <- make.unique(colnames(df), sep = "")
+  df
 }
 
 
@@ -3287,8 +3291,12 @@ read_excel_files <- function(files, forPreview = FALSE, sheet = 1, col_names = T
     id_col <- avoid_conflict(colnames(df), "id")
     # copy internal exp.file.id to the id column.
     df[[id_col]] <- df[["exp.file.id"]]
+
     # drop internal column and move the id column to the very beginning.
-    df %>% dplyr::select(!!rlang::sym(id_col), dplyr::everything(), -exp.file.id)
+    df <- df %>% dplyr::select(!!rlang::sym(id_col), dplyr::everything(), -exp.file.id)
+    # make the column names unique
+    colnames(df) <- make.unique(colnames(df), sep = "")
+    df
 }
 
 #'Wrapper for openxlsx::read.xlsx (in case of .xlsx file) and readxl::read_excel (in case of old .xls file)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -573,3 +573,15 @@ test_that("test filter_cascade",{
   df <- df %>% filter_cascade(detect_outlier(reviews_per_month, "iqr") == "Normal", cut(reviews_per_month, breaks = 5, dig.lab = 10) %in% c("(0.21,0.31]"))
   expect_equal(nrow(df), 2661)
 })
+
+test_that("read_excel_files", {
+  # Download the files to a local directory
+  t_file <- tempfile(fileext = ".xls")
+  t_file2 <- tempfile(fileext = ".xls")
+  download.file("https://www.dropbox.com/scl/fi/7m4ay1x18jm1kq7kv58if/merge1.xls?rlkey=4wyi45j2cer002deefi7ndaav&dl=1", destfile = t_file, mode = "wb")
+  download.file("https://www.dropbox.com/scl/fi/by7ulgjstptwo7jnftnrm/merge2.xls?rlkey=fql98njdx0vbgrw13h4n23iaz&dl=1", destfile = t_file2, mode = "wb")
+
+  # Read the downloaded files
+  df <- exploratory::read_excel_files(c(t_file, t_file2))
+  expect_equal(colnames(df), c("id", "放送...1", "放送...2", "個人...3", "個人...4"))
+})


### PR DESCRIPTION
# Description

Added logic to make data frame column names unique.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
