### PR TITLE
Fix connection pool clean up issue.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 11.4.2
+Version: 12.0.0
 Date: 2025-02-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 11.4.1
+Version: 11.4.2
 Date: 2025-02-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -54,6 +54,7 @@ setConnectionPoolMode <- function(val) {
         }, warning = function(w) {
         }, error = function(e) {
         })
+        rm(list = key, envir = connection_pool)
       }
     })
   }

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -585,3 +585,19 @@ test_that("read_excel_files", {
   df <- exploratory::read_excel_files(c(t_file, t_file2))
   expect_equal(colnames(df), c("id", "放送...1", "放送...2", "個人...3", "個人...4"))
 })
+
+test_that("test setConnectionPoolMode", {
+  # Save the original pool_connection value to restore later
+  original_pool_connection <- exploratory::getConnectionPoolMode()
+
+  # Test setting connection pool mode to TRUE
+  exploratory::setConnectionPoolMode(TRUE)
+  expect_true(exploratory::getConnectionPoolMode())
+
+  # Test setting connection pool mode to FALSE
+  exploratory::setConnectionPoolMode(FALSE)
+  expect_false(exploratory::getConnectionPoolMode())
+
+  # Restore the original value
+  exploratory::setConnectionPoolMode(original_pool_connection)
+})


### PR DESCRIPTION
# Description
Describe your fix here

This pull request includes a version update for the `exploratory` package and a fix in the `setConnectionPoolMode` function. The most important changes are:

Version update:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL4-R4): Updated the package version from `11.4.1` to `11.4.2`.

Bug fix:

* [`R/system.R`](diffhunk://#diff-2d765c83d05448d923848ac4b25dc04a1eedca5294621e552785ed58ec672768R57): Added a line to remove the `key` from the `connection_pool` environment in the `setConnectionPoolMode` function.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
