### PR TITLE
Refactor do_chisq.test and do_t.test to wrap exp_chisq and exp_ttest respectively

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 12.1.1
-Date: 2025-03-27
+Version: 12.1.2
+Date: 2025-04-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -367,20 +367,22 @@ do_chisq.test <- function(df, ...,
                           rescale.p = TRUE,
                           simulate.p.value = FALSE,
                           B = 2000){
-  select_dots <- lazyeval::lazy_dots(...)
-  cols <- evaluate_select(df, select_dots, excluded = grouped_by(df))
+  # Comment out below since we switch to use exp_chis and make this do_chisq.test as a wrapper function.
+  #select_dots <- lazyeval::lazy_dots(...)
+  #cols <- evaluate_select(df, select_dots, excluded = grouped_by(df))
   # p should be able to be NSE column name or numeric vector
   # , so evaluated lazily
-  lazy_p <- lazyeval::lazy(p)
-  p <- lazyeval::lazy_eval(lazy_p, data = df)
+  #lazy_p <- lazyeval::lazy(p)
+  #p <- lazyeval::lazy_eval(lazy_p, data = df)
 
-  do_chisq.test_(df,
-                 selected_cols = cols,
-                 correct = correct,
-                 p = p,
-                 rescale.p = rescale.p,
-                 simulate.p.value = simulate.p.value,
-                 B = B)
+  #do_chisq.test_(df,
+  #               selected_cols = cols,
+  #               correct = correct,
+  #               p = p,
+  #               rescale.p = rescale.p,
+  #               simulate.p.value = simulate.p.value,
+  #               B = B)
+  exp_chisq(df, ...) %>% exploratory::glance_rowwise(model)
 }
 
 #' chisq.test wrapper

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -264,67 +264,17 @@ test_that("test f-test with 3 groups", {
   }, "Group Column has to have 2 unique values")
 })
 
-test_that("test chisq.test with one column", {
-  test_df <- data.frame(
-    group = rep(letters[1:2], each = 500),
-    cat1 = letters[round(runif(1000)*5)+1],
-    cat2 = letters[round(runif(1000)*3)+1]
-  ) %>%
-    dplyr::group_by(group, cat1, cat2) %>%
-    dplyr::summarize(count = n()) %>%
-    dplyr::group_by(group)
+test_that("test do_chis", {
+  mtcars2 <- mtcars
+  mtcars2$gear[[1]] <- NA # test handling of NAs
+  mtcars2$carb[[2]] <- NA
+  mtcars2$cyl[[3]] <- NA
+  summary <- do_chisq.test(mtcars2 %>% mutate(gear=factor(gear)), gear, carb) # factor order should be kept in the model
 
-  ret <- test_df %>%
-    do_chisq.test(count)
-
-  expect_equal(nrow(ret), 2)
-
-})
-
-test_that("test chisq.test with select argument", {
-  test_df <- data.frame(
-    group = rep(letters[1:2], each = 500),
-    cat1 = letters[round(runif(1000)*5)+1],
-    cat2 = letters[round(runif(1000)*3)+1]
-  ) %>%
-    dplyr::group_by(group, cat1, cat2) %>%
-    dplyr::summarize(count = n()) %>%
-    tidyr::spread(cat2, count) %>%
-    dplyr::group_by(group)
-
-  ret <- test_df %>%
-    do_chisq.test(-cat1)
-
-  expect_equal(nrow(ret), 2)
-
-})
-
-test_that("test chisq.test with p column", {
-  test_df <- structure(
-    list(
-      clarity = c("IF", "VS1", "VS2", "VVS1", "VVS2"),
-      GIA = c(6, 61, 36, 15, 33),
-      HRD = c(4, 13, 15, 23, 24),
-      IGI = c(34, 7, 2, 14, 21)),
-    .Names = c("clarity", "GIA", "HRD", "IGI"),
-    class = "data.frame",
-    row.names = c(NA,-5L)) %>%
-    dplyr::mutate(p = seq(5))
-
-  ret <- test_df %>%
-    do_chisq.test(GIA, p = p)
-  expect_equal(nrow(ret), 1)
-
-  p_from_outside <- seq(5)
-
-  ret2 <- test_df %>%
-    do_chisq.test(IGI, p = p_from_outside)
-  expect_equal(nrow(ret), 1)
-
-  ret3 <- test_df %>%
-    do_chisq.test(IGI, p = c(1, 2, 3, 4, 5))
-  expect_equal(nrow(ret), 1)
-
+  expect_true(all(c("Cramer's V","Chi-Square","DF","P Value","Cohen's W",
+                    "Power", "Type 2 Error","Rows") %in% colnames(summary)
+  ))
+  expect_true(summary$`Cramer's V` >= 0 && summary$`Cramer's V` <= 1)
 })
 
 test_that("test exp_chisq", {

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -152,8 +152,7 @@ test_that("test two sample t-test with column name", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_cat1, 5)
-  expect_equal(result$mean_cat2, 6)
+  expect_equal(result$Difference, 1)
 
   # swap cat1 and cat2
   test_df <- data.frame(
@@ -164,8 +163,7 @@ test_that("test two sample t-test with column name", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_cat1, 6)
-  expect_equal(result$mean_cat2, 5)
+  expect_equal(result$Difference, -1)
 })
 
 test_that("test two sample t-test with factor", {
@@ -177,8 +175,7 @@ test_that("test two sample t-test with factor", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_cat1, 5)
-  expect_equal(result$mean_cat2, 6)
+  expect_equal(result$Difference, 1)
 
   # swap cat1 and cat2
   test_df <- data.frame(
@@ -189,8 +186,7 @@ test_that("test two sample t-test with factor", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_cat1, 6)
-  expect_equal(result$mean_cat2, 5)
+  expect_equal(result$Difference, 1)
 })
 
 test_that("test two sample t-test with logical", {
@@ -202,8 +198,7 @@ test_that("test two sample t-test with logical", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_TRUE, 5)
-  expect_equal(result$mean_FALSE, 6)
+  expect_equal(result$Difference, -1) #base is FALSE
 
   # swap TRUE and FALSE
   test_df <- data.frame(
@@ -214,8 +209,7 @@ test_that("test two sample t-test with logical", {
   result <- test_df %>%
     do_t.test(val, cat)
 
-  expect_equal(result$mean_FALSE, 5)
-  expect_equal(result$mean_TRUE, 6)
+  expect_equal(result$Difference, 1)
 })
 
 test_that("test two sample t-test more than 2 levels", {
@@ -234,19 +228,19 @@ test_that("test two sample t-test less than 2 levels", {
   })
 })
 
-test_that("test one sample t-test", {
-  result <- test_df %>%
-    dplyr::group_by(dim) %>%
-    do_t.test("with space", mu=3)
-  expect_equal(result[result[["dim"]]=="dim1", "p.value"][[1]], 1)
-})
+#test_that("test one sample t-test", {
+#  result <- test_df %>%
+#    dplyr::group_by(dim) %>%
+#    do_t.test("with space", mu=3)
+#  expect_equal(result[result[["dim"]]=="dim1", "p.value"][[1]], 1)
+#})
 
 test_that("test t-test with 3 groups", {
   data <- data.frame(val = seq(12), group = rep(c(1,2,3), each = 4))
   expect_error({
     result <- data %>%
       do_t.test(val, group)
-  }, "Group Column has to have 2 unique values")
+  }, "The explanatory variable needs to have 2 unique values.")
 })
 
 test_that("test f-test", {


### PR DESCRIPTION
# Description

Refactor do_chisq.test and do_t.test to wrap exp_chisq and exp_ttest respectively

This pull request includes significant updates to the `exploratory` package, primarily focusing on refactoring statistical test functions and updating corresponding tests. The most important changes are the replacement of custom test functions with functions from the `exploratory` package and the modification of test cases to align with the new function outputs.

Refactoring of statistical test functions:

* [`R/test_wrapper.R`](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL239-R240): Replaced the implementation of `do_t.test` with a call to `exp_ttest` and `do_chisq.test` with a call to `exp_chisq`. [[1]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL239-R240) [[2]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL370-R317)

Updates to test cases:

* [`tests/testthat/test_test_wrapper_1.R`](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L155-R155): Updated test cases to check for the new output structure of `do_t.test`, focusing on the `Difference` column instead of mean columns. [[1]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L155-R155) [[2]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L167-R166) [[3]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L180-R178) [[4]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L192-R189) [[5]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L205-R201) [[6]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L217-R212)
* [`tests/testthat/test_test_wrapper_1.R`](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L237-R243): Removed outdated test cases for one-sample t-tests and chi-square tests, and added new test cases for `do_chisq.test` to validate the output structure. [[1]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L237-R243) [[2]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L267-R271)

Version update:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL4-R5): Updated the package version from 12.1.1 to 12.1.2 and the date to 2025-04-14.
# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
