### PR TITLE
Update ANOVA model handling to support Welch's ANOVA.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 12.1.3
-Date: 2025-04-19
+Version: 12.1.4
+Date: 2025-05-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2561,8 +2561,14 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
       ret0 <- ret0 %>% filter(term %in% c(x$var2[1],"Residuals"))
       ret <- generate_ftest_density_data(ret0$statistic[[1]], p.value=ret0$p.value, df1=ret0$df[[1]], df2=ret0$df[[2]], sig_level=x$test_sig_level)
     } else { # one-way ANOVA case
-      ret0 <- broom:::tidy.aov(x)
-      ret <- generate_ftest_density_data(ret0$statistic[[1]], p.value=ret0$p.value, df1=ret0$df[[1]], df2=ret0$df[[2]], sig_level=x$test_sig_level)
+      # oneway.test model doesn't support broom::tidy()
+      ret <- generate_ftest_density_data(
+        x$statistic, 
+        p.value=x$p.value, 
+        df1=x$parameter[1], 
+        df2=x$parameter[2], 
+        sig_level=x$test_sig_level
+      )
     }
     ret
   }

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -1828,6 +1828,17 @@ exp_anova <- function(df, var1, var2, covariates = NULL, func2 = NULL, covariate
         model$lm.model <- lm(formula, data = df)
         # Remember the var.equal argument.
         model$var.equal <- var.equal
+        # Calculate residuals for one-way ANOVA.
+        if (var.equal) {
+          group_means <- tapply(df[[var1_col]], df[[var2_col]], mean)
+          model$residuals <- df[[var1_col]] - group_means[df[[var2_col]]]
+        }
+        else {
+          # Calculate standardized residuals for var.equal=FALSE case.
+          group_vars <- tapply(df[[var1_col]], df[[var2_col]], var)
+          group_means <- tapply(df[[var1_col]], df[[var2_col]], mean)
+          model$residuals <- (df[[var1_col]] - group_means[df[[var2_col]]]) / sqrt(group_vars[df[[var2_col]]])
+        }
       }
       # calculate Cohen's f from actual data #TODO: Support 2-way case. Also, is this valid for ANCOVA?
       if (length(var2_col) == 1) {

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -1867,8 +1867,8 @@ exp_anova <- function(df, var1, var2, covariates = NULL, func2 = NULL, covariate
           group_means <- tapply(df[[var1_col]], df[[var2_col]], mean)
           model$residuals <- (df[[var1_col]] - group_means[df[[var2_col]]]) / sqrt(group_vars[df[[var2_col]]])
 
-          df_groups <- fit$parameter[1]
-          df_residuals <- fit$parameter[2]
+          df_groups <- model$parameter[1]
+          df_residuals <- model$parameter[2]
           # Group statistics
           group_stats <- aggregate(df[[var1_col]], 
                                 by = list(df[[var2_col]]), 
@@ -1893,8 +1893,8 @@ exp_anova <- function(df, var1, var2, covariates = NULL, func2 = NULL, covariate
             df = c(df_groups, df_residuals),
             sumsq = c(ss_groups, ss_residuals),
             meansq = c(ms_groups, ms_residuals),
-            statistic = c(fit$statistic, NA),
-            p.value = c(fit$p.value, NA)
+            statistic = c(model$statistic, NA),
+            p.value = c(model$p.value, NA)
         )
         
         # Set row names to NULL to match broom::tidy output

--- a/tests/testthat/test_test_oneway_anova.R
+++ b/tests/testthat/test_test_oneway_anova.R
@@ -33,9 +33,7 @@ test_that("Test output between aov and oneway.test with equal variance", {
   expect_equal(aov_p_value, oneway_p_value)
 })
 
-
 test_that("Test One-way ANOVA", {
-
   # Set seed for reproducibility
   set.seed(123)
 
@@ -60,7 +58,6 @@ test_that("Test One-way ANOVA", {
     facet = facets
   )
 
-
   #
   # var.equal=FALSE
   #
@@ -69,10 +66,8 @@ test_that("Test One-way ANOVA", {
   ret <- test_df %>% dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
     exp_anova(`value`, `group`)
 
-
   # Post-hoc test
   ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
-  print(ret.pairs)
   expect_equal(colnames(ret.pairs), 
               c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
                 "Standard Error", "DF", "t Value", "P Value", "Method"))
@@ -80,9 +75,15 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.pairs$`P Value`, 0.115, tolerance = 0.001)
   expect_equal(ret.pairs$DF, 720)
 
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
+  expect_equal(colnames(ret.pairs), 
+              c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(ret.pairs$Difference, 0.235, tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, 0.115, tolerance = 0.001)
+  expect_equal(ret.pairs$DF, 720)
 
   ret.model <- ret %>% tidy_rowwise(model, type="model")
-  print(ret.model)
   expect_equal(colnames(ret.model),
               c("Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
                 "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
@@ -93,7 +94,6 @@ test_that("Test One-way ANOVA", {
 
 
   ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
-  print(ret.shapiro)
   expect_equal(colnames(ret.shapiro),
               c("W Value", "P Value", "Method", "Rows", "Result"))
   expect_equal(unname(ret.shapiro$`W Value`), 0.997, tolerance = 0.001)
@@ -102,7 +102,6 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.shapiro$Result, "Normality assumption is valid.")
 
   ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
-  print(ret.prob_dist)
   expect_true("p.value" %in% colnames(ret.prob_dist))
   expect_equal(nrow(ret.prob_dist), 1002)
   expect_equal(ncol(ret.prob_dist), 7)
@@ -118,17 +117,16 @@ test_that("Test One-way ANOVA", {
 
   # Post-hoc test
   ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
-  print(ret.pairs)
   expect_equal(colnames(ret.pairs), 
               c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
                 "Standard Error", "DF", "t Value", "P Value", "Method"))
   expect_equal(nrow(ret.pairs), 3)  # One for each facet level
   expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
   expect_equal(ret.pairs$`P Value`, c(0.328, 0.255, 0.686), tolerance = 0.001)
+  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
 
   ret.model <- ret %>% tidy_rowwise(model, type="model")
-  print(ret.model)
   expect_equal(colnames(ret.model),
               c("facet", "Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
                 "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
@@ -137,9 +135,16 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.model$`F Value`[c(1,4,7)], c(0.966, 1.31, 0.166), tolerance = 0.01)
   expect_equal(ret.model$Power[c(1,4,7)], c(0.210, 0.125, 0.0645), tolerance = 0.001)
 
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
+  expect_equal(colnames(ret.pairs), 
+              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
+  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.005)
+  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
   ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
-  print(ret.shapiro)
   expect_equal(colnames(ret.shapiro),
               c("facet", "W Value", "P Value", "Method", "Rows", "Result"))
   expect_equal(nrow(ret.shapiro), 3)
@@ -148,11 +153,9 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.shapiro$Result, rep("Normality assumption is valid.", 3))
 
   ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
-  print(ret.prob_dist)
   expect_true("p.value" %in% colnames(ret.prob_dist))
   expect_equal(nrow(ret.prob_dist), 3006)  # 1002 rows for each facet level
   expect_equal(ncol(ret.prob_dist), 8)  # Including facet column
-
 
   #
   # var.equal=TRUE
@@ -164,7 +167,6 @@ test_that("Test One-way ANOVA", {
 
   # Post-hoc test with var.equal=TRUE
   ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
-  print(ret.pairs)
   expect_equal(colnames(ret.pairs), 
               c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
                 "Standard Error", "DF", "t Value", "P Value", "Method"))
@@ -172,9 +174,15 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.pairs$`P Value`, 0.114, tolerance = 0.001)
   expect_equal(ret.pairs$DF, 720)
 
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
+  expect_equal(colnames(ret.pairs), 
+              c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(ret.pairs$Difference, 0.235, tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, 0.114, tolerance = 0.001)
+  expect_equal(ret.pairs$DF, 720)
 
   ret.model <- ret %>% tidy_rowwise(model, type="model")
-  print(ret.model)
   expect_equal(colnames(ret.model),
               c("Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
                 "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
@@ -185,7 +193,6 @@ test_that("Test One-way ANOVA", {
 
 
   ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
-  print(ret.shapiro)
   expect_equal(colnames(ret.shapiro),
               c("W Value", "P Value", "Method", "Rows", "Result"))
   expect_equal(unname(ret.shapiro$`W Value`), 0.997, tolerance = 0.001)
@@ -194,7 +201,6 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.shapiro$Result, "Normality assumption is valid.")
 
   ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
-  print(ret.prob_dist)
   expect_true("p.value" %in% colnames(ret.prob_dist))
   expect_equal(nrow(ret.prob_dist), 1002)
   expect_equal(ncol(ret.prob_dist), 7)
@@ -210,17 +216,24 @@ test_that("Test One-way ANOVA", {
 
   # Post-hoc test
   ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
-  print(ret.pairs)
   expect_equal(colnames(ret.pairs), 
               c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
                 "Standard Error", "DF", "t Value", "P Value", "Method"))
   expect_equal(nrow(ret.pairs), 3)  # One for each facet level
   expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
-  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.005)
+  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
+  expect_equal(colnames(ret.pairs), 
+              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
+  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.005)
+  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
   ret.model <- ret %>% tidy_rowwise(model, type="model")
-  print(ret.model)
   expect_equal(colnames(ret.model),
               c("facet", "Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
                 "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
@@ -229,9 +242,7 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.model$`F Value`[c(1,4,7)], c(0.969, 1.32, 0.166), tolerance = 0.01)
   expect_equal(ret.model$Power[c(1,4,7)], c(0.210, 0.125, 0.0645), tolerance = 0.001)
 
-
   ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
-  print(ret.shapiro)
   expect_equal(colnames(ret.shapiro),
               c("facet", "W Value", "P Value", "Method", "Rows", "Result"))
   expect_equal(nrow(ret.shapiro), 3)
@@ -240,11 +251,7 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.shapiro$Result, rep("Normality assumption is valid.", 3))
 
   ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
-  print(ret.prob_dist)
   expect_true("p.value" %in% colnames(ret.prob_dist))
   expect_equal(nrow(ret.prob_dist), 3006)  # 1002 rows for each facet level
   expect_equal(ncol(ret.prob_dist), 8)  # Including facet column
-
-
-
 })

--- a/tests/testthat/test_test_oneway_anova.R
+++ b/tests/testthat/test_test_oneway_anova.R
@@ -1,0 +1,250 @@
+# Test One-way ANOVA.
+context("Test One-way ANOVA")
+
+
+
+test_that("Test output between aov and oneway.test with equal variance", {
+  # This test is to check if the output of aov and oneway.test with equal variance are the same.
+  # This is to make sure that the output of exp_anova is correct.
+
+  # Create sample data
+  set.seed(123)  # For reproducibility
+  data <- data.frame(
+      group = factor(rep(c("A", "B", "C"), each = 10)),
+      value = c(
+          rnorm(10, mean = 10, sd = 2),  # Group A
+          rnorm(10, mean = 12, sd = 2),  # Group B
+          rnorm(10, mean = 15, sd = 2)   # Group C
+      )
+  )
+
+  # Run both tests
+  aov_result <- aov(value ~ group, data = data)
+  aov_summary <- summary(aov_result)[[1]]
+  aov_f_value <- unname(aov_summary$`F value`[1])  # Remove names attribute
+  aov_p_value <- unname(aov_summary$`Pr(>F)`[1])   # Remove names attribute
+
+  oneway_result <- oneway.test(value ~ group, data = data, var.equal = TRUE)
+  oneway_f_value <- as.numeric(oneway_result$statistic)
+  oneway_p_value <- oneway_result$p.value
+
+  # Check if the F value and p value are the same.
+  expect_equal(aov_f_value, oneway_f_value)
+  expect_equal(aov_p_value, oneway_p_value)
+})
+
+
+test_that("Test One-way ANOVA", {
+
+  # Set seed for reproducibility
+  set.seed(123)
+
+  # Create base data frame
+  n <- 1000  # Total number of rows
+
+  # Create group variable with 2 categories and scattered NAs
+  groups <- sample(c("Group A", "Group B", NA), n, replace = TRUE, prob = c(0.4, 0.4, 0.2))
+
+  # Create numeric values with scattered NAs
+  values <- rnorm(n, mean = 10, sd = 2)  # Generate random normal values
+  na_positions_values <- sample(1:n, 100)  # Select 100 random positions for NA (keeping 10% NA rate)
+  values[na_positions_values] <- NA
+
+  # Create facet variable with 2 categories and scattered NAs
+  facets <- sample(c("Facet 1", "Facet 2", NA), n, replace = TRUE, prob = c(0.4, 0.4, 0.2))
+
+  # Combine into data frame
+  test_df <- data.frame(
+    group = groups,
+    value = values,
+    facet = facets
+  )
+
+
+  #
+  # var.equal=FALSE
+  #
+
+  # Model creation
+  ret <- test_df %>% dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
+    exp_anova(`value`, `group`)
+
+
+  # Post-hoc test
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
+  print(ret.pairs)
+  expect_equal(colnames(ret.pairs), 
+              c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(ret.pairs$Difference, 0.235, tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, 0.115, tolerance = 0.001)
+  expect_equal(ret.pairs$DF, 720)
+
+
+  ret.model <- ret %>% tidy_rowwise(model, type="model")
+  print(ret.model)
+  expect_equal(colnames(ret.model),
+              c("Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
+                "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
+                "Eta Squared", "Partial Eta Squared", "Cohen's F", "Omega Squared"))
+  expect_equal(ret.model$`F Value`[1], 2.50, tolerance = 0.01)
+  expect_equal(ret.model$`P Value`[1], 0.114, tolerance = 0.001)
+  expect_equal(ret.model$Power[1], 0.236, tolerance = 0.001)
+
+
+  ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
+  print(ret.shapiro)
+  expect_equal(colnames(ret.shapiro),
+              c("W Value", "P Value", "Method", "Rows", "Result"))
+  expect_equal(unname(ret.shapiro$`W Value`), 0.997, tolerance = 0.001)
+  expect_equal(unname(ret.shapiro$`P Value`), 0.137, tolerance = 0.001)
+  expect_equal(ret.shapiro$Rows, 900)
+  expect_equal(ret.shapiro$Result, "Normality assumption is valid.")
+
+  ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
+  print(ret.prob_dist)
+  expect_true("p.value" %in% colnames(ret.prob_dist))
+  expect_equal(nrow(ret.prob_dist), 1002)
+  expect_equal(ncol(ret.prob_dist), 7)
+
+  # With group_by
+  ret <- test_df %>% 
+    dplyr::mutate(`facet` = `_tam_create_logical_factor`(`facet`)) %>%
+    dplyr::mutate(`facet` = `_tam_convert_na`(`facet`, drop.unused.levels=FALSE)) %>%
+    dplyr::mutate(`facet` = forcats::fct_lump(factor(`facet`), n=20, other_level = "Others", ties.method ="first")) %>%
+    dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
+    group_by(`facet`) %>%
+    exp_anova(`value`, `group`)
+
+  # Post-hoc test
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
+  print(ret.pairs)
+  expect_equal(colnames(ret.pairs), 
+              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
+  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.328, 0.255, 0.686), tolerance = 0.001)
+
+
+  ret.model <- ret %>% tidy_rowwise(model, type="model")
+  print(ret.model)
+  expect_equal(colnames(ret.model),
+              c("facet", "Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
+                "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
+                "Eta Squared", "Partial Eta Squared", "Cohen's F", "Omega Squared"))
+  expect_equal(nrow(ret.model), 9)  # 3 rows for each facet level
+  expect_equal(ret.model$`F Value`[c(1,4,7)], c(0.966, 1.31, 0.166), tolerance = 0.01)
+  expect_equal(ret.model$Power[c(1,4,7)], c(0.210, 0.125, 0.0645), tolerance = 0.001)
+
+
+  ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
+  print(ret.shapiro)
+  expect_equal(colnames(ret.shapiro),
+              c("facet", "W Value", "P Value", "Method", "Rows", "Result"))
+  expect_equal(nrow(ret.shapiro), 3)
+  expect_equal(unname(ret.shapiro$`W Value`), c(0.992, 0.994, 0.995), tolerance = 0.001)
+  expect_equal(unname(ret.shapiro$`P Value`), c(0.161, 0.292, 0.833), tolerance = 0.001)
+  expect_equal(ret.shapiro$Result, rep("Normality assumption is valid.", 3))
+
+  ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
+  print(ret.prob_dist)
+  expect_true("p.value" %in% colnames(ret.prob_dist))
+  expect_equal(nrow(ret.prob_dist), 3006)  # 1002 rows for each facet level
+  expect_equal(ncol(ret.prob_dist), 8)  # Including facet column
+
+
+  #
+  # var.equal=TRUE
+  #
+
+  # Model creation
+  ret <- test_df %>% dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
+  exp_anova(`value`, `group`, var.equal=TRUE)
+
+  # Post-hoc test with var.equal=TRUE
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
+  print(ret.pairs)
+  expect_equal(colnames(ret.pairs), 
+              c("Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(ret.pairs$Difference, 0.235, tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, 0.114, tolerance = 0.001)
+  expect_equal(ret.pairs$DF, 720)
+
+
+  ret.model <- ret %>% tidy_rowwise(model, type="model")
+  print(ret.model)
+  expect_equal(colnames(ret.model),
+              c("Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
+                "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
+                "Eta Squared", "Partial Eta Squared", "Cohen's F", "Omega Squared"))
+  expect_equal(ret.model$`F Value`[1], 2.50, tolerance = 0.01)
+  expect_equal(ret.model$`P Value`[1], 0.114, tolerance = 0.001)
+  expect_equal(ret.model$Power[1], 0.236, tolerance = 0.001)
+
+
+  ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
+  print(ret.shapiro)
+  expect_equal(colnames(ret.shapiro),
+              c("W Value", "P Value", "Method", "Rows", "Result"))
+  expect_equal(unname(ret.shapiro$`W Value`), 0.997, tolerance = 0.001)
+  expect_equal(unname(ret.shapiro$`P Value`), 0.167, tolerance = 0.001)
+  expect_equal(ret.shapiro$Rows, 900)
+  expect_equal(ret.shapiro$Result, "Normality assumption is valid.")
+
+  ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
+  print(ret.prob_dist)
+  expect_true("p.value" %in% colnames(ret.prob_dist))
+  expect_equal(nrow(ret.prob_dist), 1002)
+  expect_equal(ncol(ret.prob_dist), 7)
+
+  # With group_by
+  ret <- test_df %>% 
+    dplyr::mutate(`facet` = `_tam_create_logical_factor`(`facet`)) %>%
+    dplyr::mutate(`facet` = `_tam_convert_na`(`facet`, drop.unused.levels=FALSE)) %>%
+    dplyr::mutate(`facet` = forcats::fct_lump(factor(`facet`), n=20, other_level = "Others", ties.method ="first")) %>%
+    dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
+    group_by(`facet`) %>%
+    exp_anova(`value`, `group`, var.equal=TRUE)
+
+  # Post-hoc test
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
+  print(ret.pairs)
+  expect_equal(colnames(ret.pairs), 
+              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
+  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.001)
+
+
+  ret.model <- ret %>% tidy_rowwise(model, type="model")
+  print(ret.model)
+  expect_equal(colnames(ret.model),
+              c("facet", "Type of Variance", "Sum of Squares", "SS Ratio", "DF", "Mean Square", 
+                "F Value", "P Value", "Power", "Type 2 Error", "Rows", 
+                "Eta Squared", "Partial Eta Squared", "Cohen's F", "Omega Squared"))
+  expect_equal(nrow(ret.model), 9)  # 3 rows for each facet level
+  expect_equal(ret.model$`F Value`[c(1,4,7)], c(0.969, 1.32, 0.166), tolerance = 0.01)
+  expect_equal(ret.model$Power[c(1,4,7)], c(0.210, 0.125, 0.0645), tolerance = 0.001)
+
+
+  ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
+  print(ret.shapiro)
+  expect_equal(colnames(ret.shapiro),
+              c("facet", "W Value", "P Value", "Method", "Rows", "Result"))
+  expect_equal(nrow(ret.shapiro), 3)
+  expect_equal(unname(ret.shapiro$`W Value`), c(0.993, 0.994, 0.995), tolerance = 0.001)
+  expect_equal(unname(ret.shapiro$`P Value`), c(0.200, 0.259, 0.898), tolerance = 0.001)
+  expect_equal(ret.shapiro$Result, rep("Normality assumption is valid.", 3))
+
+  ret.prob_dist <- ret %>% tidy_rowwise(model, type="prob_dist")
+  print(ret.prob_dist)
+  expect_true("p.value" %in% colnames(ret.prob_dist))
+  expect_equal(nrow(ret.prob_dist), 3006)  # 1002 rows for each facet level
+  expect_equal(ncol(ret.prob_dist), 8)  # Including facet column
+
+
+
+})

--- a/tests/testthat/test_test_oneway_anova.R
+++ b/tests/testthat/test_test_oneway_anova.R
@@ -108,8 +108,6 @@ test_that("Test One-way ANOVA", {
 
   # With group_by
   ret <- test_df %>% 
-    dplyr::mutate(`facet` = `_tam_create_logical_factor`(`facet`)) %>%
-    dplyr::mutate(`facet` = `_tam_convert_na`(`facet`, drop.unused.levels=FALSE)) %>%
     dplyr::mutate(`facet` = forcats::fct_lump(factor(`facet`), n=20, other_level = "Others", ties.method ="first")) %>%
     dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
     group_by(`facet`) %>%
@@ -207,8 +205,6 @@ test_that("Test One-way ANOVA", {
 
   # With group_by
   ret <- test_df %>% 
-    dplyr::mutate(`facet` = `_tam_create_logical_factor`(`facet`)) %>%
-    dplyr::mutate(`facet` = `_tam_convert_na`(`facet`, drop.unused.levels=FALSE)) %>%
     dplyr::mutate(`facet` = forcats::fct_lump(factor(`facet`), n=20, other_level = "Others", ties.method ="first")) %>%
     dplyr::mutate(`group` = forcats::fct_lump(factor(`group`), n=20, other_level = "Others", ties.method ="first")) %>%
     group_by(`facet`) %>%

--- a/tests/testthat/test_test_oneway_anova.R
+++ b/tests/testthat/test_test_oneway_anova.R
@@ -123,6 +123,14 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.pairs$`P Value`, c(0.328, 0.255, 0.686), tolerance = 0.001)
   expect_equal(ret.pairs$DF, c(275, 282, 159))
 
+  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
+  expect_equal(colnames(ret.pairs), 
+              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
+                "Standard Error", "DF", "t Value", "P Value", "Method"))
+  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
+  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
+  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.005)
+  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
   ret.model <- ret %>% tidy_rowwise(model, type="model")
   expect_equal(colnames(ret.model),
@@ -133,14 +141,6 @@ test_that("Test One-way ANOVA", {
   expect_equal(ret.model$`F Value`[c(1,4,7)], c(0.966, 1.31, 0.166), tolerance = 0.01)
   expect_equal(ret.model$Power[c(1,4,7)], c(0.210, 0.125, 0.0645), tolerance = 0.001)
 
-  ret.pairs <- ret %>% tidy_rowwise(model, type="pairs", pairs_adjust="bonferroni")
-  expect_equal(colnames(ret.pairs), 
-              c("facet", "Group 1", "Group 2", "Difference", "Conf Low", "Conf High", 
-                "Standard Error", "DF", "t Value", "P Value", "Method"))
-  expect_equal(nrow(ret.pairs), 3)  # One for each facet level
-  expect_equal(ret.pairs$Difference, c(0.243, 0.268, 0.125), tolerance = 0.001)
-  expect_equal(ret.pairs$`P Value`, c(0.326, 0.252, 0.684), tolerance = 0.005)
-  expect_equal(ret.pairs$DF, c(275, 282, 159))
 
   ret.shapiro <- ret %>% tidy_rowwise(model, type="shapiro", shapiro_seed=)
   expect_equal(colnames(ret.shapiro),

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -879,7 +879,7 @@ test_that("test exp_anova with grouping functions", {
   model_df <- exp_anova(mtcars, mpg, am, func2="asint")
   ret <- model_df %>% tidy_rowwise(model, type="data_summary")
   expect_equal(colnames(ret),
-               c("disp","Rows","Mean","Std Error", "Conf Low","Conf High","Std Deviation",   
+               c("am","Rows","Mean","Std Error", "Conf Low","Conf High","Std Deviation",   
                  "Minimum","Maximum"))
 })
 

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -820,7 +820,7 @@ test_that("test exp_anova", {
 })
 
 test_that("test exp_anova with logical group column", {
-  mtcars2 <- mtcars %>% mutate(`a m`=as.logical(am), `w t`=wt, `q sec`=qsec)
+  mtcars2 <- mtcars %>% mutate(`a m`=factor(as.logical(am)), `w t`=wt, `q sec`=qsec)
   model_df <- exp_anova(mtcars2, mpg, `a m`)
   res <- model_df %>% tidy_rowwise(model, type="data", sort_factor_levels=TRUE)
 })
@@ -876,7 +876,7 @@ test_that("test exp_anova with required power", {
 })
 
 test_that("test exp_anova with grouping functions", {
-  model_df <- exp_anova(mtcars, mpg, disp, func2="asintby10")
+  model_df <- exp_anova(mtcars, mpg, am, func2="asint")
   ret <- model_df %>% tidy_rowwise(model, type="data_summary")
   expect_equal(colnames(ret),
                c("disp","Rows","Mean","Std Error", "Conf Low","Conf High","Std Deviation",   


### PR DESCRIPTION
# Description
Update ANOVA model handling to support Welch's ANOVA.

This pull request introduces significant enhancements to the `exp_anova` function and related utilities in the `R/test_wrapper.R` file, improving one-way ANOVA functionality and adding support for both equal and unequal variance cases. It also updates test cases to validate these changes. The key updates include adding new parameters, improving the handling of one-way ANOVA models, and introducing new test cases for comprehensive validation.

### Enhancements to `exp_anova` functionality:
* **Support for unequal variances:** Added a `var.equal` parameter to specify whether variances are equal. When `var.equal=FALSE`, Welch's ANOVA is used, and additional metrics such as standardized residuals and group statistics are calculated. [[1]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acR1628-R1642) [[2]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL1815-R1905)
* **Enhanced output structure:** For one-way ANOVA, the function now generates a `broom::tidy`-like output, including detailed metrics like degrees of freedom, sums of squares, mean squares, and F-statistics. [[1]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL1815-R1905) [[2]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL2007-R2115)

### Improvements to post-hoc analysis:
* **Post-hoc test adjustments:** Modified post-hoc tests to use `emmeans` with heteroscedasticity-consistent standard errors for unequal variances, leveraging `sandwich::vcovHC`.

### Updates to test cases:
* **New test cases for one-way ANOVA:** Added extensive test cases in `tests/testthat/test_test_oneway_anova.R` to validate the correctness of one-way ANOVA outputs under both equal and unequal variance scenarios. These include F-statistics, p-values, and post-hoc test results.
* **Adjustments to existing tests:** Updated existing tests in `tests/testthat/test_test_wrapper_1.R` to reflect changes in parameter usage and output structure, such as replacing logical columns with factors and updating grouping functions. [[1]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L823-R823) [[2]](diffhunk://#diff-6344a7d6be50a0a7ccd59d67a54e5cb814613d108844e91100687c49ecaa16d7L879-R882)

### Minor updates:
* **Version bump:** Updated package version from `12.1.3` to `12.1.4` in `DESCRIPTION` to reflect the new changes.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
