### PR TITLE
Enhance t-test output by adding standard error calculation.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 13.0.1
+Version: 12.1.5
 Date: 2025-05-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 12.1.4
-Date: 2025-05-01
+Version: 13.0.1
+Date: 2025-05-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -1170,6 +1170,9 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
       ret <- ret %>% dplyr::mutate(estimate = estimate1 - estimate2)
     }
 
+    # Calculate stderr.  Difference (estimate) / t-value (statistic)
+    ret <- ret %>% dplyr::mutate(stderr = estimate / statistic)
+
     # Get sample sizes for the 2 groups (n1, n2).
     n1 <- x$n1 # number of 1st class
     n2 <- x$n2 # number of 2nd class
@@ -1195,12 +1198,13 @@ tidy.ttest_exploratory <- function(x, type="model", conf_level=0.95) {
         power_val <<- NA_real_
       })
 
-      ret <- ret %>% dplyr::select(statistic, p.value, parameter, estimate, conf.low, conf.high, base.level) %>%
+      ret <- ret %>% dplyr::select(estimate, stderr, statistic, p.value, parameter, conf.low, conf.high, base.level) %>%
         dplyr::mutate(d=!!(x$cohens_d), power=!!power_val, beta=1.0-!!power_val) %>%
         dplyr::rename(`t Value`=statistic,
                       `P Value`=p.value,
                       `DF`=parameter,
                       Difference=estimate,
+                      `Std Error`=stderr,
                       `Conf High`=conf.high,
                       `Conf Low`=conf.low,
                       `Base Level`=base.level,

--- a/tests/testthat/test_ttest_paired.R
+++ b/tests/testthat/test_ttest_paired.R
@@ -36,7 +36,7 @@ test_that("test paired ttest", {
   # model type output
   ret <- model_df %>% tidy_rowwise(model, type="model")
   expect_equal(colnames(ret),
-               c("t Value", "P Value", "DF", "Difference", "Conf Low", "Conf High", "Base Level", "Cohen's D", "Power", "Type 2 Error",
+               c("Difference", "Std Error", "t Value", "P Value", "DF", "Conf Low", "Conf High", "Base Level", "Cohen's D", "Power", "Type 2 Error",
                  "Rows", "Rows (After_Treatment)", "Rows (Before_Treatment)"))
 
   # data summary type output


### PR DESCRIPTION

# Description

Enhance t-test output by adding standard error calculation and updating output structure to include stderr in results.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
