### PR TITLE
Enhance read_delim_file function to handle delimiter guessing errors by retrying with a default comma delimiter. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 13.0.2
-Date: 2025-05-31
+Version: 13.0.3
+Date: 2025-06-02
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -3571,7 +3571,7 @@ read_delim_file <- function(file, delim, quote = '"',
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "does not exist")) { #for the case Error: Error : '/tmp/RtmpVAk1Jf/filed3636522650.csv' does not exist.
         stop(stringr::str_c("Could not read data from ", file)); # Show the original URL name in the error message.
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "could not guess the delimiter")) {
-        # retry with default delimiter which is comma.
+        # retry with default delimiter which is comma. This error only happens when delimiter is not specified.
         exploratory::read_delim_file(
           file,
           delim = ",",
@@ -3639,7 +3639,7 @@ read_delim_file <- function(file, delim, quote = '"',
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "does not exist")) {
         stop(paste0('EXP-DATASRC-14 :: ', jsonlite::toJSON(file), ' :: The file does not exist.'))
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "could not guess the delimiter")) {
-        # retry with default delimiter which is comma.
+        # retry with default delimiter which is comma. This error only happens when delimiter is not specified.
         exploratory::read_delim_file(
           file,
           delim = ",",

--- a/R/system.R
+++ b/R/system.R
@@ -3570,6 +3570,28 @@ read_delim_file <- function(file, delim, quote = '"',
         }
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "does not exist")) { #for the case Error: Error : '/tmp/RtmpVAk1Jf/filed3636522650.csv' does not exist.
         stop(stringr::str_c("Could not read data from ", file)); # Show the original URL name in the error message.
+      } else if (stringr::str_detect(stringr::str_to_lower(e$message), "could not guess the delimiter")) {
+        # retry with default delimiter which is comma.
+        exploratory::read_delim_file(
+          file,
+          delim = ",",
+          quote = quote,
+          escape_backslash = escape_backslash,
+          escape_double = escape_double,
+          col_names = col_names,
+          col_types = col_types,
+          locale = locale,
+          na = na,
+          quoted_na = quoted_na,
+          comment = comment,
+          trim_ws = trim_ws,
+          skip = skip,
+          n_max = n_max,
+          guess_max = guess_max,
+          progress = progress,
+          with_api_key = with_api_key,
+          data_text = data_text
+        )
       } else {
         stop(paste0('EXP-DATASRC-13 :: ', jsonlite::toJSON(c(file, e$message)), ' :: Failed to import file.'))
       }
@@ -3616,6 +3638,28 @@ read_delim_file <- function(file, delim, quote = '"',
         stop(paste0("EXP-DATASRC-1 :: ", jsonlite::toJSON(file), " ::  Failed to read file."))
       } else if (stringr::str_detect(stringr::str_to_lower(e$message), "does not exist")) {
         stop(paste0('EXP-DATASRC-14 :: ', jsonlite::toJSON(file), ' :: The file does not exist.'))
+      } else if (stringr::str_detect(stringr::str_to_lower(e$message), "could not guess the delimiter")) {
+        # retry with default delimiter which is comma.
+        exploratory::read_delim_file(
+          file,
+          delim = ",",
+          quote = quote,
+          escape_backslash = escape_backslash,
+          escape_double = escape_double,
+          col_names = col_names,
+          col_types = col_types,
+          locale = locale,
+          na = na,
+          quoted_na = quoted_na,
+          comment = comment,
+          trim_ws = trim_ws,
+          skip = skip,
+          n_max = n_max,
+          guess_max = guess_max,
+          progress = progress,
+          with_api_key = with_api_key,
+          data_text = data_text
+        )
       } else {
         if (is_free_input_text) {
           stop(paste0('EXP-DATASRC-13 :: ', jsonlite::toJSON(c("", e$message)), ' :: Failed to import file.'))

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -479,6 +479,11 @@ test_that("read_delim_file downlod failed error message", {
   })
 })
 
+test_that("read_delim_file with guess delimiter error handling and retry with default comma delimiter", {
+  df <- exploratory::read_delim_file("https://www.dropbox.com/scl/fi/o3vuqea89mp6t24e61cmg/one-col.csv?rlkey=6ko09im7w4bn5x0yrj9kjduzv&dl=1", delim = NULL)
+  expect_equal(colnames(df), c("a"))
+})
+
 test_that("read_delim_file witout requirement delim argument error message", {
   tryCatch({
     df <- exploratory::read_delim_file("https://www.dropbox.com/s/tb6ppzockjao7vg/too_longer_header.csv?dl=1")


### PR DESCRIPTION
# Description

Enhance read_delim_file function to handle delimiter guessing errors by retrying with a default comma delimiter. 
This improves robustness in file reading operations.

This pull request enhances the `read_delim_file` function in `R/system.R` by adding error handling for cases where the delimiter cannot be guessed and implementing a retry mechanism with a default comma delimiter. Additionally, a new test case has been added to validate this behavior.

### Enhancements to `read_delim_file` function:
* Added error handling for situations where the delimiter cannot be guessed. The function now retries reading the file using a default delimiter (comma) in such cases. (`R/system.R`, [[1]](diffhunk://#diff-2d765c83d05448d923848ac4b25dc04a1eedca5294621e552785ed58ec672768R3573-R3594) [[2]](diffhunk://#diff-2d765c83d05448d923848ac4b25dc04a1eedca5294621e552785ed58ec672768R3641-R3662)

### Testing improvements:
* Introduced a new test case to verify that the `read_delim_file` function correctly handles delimiter-guessing errors and successfully retries with the default comma delimiter. (`tests/testthat/test_system.R`, [tests/testthat/test_system.RR482-R486](diffhunk://#diff-aea0e040511d3b75ed7629a0e9443da06f7b8f9aebf5aef88224a75898d63759R482-R486))

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
