### PR TITLE
Update version to 13.0.10 in DESCRIPTION file and modify authentication method in downloadDataFromGoogleCloudStorage function to use gar_auth_service for service account support.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 13.0.9
+Version: 13.0.10
 Date: 2025-06-15
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/system.R
+++ b/R/system.R
@@ -2299,7 +2299,7 @@ downloadDataFromGoogleCloudStorage <- function(bucket, folder, download_dir, tok
      service_account_file <- Sys.getenv("GOOGLE_BIGQUERY_SERVICE_ACCOUNT_FILE")
   }
   if (!is.null(service_account_file)) {
-    googleAuthR::gar_auth(json_file = service_account_file)
+    googleAuthR::gar_auth_service(json_file = service_account_file)
   } else {
     token <- getGoogleTokenForBigQuery(tokenFileId)
     googleAuthR::gar_auth(token = token, skip_fetch = TRUE)


### PR DESCRIPTION
# Description

Fix issue for downloadDataFromGoogleCloudStorage to use googleAuthR::gar_auth_service to set service account.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
