### PR TITLE
Support col_types and guess_max arguments to getGoogleSheet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 13.0.10
-Date: 2025-06-15
+Version: 13.0.11
+Date: 2025-07-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -183,14 +183,14 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NUL
     } else {
       gsheet <- googledrive::drive_get(title)
     }
-    if(!is.null(col_types)) {
-      # if col_types is provided, use it.
-    } else if(!guessDataType) {
-      # if guessDataType is FALSE, use character as the default column data type.
-      col_types <- c(.default="c")
-    } else {
-      # if guessDataType is TRUE, use the default column data type.
-      col_types <- NULL
+    if(is.null(col_types)) {
+      if(!guessDataType) {
+        # if guessDataType is FALSE, use character as the default column data type.
+        col_types <- c(.default="c")
+      } else {
+        # if guessDataType is TRUE, use the default column data type.
+        col_types <- NULL
+      }
     }
     # The "na" argument of googlesheets4::read_sheet does not accept null,
     # so if the treatTheseAsNA is null, do not pass it to googlesheets4::read_sheet

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -157,8 +157,10 @@ normalizeDataForGoogleSheetsExport <- function (df) {
 #' @param guessDataType - flag to tell if you want googlesheets::gs_read to guess column data type
 #' @param tzone - timezone
 #' @param id - ID of the sheet
+#' @param col_types - column data type
+#' @param guess_max - maximum number of rows to guess column data type (default is Inf)
 #' @export
-getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NULL, firstRowAsHeader = TRUE, commentChar, tokenFileId = NULL, guessDataType = TRUE, tzone = NULL, id = NULL, ...){
+getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NULL, firstRowAsHeader = TRUE, commentChar, tokenFileId = NULL, guessDataType = TRUE, tzone = NULL, id = NULL, col_types = NULL, guess_max = Inf, ...){
   if(!requireNamespace("googlesheets4")){stop("package googlesheets4 must be installed.")}
   if(!requireNamespace("googledrive")){stop("package googledrive must be installed.")}
   if(!requireNamespace("stringr")){stop("package stringr must be installed.")}
@@ -181,19 +183,23 @@ getGoogleSheet <- function(title, sheetName, skipNRows = 0, treatTheseAsNA = NUL
     } else {
       gsheet <- googledrive::drive_get(title)
     }
-    col_types <- NULL
-    if(!guessDataType) {
+    if(!is.null(col_types)) {
+      # if col_types is provided, use it.
+    } else if(!guessDataType) {
       # if guessDataType is FALSE, use character as the default column data type.
       col_types <- c(.default="c")
+    } else {
+      # if guessDataType is TRUE, use the default column data type.
+      col_types <- NULL
     }
     # The "na" argument of googlesheets4::read_sheet does not accept null,
     # so if the treatTheseAsNA is null, do not pass it to googlesheets4::read_sheet
     if(!is.null(treatTheseAsNA)) {
-      df <- gsheet %>% googlesheets4::read_sheet(range = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, col_types = col_types)
+      df <- gsheet %>% googlesheets4::read_sheet(range = sheetName, skip = skipNRows, na = treatTheseAsNA, col_names = firstRowAsHeader, col_types = col_types, guess_max = guess_max)
     } else {
-      df <- gsheet %>% googlesheets4::read_sheet(range = sheetName, skip = skipNRows, col_names = firstRowAsHeader, col_types = col_types)
+      df <- gsheet %>% googlesheets4::read_sheet(range = sheetName, skip = skipNRows, col_names = firstRowAsHeader, col_types = col_types, guess_max = guess_max)
     }
-    if(!is.null(tzone)) { # if timezone is specified, apply the timezeon to POSIXct columns
+    if(!is.null(tzone)) { # if timezone is specified, apply the timezone to POSIXct columns
       df <- df %>% dplyr::mutate(across(where(lubridate::is.POSIXct), ~ lubridate::force_tz(.x, tzone=tzone)))
     }
     # For list columns, change the data type to characters


### PR DESCRIPTION
# Description

Support the below arguments that are passed to the underlying googlesheets API

- col_types
- guess_max

This pull request introduces a version update to the `exploratory` R package and enhances the `getGoogleSheet` function to provide more flexibility in handling column data types and row guessing for Google Sheets. Below is a summary of the most important changes:

### Package Metadata Updates:
* Updated the package version from `13.0.10` to `13.0.11` and the release date to `2025-07-01` in the `DESCRIPTION` file.

### Enhancements to `getGoogleSheet` Function:
* Added new parameters `col_types` and `guess_max` to the `getGoogleSheet` function to allow explicit specification of column data types and control over the number of rows used for guessing column types.
* Updated logic to handle the new `col_types` parameter:
  - If `col_types` is provided, it is used directly.
  - If `guessDataType` is `FALSE`, the default column type is set to character.
  - If `guessDataType` is `TRUE`, the default behavior is retained.
* Modified calls to `googlesheets4::read_sheet` to include the new `guess_max` parameter for better control over column type inference.

These changes improve the functionality and usability of the `getGoogleSheet` function, making it more robust for diverse use cases.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [ ] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
