### PR TITLE
Fix PostgreSQL 9.3 column lookup for 15.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.1
-Date: 2026-1-30
+Version: 15.0.2
+Date: 2026-4-2
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -1811,7 +1811,7 @@ clearDBConnection <- function(type, host = NULL, port = NULL, databaseName, user
   }
   else if (type %in% c("postgres", "redshift", "vertica")) {
     # they use common key "postgres"
-    key <- paste("postgres", host, port, databaseName, username, timezone, sep = ":")
+    key <- paste("postgres", host, port, databaseName, username, timezone, sslMode, sslCA, sep = ":")
     conn <- connection_pool[[key]]
     if (!is.null(conn)) {
       tryCatch({ # try to close connection and ignore error
@@ -1890,6 +1890,45 @@ isConnecitonPoolEnabled <- function(type){
   type %in% c("dbiodbc", "odbc", "postgres", "redshift", "vertica", "mysql", "aurora", "presto", "treasuredata", "mssqlserver", "snowflake", "teradata")
 }
 
+getListOfColumnsPostgres <- function(conn, table) {
+  table_name <- table
+  schema_name <- NULL
+
+  if (is.character(table) && length(table) == 1) {
+    parts <- stringr::str_split(table, "\\.", n = 2)[[1]]
+    if (length(parts) == 2) {
+      schema_name <- stringr::str_replace_all(parts[[1]], '^"|"$', "")
+      table_name <- stringr::str_replace_all(parts[[2]], '^"|"$', "")
+    }
+  }
+
+  if (!is.null(schema_name) && nzchar(schema_name)) {
+    query <- paste0(
+      "SELECT column_name ",
+      "FROM information_schema.columns ",
+      "WHERE table_schema = ", DBI::dbQuoteString(conn, schema_name), " ",
+      "AND table_name = ", DBI::dbQuoteString(conn, table_name), " ",
+      "ORDER BY ordinal_position"
+    )
+  } else {
+    # PostgreSQL 9.3 does not support WITH ORDINALITY, which recent RPostgres
+    # versions use internally for dbListFields(). Build an equivalent query
+    # using generate_subscripts() so older servers still work.
+    query <- paste0(
+      "SELECT c.column_name ",
+      "FROM information_schema.columns c ",
+      "JOIN (",
+      "  SELECT i AS idx, (current_schemas(true))[i] AS schema_name ",
+      "  FROM generate_subscripts(current_schemas(true), 1) g(i)",
+      ") sp ON c.table_schema = sp.schema_name ",
+      "WHERE c.table_name = ", DBI::dbQuoteString(conn, table_name), " ",
+      "ORDER BY sp.idx, c.ordinal_position"
+    )
+  }
+
+  DBI::dbGetQuery(conn, query)$column_name
+}
+
 getListOfTablesWithODBC <- function(conn){
   topLevels <- odbc::odbcListObjects(conn)
   schemas <- NULL
@@ -1949,10 +1988,14 @@ getListOfColumns <- function(type, host, port, databaseName, username, password,
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
   conn <- getDBConnection(type, host, port, databaseName, username, password, sslMode = sslMode, sslCA = sslCA, role = role)
   tryCatch({
-    columns <- DBI::dbListFields(conn, table)
+    if (type == "postgres") {
+      columns <- getListOfColumnsPostgres(conn, table)
+    } else {
+      columns <- DBI::dbListFields(conn, table)
+    }
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try
-    clearDBConnection(type, host, port, databaseName, username)
+    clearDBConnection(type, host, port, databaseName, username, sslMode = sslMode, sslCA = sslCA, role = role)
     if (!!isConnecitonPoolEnabled(type)) { # only if conn pool is not used yet
       tryCatch({ # try to close connection and ignore error
         DBI::dbDisconnect(conn)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -124,6 +124,43 @@ test_that("test parse_html_tables with japanese shift_jis table",{
   expect_equal(length(result), 1)
 })
 
+test_that("getListOfColumnsPostgres uses 9.3-safe search_path query for unqualified tables", {
+  query <- NULL
+  testthat::local_mocked_bindings(
+    dbQuoteString = function(conn, x) paste0("'", x, "'"),
+    dbGetQuery = function(conn, sql) {
+      query <<- sql
+      data.frame(column_name = c("FL_DATE", "CARRIER"))
+    },
+    .package = "DBI"
+  )
+
+  cols <- exploratory:::getListOfColumnsPostgres(structure(list(), class = "dummy"), "flight")
+
+  expect_equal(cols, c("FL_DATE", "CARRIER"))
+  expect_match(query, "generate_subscripts\\(current_schemas\\(true\\), 1\\)")
+  expect_match(query, "WHERE c.table_name = 'flight'")
+})
+
+test_that("getListOfColumnsPostgres uses schema-qualified query when schema is provided", {
+  query <- NULL
+  testthat::local_mocked_bindings(
+    dbQuoteString = function(conn, x) paste0("'", x, "'"),
+    dbGetQuery = function(conn, sql) {
+      query <<- sql
+      data.frame(column_name = c("id", "value"))
+    },
+    .package = "DBI"
+  )
+
+  cols <- exploratory:::getListOfColumnsPostgres(structure(list(), class = "dummy"), 'public."flight"')
+
+  expect_equal(cols, c("id", "value"))
+  expect_match(query, "WHERE table_schema = 'public'")
+  expect_match(query, "AND table_name = 'flight'")
+  expect_false(grepl("generate_subscripts", query, fixed = TRUE))
+})
+
 if (FALSE) { # Disabled for now since this test is susceptible to webpage change and unstable.
   test_that("test scrape_html_table",{
     result <- scrape_html_table('https://www.cbinsights.com/research-unicorn-companies', 1, TRUE)


### PR DESCRIPTION
## Summary
- fix PostgreSQL column introspection for PostgreSQL 9.3 by avoiding the RPostgres `WITH ORDINALITY` path in `getListOfColumns()`
- fix PostgreSQL connection-pool cleanup key mismatch in `clearDBConnection()`
- bump package version to `15.0.2` and add regression tests for the fallback query path

## Verification
- verified in `r-exploratory:15.0.1_SSL` on stage2 that `getListOfColumns("postgres", ..., "flight")` now succeeds and returns `FL_DATE`
- verified `clearDBConnection("postgres", ...)` runs cleanly without the stale key warning
- parsed updated R and test files successfully
