### PR TITLE
fix(test): replace deprecated Dropbox URL with S3 URL for airline test data

### DIFF
--- a/tests/testthat/test_logistic_negative_1.R
+++ b/tests/testthat/test_logistic_negative_1.R
@@ -3,7 +3,7 @@ context("logistic regression - handle failed model building")
 
 test_that("logistic regression can handle failed model building", {
   # TODO: optimize performance
-  df <- exploratory::read_delim_file("https://www.dropbox.com/s/nv3oxz7w9usnfu3/airline_2013_10.csv?dl=1" , ",", quote = "\"", skip = 0 , col_names = TRUE , na = c("","NA") , locale=readr::locale(encoding = "UTF-8", decimal_mark = "."), trim_ws = FALSE , progress = FALSE) %>%
+  df <- exploratory::read_delim_file("https://exploratory-download.s3.us-west-2.amazonaws.com/test/airline_2013_10.csv" , ",", quote = "\"", skip = 0 , col_names = TRUE , na = c("","NA") , locale=readr::locale(encoding = "UTF-8", decimal_mark = "."), trim_ws = FALSE , progress = FALSE) %>%
     exploratory::clean_data_frame() %>%
     mutate(delayed = ARR_DELAY > 30)
 


### PR DESCRIPTION
## Summary
- `test_logistic_negative_1.R` loaded airline CSV data from a Dropbox shared link
- Dropbox changed behavior: the link now returns `Content-Type: application/json` instead of CSV content
- `read_delim_file` parses it as a CSV with no `ARR_DELAY` column → test fails with `object 'ARR_DELAY' not found`
- Fix: replace with stable S3 URL (`https://exploratory-download.s3.us-west-2.amazonaws.com/test/airline_2013_10.csv`)
- The 78MB file was already uploaded to `s3://exploratory-download/test/` with public-read ACL

## Test plan
- [ ] Run `test_logistic_negative_1.R` on Windows VM — test passes with airline data loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)