### PR TITLE
test: add assertions to empty nnet build_model test

### DIFF
--- a/tests/testthat/test_build_multinom.R
+++ b/tests/testthat/test_build_multinom.R
@@ -171,7 +171,10 @@ test_that("test nnet build_model", {
   # these should work without error to 2 class classification
   prediction_train_ret <- prediction(model_df, data = "training")
   prediction_test_ret <- prediction(model_df, data = "test")
-
+  expect_true(is.data.frame(prediction_train_ret))
+  expect_true(nrow(prediction_train_ret) > 0)
+  expect_true(is.data.frame(prediction_test_ret))
+  expect_true(nrow(prediction_test_ret) > 0)
 })
 
 test_that("test group error message", {


### PR DESCRIPTION
## Summary
- `test_build_multinom.R:152` had no `expect_*` calls — testthat flagged it as an empty test (skipped with warning)
- Added `is.data.frame` and `nrow > 0` assertions matching the original intent: verify 2-class prediction works without error

## Test plan
- [ ] Run `test_build_multinom.R` on M1 Mac — FAIL 0, no empty test skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)