### PR TITLE
fix(xgboost): use seq_len(nrow(mat_data)) instead of as.integer(rownames)

### DIFF
--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -787,13 +787,13 @@ predict_xgboost <- function(model, df) {
   }
   else if (obj == "multi:softmax") {
     predicted <- model$y_levels[predicted+1]
-    # fill rows with NA
+    # na.action=na.pass keeps all rows, so this is a no-op in normal cases.
+    # Kept as a safety net in case nrow(mat_data) < nrow(df).
     predicted <- fill_vec_NA(seq_len(nrow(mat_data)), predicted, nrow(df))
   }
   else { # TODO: Here we assume all other cases returns vector prediction result.
-    # model.matrix removes rows with NA and stats::predict returns a matrix
-    # whose number of rows is the same with its size,
-    # so the result should be filled by NA
+    # na.action=na.pass keeps all rows so nrow(mat_data) == nrow(df) and
+    # fill_vec_NA is a no-op in normal cases. Kept as a safety net.
     predicted <- fill_vec_NA(seq_len(nrow(mat_data)), predicted, nrow(df))
   }
   predicted

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -788,13 +788,13 @@ predict_xgboost <- function(model, df) {
   else if (obj == "multi:softmax") {
     predicted <- model$y_levels[predicted+1]
     # fill rows with NA
-    predicted <- fill_vec_NA(as.integer(rownames(mat_data)), predicted, nrow(df))
+    predicted <- fill_vec_NA(seq_len(nrow(mat_data)), predicted, nrow(df))
   }
   else { # TODO: Here we assume all other cases returns vector prediction result.
     # model.matrix removes rows with NA and stats::predict returns a matrix
     # whose number of rows is the same with its size,
     # so the result should be filled by NA
-    predicted <- fill_vec_NA(as.integer(rownames(mat_data)), predicted, nrow(df))
+    predicted <- fill_vec_NA(seq_len(nrow(mat_data)), predicted, nrow(df))
   }
   predicted
 }


### PR DESCRIPTION
# Description

as.integer(rownames(mat_data)) fails when df has non-numeric rownames (e.g. mtcars with car name rownames), producing NAs that cause "NAs are not allowed in subscripted assignments" in fill_vec_NA. na.action=na.pass ensures mat_data always has nrow(df) rows, so sequential indices are correct. Consistent with LightGBM fix at line 1104.


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
