### PR TITLE
Migrate system.R to bigrquery 1.6.1 API (#35107)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.2
-Date: 2026-1-30
+Version: 15.0.3
+Date: 2026-04-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -2219,7 +2219,7 @@ submitGoogleBigQueryJob <- function(project, sqlquery, destination_table, write_
     bigrquery::bq_auth(path = service_account_file)
   } else {
     token <- getGoogleTokenForBigQuery(tokenFileId)
-    bigrquery::set_access_cred(token)
+    bigrquery::bq_auth(token = token)
   }
   sqlquery <- convertUserInputToUtf8(sqlquery)
   # pass desitiona_table to support large data
@@ -2260,11 +2260,11 @@ getDataFromGoogleBigQueryTable <- function(project, dataset, table, page_size = 
       bigrquery::bq_auth(path = service_account_file)
     } else {
       token <- getGoogleTokenForBigQuery(tokenFileId)
-      bigrquery::set_access_cred(token)
+      bigrquery::bq_auth(token = token)
     }
     tb <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
     # Since Exploratory Desktop does not handle int64, convert int64 to numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
-    bigrquery::bq_table_download(tb,  page_size = page_size, max_results = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
+    bigrquery::bq_table_download(tb,  page_size = page_size, n_max = max_page, bigint = "numeric", quiet = TRUE, max_connections = max_connections)
   }, finally = {
     # Set original scipen
     options(scipen = original_scipen)
@@ -2282,7 +2282,7 @@ extractDataFromGoogleBigQueryToCloudStorage <- function(project, dataset, table,
     bigrquery::bq_auth(path = service_account_file)
   } else {
     token <- getGoogleTokenForBigQuery(tokenFileId)
-    bigrquery::set_access_cred(token)
+    bigrquery::bq_auth(token = token)
   }
   # call forked bigrquery for submitting extract job
   table <- bigrquery::bq_table(project, dataset, table = table)
@@ -2374,12 +2374,12 @@ saveGoogleBigQueryResultAs <- function(projectId, sourceDatasetId, sourceTableId
     bigrquery::bq_auth(path = service_account_file)
   } else {
     token <- getGoogleTokenForBigQuery(tokenFileId)
-    bigrquery::set_access_cred(token)
+    bigrquery::bq_auth(token = token)
   }
 
-  src <- list(project_id = projectId, dataset_id = sourceDatasetId, table_id = sourceTableId)
-  dest <- list(project_id = targetProjectId, dataset_id = targetDatasetId, table_id = targetTableId)
-  bigrquery::copy_table(src, dest)
+  src <- bigrquery::bq_table(project = projectId, dataset = sourceDatasetId, table = sourceTableId)
+  dest <- bigrquery::bq_table(project = targetProjectId, dataset = targetDatasetId, table = targetTableId)
+  bigrquery::bq_table_copy(src, dest)
 }
 
 generate_random_string <- function(length) {
@@ -2457,9 +2457,8 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
     } else {
       # direct import case (for refresh data frame case)
 
-      # bigquery::set_access_cred is deprecated, however, switching to bigquery::bq_auth forces the oauth token refresh
-      # inside of it. We don't want this since Exploratory Desktop always sends a valid oauth token and use it without refreshing it.
-      # so for now, stick to bigrquery::set_access_cred
+      # bq_auth() is now safe: bigrquery is forked at exploratory-io/bigrquery (>=1.6.1.1) with bq_token() patched
+      # to send the access token as a static Bearer header, bypassing httr's auto-refresh path. (#35107)
       if(Sys.info()["sysname"] == "Linux" && !is.null(service_account_file) && Sys.getenv("GOOGLE_BIGQUERY_SERVICE_ACCOUNT_FILE") != ""){
          service_account_file <- Sys.getenv("GOOGLE_BIGQUERY_SERVICE_ACCOUNT_FILE")
       }
@@ -2467,7 +2466,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
         bigrquery::bq_auth(path = service_account_file)
       } else {
         token <- getGoogleTokenForBigQuery(tokenFileId)
-        bigrquery::set_access_cred(token)
+        bigrquery::bq_auth(token = token)
       }
       # check if the query contains special key word for standardSQL
       # If we do not pass the useLegaySql argument, bigrquery set TRUE for it, so we need to expliclity set it to make standard SQL work.
@@ -2481,7 +2480,7 @@ executeGoogleBigQuery <- function(project, query, destinationTable, pageSize = 1
       query <- glue_exploratory(query, .transformer=bigquery_glue_transformer, .envir = parent.frame())
       tb <- bigrquery::bq_project_query(x = project, query = query, quiet = TRUE, use_legacy_sql = !isStandardSQL)
       # Since Exploratory Desktop does not handle int64, convert int64 to numeric by passing bigint = "numeric" ref: https://bigrquery.r-dbi.org/reference/bq_table_download.html
-      df <- bigrquery::bq_table_download(x = tb, max_results = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
+      df <- bigrquery::bq_table_download(x = tb, n_max = Inf, page_size = pageSize, bigint = "numeric", max_connections = max_connections, quiet = TRUE)
     }
     df
   }, finally = {
@@ -2518,7 +2517,7 @@ getGoogleBigQueryProjects <- function(tokenFileId="", service = "bigquery", serv
       } else if (service == "bigquery") {
         token <- getGoogleTokenForBigQuery(tokenFileId);
       }
-      bigrquery::set_access_cred(token)
+      bigrquery::bq_auth(token = token)
     }
     bigrquery::bq_projects(page_size = 100, max_pages = Inf, warn = TRUE)
   }
@@ -2550,7 +2549,7 @@ getGoogleBigQueryDataSets <- function(project, tokenFileId="", service_account_f
       bigrquery::bq_auth(path = service_account_file)
     } else {
       token <- getGoogleTokenForBigQuery(tokenFileId);
-      bigrquery::set_access_cred(token)
+      bigrquery::bq_auth(token = token)
     }
     # make sure to pass max_pages as Inf to get all the datasets
     resultdatasets <- bigrquery::bq_project_datasets(project, page_size=1000, max_pages=Inf);
@@ -2584,7 +2583,7 @@ getGoogleBigQueryTables <- function(project, dataset, tokenFileId="", service_ac
       bigrquery::bq_auth(path = service_account_file)
     } else {
       token <- getGoogleTokenForBigQuery(tokenFileId);
-      bigrquery::set_access_cred(token)
+      bigrquery::bq_auth(token = token)
     }
     # if we do not pass max_results (via page_size argument), it only returnss 50 items. so explicitly set it.
     # See https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/list for max_results
@@ -2624,7 +2623,7 @@ getGoogleBigQueryTable <- function(project, dataset, table, tokenFileId="", serv
       bigrquery::bq_auth(path = service_account_file)
     } else {
       token <- getGoogleTokenForBigQuery(tokenFileId);
-      bigrquery::set_access_cred(token)
+      bigrquery::bq_auth(token = token)
     }
     table <- bigrquery::bq_table(project = project, dataset = dataset, table = table)
     bigrquery::bq_table_meta(table);
@@ -2650,9 +2649,9 @@ deleteGoogleBigQueryTable <- function(project, dataset, table, tokenFileId="", s
     bigrquery::bq_auth(path = service_account_file)
   } else {
     token <- getGoogleTokenForBigQuery(tokenFileId);
-    bigrquery::set_access_cred(token)
+    bigrquery::bq_auth(token = token)
   }
-  bigrquery::delete_table(project, dataset, table);
+  bigrquery::bq_table_delete(bigrquery::bq_table(project, dataset, table));
 }
 
 #' Parses all the 'scrapable' html tables from the web page.


### PR DESCRIPTION
## Summary

Desktop upgrades the bundled bigrquery from 1.4.2 to a forked 1.6.1.1 — bigrquery 1.4.2 binary on server against R 4.4 libR and fails to load on a fresh R 4.5 install.

bigrquery 1.6.1 removes/renames several APIs this file used. Migrations:

| 1.4.2 call | 1.6.1 replacement | Count |
|------------|------------------|------:|
| `set_access_cred(token)` | `bq_auth(token = token)` | 9 |
| `bq_table_download(max_results = …)` | `bq_table_download(n_max = …)` | 2 |
| `delete_table(project, dataset, table)` | `bq_table_delete(bq_table(…))` | 1 |
| `copy_table(src_list, dest_list)` | `bq_table_copy(bq_table, bq_table)` | 1 |

Also removes the stale "stick to set_access_cred to avoid auto-refresh" comment block — the Exploratory-io fork ([exploratory-io/bigrquery](https://github.com/exploratory-io/bigrquery/tree/1.6.1) tag [v1.6.1.1](https://github.com/exploratory-io/bigrquery/releases/tag/v1.6.1.1)) patches `bq_token()` to send the access token as a static `Authorization: Bearer …` header, which bypasses httr's auto-refresh entirely. So `bq_auth(token = …)` is now safe to use.

## Test plan

- [ ] Import data from public BigQuery dataset via Exploratory Desktop (Mac ARM, Mac Intel, Windows)
- [ ] Run a custom BigQuery SQL job → save as table (`saveGoogleBigQueryResultAs` exercises `bq_table_copy`)
- [ ] Delete a BigQuery table from UI (`deleteGoogleBigQueryTable` exercises `bq_table_delete`)
- [ ] Extract BigQuery table to Cloud Storage (`extractDataFromGoogleBigQueryToCloudStorage` exercises `bq_perform_extract`)
- [ ] List datasets, tables, projects via UI
- [ ] Confirm token refresh stays Exploratory-managed: leave the app idle past token expiry, then run a query — expect server-side refresh, not bigrquery-initiated refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)