### PR TITLE
Random Forest: Add mtry/max.depth params, bump ntree default

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^data-raw$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 man
 # Exclude intermediate testcases for the development purpose.
 tests/testthat/test-dev*.R
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.3
+Version: 15.0.4
 Date: 2026-04-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2125,8 +2125,10 @@ calc_feature_imp <- function(df,
                              predictor_funs = NULL,
                              max_nrow = 50000, # Down from 200000 when we added partial dependence
                              max_sample_size = NULL, # Half of max_nrow. down from 100000 when we added partial dependence
-                             ntree = 20,
+                             ntree = 200,
                              nodesize = 12,
+                             mtry = NULL, # ranger default: floor(sqrt(p)) for classification, floor(p/3) for regression.
+                             max.depth = NULL, # ranger default: NULL (no limit).
                              target_n = 20,
                              predictor_n = 12, # So that at least months can fit in it.
                              smote = FALSE,
@@ -2357,6 +2359,8 @@ calc_feature_imp <- function(df,
         importance = ranger_importance_measure,
         num.trees = ntree,
         min.node.size = nodesize,
+        mtry = mtry,
+        max.depth = max.depth,
         keep.inbag=TRUE,
         sample.fraction = sample.fraction,
         probability = (classification_type %in% c("multi", "binary"))
@@ -2407,6 +2411,8 @@ calc_feature_imp <- function(df,
           # Following parameters are to be relayed to ranger::ranger through Boruta::Boruta, then Boruta::getImpRfZ.
           num.trees = ntree,
           min.node.size = nodesize,
+          mtry = mtry,
+          max.depth = max.depth,
           sample.fraction = sample.fraction,
           probability = (classification_type == "binary") # build probability tree for AUC only for binary classification.
         )

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2169,6 +2169,12 @@ calc_feature_imp <- function(df,
   # this evaluates select arguments like starts_with
   orig_selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
 
+  # Validate mtry up front. ranger reports this through stderr and aborts
+  # in a way that surfaces as "User interrupt or internal error." in the UI.
+  if (!is.null(mtry) && mtry > length(orig_selected_cols)) {
+    stop(paste0("mtry (", mtry, ") cannot be larger than the number of predictor variables (", length(orig_selected_cols), ")."))
+  }
+
   target_funs <- NULL
   if (!is.null(target_fun)) {
     target_funs <- list(target_fun)

--- a/tests/testthat/test_randomForest_tidiers_1.R
+++ b/tests/testthat/test_randomForest_tidiers_1.R
@@ -602,6 +602,21 @@ test_that("calc_feature_imp defaults leave mtry/max.depth as ranger auto-default
   expect_equal(result$model[[1]]$max.depth, 0)
 })
 
+test_that("calc_feature_imp errors clearly when mtry exceeds the number of predictors", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(50),
+    x1 = rnorm(50),
+    x2 = rnorm(50),
+    x3 = rnorm(50)
+  )
+
+  expect_error(
+    test_data %>% calc_feature_imp(y, x1, x2, x3, ntree = 5, mtry = 10, smote = FALSE),
+    "mtry \\(10\\) cannot be larger than the number of predictor variables \\(3\\)\\."
+  )
+})
+
 test_that("calc_feature_imp forwards mtry/max.depth through Boruta path", {
   set.seed(1)
   test_data <- data.frame(

--- a/tests/testthat/test_randomForest_tidiers_1.R
+++ b/tests/testthat/test_randomForest_tidiers_1.R
@@ -535,3 +535,93 @@ test_that("calc_feature_imp handles all rows removed due to Inf values", {
     "All rows were removed due to Inf values"
   )
 })
+
+test_that("calc_feature_imp forwards mtry to ranger", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(200),
+    x1 = rnorm(200),
+    x2 = rnorm(200),
+    x3 = rnorm(200),
+    x4 = rnorm(200),
+    x5 = rnorm(200)
+  )
+
+  result <- test_data %>% calc_feature_imp(y, x1, x2, x3, x4, x5, ntree = 10, mtry = 2, smote = FALSE)
+  expect_false("error" %in% class(result$model[[1]]))
+  expect_equal(result$model[[1]]$mtry, 2)
+})
+
+test_that("calc_feature_imp forwards max.depth to ranger", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(200),
+    x1 = rnorm(200),
+    x2 = rnorm(200),
+    x3 = rnorm(200)
+  )
+
+  result <- test_data %>% calc_feature_imp(y, x1, x2, x3, ntree = 10, max.depth = 3, smote = FALSE)
+  expect_false("error" %in% class(result$model[[1]]))
+  expect_equal(result$model[[1]]$max.depth, 3)
+})
+
+test_that("calc_feature_imp forwards mtry and max.depth together", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(200),
+    x1 = rnorm(200),
+    x2 = rnorm(200),
+    x3 = rnorm(200),
+    x4 = rnorm(200),
+    x5 = rnorm(200)
+  )
+
+  result <- test_data %>% calc_feature_imp(y, x1, x2, x3, x4, x5, ntree = 10, mtry = 3, max.depth = 5, smote = FALSE)
+  expect_false("error" %in% class(result$model[[1]]))
+  expect_equal(result$model[[1]]$mtry, 3)
+  expect_equal(result$model[[1]]$max.depth, 5)
+})
+
+test_that("calc_feature_imp defaults leave mtry/max.depth as ranger auto-default", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(200),
+    x1 = rnorm(200),
+    x2 = rnorm(200),
+    x3 = rnorm(200),
+    x4 = rnorm(200),
+    x5 = rnorm(200)
+  )
+
+  # No mtry / max.depth specified: ranger picks its own default for mtry,
+  # and max.depth = 0 (no limit).
+  result <- test_data %>% calc_feature_imp(y, x1, x2, x3, x4, x5, ntree = 10, smote = FALSE)
+  expect_false("error" %in% class(result$model[[1]]))
+  expect_true(result$model[[1]]$mtry >= 1 && result$model[[1]]$mtry <= 5)
+  expect_equal(result$model[[1]]$max.depth, 0)
+})
+
+test_that("calc_feature_imp forwards mtry/max.depth through Boruta path", {
+  set.seed(1)
+  test_data <- data.frame(
+    y  = rnorm(200),
+    x1 = rnorm(200),
+    x2 = rnorm(200),
+    x3 = rnorm(200),
+    x4 = rnorm(200),
+    x5 = rnorm(200)
+  )
+
+  result <- test_data %>% calc_feature_imp(
+    y, x1, x2, x3, x4, x5,
+    ntree = 10, mtry = 2, max.depth = 4,
+    smote = FALSE,
+    with_boruta = TRUE, boruta_max_runs = 11
+  )
+  expect_false("error" %in% class(result$model[[1]]))
+  expect_equal(result$model[[1]]$mtry, 2)
+  expect_equal(result$model[[1]]$max.depth, 4)
+  # Boruta-built ranger should also have received the params.
+  expect_true(!is.null(result$model[[1]]$boruta))
+})


### PR DESCRIPTION
## Summary
- Expose `mtry` and `max.depth` as `calc_feature_imp` formal arguments and forward them to both the direct `ranger::ranger()` calls and the Boruta path, so the tuning knobs actually take effect.
- Bump default `ntree` from 20 to 200, closer to ranger's own default (500) and matching the new Analytics View default in tam (issue #28711).
- Validate `mtry > num_predictors` up front, since ranger aborts via stderr in a way that surfaces as a generic "User interrupt or internal error." in the UI.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory