### PR TITLE
Fix Google Sheets export limits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.4
-Date: 2026-04-28
+Version: 15.0.5
+Date: 2026-05-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -118,11 +118,13 @@ uploadDataToGoogleSheets <- function(df, type = "newSpreadSheet", spreadSheetNam
   if (type == "newSpreadSheet") {
     sheetsList <- list(df)
     names(sheetsList) <- c(workSheet)
-    googlesheets4::gs4_create(spreadSheetName, sheets = sheetsList)
+    return(googlesheets4::gs4_create(spreadSheetName, sheets = sheetsList))
   } else if (type %in% c("overrideSpreadSheet", "newWorkSheet")) {
     googlesheets4::sheet_write(df, spreadSheetName, sheet = workSheet)
+    return(spreadSheetName)
   } else if (type == "appendToWorkSheet") {
     googlesheets4::sheet_append(spreadSheetName, df, sheet = workSheet)
+    return(spreadSheetName)
   } else {
     stop("Invalid 'type' parameter provided.")
   }
@@ -134,13 +136,14 @@ normalizeDataForGoogleSheetsExport <- function (df) {
   requireNamespace("dplyr")
   requireNamespace("lubridate")
   requireNamespace("bit64")
-  df <- df %>%
-   mutate(
-     across(where(is.numeric), ~ifelse(is.infinite(.), as.numeric(NA), .)),
-     across(where(lubridate::is.difftime), ~ as.numeric(.)),
-     across(where(lubridate::is.period), ~ as.numeric(.)),
-     across(where(bit64::is.integer64), ~ as.numeric(.))
-   )
+  df <- dplyr::mutate(
+    df,
+    dplyr::across(dplyr::where(is.numeric), ~ifelse(is.infinite(.), as.numeric(NA), .)),
+    dplyr::across(dplyr::where(lubridate::is.difftime), ~ as.numeric(.)),
+    dplyr::across(dplyr::where(lubridate::is.period), ~ as.numeric(.)),
+    dplyr::across(dplyr::where(bit64::is.integer64), ~ as.numeric(.)),
+    dplyr::across(dplyr::where(is.character), ~ substr(.x, 1, 50000))
+  )
   df
 }
 

--- a/tests/testthat/test_google_sheets.R
+++ b/tests/testthat/test_google_sheets.R
@@ -34,3 +34,12 @@ test_that("normalizeDataForGoogleSheetsExport with local data", {
   # integer64 should become numeric
   expect_equal(class(result$int64_col), "numeric")
 })
+
+test_that("normalizeDataForGoogleSheetsExport truncates cells to Google Sheets limit", {
+  long_text <- paste(rep("x", 50001), collapse = "")
+  df <- data.frame(text_col = long_text, stringsAsFactors = FALSE)
+
+  result <- exploratory::normalizeDataForGoogleSheetsExport(df)
+
+  expect_equal(nchar(result$text_col), 50000)
+})


### PR DESCRIPTION
## Summary
- Return a stable value from `uploadDataToGoogleSheets()` after update/append operations instead of relying on `googlesheets4` return values.
- Cap character cells to 50,000 characters in `normalizeDataForGoogleSheetsExport()` to satisfy the Google Sheets single-cell limit.
- Add regression coverage for the 50,000-character truncation behavior.

## Root Cause
The desktop export path calls `exploratory::uploadDataToGoogleSheets(exploratory::normalizeDataForGoogleSheetsExport(...), type = "appendToWorkSheet", ...)`.

Two package-level behaviors caused the observed failures:
- `sheet_append()` can return `NULL`, so callers saw `R> null` and did not receive a spreadsheet id.
- Google Sheets rejects cells longer than 50,000 characters, and normalization did not cap character data before upload.

## Verification
- `Rscript -e 'parse(file="R/google_sheets.R"); parse(file="tests/testthat/test_google_sheets.R")'`
- `git diff --check`

## Test Notes
- A focused runtime smoke check for `normalizeDataForGoogleSheetsExport()` is blocked in this local system R because `dplyr` and `lubridate` are not installed.
- Standalone `testthat::test_file("tests/testthat/test_google_sheets.R")` is not representative here because the package is not installed in this local R context; it reports `{exploratory}`/`lubridate` skips and a pre-existing `read_rds_file` context error.


