### PR TITLE
Improve Google Sheets export robustness

### DIFF
--- a/R/google_sheets.R
+++ b/R/google_sheets.R
@@ -133,16 +133,25 @@ uploadDataToGoogleSheets <- function(df, type = "newSpreadSheet", spreadSheetNam
 #' @param df - data frame
 #
 normalizeDataForGoogleSheetsExport <- function (df) {
-  requireNamespace("dplyr")
-  requireNamespace("lubridate")
-  requireNamespace("bit64")
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("The 'dplyr' package must be installed.")
+  }
+  if (!requireNamespace("lubridate", quietly = TRUE)) {
+    stop("The 'lubridate' package must be installed.")
+  }
+  if (!requireNamespace("bit64", quietly = TRUE)) {
+    stop("The 'bit64' package must be installed.")
+  }
+
+  GOOGLE_SHEETS_CELL_CHAR_LIMIT <- 50000
+
   df <- dplyr::mutate(
     df,
     dplyr::across(dplyr::where(is.numeric), ~ifelse(is.infinite(.), as.numeric(NA), .)),
     dplyr::across(dplyr::where(lubridate::is.difftime), ~ as.numeric(.)),
     dplyr::across(dplyr::where(lubridate::is.period), ~ as.numeric(.)),
     dplyr::across(dplyr::where(bit64::is.integer64), ~ as.numeric(.)),
-    dplyr::across(dplyr::where(is.character), ~ substr(.x, 1, 50000))
+    dplyr::across(dplyr::where(is.character), ~ substr(.x, 1, GOOGLE_SHEETS_CELL_CHAR_LIMIT))
   )
   df
 }

--- a/tests/testthat/test_google_sheets.R
+++ b/tests/testthat/test_google_sheets.R
@@ -36,7 +36,7 @@ test_that("normalizeDataForGoogleSheetsExport with local data", {
 })
 
 test_that("normalizeDataForGoogleSheetsExport truncates cells to Google Sheets limit", {
-  long_text <- paste(rep("x", 50001), collapse = "")
+  long_text <- strrep("x", 50001)
   df <- data.frame(text_col = long_text, stringsAsFactors = FALSE)
 
   result <- exploratory::normalizeDataForGoogleSheetsExport(df)


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PR #1500 to improve code robustness and maintainability:

- ✅ Add proper dependency checks for `dplyr`, `lubridate`, and `bit64` packages with clear error messages
- ✅ Define `GOOGLE_SHEETS_CELL_CHAR_LIMIT` constant instead of hard-coded values  
- ✅ Use `strrep()` instead of `paste(rep())` for more efficient string generation in tests

## Changes
- **R/google_sheets.R**: Add dependency checks with error handling and use named constant for character limit
- **tests/testthat/test_google_sheets.R**: Use more efficient `strrep()` function in test

Related to #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)