### PR TITLE
Fix ANCOVA covariate issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.5
-Date: 2026-05-08
+Version: 15.1.1
+Date: 2026-05-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -1775,8 +1775,11 @@ exp_anova <- function(df, var1, var2, covariates = NULL, func2 = NULL, covariate
         if (!with_interaction) {
           formula <- as.formula(paste0('`', var1_col, '`~`', var2_col, '`+`', paste(covariates, collapse="`+`"), '`'))
         }
-        else { # Calculating interaction only with the first covariate for simplicity for now.
-          formula <- as.formula(paste0('`', var1_col, '`~`', var2_col, '`*`', covariates[1], '`'))
+        else {
+          # Include all covariates and their interactions with the explanatory variable.
+          # `group * (cov1 + cov2)` expands to `group + cov1 + cov2 + group:cov1 + group:cov2`.
+          formula <- as.formula(paste0('`', var1_col, '`~`', var2_col, '`*(`',
+                                       paste(covariates, collapse = "`+`"), '`)'))
         }
       }
 
@@ -2258,8 +2261,17 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
       }
       # Map the variable names in the term column back to the original.
       terms_mapping <- x$terms_mapping
-      # Add mapping for interaction term
-      terms_mapping <- c(terms_mapping,c(`c2_:c3_`=paste0(terms_mapping["c2_"], " * ", terms_mapping["c3_"])))
+      # Add mapping for interaction term(s). For ANCOVA with multiple covariates and
+      # with_interaction=TRUE, add a mapping for every covariate interaction (c2_:c3_,
+      # c2_:c4_, ...). For 2-way ANOVA the loop runs once and produces c2_:c3_.
+      {
+        n_covariates <- if (!is.null(x$covariates)) length(x$covariates) else 1L
+        for (i in seq_len(n_covariates)) {
+          cov_key <- paste0("c", i + 2L, "_")
+          int_key <- paste0("c2_:", cov_key)
+          terms_mapping[int_key] <- paste0(terms_mapping["c2_"], " * ", terms_mapping[cov_key])
+        }
+      }
       orig_term <- terms_mapping[ret$term]
       orig_term[is.na(orig_term)] <- ret$term[is.na(orig_term)] # Fill the element that did not have a matching mapping. (Should be "Residual")
       ret$term <- orig_term
@@ -2426,7 +2438,12 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
       if (!x$with_interaction) {
         formula <- as.formula(paste0('~`', x$var2, '`|`', paste(x$covariates, collapse='`+`'), '`'))
       } else {
-        formula <- as.formula(paste0('~`', x$var2, '`|`', x$covariates[1], '`+', x$var2, ':', x$covariates[1]))
+        # Include every covariate main effect and every group:covariate interaction in the by-clause,
+        # mirroring the single-covariate pattern. All terms are backtick-quoted so non-ASCII
+        # column names (e.g. `bu syo`, `kinzoku nen`) parse correctly.
+        cov_main <- paste0('`', paste(x$covariates, collapse = '`+`'), '`')
+        cov_interactions <- paste(paste0('`', x$var2, '`:`', x$covariates, '`'), collapse = '+')
+        formula <- as.formula(paste0('~`', x$var2, '`|', cov_main, '+', cov_interactions))
       }
     } else { # 2-way ANOVA case. The separator (*, :, or +) should not matter.
       formula <- as.formula(paste0('~`', paste(x$var2, collapse='`*`'), '`'))
@@ -2499,7 +2516,12 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
       if (!x$with_interaction) {
         formula <- as.formula(paste0('~`', x$var2, '`|`', paste(x$covariates, collapse='`+`'), '`'))
       } else {
-        formula <- as.formula(paste0('~`', x$var2, '`|`', x$covariates[1], '`+', x$var2, ':', x$covariates[1]))
+        # Include every covariate main effect and every group:covariate interaction in the by-clause,
+        # mirroring the single-covariate pattern. All terms are backtick-quoted so non-ASCII
+        # column names (e.g. `bu syo`, `kinzoku nen`) parse correctly.
+        cov_main <- paste0('`', paste(x$covariates, collapse = '`+`'), '`')
+        cov_interactions <- paste(paste0('`', x$var2, '`:`', x$covariates, '`'), collapse = '+')
+        formula <- as.formula(paste0('~`', x$var2, '`|', cov_main, '+', cov_interactions))
       }
     } else { # 1-way/2-way ANOVA case. The separator (*, :, or +) should not matter.
       formula <- as.formula(paste0('~`', paste(x$var2, collapse='`*`'), '`'))

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -723,6 +723,24 @@ test_that("test ANCOVA with exp_anova", {
   expect_true("a m * q sec" %in% ret_model$Variable)
 })
 
+test_that("ANCOVA with multi-covariates and with_interaction=FALSE includes all covariates", {
+  mtcars2 <- mtcars %>% mutate(`a m` = factor(am), `w t` = wt, `q sec` = qsec)
+  model_df <- mtcars2 %>% exp_anova(mpg, `a m`,
+                                    covariates = c("w t", "q sec"),
+                                    covariate_funs = list("w t" = "none", "q sec" = "none"),
+                                    with_interaction = FALSE)
+  ret_model <- model_df %>% tidy_rowwise(model, type = "model")
+  expect_true("w t" %in% ret_model$Variable)
+  expect_true("q sec" %in% ret_model$Variable)
+  # No interaction terms should appear.
+  expect_false(any(grepl("\\*", ret_model$Variable)))
+
+  ret_emmeans <- model_df %>% tidy_rowwise(model, type = "emmeans", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_emmeans))
+  ret_pairs <- model_df %>% tidy_rowwise(model, type = "pairs", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_pairs))
+})
+
 test_that("ANCOVA with single covariate is unchanged after multi-covariate fix (#35347)", {
   mtcars2 <- mtcars %>% mutate(`a m` = factor(am), `w t` = wt)
   model_df <- mtcars2 %>% exp_anova(mpg, `a m`,

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -684,9 +684,10 @@ test_that("test ANCOVA with exp_anova", {
   ret <- model_df %>% tidy_rowwise(model, type="levene", levene_test_center="mean")
   ret <- model_df %>% tidy_rowwise(model, type="emmeans", pairs_adjust="tukey")
 
+  # With 2 covariates + with_interaction=TRUE, both covariate columns appear in emmeans output.
   expect_equal(colnames(ret),
-    c("a m", "w t", "Rows", "Mean", "Std Deviation", "Std Error", 
-    "Conf Low", "Conf High", "Mean (Adj)", "Std Error (Adj)", 
+    c("a m", "w t", "q sec", "Rows", "Mean", "Std Deviation", "Std Error",
+    "Conf Low", "Conf High", "Mean (Adj)", "Std Error (Adj)",
     "Conf Low (Adj)", "Conf High (Adj)", "DF", "Minimum", "Maximum"))
 
   ret <- model_df %>% tidy_rowwise(model, type="pairs", pairs_adjust="tukey")
@@ -711,6 +712,53 @@ test_that("test ANCOVA with exp_anova", {
   ret <- broom::tidy(shapiro.test(x$residuals))
   expect_equal(colnames(ret),
                c("statistic", "p.value", "method"))
+
+  # Issue #35347 regression: with_interaction=TRUE + multiple covariates must include
+  # every covariate's main effect AND every group:covariate interaction in the output.
+  # type="model" returns renamed Variable column; ss3$term uses internal encoded names.
+  ret_model <- model_df %>% tidy_rowwise(model, type = "model")
+  expect_true("w t" %in% ret_model$Variable)
+  expect_true("q sec" %in% ret_model$Variable)
+  expect_true("a m * w t" %in% ret_model$Variable)
+  expect_true("a m * q sec" %in% ret_model$Variable)
+})
+
+test_that("ANCOVA with single covariate is unchanged after multi-covariate fix (#35347)", {
+  mtcars2 <- mtcars %>% mutate(`a m` = factor(am), `w t` = wt)
+  model_df <- mtcars2 %>% exp_anova(mpg, `a m`,
+                                    covariates = c("w t"),
+                                    covariate_funs = list("w t" = "none"),
+                                    with_interaction = TRUE)
+  ret_model <- model_df %>% tidy_rowwise(model, type = "model")
+  expect_true("w t" %in% ret_model$Variable)
+  expect_true("a m * w t" %in% ret_model$Variable)
+  # The 2-covariate-only rows must NOT appear.
+  expect_false("q sec" %in% ret_model$Variable)
+})
+
+test_that("ANCOVA handles multi-covariate interaction with complex column names (#35347)", {
+  # Multibyte + space; keep simple to avoid touching unrelated bugs in factor coercion.
+  df <- mtcars %>% mutate(`分 類` = factor(am),
+                          `航空 会社 表` = wt,
+                          `到着 遅れ表` = qsec)
+  model_df <- df %>% exp_anova(mpg, `分 類`,
+                               covariates = c("航空 会社 表", "到着 遅れ表"),
+                               covariate_funs = list("航空 会社 表" = "none",
+                                                     "到着 遅れ表" = "none"),
+                               with_interaction = TRUE)
+  ret_model <- model_df %>% tidy_rowwise(model, type = "model")
+  expect_true("航空 会社 表" %in% ret_model$Variable)
+  expect_true("到着 遅れ表" %in% ret_model$Variable)
+  expect_true(any(grepl("航空 会社 表", ret_model$Variable) & grepl("分 類", ret_model$Variable)))
+  expect_true(any(grepl("到着 遅れ表", ret_model$Variable) & grepl("分 類", ret_model$Variable)))
+
+  # Downstream paths must still succeed end-to-end.
+  ret_emmeans <- model_df %>% tidy_rowwise(model, type = "emmeans", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_emmeans))
+  ret_pairs <- model_df %>% tidy_rowwise(model, type = "pairs", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_pairs))
+  ret_anova <- model_df %>% tidy_rowwise(model, type = "anova")
+  expect_true(is.data.frame(ret_anova))
 })
 
 test_that("test ANCOVA with exp_anova with NA and others in the variable.", {


### PR DESCRIPTION
This pull request updates the handling of ANCOVA models with multiple covariates and group-covariate interactions in the `exp_anova` function and its associated tidy methods. The changes ensure that all covariate main effects and their interactions with the grouping variable are correctly included in model formulas, output mappings, and downstream summary tables. Several new and enhanced tests verify this behavior, including support for non-ASCII and complex column names.

**ANCOVA multi-covariate interaction improvements:**

* The formula construction in `exp_anova` now includes all covariates and their interactions with the group variable when `with_interaction=TRUE`, instead of just the first covariate. (`R/test_wrapper.R`)
* The mapping from internal term names to original variable names in `tidy.anova_exploratory` is expanded to handle every covariate interaction, ensuring correct labeling in outputs. (`R/test_wrapper.R`)
* The emmeans and pairs summary formulae now include all covariate main effects and all group:covariate interactions, with robust handling for non-ASCII and complex column names. (`R/test_wrapper.R`) [[1]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL2429-R2446) [[2]](diffhunk://#diff-6ed650adf6bb859940c95c8f5e2ce5d7410fdb313eba1b745084e59f50ee92acL2502-R2524)


# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory
