### PR TITLE
Fix ANCOVA issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.1
+Version: 15.1.2
 Date: 2026-05-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2448,8 +2448,10 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
     } else { # 2-way ANOVA case. The separator (*, :, or +) should not matter.
       formula <- as.formula(paste0('~`', paste(x$var2, collapse='`*`'), '`'))
     }
-    # For 1-way ANOVA (oneway.test -> htest), emmeans cannot dispatch recover_data.htest,
-    # so use the stored lm model instead, mirroring get_pairwise_contrast_df.
+    # x$lm.model is set only for 1-way ANOVA (oneway.test() stores its result as htest,
+    # which emmeans cannot dispatch recover_data for). For 2-way ANOVA and ANCOVA, the
+    # model itself is an lm object and x$lm.model is NULL. So this check reliably
+    # identifies the 1-way ANOVA case without affecting other branches.
     if (!is.null(x$lm.model)) {
       if (isTRUE(x$var.equal)) {
         ret <- emmeans::emmeans(x$lm.model, formula)

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -2448,8 +2448,18 @@ tidy.anova_exploratory <- function(x, type="model", conf_level=0.95, pairs_adjus
     } else { # 2-way ANOVA case. The separator (*, :, or +) should not matter.
       formula <- as.formula(paste0('~`', paste(x$var2, collapse='`*`'), '`'))
     }
-    # emmeans seems to work even with afex_aov objects, as well as car::Anova objects or aov objects.
-    ret <- emmeans::emmeans(x, formula)
+    # For 1-way ANOVA (oneway.test -> htest), emmeans cannot dispatch recover_data.htest,
+    # so use the stored lm model instead, mirroring get_pairwise_contrast_df.
+    if (!is.null(x$lm.model)) {
+      if (isTRUE(x$var.equal)) {
+        ret <- emmeans::emmeans(x$lm.model, formula)
+      } else {
+        ret <- emmeans::emmeans(x$lm.model, formula, vcov = sandwich::vcovHC)
+      }
+    } else {
+      # emmeans works for afex_aov (2-way ANOVA) and lm (ANCOVA).
+      ret <- emmeans::emmeans(x, formula)
+    }
     ret <- tibble::as.tibble(ret)
     if (!is.null(x$covariates)) { # ANCOVA case
       conf_threshold = 1 - (1 - conf_level)/2

--- a/tests/testthat/test_test_wrapper_1.R
+++ b/tests/testthat/test_test_wrapper_1.R
@@ -1072,3 +1072,14 @@ test_that("wilcox_norm_dist_sd returns positive numeric", {
   expect_true(is.numeric(sd_paired))
   expect_true(sd_paired > 0)
 })
+
+test_that("1-way ANOVA with complex column names works for type='emmeans' and type='pairs'", {
+  # Regression test: oneway.test() returns htest class; emmeans cannot handle htest directly.
+  # The fix uses x$lm.model instead of x (the anova_exploratory/htest object).
+  df <- mtcars %>% dplyr::mutate(`航空 会社 !` = factor(am), `出発 遅れ |` = mpg)
+  model_df <- df %>% exp_anova(`出発 遅れ |`, `航空 会社 !`)
+  ret_emmeans <- model_df %>% tidy_rowwise(model, type = "emmeans", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_emmeans))
+  ret_pairs <- model_df %>% tidy_rowwise(model, type = "pairs", pairs_adjust = "tukey")
+  expect_true(is.data.frame(ret_pairs))
+})


### PR DESCRIPTION
# Description

## Bug

Calling `type="emmeans"` on a 1-way ANOVA model (no covariates) raised the error: \"Can't handle an object of class 'anova_exploratory'\".

## Root cause

`oneway.test()` returns an `htest` object. Since emmeans has no `recover_data` method for `htest`, it fell back to `recover_data.default` and failed.

The `type=\"pairs\"` code path already handled this correctly by using `x$lm.model` (a stored `lm` object) instead of passing the `htest` object directly to emmeans. The same branching logic was missing from `type=\"emmeans\"`.

## Fix

Added the same `x$lm.model` branching to `type=\"emmeans\"`, mirroring the existing `type=\"pairs\"` logic.

The bug occurs with any column names whenever there are no covariates (1-way ANOVA). Column name complexity is unrelated.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory