### PR TITLE
feat: add skip_nul argument to read_parquet_file chain

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3894,14 +3894,14 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
 
 #'API that imports multiple same structure parquet files and merge it to a single data frame
 #'@export
-read_parquet_files <- function(files, forPreview = FALSE, col_select = NULL) {
+read_parquet_files <- function(files, forPreview = FALSE, col_select = NULL, skip_nul = FALSE) {
   # for preview mode, just use the first file.
   if (forPreview & length(files) > 0) {
     files <- files[1]
   }
   # set name to the files so that it can be used for the "id" column created by purrr:map_dfr.
   files <- setNames(as.list(files), files)
-  df <- purrr::map_dfr(files, exploratory::read_parquet_file, col_select = col_select, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
+  df <- purrr::map_dfr(files, read_parquet_file, col_select = col_select, skip_nul = skip_nul, .id = "exp.file.id") %>% mutate(exp.file.id = basename(exp.file.id))  # extract file name from full path with basename and create file.id column.
   id_col <- avoid_conflict(colnames(df), "id")
   # copy internal exp.file.id to the id column.
   df[[id_col]] <- df[["exp.file.id"]]
@@ -3912,7 +3912,7 @@ read_parquet_files <- function(files, forPreview = FALSE, col_select = NULL) {
 
 #' Wrapper for read_parquet to support remote file.
 #' @export
-read_parquet_file <- function(file, col_select = NULL) {
+read_parquet_file <- function(file, col_select = NULL, skip_nul = FALSE) {
   loadNamespace("arrow")
   tf <- NULL
   res <- NULL
@@ -3933,9 +3933,9 @@ read_parquet_file <- function(file, col_select = NULL) {
     # Read the local parquet file.
     tryCatch({
       if (is.null(col_select)) {
-        res <- read_parquet_file_internal(tf)
+        res <- read_parquet_file_internal(tf, skip_nul = skip_nul)
       } else {
-        res <- read_parquet_file_internal(tf, col_select = col_select)
+        res <- read_parquet_file_internal(tf, col_select = col_select, skip_nul = skip_nul)
       }
     }, error = function(e) {
       stop(paste0('EXP-DATASRC-13 :: ', jsonlite::toJSON(c(file, e$message)), ' :: Failed to import file.'))
@@ -3943,9 +3943,9 @@ read_parquet_file <- function(file, col_select = NULL) {
   } else {
     tryCatch({
       if (is.null(col_select)) {
-        res <- read_parquet_file_internal(file)
+        res <- read_parquet_file_internal(file, skip_nul = skip_nul)
       } else {
-        res <- read_parquet_file_internal(file, col_select = col_select)
+        res <- read_parquet_file_internal(file, col_select = col_select, skip_nul = skip_nul)
       }
     }, error = function(e) {
       # Error message for non-existent file case looks like this - "Error : IOError: Failed to open local file '<full filepath>'. Detail: [errno 2] No such file or directory"
@@ -3963,7 +3963,15 @@ read_parquet_file <- function(file, col_select = NULL) {
 # Wrapper around arrow::read_parquet to work around https://issues.apache.org/jira/browse/ARROW-13860 by applying group_by column stored in the parquet file
 # as one of the class names.
 # To avoid the resource lock issue, set mmap as FALSE by default.
-read_parquet_file_internal <- function(filepath, col_select = NULL, mmap = FALSE) {
+# When skip_nul is TRUE, arrow::read_parquet strips NUL bytes from string columns during R conversion
+# via the arrow.skip_nul global option. The prior value of the option is restored on exit so the
+# call does not leak state into the user's R session.
+read_parquet_file_internal <- function(filepath, col_select = NULL, mmap = FALSE, skip_nul = FALSE) {
+  prior_skip_nul <- getOption("arrow.skip_nul")
+  on.exit(options(arrow.skip_nul = prior_skip_nul), add = TRUE)
+  if (isTRUE(skip_nul) && !isTRUE(prior_skip_nul)) {
+    options(arrow.skip_nul = TRUE)
+  }
   res <- NULL
   if (is.null(col_select)) {
     res <- arrow::read_parquet(filepath, mmap = mmap)

--- a/R/system.R
+++ b/R/system.R
@@ -3866,7 +3866,7 @@ read_rds_file <- function(file, refhook = NULL){
 
 #'API that search and imports multiple same structure parquet files and merge it to a single data frame
 #'@export
-searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files, col_select = NULL){
+searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files, col_select = NULL, skip_nul = FALSE){
   # search condition is case insensitive. (ref: https://www.regular-expressions.info/modifiers.html, https://stackoverflow.com/questions/5671719/case-insensitive-search-of-a-list-in-r)
   if (!dir.exists(folder)) {
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
@@ -3889,7 +3889,7 @@ searchAndReadParquetFiles <- function(folder, forPreview = FALSE, pattern, files
   if (length(files) == 0) {
     stop(paste0('EXP-DATASRC-3 :: ', jsonlite::toJSON(folder), ' :: There is no file in the folder that matches with the specified condition.')) # TODO: escape folder name.
   }
-  read_parquet_files(as.character(files), forPreview = forPreview, col_select = col_select)
+  read_parquet_files(as.character(files), forPreview = forPreview, col_select = col_select, skip_nul = skip_nul)
 }
 
 #'API that imports multiple same structure parquet files and merge it to a single data frame

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -555,6 +555,92 @@ test_that("read_parquet_file should be to read the parquet file with an invalid 
   expect_equal(TRUE, is.data.frame(df))
 })
 
+# Issue #35740 — skip_nul argument lets the user opt into arrow.skip_nul = TRUE so the
+# Arrow -> R data.frame conversion strips NUL bytes from string columns instead of
+# throwing "embedded nul in string". The R-side contract is that getOption("arrow.skip_nul")
+# is restored to its prior value after the call, success or failure.
+
+test_that("read_parquet_file restores arrow.skip_nul option to NULL after successful skip_nul = TRUE call", {
+  loadNamespace("arrow")
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp))
+  arrow::write_parquet(tibble::tibble(x = c("a", "b", "c")), tmp)
+
+  # Establish a known starting state: option unset.
+  prior_holder <- options(arrow.skip_nul = NULL)
+  on.exit(options(prior_holder), add = TRUE)
+  expect_null(getOption("arrow.skip_nul"))
+
+  df <- exploratory::read_parquet_file(tmp, skip_nul = TRUE)
+  expect_true(is.data.frame(df))
+  # Restored.
+  expect_null(getOption("arrow.skip_nul"))
+})
+
+test_that("read_parquet_file preserves prior arrow.skip_nul = TRUE when call uses skip_nul = FALSE", {
+  loadNamespace("arrow")
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp))
+  arrow::write_parquet(tibble::tibble(x = c("a", "b", "c")), tmp)
+
+  prior_holder <- options(arrow.skip_nul = TRUE)
+  on.exit(options(prior_holder), add = TRUE)
+  expect_true(isTRUE(getOption("arrow.skip_nul")))
+
+  df <- exploratory::read_parquet_file(tmp, skip_nul = FALSE)
+  expect_true(is.data.frame(df))
+  # Prior TRUE preserved — call does NOT flip it to FALSE.
+  expect_true(isTRUE(getOption("arrow.skip_nul")))
+})
+
+test_that("read_parquet_file_internal default skip_nul is FALSE (back-compat for old callers)", {
+  loadNamespace("arrow")
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp))
+  arrow::write_parquet(tibble::tibble(x = c("a", "b", "c")), tmp)
+
+  prior_holder <- options(arrow.skip_nul = NULL)
+  on.exit(options(prior_holder), add = TRUE)
+
+  # Call internal directly with default args to verify the parameter default.
+  df <- exploratory:::read_parquet_file_internal(tmp)
+  expect_true(is.data.frame(df))
+  expect_null(getOption("arrow.skip_nul"))
+})
+
+test_that("read_parquet_files forwards skip_nul to read_parquet_file (option restored after multi-file call)", {
+  loadNamespace("arrow")
+  tmp1 <- tempfile(fileext = ".parquet")
+  tmp2 <- tempfile(fileext = ".parquet")
+  on.exit(unlink(c(tmp1, tmp2)))
+  arrow::write_parquet(tibble::tibble(x = c("a", "b")), tmp1)
+  arrow::write_parquet(tibble::tibble(x = c("c", "d")), tmp2)
+
+  prior_holder <- options(arrow.skip_nul = NULL)
+  on.exit(options(prior_holder), add = TRUE)
+
+  df <- exploratory::read_parquet_files(c(tmp1, tmp2), skip_nul = TRUE)
+  expect_true(is.data.frame(df))
+  expect_equal(nrow(df), 4L)
+  expect_null(getOption("arrow.skip_nul"))
+})
+
+test_that("read_parquet_file_internal restores arrow.skip_nul on error path", {
+  # Hand a non-existent file to arrow::read_parquet so it throws. The on.exit() restore
+  # must still fire — otherwise a failed import would leak arrow.skip_nul = TRUE into
+  # the user's R session.
+  loadNamespace("arrow")
+  prior_holder <- options(arrow.skip_nul = NULL)
+  on.exit(options(prior_holder), add = TRUE)
+  expect_null(getOption("arrow.skip_nul"))
+
+  expect_error(
+    exploratory:::read_parquet_file_internal("/tmp/__nonexistent_parquet_35740__.parquet", skip_nul = TRUE)
+  )
+  # Option must be restored even though the call errored.
+  expect_null(getOption("arrow.skip_nul"))
+})
+
 test_that("test filter_cascade",{
   library(stringr)
   df <- readRDS(url("https://www.dropbox.com/s/p2vmd79ly1zugh9/airbnb_nyc_filter_7.rds?dl=1"))


### PR DESCRIPTION
## Description

For [exploratory-io/tam#35740](https://github.com/exploratory-io/tam/issues/35740). Pairs with [exploratory-io/tam#35768](https://github.com/exploratory-io/tam/pull/35768).

Adds an optional `skip_nul = FALSE` argument to `read_parquet_file`, `read_parquet_files`, and `read_parquet_file_internal`. When `TRUE`, the internal wrapper sets `options(arrow.skip_nul = TRUE)` around `arrow::read_parquet()` so NUL bytes in string columns are stripped during the Arrow → R data.frame conversion, avoiding the `embedded nul in string` error.

The prior value of `arrow.skip_nul` is captured at function entry and restored via `on.exit()` so the call cannot leak the option into the user's R session — even on the error path.

## Implementation Details

- `R/system.R`:
  - `read_parquet_files(files, forPreview = FALSE, col_select = NULL, skip_nul = FALSE)` — forwards `skip_nul` to each per-file call.
  - `read_parquet_file(file, col_select = NULL, skip_nul = FALSE)` — forwards `skip_nul` to `read_parquet_file_internal`.
  - `read_parquet_file_internal(filepath, col_select = NULL, mmap = FALSE, skip_nul = FALSE)` — wraps the `arrow::read_parquet()` call with:
    ```r
    prior_skip_nul <- getOption("arrow.skip_nul")
    on.exit(options(arrow.skip_nul = prior_skip_nul), add = TRUE)
    if (isTRUE(skip_nul) && !isTRUE(prior_skip_nul)) {
      options(arrow.skip_nul = TRUE)
    }
    ```
  - Dropped redundant `exploratory::` namespace prefix on the internal `read_parquet_file` reference in `read_parquet_files`. Both functions are in the same package — the prefix is unnecessary, and dropping it lets source-only (non-namespace) test environments resolve the freshly-defined function consistently across single-file and multi-file paths.
- `tests/testthat/test_system.R` — 5 new tests covering:
  - Option restored to NULL after successful `skip_nul = TRUE` call.
  - Prior `arrow.skip_nul = TRUE` preserved when call uses `skip_nul = FALSE` (we do NOT flip user's setting off).
  - `read_parquet_file_internal` default `skip_nul = FALSE` keeps old behavior.
  - `read_parquet_files` multi-file path forwards `skip_nul`.
  - **Error path**: `on.exit` fires when `arrow::read_parquet` throws — option is still restored.

## How to Test

```r
library(devtools)
load_all()
testthat::test_file("tests/testthat/test_system.R", filter = "skip_nul")
```

All 5 new tests should pass. Existing tests are unaffected (default arg keeps backwards compatibility for every caller that does not opt in).

Manual: build the new package, install into tam, and follow the test steps in the paired tam PR.

## Versioning

Suggested 3rd-digit bump only — no server impact, additive arg with safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
