### PR TITLE
feat: support multi-statement Presto/Treasure Data queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.2
+Version: 15.1.3
 Date: 2026-05-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.0.5
+Version: 15.0.6
 Date: 2026-05-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.3
+Version: 15.1.4
 Date: 2026-05-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/presto.R
+++ b/R/presto.R
@@ -1,3 +1,124 @@
+# Split a Presto/Trino SQL string into individual statements on top-level `;`.
+# Recognizes single-quoted literals ('') with '' escape, double-quoted identifiers ("") with "" escape,
+# line comments (-- ... \n), and block comments (/* ... */, no nesting).
+# Returns a character vector of trimmed, non-empty statements.
+splitPrestoStatements <- function(sql) {
+  if (is.null(sql) || length(sql) == 0 || !nzchar(sql)) {
+    return(character(0))
+  }
+  chars <- strsplit(sql, "", fixed = TRUE)[[1]]
+  n <- length(chars)
+  state <- "normal" # normal | sq | dq | lc | bc
+  buf <- character(0)
+  out <- character(0)
+  i <- 1L
+  start <- 1L
+  flush <- function(end) {
+    if (end >= start) {
+      piece <- paste0(chars[start:end], collapse = "")
+      piece <- trimws(piece)
+      if (nzchar(piece)) {
+        out[[length(out) + 1L]] <<- piece
+      }
+    }
+  }
+  while (i <= n) {
+    ch <- chars[i]
+    nx <- if (i < n) chars[i + 1L] else ""
+    if (state == "normal") {
+      if (ch == "'") {
+        state <- "sq"
+      } else if (ch == "\"") {
+        state <- "dq"
+      } else if (ch == "-" && nx == "-") {
+        state <- "lc"
+        i <- i + 1L
+      } else if (ch == "/" && nx == "*") {
+        state <- "bc"
+        i <- i + 1L
+      } else if (ch == ";") {
+        flush(i - 1L)
+        start <- i + 1L
+      }
+    } else if (state == "sq") {
+      if (ch == "'") {
+        if (nx == "'") {
+          i <- i + 1L # escaped quote
+        } else {
+          state <- "normal"
+        }
+      }
+    } else if (state == "dq") {
+      if (ch == "\"") {
+        if (nx == "\"") {
+          i <- i + 1L # escaped quote
+        } else {
+          state <- "normal"
+        }
+      }
+    } else if (state == "lc") {
+      if (ch == "\n") {
+        state <- "normal"
+      }
+    } else if (state == "bc") {
+      if (ch == "*" && nx == "/") {
+        state <- "normal"
+        i <- i + 1L
+      }
+    }
+    i <- i + 1L
+  }
+  flush(n)
+  out
+}
+
+# Returns TRUE when the statement starts with a row-returning Presto keyword.
+# Strips leading whitespace, leading line/block comments, and a leading `(` before checking.
+prestoStatementReturnsRows <- function(sql) {
+  if (is.null(sql) || !nzchar(sql)) {
+    return(FALSE)
+  }
+  s <- sql
+  repeat {
+    s <- sub("^[[:space:]]+", "", s)
+    if (startsWith(s, "--")) {
+      s <- sub("^--[^\n]*\n?", "", s)
+      next
+    }
+    if (startsWith(s, "/*")) {
+      s <- sub("^/\\*.*?\\*/", "", s, perl = TRUE)
+      next
+    }
+    if (startsWith(s, "(")) {
+      s <- sub("^\\(", "", s)
+      next
+    }
+    break
+  }
+  m <- regmatches(s, regexpr("^[A-Za-z]+", s))
+  if (length(m) == 0L || !nzchar(m)) {
+    return(FALSE)
+  }
+  toupper(m) %in% c("SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "VALUES", "TABLE")
+}
+
+# Internal: execute a single Presto statement and return its result data frame.
+# Mirrors the original single-statement behavior of queryPresto.
+.queryPrestoSingle <- function(conn, query, numOfRows) {
+  resultSet <- NULL
+  df <- tryCatch({
+    resultSet <- RPresto::dbSendQuery(conn, query)
+    DBI::dbFetch(resultSet, n = numOfRows)
+  }, error = function(err) {
+    stop(err)
+  }, finally = {
+    if (!is.null(resultSet)) {
+      try(RPresto::dbClearResult(resultSet), silent = TRUE)
+    }
+  })
+  df
+}
+
 #' @export
 queryPresto <- function(host, port, username, password = "", schema, catalog, numOfRows = -1, query, ...){
   if(!requireNamespace("httr")){stop("package httr must be installed.")}
@@ -6,18 +127,55 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
 
   conn <- getDBConnection("presto", host = host, port = port, databaseName = "", username = username, password = password, catalog = catalog, schema = schema, dsn="", additionalParams = "",
                           collection = "", isSSL = FALSE, authSource = NULL, cluster = NULL, timeout = NULL)
-  tryCatch({
-    query <- convertUserInputToUtf8(query)
-    # set envir = parent.frame() to get variables from users environment, not package environment
-    # glue_sql does not quote Date or POSIXct. Let's use our sql_glue_transformer here.
-    query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
-    resultSet <- RPresto::dbSendQuery(conn,query)
-    df <- DBI::dbFetch(resultSet, n = numOfRows)
-  }, error = function(err) {
-    # clear connection in pool so that new connection will be used for the next try
-    clearDBConnection("presto", host, port, databaseName, username)
-    stop(err)
-  })
-  RPresto::dbClearResult(resultSet)
-  df
+  query <- convertUserInputToUtf8(query)
+  # set envir = parent.frame() to get variables from users environment, not package environment
+  # glue_sql does not quote Date or POSIXct. Let's use our sql_glue_transformer here.
+  query <- glue_exploratory(query, .transformer=sql_glue_transformer, .envir = parent.frame())
+
+  statements <- splitPrestoStatements(query)
+  total <- length(statements)
+  if (total == 0L) {
+    return(data.frame())
+  }
+  if (total == 1L) {
+    # single-statement fast path: preserve byte-for-byte the original behavior
+    df <- tryCatch({
+      .queryPrestoSingle(conn, statements[[1L]], numOfRows)
+    }, error = function(err) {
+      clearDBConnection("presto", host, port, "", username)
+      stop(err)
+    })
+    return(df)
+  }
+
+  # multi-statement: execute non-final via dbExecute, then classify final
+  if (total > 1L) {
+    for (i in seq_len(total - 1L)) {
+      tryCatch({
+        RPresto::dbExecute(conn, statements[[i]])
+      }, error = function(err) {
+        clearDBConnection("presto", host, port, "", username)
+        stop(sprintf("Statement %d of %d failed: %s", i, total, conditionMessage(err)))
+      })
+    }
+  }
+
+  last <- statements[[total]]
+  if (prestoStatementReturnsRows(last)) {
+    df <- tryCatch({
+      .queryPrestoSingle(conn, last, numOfRows)
+    }, error = function(err) {
+      clearDBConnection("presto", host, port, "", username)
+      stop(sprintf("Statement %d of %d failed: %s", total, total, conditionMessage(err)))
+    })
+    return(df)
+  } else {
+    tryCatch({
+      RPresto::dbExecute(conn, last)
+    }, error = function(err) {
+      clearDBConnection("presto", host, port, "", username)
+      stop(sprintf("Statement %d of %d failed: %s", total, total, conditionMessage(err)))
+    })
+    return(data.frame())
+  }
 }

--- a/R/presto.R
+++ b/R/presto.R
@@ -155,7 +155,7 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
   if (total > 1L) {
     for (i in seq_len(total - 1L)) {
       tryCatch({
-        RPresto::dbExecute(conn, statements[[i]])
+        DBI::dbExecute(conn, statements[[i]])
       }, error = function(err) {
         clearDBConnection("presto", host, port, catalog, schema, username)
         stop(sprintf("Statement %d of %d failed: %s", i, total, conditionMessage(err)))
@@ -174,7 +174,7 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
     return(df)
   } else {
     tryCatch({
-      RPresto::dbExecute(conn, last)
+      DBI::dbExecute(conn, last)
     }, error = function(err) {
       clearDBConnection("presto", host, port, catalog, schema, username)
       stop(sprintf("Statement %d of %d failed: %s", total, total, conditionMessage(err)))

--- a/R/presto.R
+++ b/R/presto.R
@@ -9,7 +9,6 @@ splitPrestoStatements <- function(sql) {
   chars <- strsplit(sql, "", fixed = TRUE)[[1]]
   n <- length(chars)
   state <- "normal" # normal | sq | dq | lc | bc
-  buf <- character(0)
   out <- character(0)
   i <- 1L
   start <- 1L
@@ -86,7 +85,11 @@ prestoStatementReturnsRows <- function(sql) {
       next
     }
     if (startsWith(s, "/*")) {
-      s <- sub("^/\\*.*?\\*/", "", s, perl = TRUE)
+      s_before <- s
+      s <- sub("^/\\*(?s).*?\\*/", "", s, perl = TRUE)
+      if (identical(s, s_before)) {
+        return(FALSE)
+      }
       next
     }
     if (startsWith(s, "(")) {
@@ -138,11 +141,11 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
     return(data.frame())
   }
   if (total == 1L) {
-    # single-statement fast path: preserve byte-for-byte the original behavior
+    # single-statement fast path: uses trimmed statement from splitPrestoStatements
     df <- tryCatch({
       .queryPrestoSingle(conn, statements[[1L]], numOfRows)
     }, error = function(err) {
-      clearDBConnection("presto", host, port, "", username)
+      clearDBConnection("presto", host, port, catalog, schema, username)
       stop(err)
     })
     return(df)
@@ -154,7 +157,7 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
       tryCatch({
         RPresto::dbExecute(conn, statements[[i]])
       }, error = function(err) {
-        clearDBConnection("presto", host, port, "", username)
+        clearDBConnection("presto", host, port, catalog, schema, username)
         stop(sprintf("Statement %d of %d failed: %s", i, total, conditionMessage(err)))
       })
     }
@@ -165,7 +168,7 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
     df <- tryCatch({
       .queryPrestoSingle(conn, last, numOfRows)
     }, error = function(err) {
-      clearDBConnection("presto", host, port, "", username)
+      clearDBConnection("presto", host, port, catalog, schema, username)
       stop(sprintf("Statement %d of %d failed: %s", total, total, conditionMessage(err)))
     })
     return(df)
@@ -173,7 +176,7 @@ queryPresto <- function(host, port, username, password = "", schema, catalog, nu
     tryCatch({
       RPresto::dbExecute(conn, last)
     }, error = function(err) {
-      clearDBConnection("presto", host, port, "", username)
+      clearDBConnection("presto", host, port, catalog, schema, username)
       stop(sprintf("Statement %d of %d failed: %s", total, total, conditionMessage(err)))
     })
     return(data.frame())

--- a/tests/testthat/test_presto.R
+++ b/tests/testthat/test_presto.R
@@ -328,3 +328,371 @@ test_that("prestoStatementReturnsRows: empty / comment-only / non-alpha / unterm
   # an unterminated block comment cannot be stripped -> not row-returning
   expect_false(prestoStatementReturnsRows("/* never closed SELECT 1"))
 })
+
+# ---------------------------------------------------------------------------
+# Complex real-world Presto / Treasure Data patterns
+# (fictional schema: sandbox_retail, l1_web, l1_crm, l1_store, l0_segment)
+# ---------------------------------------------------------------------------
+
+test_that("splitPrestoStatements: inline -- comment with non-ASCII text sits before semicolon", {
+  # Pattern: WHERE ... -- 期間変更箇所\n; next-statement
+  sql <- paste0(
+    "SELECT user_id, COUNT(1) AS sessions\n",
+    "FROM l1_web.session_log\n",
+    "WHERE TD_TIME_RANGE(time, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所\n",
+    "  AND hostname = 'shop.example.com'\n",
+    "GROUP BY 1;\n",
+    "SELECT COUNT(DISTINCT user_id) AS dau FROM l1_web.session_log"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 2)
+  expect_true(grepl("-- 期間変更箇所", stmts[[1]]))
+  expect_true(grepl("TD_TIME_RANGE", stmts[[1]]))
+  expect_equal(stmts[[2]], "SELECT COUNT(DISTINCT user_id) AS dau FROM l1_web.session_log")
+})
+
+test_that("splitPrestoStatements: REGEXP_LIKE patterns with | inside string literals don't split", {
+  sql <- paste(
+    "SELECT user_id,",
+    "  CASE",
+    "    WHEN REGEXP_LIKE(category, 'shoes|bags|apparel') THEN 'fashion'",
+    "    WHEN REGEXP_LIKE(category, 'tv|laptop|phone') THEN 'electronics'",
+    "    ELSE 'other'",
+    "  END AS segment",
+    "FROM l1_crm.purchase_log",
+    "WHERE TD_TIME_RANGE(time, '2026-01-01', NULL, 'JST');",
+    "SELECT segment, COUNT(DISTINCT user_id) AS users FROM l1_crm.purchase_log GROUP BY 1",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 2)
+  expect_true(grepl("REGEXP_LIKE", stmts[[1]]))
+  expect_true(grepl("'shoes\\|bags\\|apparel'", stmts[[1]]))
+})
+
+test_that("splitPrestoStatements: VALUES inline table with many literals inside a CTE", {
+  # Pattern: excluded IDs defined as inline VALUES, semicolon must not fire inside literals
+  sql <- paste(
+    "WITH excluded_ids AS (",
+    "  SELECT user_id FROM (",
+    "    VALUES",
+    "    ('uid-aaa-001'), ('uid-bbb-002'), ('uid-ccc-003'),",
+    "    ('uid-ddd-004'), ('uid-eee-005'), ('uid-fff-006'),",
+    "    ('uid-ggg-007'), ('uid-hhh-008')",
+    "  ) AS t (user_id)",
+    ")",
+    "SELECT m.user_id, m.email",
+    "FROM l1_crm.members AS m",
+    "WHERE m.user_id NOT IN (SELECT user_id FROM excluded_ids)",
+    "  AND m.status = 'active';",
+    "SELECT COUNT(*) FROM l1_crm.members WHERE status = 'active'",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 2)
+  expect_true(grepl("VALUES", stmts[[1]]))
+  expect_true(grepl("'uid-hhh-008'", stmts[[1]]))
+  expect_equal(stmts[[2]], "SELECT COUNT(*) FROM l1_crm.members WHERE status = 'active'")
+})
+
+test_that("splitPrestoStatements: CROSS JOIN UNNEST + UNION ALL is a single statement", {
+  # Pattern: REGEXP_EXTRACT_ALL produces array, UNNEST expands it,
+  # UNION ALL re-attaches rows where array was empty
+  sql <- paste(
+    "WITH raw_events AS (",
+    "  SELECT user_id,",
+    "    REGEXP_EXTRACT_ALL(tag_string, '[a-z_]+') AS tag_array",
+    "  FROM l1_web.event_log",
+    "  WHERE TD_TIME_RANGE(time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "),",
+    "expanded AS (",
+    "  SELECT user_id, tag",
+    "  FROM raw_events CROSS JOIN UNNEST(tag_array) AS t(tag)",
+    "  UNION ALL",
+    "  SELECT user_id, '' AS tag",
+    "  FROM raw_events",
+    "  WHERE ARRAY_JOIN(tag_array, ',') = ''",
+    ")",
+    "SELECT user_id, tag, COUNT(1) AS cnt",
+    "FROM expanded",
+    "GROUP BY 1, 2",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 1)
+  expect_true(grepl("CROSS JOIN UNNEST", stmts[[1]]))
+  expect_true(grepl("UNION ALL", stmts[[1]]))
+  expect_true(grepl("ARRAY_JOIN", stmts[[1]]))
+})
+
+test_that("splitPrestoStatements: nested WITH (CTE inside outer CTE subquery)", {
+  # Presto allows WITH inside a subquery — the inner WITH is not a statement separator
+  sql <- paste(
+    "WITH outer_cte AS (",
+    "  WITH inner_agg AS (",
+    "    SELECT user_id, MAX(score) AS top_score",
+    "    FROM l1_crm.user_scores",
+    "    GROUP BY 1",
+    "  ),",
+    "  inner_filter AS (",
+    "    SELECT user_id FROM inner_agg WHERE top_score > 80",
+    "  )",
+    "  SELECT user_id, top_score FROM inner_agg",
+    "  WHERE user_id IN (SELECT user_id FROM inner_filter)",
+    ")",
+    "SELECT user_id, top_score FROM outer_cte ORDER BY top_score DESC",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 1)
+  expect_true(grepl("WITH inner_agg AS", stmts[[1]]))
+  expect_true(grepl("ORDER BY top_score DESC", stmts[[1]]))
+})
+
+test_that("splitPrestoStatements: MAX_BY / MIN_BY / TD functions preserved across 3 statements", {
+  # Pattern: aggregate using TD-specific MAX_BY / MIN_BY, split into 3 statements
+  sql <- paste(
+    "DROP TABLE IF EXISTS sandbox_retail.latest_purchase;",
+    "CREATE TABLE sandbox_retail.latest_purchase AS",
+    "WITH base AS (",
+    "  SELECT",
+    "    user_id,",
+    "    MAX_BY(product_id, purchase_time) AS last_product,",
+    "    MIN_BY(product_id, purchase_time) AS first_product,",
+    "    COUNT(1) AS purchase_cnt",
+    "  FROM l1_store.purchase_log",
+    "  WHERE TD_TIME_RANGE(purchase_time, '2025-12-01', '2026-03-01', 'JST') -- 期間変更箇所",
+    "  GROUP BY 1",
+    ")",
+    "SELECT user_id, last_product, first_product, purchase_cnt",
+    "FROM base",
+    "WHERE purchase_cnt >= 2;",
+    "SELECT user_id, last_product FROM sandbox_retail.latest_purchase LIMIT 100",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 3)
+  expect_equal(stmts[[1]], "DROP TABLE IF EXISTS sandbox_retail.latest_purchase")
+  expect_true(startsWith(stmts[[2]], "CREATE TABLE sandbox_retail.latest_purchase AS"))
+  expect_true(grepl("MAX_BY", stmts[[2]]))
+  expect_true(grepl("MIN_BY", stmts[[2]]))
+  expect_true(grepl("TD_TIME_RANGE", stmts[[2]]))
+  expect_equal(stmts[[3]], "SELECT user_id, last_product FROM sandbox_retail.latest_purchase LIMIT 100")
+})
+
+test_that("splitPrestoStatements: 5-stmt pipeline with step comments embedded in statements", {
+  # Mirrors the real-world 3-step pattern: DROP+CREATE, DROP+CREATE, final SELECT
+  # The step-header comments (--) are attached to the following DROP statement
+  sql <- paste(
+    "-- Step 1: build campaign user list",
+    "DROP TABLE IF EXISTS sandbox_retail.kpi_user_list;",
+    "CREATE TABLE sandbox_retail.kpi_user_list AS",
+    "WITH uid_map AS (",
+    "  SELECT user_hash AS uid, member_id",
+    "  FROM l1_member.uid_member_mapping",
+    "  WHERE is_latest = 1 AND member_id IS NOT NULL",
+    "  GROUP BY 1, 2",
+    "),",
+    "web_access AS (",
+    "  SELECT m.member_id",
+    "  FROM l1_web.session_log AS s",
+    "  LEFT JOIN l1_web.user_id_map AS m USING(session_uid)",
+    "  WHERE TD_TIME_RANGE(s.access_time, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所",
+    "    AND s.hostname = 'shop.example.com'",
+    "    AND m.member_id IS NOT NULL",
+    "  GROUP BY 1",
+    ")",
+    "SELECT t1.member_id,",
+    "  IF(t2.member_id IS NOT NULL, 1, 0) AS is_priority",
+    "FROM l1_crm.registered_members AS t1",
+    "LEFT JOIN web_access AS t2 ON t1.member_id = t2.member_id",
+    "WHERE t1.status = 'active';",
+    "",
+    "-- Step 2: build action log",
+    "DROP TABLE IF EXISTS sandbox_retail.kpi_action_list;",
+    "CREATE TABLE sandbox_retail.kpi_action_list AS",
+    "WITH actions AS (",
+    "  SELECT user_id, event_type,",
+    "    MIN(event_time) AS first_time, COUNT(1) AS cnt",
+    "  FROM l1_web.event_log",
+    "  WHERE TD_TIME_RANGE(event_time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "    AND event_type IS NOT NULL",
+    "  GROUP BY 1, 2",
+    ")",
+    "SELECT * FROM actions;",
+    "",
+    "-- Step 3: final aggregation",
+    "SELECT u.member_id,",
+    "  COALESCE(a.cnt, 0) AS action_cnt,",
+    "  u.is_priority",
+    "FROM sandbox_retail.kpi_user_list AS u",
+    "LEFT JOIN sandbox_retail.kpi_action_list AS a USING(member_id)",
+    "ORDER BY 2 DESC",
+    sep = "\n"
+  )
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 5)
+  # step comment is part of the DROP statement that follows it
+  expect_true(grepl("DROP TABLE IF EXISTS sandbox_retail.kpi_user_list", stmts[[1]]))
+  expect_true(startsWith(stmts[[2]], "CREATE TABLE sandbox_retail.kpi_user_list AS"))
+  expect_true(grepl("MAX_BY\\|MIN_BY\\|IF\\|TD_TIME_RANGE\\|web_access", stmts[[2]]) ||
+              grepl("IF\\(t2", stmts[[2]]))
+  expect_true(grepl("DROP TABLE IF EXISTS sandbox_retail.kpi_action_list", stmts[[3]]))
+  expect_true(startsWith(stmts[[4]], "CREATE TABLE sandbox_retail.kpi_action_list AS"))
+  expect_true(grepl("SELECT u.member_id", stmts[[5]]))
+  expect_true(grepl("ORDER BY 2 DESC", stmts[[5]]))
+})
+
+test_that("prestoStatementReturnsRows: complex WITH + nested WITH + UNION ALL + ORDER BY is row-returning", {
+  # Mirrors Step 4 in the real-world script: final SELECT-only with
+  # outer CTEs each containing inner WITH, joined by UNION ALL, ORDER BY at end
+  sql <- paste(
+    "WITH prev_stage AS (",
+    "  WITH stage_scores AS (",
+    "    SELECT user_id,",
+    "      CASE",
+    "        WHEN COUNT(DISTINCT stage || behavior) >= 3 THEN 2",
+    "        WHEN COUNT(DISTINCT stage || behavior) >= 1 THEN 1",
+    "        ELSE 0",
+    "      END AS stage_lvl",
+    "    FROM sandbox_retail.kpi_action_list",
+    "    WHERE TD_TIME_RANGE(action_time, '2026-01-01', '2026-02-01', 'JST') -- 期間変更箇所",
+    "      AND stage IN ('awareness', 'interest')",
+    "    GROUP BY 1",
+    "  )",
+    "  SELECT user_id, MAX(stage_lvl) AS start_stage FROM stage_scores GROUP BY 1",
+    "),",
+    "curr_stage AS (",
+    "  WITH stage_scores AS (",
+    "    SELECT user_id,",
+    "      CASE",
+    "        WHEN COUNT(DISTINCT stage || behavior) >= 3 THEN 2",
+    "        WHEN COUNT(DISTINCT stage || behavior) >= 1 THEN 1",
+    "        ELSE 0",
+    "      END AS stage_lvl",
+    "    FROM sandbox_retail.kpi_action_list",
+    "    WHERE TD_TIME_RANGE(action_time, '2026-02-01', NULL, 'JST') -- 期間変更箇所",
+    "      AND stage IN ('awareness', 'interest')",
+    "    GROUP BY 1",
+    "  )",
+    "  SELECT user_id, MAX(stage_lvl) AS latest_stage FROM stage_scores GROUP BY 1",
+    "),",
+    "ai_chat_users AS (",
+    "  SELECT DISTINCT user_id FROM sandbox_retail.kpi_action_list",
+    "  WHERE type = 'AI chat'",
+    "    AND TD_TIME_RANGE(action_time, '2026-02-01', NULL, 'JST')",
+    ")",
+    "-- group A: AI chat users",
+    "SELECT 'A: AI chat users' AS cohort,",
+    "  CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "    WHEN 1 THEN '1:interest' ELSE '0:none' END AS start_stage,",
+    "  CASE WHEN COALESCE(t3.latest_stage, 0) >= t2.start_stage",
+    "    THEN CASE t3.latest_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "    ELSE CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "  END AS latest_stage,",
+    "  COUNT(DISTINCT t1.user_id) AS cnt",
+    "FROM sandbox_retail.kpi_user_list AS t1",
+    "LEFT JOIN prev_stage AS t2 ON t1.user_id = t2.user_id",
+    "LEFT JOIN curr_stage AS t3 ON t1.user_id = t3.user_id",
+    "INNER JOIN ai_chat_users AS t4 ON t1.user_id = t4.user_id",
+    "WHERE t3.latest_stage IS NOT NULL",
+    "GROUP BY 1, 2, 3",
+    "UNION ALL",
+    "-- group B: no AI chat",
+    "SELECT 'B: no AI chat' AS cohort,",
+    "  CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "    WHEN 1 THEN '1:interest' ELSE '0:none' END AS start_stage,",
+    "  CASE WHEN COALESCE(t3.latest_stage, 0) >= t2.start_stage",
+    "    THEN CASE t3.latest_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "    ELSE CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
+    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "  END AS latest_stage,",
+    "  COUNT(DISTINCT t1.user_id) AS cnt",
+    "FROM sandbox_retail.kpi_user_list AS t1",
+    "LEFT JOIN prev_stage AS t2 ON t1.user_id = t2.user_id",
+    "LEFT JOIN curr_stage AS t3 ON t1.user_id = t3.user_id",
+    "LEFT JOIN ai_chat_users AS t4 ON t1.user_id = t4.user_id",
+    "WHERE t3.latest_stage IS NOT NULL",
+    "  AND t4.user_id IS NULL",
+    "GROUP BY 1, 2, 3",
+    "ORDER BY 1, 2",
+    sep = "\n"
+  )
+  # the statement starts with WITH → row-returning
+  expect_true(prestoStatementReturnsRows(sql))
+  # it is one unsplit statement
+  stmts <- splitPrestoStatements(sql)
+  expect_equal(length(stmts), 1)
+})
+
+test_that("prestoStatementReturnsRows: CREATE TABLE AS WITH multi-CTE is not row-returning", {
+  sql <- paste(
+    "CREATE TABLE sandbox_retail.kpi_action_list AS",
+    "WITH web_log AS (",
+    "  SELECT m.user_id, 'Web' AS channel,",
+    "    CASE",
+    "      WHEN REGEXP_LIKE(cat, 'pricing|specs|compare') THEN 'consideration'",
+    "      WHEN REGEXP_LIKE(cat, 'brand|campaign') THEN 'awareness'",
+    "    END AS stage,",
+    "    TD_TIME_STRING(MIN(s.event_time), 'M!', 'JST') AS report_month,",
+    "    MIN(s.event_time) AS action_time,",
+    "    COUNT(1) AS cnt",
+    "  FROM l1_web.event_log AS s",
+    "  LEFT JOIN l1_web.user_id_map AS m USING(session_uid)",
+    "  WHERE TD_TIME_RANGE(s.event_time, '2025-12-01', NULL, 'JST') -- 期間変更箇所",
+    "    AND s.hostname = 'shop.example.com'",
+    "    AND m.user_id IS NOT NULL",
+    "    AND cat IS NOT NULL",
+    "  GROUP BY 1, 2, 3, 4",
+    "),",
+    "chat_log AS (",
+    "  SELECT user_id, 'AI chat' AS channel,",
+    "    CASE",
+    "      WHEN REGEXP_LIKE(intent_tags, 'price|discount|budget') THEN 'consideration'",
+    "      WHEN REGEXP_LIKE(intent_tags, 'brand|model') THEN 'awareness'",
+    "      WHEN conversation_completed IS NULL THEN 'no conversation'",
+    "      ELSE 'other'",
+    "    END AS stage,",
+    "    TD_TIME_STRING(TD_TIME_PARSE(session_date, 'JST'), 'M!', 'JST') AS report_month,",
+    "    MIN(TD_TIME_PARSE(session_date, 'JST')) AS action_time,",
+    "    COUNT(1) AS cnt",
+    "  FROM l1_store.ai_chat_sessions",
+    "  WHERE TD_TIME_RANGE(TD_TIME_PARSE(session_date, 'JST'), '2026-01-01', NULL, 'JST')",
+    "    AND user_id IS NOT NULL",
+    "  GROUP BY 1, 2, 3, 4",
+    ")",
+    "SELECT * FROM web_log",
+    "UNION ALL",
+    "SELECT * FROM chat_log",
+    sep = "\n"
+  )
+  expect_false(prestoStatementReturnsRows(sql))
+})
+
+test_that("prestoStatementReturnsRows: SELECT with CASE, REGEXP_LIKE, TD functions is row-returning", {
+  sql <- paste(
+    "SELECT",
+    "  user_id,",
+    "  CASE",
+    "    WHEN REGEXP_LIKE(behavior_tags, 'purchase|checkout|payment') THEN 'converted'",
+    "    WHEN REGEXP_LIKE(behavior_tags, 'wishlist|cart|compare') THEN 'considering'",
+    "    WHEN REGEXP_LIKE(behavior_tags, 'view|search|browse') THEN 'browsing'",
+    "    ELSE 'unknown'",
+    "  END AS funnel_stage,",
+    "  TD_TIME_STRING(MIN(event_time), 'yyyy-MM-dd', 'JST') AS first_event_date,",
+    "  TD_TIME_STRING(MAX(event_time), 'yyyy-MM-dd', 'JST') AS last_event_date,",
+    "  COUNT(DISTINCT session_id) AS session_cnt,",
+    "  COUNT(1) AS event_cnt",
+    "FROM l1_web.event_log",
+    "WHERE TD_TIME_RANGE(event_time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "  AND hostname = 'shop.example.com'",
+    "  AND user_id IS NOT NULL",
+    "GROUP BY 1, 2",
+    "ORDER BY session_cnt DESC",
+    sep = "\n"
+  )
+  expect_true(prestoStatementReturnsRows(sql))
+})

--- a/tests/testthat/test_presto.R
+++ b/tests/testthat/test_presto.R
@@ -1,17 +1,27 @@
 context("test presto helpers")
 
+# ---------------------------------------------------------------------------
+# splitPrestoStatements
+# ---------------------------------------------------------------------------
+
 test_that("splitPrestoStatements: empty / null / whitespace", {
   expect_equal(splitPrestoStatements(NULL), character(0))
+  expect_equal(splitPrestoStatements(character(0)), character(0))
   expect_equal(splitPrestoStatements(""), character(0))
+  expect_equal(splitPrestoStatements("   "), character(0))
   expect_equal(splitPrestoStatements("   \n  "), character(0))
+  expect_equal(splitPrestoStatements("\t\r\n"), character(0))
   expect_equal(splitPrestoStatements(";"), character(0))
   expect_equal(splitPrestoStatements(";;;"), character(0))
+  expect_equal(splitPrestoStatements("  ;  ;  "), character(0))
 })
 
 test_that("splitPrestoStatements: single statement with and without trailing semicolon", {
   expect_equal(splitPrestoStatements("SELECT 1"), c("SELECT 1"))
   expect_equal(splitPrestoStatements("SELECT 1;"), c("SELECT 1"))
   expect_equal(splitPrestoStatements("  SELECT 1  ;  "), c("SELECT 1"))
+  expect_equal(splitPrestoStatements(";SELECT 1"), c("SELECT 1"))
+  expect_equal(splitPrestoStatements(";;SELECT 1;;"), c("SELECT 1"))
 })
 
 test_that("splitPrestoStatements: multiple statements", {
@@ -22,6 +32,23 @@ test_that("splitPrestoStatements: multiple statements", {
   expect_equal(
     splitPrestoStatements("SELECT 1;\nSELECT 2;\nSELECT 3;"),
     c("SELECT 1", "SELECT 2", "SELECT 3")
+  )
+  # empty statements between separators are dropped
+  expect_equal(
+    splitPrestoStatements("SELECT 1;;SELECT 2"),
+    c("SELECT 1", "SELECT 2")
+  )
+  expect_equal(
+    splitPrestoStatements("SELECT 1; ; \n ; SELECT 2"),
+    c("SELECT 1", "SELECT 2")
+  )
+})
+
+test_that("splitPrestoStatements: multi-line statements keep their internal newlines", {
+  sql <- "SELECT a,\n       b\nFROM t;\nSELECT c\nFROM u"
+  expect_equal(
+    splitPrestoStatements(sql),
+    c("SELECT a,\n       b\nFROM t", "SELECT c\nFROM u")
   )
 })
 
@@ -36,12 +63,41 @@ test_that("splitPrestoStatements: ; inside single-quoted literal does not split"
     splitPrestoStatements("SELECT 'it''s; ok'; SELECT 2"),
     c("SELECT 'it''s; ok'", "SELECT 2")
   )
+  # consecutive escaped quotes
+  expect_equal(
+    splitPrestoStatements("SELECT '''';SELECT 2"),
+    c("SELECT ''''", "SELECT 2")
+  )
+  # comment markers inside a literal are inert
+  expect_equal(
+    splitPrestoStatements("SELECT '-- not a comment ; still literal'; SELECT 2"),
+    c("SELECT '-- not a comment ; still literal'", "SELECT 2")
+  )
+  expect_equal(
+    splitPrestoStatements("SELECT '/* not a comment ; */'; SELECT 2"),
+    c("SELECT '/* not a comment ; */'", "SELECT 2")
+  )
+  # double-quote char inside a single-quoted literal is just data
+  expect_equal(
+    splitPrestoStatements("SELECT 'a\";b'; SELECT 2"),
+    c("SELECT 'a\";b'", "SELECT 2")
+  )
 })
 
 test_that("splitPrestoStatements: ; inside double-quoted identifier does not split", {
   expect_equal(
     splitPrestoStatements("SELECT \"a;b\" FROM t; SELECT 2"),
     c("SELECT \"a;b\" FROM t", "SELECT 2")
+  )
+  # escaped double-quote ("") inside identifier
+  expect_equal(
+    splitPrestoStatements("SELECT \"weird\"\";name\" FROM t; SELECT 2"),
+    c("SELECT \"weird\"\";name\" FROM t", "SELECT 2")
+  )
+  # single-quote char inside a double-quoted identifier is just data
+  expect_equal(
+    splitPrestoStatements("SELECT \"a';b\" FROM t; SELECT 2"),
+    c("SELECT \"a';b\" FROM t", "SELECT 2")
   )
 })
 
@@ -50,6 +106,16 @@ test_that("splitPrestoStatements: ; inside line comment does not split", {
     splitPrestoStatements("SELECT 1 -- comment ; not a split\n; SELECT 2"),
     c("SELECT 1 -- comment ; not a split", "SELECT 2")
   )
+  # line comment runs to end of input when no trailing newline
+  expect_equal(
+    splitPrestoStatements("SELECT 1 -- trailing ; comment"),
+    c("SELECT 1 -- trailing ; comment")
+  )
+  # a statement consisting solely of a comment is preserved (non-empty after trim)
+  expect_equal(
+    splitPrestoStatements("SELECT 1;-- only a comment"),
+    c("SELECT 1", "-- only a comment")
+  )
 })
 
 test_that("splitPrestoStatements: ; inside block comment does not split", {
@@ -57,34 +123,188 @@ test_that("splitPrestoStatements: ; inside block comment does not split", {
     splitPrestoStatements("SELECT 1 /* a;b;c */; SELECT 2"),
     c("SELECT 1 /* a;b;c */", "SELECT 2")
   )
+  # multi-line block comment
+  expect_equal(
+    splitPrestoStatements("SELECT 1 /* line1 ;\n line2 ; */; SELECT 2"),
+    c("SELECT 1 /* line1 ;\n line2 ; */", "SELECT 2")
+  )
+  # quote chars inside a block comment are inert
+  expect_equal(
+    splitPrestoStatements("SELECT 1 /* it's a \"trap\" ; */; SELECT 2"),
+    c("SELECT 1 /* it's a \"trap\" ; */", "SELECT 2")
+  )
+  # block comments do NOT nest: the first */ closes the comment, so a ; after it splits
+  expect_equal(
+    splitPrestoStatements("SELECT 1 /* outer /* inner */ ; SELECT 2"),
+    c("SELECT 1 /* outer /* inner */", "SELECT 2")
+  )
 })
 
-test_that("prestoStatementReturnsRows: positive cases", {
+test_that("splitPrestoStatements: leading comments before a statement are retained", {
+  expect_equal(
+    splitPrestoStatements("-- header\nSELECT 1"),
+    c("-- header\nSELECT 1")
+  )
+  expect_equal(
+    splitPrestoStatements("/* header */ SELECT 1; SELECT 2"),
+    c("/* header */ SELECT 1", "SELECT 2")
+  )
+})
+
+test_that("splitPrestoStatements: realistic multi-statement DDL + CTE script", {
+  sql <- paste(
+    "DROP TABLE IF EXISTS sandbox.tmp;",
+    "CREATE TABLE sandbox.tmp AS",
+    "WITH base AS (SELECT id, name FROM src WHERE name <> 'a;b')",
+    "SELECT * FROM base;",
+    "SELECT * FROM sandbox.tmp",
+    sep = "\n"
+  )
+  expect_equal(
+    splitPrestoStatements(sql),
+    c(
+      "DROP TABLE IF EXISTS sandbox.tmp",
+      "CREATE TABLE sandbox.tmp AS\nWITH base AS (SELECT id, name FROM src WHERE name <> 'a;b')\nSELECT * FROM base",
+      "SELECT * FROM sandbox.tmp"
+    )
+  )
+})
+
+test_that("splitPrestoStatements: INSERT with a string literal containing a semicolon", {
+  expect_equal(
+    splitPrestoStatements("INSERT INTO t VALUES ('x;y'); SELECT * FROM t"),
+    c("INSERT INTO t VALUES ('x;y')", "SELECT * FROM t")
+  )
+})
+
+# ---------------------------------------------------------------------------
+# prestoStatementReturnsRows
+# ---------------------------------------------------------------------------
+
+test_that("prestoStatementReturnsRows: SELECT / WITH / VALUES / TABLE", {
   expect_true(prestoStatementReturnsRows("SELECT 1"))
   expect_true(prestoStatementReturnsRows("  SELECT 1"))
+  expect_true(prestoStatementReturnsRows("\t\nSELECT 1"))
+  expect_true(prestoStatementReturnsRows("select 1"))
+  expect_true(prestoStatementReturnsRows("SeLeCt 1"))
+  expect_true(prestoStatementReturnsRows("SELECT * FROM t WHERE x = 1 GROUP BY y ORDER BY z LIMIT 10"))
+  expect_true(prestoStatementReturnsRows("SELECT a FROM t UNION ALL SELECT b FROM u"))
   expect_true(prestoStatementReturnsRows("WITH t AS (SELECT 1) SELECT * FROM t"))
-  expect_true(prestoStatementReturnsRows("show schemas"))
-  expect_true(prestoStatementReturnsRows("DESCRIBE foo"))
-  expect_true(prestoStatementReturnsRows("DESC foo"))
-  expect_true(prestoStatementReturnsRows("EXPLAIN SELECT 1"))
+  expect_true(prestoStatementReturnsRows("with a as (select 1), b as (select 2) select * from a join b on true"))
   expect_true(prestoStatementReturnsRows("VALUES (1), (2)"))
+  expect_true(prestoStatementReturnsRows("values (1, 'a')"))
   expect_true(prestoStatementReturnsRows("TABLE foo"))
-  expect_true(prestoStatementReturnsRows("(SELECT 1)"))
-  expect_true(prestoStatementReturnsRows("-- leading comment\nSELECT 1"))
-  expect_true(prestoStatementReturnsRows("/* block */ SELECT 1"))
-  expect_true(prestoStatementReturnsRows("/* multi\nline\nblock */ SELECT 1"))
-  expect_true(prestoStatementReturnsRows("  /* a */ -- b\n /* c */ \n  SELECT 1"))
+  expect_true(prestoStatementReturnsRows("TABLE catalog.schema.foo"))
 })
 
-test_that("prestoStatementReturnsRows: negative cases", {
-  expect_false(prestoStatementReturnsRows("DROP TABLE foo"))
+test_that("prestoStatementReturnsRows: SHOW family", {
+  expect_true(prestoStatementReturnsRows("SHOW SCHEMAS"))
+  expect_true(prestoStatementReturnsRows("show schemas from catalog"))
+  expect_true(prestoStatementReturnsRows("SHOW TABLES"))
+  expect_true(prestoStatementReturnsRows("SHOW TABLES FROM sandbox"))
+  expect_true(prestoStatementReturnsRows("SHOW COLUMNS FROM t"))
+  expect_true(prestoStatementReturnsRows("SHOW CATALOGS"))
+  expect_true(prestoStatementReturnsRows("SHOW FUNCTIONS"))
+  expect_true(prestoStatementReturnsRows("SHOW SESSION"))
+  expect_true(prestoStatementReturnsRows("SHOW STATS FOR t"))
+  expect_true(prestoStatementReturnsRows("SHOW CREATE TABLE t"))
+})
+
+test_that("prestoStatementReturnsRows: DESCRIBE / DESC / EXPLAIN", {
+  expect_true(prestoStatementReturnsRows("DESCRIBE foo"))
+  expect_true(prestoStatementReturnsRows("describe foo"))
+  expect_true(prestoStatementReturnsRows("DESC foo"))
+  expect_true(prestoStatementReturnsRows("DESCRIBE INPUT my_query"))
+  expect_true(prestoStatementReturnsRows("DESCRIBE OUTPUT my_query"))
+  expect_true(prestoStatementReturnsRows("EXPLAIN SELECT 1"))
+  expect_true(prestoStatementReturnsRows("EXPLAIN ANALYZE SELECT 1"))
+  expect_true(prestoStatementReturnsRows("EXPLAIN (TYPE LOGICAL) SELECT 1"))
+})
+
+test_that("prestoStatementReturnsRows: leading parentheses", {
+  expect_true(prestoStatementReturnsRows("(SELECT 1)"))
+  expect_true(prestoStatementReturnsRows("((SELECT 1))"))
+  expect_true(prestoStatementReturnsRows("  ( ( SELECT 1 ) )"))
+  expect_true(prestoStatementReturnsRows("(SELECT 1) UNION (SELECT 2)"))
+})
+
+test_that("prestoStatementReturnsRows: leading comments are stripped before classifying", {
+  expect_true(prestoStatementReturnsRows("-- leading comment\nSELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* block */ SELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* block */SELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* multi\nline\nblock */ SELECT 1"))
+  expect_true(prestoStatementReturnsRows("  /* a */ -- b\n /* c */ \n  SELECT 1"))
+  expect_true(prestoStatementReturnsRows("-- c1\n-- c2\nSELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* c */ ( SELECT 1 )"))
+})
+
+test_that("prestoStatementReturnsRows: DDL is not row-returning", {
+  expect_false(prestoStatementReturnsRows("CREATE TABLE foo (x INT)"))
+  expect_false(prestoStatementReturnsRows("CREATE TABLE IF NOT EXISTS foo (x INT)"))
   expect_false(prestoStatementReturnsRows("CREATE TABLE foo AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("CREATE VIEW v AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("CREATE OR REPLACE VIEW v AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("CREATE SCHEMA s"))
+  expect_false(prestoStatementReturnsRows("CREATE MATERIALIZED VIEW mv AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("DROP TABLE foo"))
+  expect_false(prestoStatementReturnsRows("DROP TABLE IF EXISTS foo"))
+  expect_false(prestoStatementReturnsRows("DROP VIEW v"))
+  expect_false(prestoStatementReturnsRows("DROP SCHEMA s"))
+  expect_false(prestoStatementReturnsRows("ALTER TABLE foo ADD COLUMN x INT"))
+  expect_false(prestoStatementReturnsRows("ALTER TABLE foo RENAME TO bar"))
+  expect_false(prestoStatementReturnsRows("COMMENT ON TABLE foo IS 'note'"))
+})
+
+test_that("prestoStatementReturnsRows: DML is not row-returning", {
   expect_false(prestoStatementReturnsRows("INSERT INTO foo VALUES (1)"))
+  expect_false(prestoStatementReturnsRows("INSERT INTO foo SELECT * FROM bar"))
   expect_false(prestoStatementReturnsRows("UPDATE foo SET x = 1"))
   expect_false(prestoStatementReturnsRows("DELETE FROM foo"))
-  expect_false(prestoStatementReturnsRows("ALTER TABLE foo ADD COLUMN x INT"))
+  expect_false(prestoStatementReturnsRows("MERGE INTO foo USING bar ON foo.id = bar.id"))
+  expect_false(prestoStatementReturnsRows("TRUNCATE TABLE foo"))
+})
+
+test_that("prestoStatementReturnsRows: session / transaction / admin are not row-returning", {
   expect_false(prestoStatementReturnsRows("USE catalog.schema"))
+  expect_false(prestoStatementReturnsRows("SET SESSION foo = 1"))
+  expect_false(prestoStatementReturnsRows("RESET SESSION foo"))
+  expect_false(prestoStatementReturnsRows("SET ROLE admin"))
+  expect_false(prestoStatementReturnsRows("SET TIME ZONE 'UTC'"))
+  expect_false(prestoStatementReturnsRows("START TRANSACTION"))
+  expect_false(prestoStatementReturnsRows("COMMIT"))
+  expect_false(prestoStatementReturnsRows("ROLLBACK"))
+  expect_false(prestoStatementReturnsRows("GRANT SELECT ON t TO u"))
+  expect_false(prestoStatementReturnsRows("REVOKE SELECT ON t FROM u"))
+  expect_false(prestoStatementReturnsRows("DENY SELECT ON t TO u"))
   expect_false(prestoStatementReturnsRows("CALL system.runtime.kill_query('q')"))
+  expect_false(prestoStatementReturnsRows("ANALYZE t"))
+  expect_false(prestoStatementReturnsRows("PREPARE my_query FROM SELECT 1"))
+  expect_false(prestoStatementReturnsRows("DEALLOCATE PREPARE my_query"))
+  # EXECUTE may return rows when the prepared statement is a SELECT, but the
+  # keyword whitelist does not include it -- classified as non-row-returning.
+  expect_false(prestoStatementReturnsRows("EXECUTE my_query"))
+})
+
+test_that("prestoStatementReturnsRows: keyword-prefixed words must not false-positive", {
+  expect_false(prestoStatementReturnsRows("SELECTED"))
+  expect_false(prestoStatementReturnsRows("SELECTION FROM t"))
+  expect_false(prestoStatementReturnsRows("WITHOUT ROWID"))
+  expect_false(prestoStatementReturnsRows("TABLES"))
+  expect_false(prestoStatementReturnsRows("DESCRIPTION"))
+  expect_false(prestoStatementReturnsRows("VALUED"))
+  expect_false(prestoStatementReturnsRows("SHOWCASE"))
+  expect_false(prestoStatementReturnsRows("EXPLAINER"))
+})
+
+test_that("prestoStatementReturnsRows: empty / comment-only / non-alpha / unterminated", {
   expect_false(prestoStatementReturnsRows(""))
   expect_false(prestoStatementReturnsRows(NULL))
+  expect_false(prestoStatementReturnsRows("   "))
+  expect_false(prestoStatementReturnsRows("-- only a comment"))
+  expect_false(prestoStatementReturnsRows("-- only a comment\n"))
+  expect_false(prestoStatementReturnsRows("/* only a block comment */"))
+  expect_false(prestoStatementReturnsRows("123"))
+  expect_false(prestoStatementReturnsRows("* FROM t"))
+  # an unterminated block comment cannot be stripped -> not row-returning
+  expect_false(prestoStatementReturnsRows("/* never closed SELECT 1"))
 })

--- a/tests/testthat/test_presto.R
+++ b/tests/testthat/test_presto.R
@@ -331,89 +331,90 @@ test_that("prestoStatementReturnsRows: empty / comment-only / non-alpha / unterm
 
 # ---------------------------------------------------------------------------
 # Complex real-world Presto / Treasure Data patterns
-# (fictional schema: sandbox_retail, l1_web, l1_crm, l1_store, l0_segment)
+# (fictional music-streaming domain: dev_music schema, raw_streams / acct_data /
+#  catalog_db / billing_data source schemas)
 # ---------------------------------------------------------------------------
 
 test_that("splitPrestoStatements: inline -- comment with non-ASCII text sits before semicolon", {
   # Pattern: WHERE ... -- 期間変更箇所\n; next-statement
   sql <- paste0(
-    "SELECT user_id, COUNT(1) AS sessions\n",
-    "FROM l1_web.session_log\n",
-    "WHERE TD_TIME_RANGE(time, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所\n",
-    "  AND hostname = 'shop.example.com'\n",
+    "SELECT listener_id, COUNT(1) AS play_cnt\n",
+    "FROM raw_streams.play_events\n",
+    "WHERE TD_TIME_RANGE(played_at, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所\n",
+    "  AND app_platform = 'ios'\n",
     "GROUP BY 1;\n",
-    "SELECT COUNT(DISTINCT user_id) AS dau FROM l1_web.session_log"
+    "SELECT COUNT(DISTINCT listener_id) AS dau FROM raw_streams.play_events"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 2)
   expect_true(grepl("-- 期間変更箇所", stmts[[1]]))
   expect_true(grepl("TD_TIME_RANGE", stmts[[1]]))
-  expect_equal(stmts[[2]], "SELECT COUNT(DISTINCT user_id) AS dau FROM l1_web.session_log")
+  expect_equal(stmts[[2]], "SELECT COUNT(DISTINCT listener_id) AS dau FROM raw_streams.play_events")
 })
 
 test_that("splitPrestoStatements: REGEXP_LIKE patterns with | inside string literals don't split", {
   sql <- paste(
-    "SELECT user_id,",
+    "SELECT listener_id,",
     "  CASE",
-    "    WHEN REGEXP_LIKE(category, 'shoes|bags|apparel') THEN 'fashion'",
-    "    WHEN REGEXP_LIKE(category, 'tv|laptop|phone') THEN 'electronics'",
+    "    WHEN REGEXP_LIKE(genre_tag, 'pop|rock|jazz') THEN 'mainstream'",
+    "    WHEN REGEXP_LIKE(genre_tag, 'classical|opera|ambient') THEN 'niche'",
     "    ELSE 'other'",
-    "  END AS segment",
-    "FROM l1_crm.purchase_log",
-    "WHERE TD_TIME_RANGE(time, '2026-01-01', NULL, 'JST');",
-    "SELECT segment, COUNT(DISTINCT user_id) AS users FROM l1_crm.purchase_log GROUP BY 1",
+    "  END AS taste_segment",
+    "FROM acct_data.listening_history",
+    "WHERE TD_TIME_RANGE(played_at, '2026-01-01', NULL, 'JST');",
+    "SELECT taste_segment, COUNT(DISTINCT listener_id) AS listeners FROM acct_data.listening_history GROUP BY 1",
     sep = "\n"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 2)
   expect_true(grepl("REGEXP_LIKE", stmts[[1]]))
-  expect_true(grepl("'shoes\\|bags\\|apparel'", stmts[[1]]))
+  expect_true(grepl("'pop\\|rock\\|jazz'", stmts[[1]]))
 })
 
 test_that("splitPrestoStatements: VALUES inline table with many literals inside a CTE", {
-  # Pattern: excluded IDs defined as inline VALUES, semicolon must not fire inside literals
+  # Pattern: excluded test-account IDs defined as inline VALUES
   sql <- paste(
-    "WITH excluded_ids AS (",
-    "  SELECT user_id FROM (",
+    "WITH excluded_accounts AS (",
+    "  SELECT account_id FROM (",
     "    VALUES",
-    "    ('uid-aaa-001'), ('uid-bbb-002'), ('uid-ccc-003'),",
-    "    ('uid-ddd-004'), ('uid-eee-005'), ('uid-fff-006'),",
-    "    ('uid-ggg-007'), ('uid-hhh-008')",
-    "  ) AS t (user_id)",
+    "    ('acct-001-test'), ('acct-002-test'), ('acct-003-test'),",
+    "    ('acct-004-demo'), ('acct-005-demo'), ('acct-006-demo'),",
+    "    ('acct-007-internal'), ('acct-008-internal')",
+    "  ) AS t (account_id)",
     ")",
-    "SELECT m.user_id, m.email",
-    "FROM l1_crm.members AS m",
-    "WHERE m.user_id NOT IN (SELECT user_id FROM excluded_ids)",
-    "  AND m.status = 'active';",
-    "SELECT COUNT(*) FROM l1_crm.members WHERE status = 'active'",
+    "SELECT p.account_id, p.plan_type",
+    "FROM billing_data.subscriptions AS p",
+    "WHERE p.account_id NOT IN (SELECT account_id FROM excluded_accounts)",
+    "  AND p.plan_type = 'premium';",
+    "SELECT COUNT(*) FROM billing_data.subscriptions WHERE plan_type = 'premium'",
     sep = "\n"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 2)
   expect_true(grepl("VALUES", stmts[[1]]))
-  expect_true(grepl("'uid-hhh-008'", stmts[[1]]))
-  expect_equal(stmts[[2]], "SELECT COUNT(*) FROM l1_crm.members WHERE status = 'active'")
+  expect_true(grepl("'acct-008-internal'", stmts[[1]]))
+  expect_equal(stmts[[2]], "SELECT COUNT(*) FROM billing_data.subscriptions WHERE plan_type = 'premium'")
 })
 
 test_that("splitPrestoStatements: CROSS JOIN UNNEST + UNION ALL is a single statement", {
   # Pattern: REGEXP_EXTRACT_ALL produces array, UNNEST expands it,
   # UNION ALL re-attaches rows where array was empty
   sql <- paste(
-    "WITH raw_events AS (",
-    "  SELECT user_id,",
-    "    REGEXP_EXTRACT_ALL(tag_string, '[a-z_]+') AS tag_array",
-    "  FROM l1_web.event_log",
-    "  WHERE TD_TIME_RANGE(time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "WITH raw_tags AS (",
+    "  SELECT listener_id,",
+    "    REGEXP_EXTRACT_ALL(mood_tags, '[a-z_]+') AS tag_array",
+    "  FROM raw_streams.play_events",
+    "  WHERE TD_TIME_RANGE(played_at, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
     "),",
     "expanded AS (",
-    "  SELECT user_id, tag",
-    "  FROM raw_events CROSS JOIN UNNEST(tag_array) AS t(tag)",
+    "  SELECT listener_id, tag",
+    "  FROM raw_tags CROSS JOIN UNNEST(tag_array) AS t(tag)",
     "  UNION ALL",
-    "  SELECT user_id, '' AS tag",
-    "  FROM raw_events",
+    "  SELECT listener_id, '' AS tag",
+    "  FROM raw_tags",
     "  WHERE ARRAY_JOIN(tag_array, ',') = ''",
     ")",
-    "SELECT user_id, tag, COUNT(1) AS cnt",
+    "SELECT listener_id, tag, COUNT(1) AS cnt",
     "FROM expanded",
     "GROUP BY 1, 2",
     sep = "\n"
@@ -428,245 +429,240 @@ test_that("splitPrestoStatements: CROSS JOIN UNNEST + UNION ALL is a single stat
 test_that("splitPrestoStatements: nested WITH (CTE inside outer CTE subquery)", {
   # Presto allows WITH inside a subquery — the inner WITH is not a statement separator
   sql <- paste(
-    "WITH outer_cte AS (",
-    "  WITH inner_agg AS (",
-    "    SELECT user_id, MAX(score) AS top_score",
-    "    FROM l1_crm.user_scores",
+    "WITH top_listeners AS (",
+    "  WITH monthly_plays AS (",
+    "    SELECT listener_id, MAX(play_count) AS peak_plays",
+    "    FROM acct_data.monthly_stats",
     "    GROUP BY 1",
     "  ),",
-    "  inner_filter AS (",
-    "    SELECT user_id FROM inner_agg WHERE top_score > 80",
+    "  qualified AS (",
+    "    SELECT listener_id FROM monthly_plays WHERE peak_plays > 500",
     "  )",
-    "  SELECT user_id, top_score FROM inner_agg",
-    "  WHERE user_id IN (SELECT user_id FROM inner_filter)",
+    "  SELECT listener_id, peak_plays FROM monthly_plays",
+    "  WHERE listener_id IN (SELECT listener_id FROM qualified)",
     ")",
-    "SELECT user_id, top_score FROM outer_cte ORDER BY top_score DESC",
+    "SELECT listener_id, peak_plays FROM top_listeners ORDER BY peak_plays DESC",
     sep = "\n"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 1)
-  expect_true(grepl("WITH inner_agg AS", stmts[[1]]))
-  expect_true(grepl("ORDER BY top_score DESC", stmts[[1]]))
+  expect_true(grepl("WITH monthly_plays AS", stmts[[1]]))
+  expect_true(grepl("ORDER BY peak_plays DESC", stmts[[1]]))
 })
 
 test_that("splitPrestoStatements: MAX_BY / MIN_BY / TD functions preserved across 3 statements", {
-  # Pattern: aggregate using TD-specific MAX_BY / MIN_BY, split into 3 statements
   sql <- paste(
-    "DROP TABLE IF EXISTS sandbox_retail.latest_purchase;",
-    "CREATE TABLE sandbox_retail.latest_purchase AS",
+    "DROP TABLE IF EXISTS dev_music.recent_track_per_listener;",
+    "CREATE TABLE dev_music.recent_track_per_listener AS",
     "WITH base AS (",
     "  SELECT",
-    "    user_id,",
-    "    MAX_BY(product_id, purchase_time) AS last_product,",
-    "    MIN_BY(product_id, purchase_time) AS first_product,",
-    "    COUNT(1) AS purchase_cnt",
-    "  FROM l1_store.purchase_log",
-    "  WHERE TD_TIME_RANGE(purchase_time, '2025-12-01', '2026-03-01', 'JST') -- 期間変更箇所",
+    "    listener_id,",
+    "    MAX_BY(track_id, played_at) AS last_track,",
+    "    MIN_BY(track_id, played_at) AS first_track,",
+    "    COUNT(1) AS total_plays",
+    "  FROM raw_streams.play_events",
+    "  WHERE TD_TIME_RANGE(played_at, '2025-12-01', '2026-03-01', 'JST') -- 期間変更箇所",
     "  GROUP BY 1",
     ")",
-    "SELECT user_id, last_product, first_product, purchase_cnt",
+    "SELECT listener_id, last_track, first_track, total_plays",
     "FROM base",
-    "WHERE purchase_cnt >= 2;",
-    "SELECT user_id, last_product FROM sandbox_retail.latest_purchase LIMIT 100",
+    "WHERE total_plays >= 10;",
+    "SELECT listener_id, last_track FROM dev_music.recent_track_per_listener LIMIT 100",
     sep = "\n"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 3)
-  expect_equal(stmts[[1]], "DROP TABLE IF EXISTS sandbox_retail.latest_purchase")
-  expect_true(startsWith(stmts[[2]], "CREATE TABLE sandbox_retail.latest_purchase AS"))
+  expect_equal(stmts[[1]], "DROP TABLE IF EXISTS dev_music.recent_track_per_listener")
+  expect_true(startsWith(stmts[[2]], "CREATE TABLE dev_music.recent_track_per_listener AS"))
   expect_true(grepl("MAX_BY", stmts[[2]]))
   expect_true(grepl("MIN_BY", stmts[[2]]))
   expect_true(grepl("TD_TIME_RANGE", stmts[[2]]))
-  expect_equal(stmts[[3]], "SELECT user_id, last_product FROM sandbox_retail.latest_purchase LIMIT 100")
+  expect_equal(stmts[[3]], "SELECT listener_id, last_track FROM dev_music.recent_track_per_listener LIMIT 100")
 })
 
 test_that("splitPrestoStatements: 5-stmt pipeline with step comments embedded in statements", {
   # Mirrors the real-world 3-step pattern: DROP+CREATE, DROP+CREATE, final SELECT
-  # The step-header comments (--) are attached to the following DROP statement
+  # The step-header -- comment is attached to the DROP statement that follows it
   sql <- paste(
-    "-- Step 1: build campaign user list",
-    "DROP TABLE IF EXISTS sandbox_retail.kpi_user_list;",
-    "CREATE TABLE sandbox_retail.kpi_user_list AS",
-    "WITH uid_map AS (",
-    "  SELECT user_hash AS uid, member_id",
-    "  FROM l1_member.uid_member_mapping",
-    "  WHERE is_latest = 1 AND member_id IS NOT NULL",
+    "-- Step 1: build target listener list",
+    "DROP TABLE IF EXISTS dev_music.campaign_listener_list;",
+    "CREATE TABLE dev_music.campaign_listener_list AS",
+    "WITH device_map AS (",
+    "  SELECT device_token AS token, account_id",
+    "  FROM acct_data.device_account_mapping",
+    "  WHERE is_active = 1 AND account_id IS NOT NULL",
     "  GROUP BY 1, 2",
     "),",
-    "web_access AS (",
-    "  SELECT m.member_id",
-    "  FROM l1_web.session_log AS s",
-    "  LEFT JOIN l1_web.user_id_map AS m USING(session_uid)",
-    "  WHERE TD_TIME_RANGE(s.access_time, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所",
-    "    AND s.hostname = 'shop.example.com'",
-    "    AND m.member_id IS NOT NULL",
+    "app_sessions AS (",
+    "  SELECT m.account_id",
+    "  FROM raw_streams.device_sessions AS s",
+    "  LEFT JOIN acct_data.device_account_mapping AS m USING(device_token)",
+    "  WHERE TD_TIME_RANGE(s.session_start, '2025-12-01', '2026-02-01', 'JST') -- 期間変更箇所",
+    "    AND s.app_version >= '3.0'",
+    "    AND m.account_id IS NOT NULL",
     "  GROUP BY 1",
     ")",
-    "SELECT t1.member_id,",
-    "  IF(t2.member_id IS NOT NULL, 1, 0) AS is_priority",
-    "FROM l1_crm.registered_members AS t1",
-    "LEFT JOIN web_access AS t2 ON t1.member_id = t2.member_id",
-    "WHERE t1.status = 'active';",
+    "SELECT t1.account_id,",
+    "  IF(t2.account_id IS NOT NULL, 1, 0) AS is_high_value",
+    "FROM billing_data.subscribers AS t1",
+    "LEFT JOIN app_sessions AS t2 ON t1.account_id = t2.account_id",
+    "WHERE t1.plan_type = 'premium';",
     "",
-    "-- Step 2: build action log",
-    "DROP TABLE IF EXISTS sandbox_retail.kpi_action_list;",
-    "CREATE TABLE sandbox_retail.kpi_action_list AS",
-    "WITH actions AS (",
-    "  SELECT user_id, event_type,",
-    "    MIN(event_time) AS first_time, COUNT(1) AS cnt",
-    "  FROM l1_web.event_log",
-    "  WHERE TD_TIME_RANGE(event_time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
-    "    AND event_type IS NOT NULL",
+    "-- Step 2: build listening-action log",
+    "DROP TABLE IF EXISTS dev_music.campaign_action_log;",
+    "CREATE TABLE dev_music.campaign_action_log AS",
+    "WITH plays AS (",
+    "  SELECT listener_id, content_type,",
+    "    MIN(played_at) AS first_play, COUNT(1) AS play_cnt",
+    "  FROM raw_streams.play_events",
+    "  WHERE TD_TIME_RANGE(played_at, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "    AND content_type IS NOT NULL",
     "  GROUP BY 1, 2",
     ")",
-    "SELECT * FROM actions;",
+    "SELECT * FROM plays;",
     "",
     "-- Step 3: final aggregation",
-    "SELECT u.member_id,",
-    "  COALESCE(a.cnt, 0) AS action_cnt,",
-    "  u.is_priority",
-    "FROM sandbox_retail.kpi_user_list AS u",
-    "LEFT JOIN sandbox_retail.kpi_action_list AS a USING(member_id)",
+    "SELECT u.account_id,",
+    "  COALESCE(a.play_cnt, 0) AS total_plays,",
+    "  u.is_high_value",
+    "FROM dev_music.campaign_listener_list AS u",
+    "LEFT JOIN dev_music.campaign_action_log AS a ON u.account_id = a.listener_id",
     "ORDER BY 2 DESC",
     sep = "\n"
   )
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 5)
-  # step comment is part of the DROP statement that follows it
-  expect_true(grepl("DROP TABLE IF EXISTS sandbox_retail.kpi_user_list", stmts[[1]]))
-  expect_true(startsWith(stmts[[2]], "CREATE TABLE sandbox_retail.kpi_user_list AS"))
-  expect_true(grepl("MAX_BY\\|MIN_BY\\|IF\\|TD_TIME_RANGE\\|web_access", stmts[[2]]) ||
-              grepl("IF\\(t2", stmts[[2]]))
-  expect_true(grepl("DROP TABLE IF EXISTS sandbox_retail.kpi_action_list", stmts[[3]]))
-  expect_true(startsWith(stmts[[4]], "CREATE TABLE sandbox_retail.kpi_action_list AS"))
-  expect_true(grepl("SELECT u.member_id", stmts[[5]]))
+  expect_true(grepl("DROP TABLE IF EXISTS dev_music.campaign_listener_list", stmts[[1]]))
+  expect_true(startsWith(stmts[[2]], "CREATE TABLE dev_music.campaign_listener_list AS"))
+  expect_true(grepl("IF\\(t2", stmts[[2]]))
+  expect_true(grepl("DROP TABLE IF EXISTS dev_music.campaign_action_log", stmts[[3]]))
+  expect_true(startsWith(stmts[[4]], "CREATE TABLE dev_music.campaign_action_log AS"))
+  expect_true(grepl("SELECT u.account_id", stmts[[5]]))
   expect_true(grepl("ORDER BY 2 DESC", stmts[[5]]))
 })
 
 test_that("prestoStatementReturnsRows: complex WITH + nested WITH + UNION ALL + ORDER BY is row-returning", {
-  # Mirrors Step 4 in the real-world script: final SELECT-only with
-  # outer CTEs each containing inner WITH, joined by UNION ALL, ORDER BY at end
+  # Mirrors Step 4 in the real-world script: final SELECT-only with outer CTEs
+  # each containing their own inner WITH, joined by UNION ALL, ORDER BY at end
   sql <- paste(
-    "WITH prev_stage AS (",
-    "  WITH stage_scores AS (",
-    "    SELECT user_id,",
+    "WITH prev_engagement AS (",
+    "  WITH engagement_scores AS (",
+    "    SELECT listener_id,",
     "      CASE",
-    "        WHEN COUNT(DISTINCT stage || behavior) >= 3 THEN 2",
-    "        WHEN COUNT(DISTINCT stage || behavior) >= 1 THEN 1",
+    "        WHEN COUNT(DISTINCT content_type || genre_tag) >= 3 THEN 2",
+    "        WHEN COUNT(DISTINCT content_type || genre_tag) >= 1 THEN 1",
     "        ELSE 0",
-    "      END AS stage_lvl",
-    "    FROM sandbox_retail.kpi_action_list",
-    "    WHERE TD_TIME_RANGE(action_time, '2026-01-01', '2026-02-01', 'JST') -- 期間変更箇所",
-    "      AND stage IN ('awareness', 'interest')",
+    "      END AS eng_lvl",
+    "    FROM dev_music.campaign_action_log",
+    "    WHERE TD_TIME_RANGE(first_play, '2026-01-01', '2026-02-01', 'JST') -- 期間変更箇所",
+    "      AND content_type IN ('track', 'album')",
     "    GROUP BY 1",
     "  )",
-    "  SELECT user_id, MAX(stage_lvl) AS start_stage FROM stage_scores GROUP BY 1",
+    "  SELECT listener_id, MAX(eng_lvl) AS start_eng FROM engagement_scores GROUP BY 1",
     "),",
-    "curr_stage AS (",
-    "  WITH stage_scores AS (",
-    "    SELECT user_id,",
+    "curr_engagement AS (",
+    "  WITH engagement_scores AS (",
+    "    SELECT listener_id,",
     "      CASE",
-    "        WHEN COUNT(DISTINCT stage || behavior) >= 3 THEN 2",
-    "        WHEN COUNT(DISTINCT stage || behavior) >= 1 THEN 1",
+    "        WHEN COUNT(DISTINCT content_type || genre_tag) >= 3 THEN 2",
+    "        WHEN COUNT(DISTINCT content_type || genre_tag) >= 1 THEN 1",
     "        ELSE 0",
-    "      END AS stage_lvl",
-    "    FROM sandbox_retail.kpi_action_list",
-    "    WHERE TD_TIME_RANGE(action_time, '2026-02-01', NULL, 'JST') -- 期間変更箇所",
-    "      AND stage IN ('awareness', 'interest')",
+    "      END AS eng_lvl",
+    "    FROM dev_music.campaign_action_log",
+    "    WHERE TD_TIME_RANGE(first_play, '2026-02-01', NULL, 'JST') -- 期間変更箇所",
+    "      AND content_type IN ('track', 'album')",
     "    GROUP BY 1",
     "  )",
-    "  SELECT user_id, MAX(stage_lvl) AS latest_stage FROM stage_scores GROUP BY 1",
+    "  SELECT listener_id, MAX(eng_lvl) AS latest_eng FROM engagement_scores GROUP BY 1",
     "),",
-    "ai_chat_users AS (",
-    "  SELECT DISTINCT user_id FROM sandbox_retail.kpi_action_list",
-    "  WHERE type = 'AI chat'",
-    "    AND TD_TIME_RANGE(action_time, '2026-02-01', NULL, 'JST')",
+    "rec_engine_users AS (",
+    "  SELECT DISTINCT listener_id FROM dev_music.campaign_action_log",
+    "  WHERE content_type = 'recommendation'",
+    "    AND TD_TIME_RANGE(first_play, '2026-02-01', NULL, 'JST')",
     ")",
-    "-- group A: AI chat users",
-    "SELECT 'A: AI chat users' AS cohort,",
-    "  CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "    WHEN 1 THEN '1:interest' ELSE '0:none' END AS start_stage,",
-    "  CASE WHEN COALESCE(t3.latest_stage, 0) >= t2.start_stage",
-    "    THEN CASE t3.latest_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
-    "    ELSE CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "-- cohort A: used recommendation engine",
+    "SELECT 'A: used recommendations' AS cohort,",
+    "  CASE t2.start_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "    WHEN 1 THEN '1:aware' ELSE '0:none' END AS start_stage,",
+    "  CASE WHEN COALESCE(t3.latest_eng, 0) >= t2.start_eng",
+    "    THEN CASE t3.latest_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "           WHEN 1 THEN '1:aware' ELSE '0:none' END",
+    "    ELSE CASE t2.start_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "           WHEN 1 THEN '1:aware' ELSE '0:none' END",
     "  END AS latest_stage,",
-    "  COUNT(DISTINCT t1.user_id) AS cnt",
-    "FROM sandbox_retail.kpi_user_list AS t1",
-    "LEFT JOIN prev_stage AS t2 ON t1.user_id = t2.user_id",
-    "LEFT JOIN curr_stage AS t3 ON t1.user_id = t3.user_id",
-    "INNER JOIN ai_chat_users AS t4 ON t1.user_id = t4.user_id",
-    "WHERE t3.latest_stage IS NOT NULL",
+    "  COUNT(DISTINCT t1.account_id) AS cnt",
+    "FROM dev_music.campaign_listener_list AS t1",
+    "LEFT JOIN prev_engagement AS t2 ON t1.account_id = t2.listener_id",
+    "LEFT JOIN curr_engagement AS t3 ON t1.account_id = t3.listener_id",
+    "INNER JOIN rec_engine_users AS t4 ON t1.account_id = t4.listener_id",
+    "WHERE t3.latest_eng IS NOT NULL",
     "GROUP BY 1, 2, 3",
     "UNION ALL",
-    "-- group B: no AI chat",
-    "SELECT 'B: no AI chat' AS cohort,",
-    "  CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "    WHEN 1 THEN '1:interest' ELSE '0:none' END AS start_stage,",
-    "  CASE WHEN COALESCE(t3.latest_stage, 0) >= t2.start_stage",
-    "    THEN CASE t3.latest_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
-    "    ELSE CASE t2.start_stage WHEN 3 THEN '3:purchase' WHEN 2 THEN '2:visit'",
-    "           WHEN 1 THEN '1:interest' ELSE '0:none' END",
+    "-- cohort B: did not use recommendation engine",
+    "SELECT 'B: no recommendations' AS cohort,",
+    "  CASE t2.start_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "    WHEN 1 THEN '1:aware' ELSE '0:none' END AS start_stage,",
+    "  CASE WHEN COALESCE(t3.latest_eng, 0) >= t2.start_eng",
+    "    THEN CASE t3.latest_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "           WHEN 1 THEN '1:aware' ELSE '0:none' END",
+    "    ELSE CASE t2.start_eng WHEN 3 THEN '3:converted' WHEN 2 THEN '2:engaged'",
+    "           WHEN 1 THEN '1:aware' ELSE '0:none' END",
     "  END AS latest_stage,",
-    "  COUNT(DISTINCT t1.user_id) AS cnt",
-    "FROM sandbox_retail.kpi_user_list AS t1",
-    "LEFT JOIN prev_stage AS t2 ON t1.user_id = t2.user_id",
-    "LEFT JOIN curr_stage AS t3 ON t1.user_id = t3.user_id",
-    "LEFT JOIN ai_chat_users AS t4 ON t1.user_id = t4.user_id",
-    "WHERE t3.latest_stage IS NOT NULL",
-    "  AND t4.user_id IS NULL",
+    "  COUNT(DISTINCT t1.account_id) AS cnt",
+    "FROM dev_music.campaign_listener_list AS t1",
+    "LEFT JOIN prev_engagement AS t2 ON t1.account_id = t2.listener_id",
+    "LEFT JOIN curr_engagement AS t3 ON t1.account_id = t3.listener_id",
+    "LEFT JOIN rec_engine_users AS t4 ON t1.account_id = t4.listener_id",
+    "WHERE t3.latest_eng IS NOT NULL",
+    "  AND t4.listener_id IS NULL",
     "GROUP BY 1, 2, 3",
     "ORDER BY 1, 2",
     sep = "\n"
   )
-  # the statement starts with WITH → row-returning
   expect_true(prestoStatementReturnsRows(sql))
-  # it is one unsplit statement
   stmts <- splitPrestoStatements(sql)
   expect_equal(length(stmts), 1)
 })
 
 test_that("prestoStatementReturnsRows: CREATE TABLE AS WITH multi-CTE is not row-returning", {
   sql <- paste(
-    "CREATE TABLE sandbox_retail.kpi_action_list AS",
-    "WITH web_log AS (",
-    "  SELECT m.user_id, 'Web' AS channel,",
+    "CREATE TABLE dev_music.campaign_action_log AS",
+    "WITH app_play_log AS (",
+    "  SELECT m.account_id, 'app' AS channel,",
     "    CASE",
-    "      WHEN REGEXP_LIKE(cat, 'pricing|specs|compare') THEN 'consideration'",
-    "      WHEN REGEXP_LIKE(cat, 'brand|campaign') THEN 'awareness'",
-    "    END AS stage,",
-    "    TD_TIME_STRING(MIN(s.event_time), 'M!', 'JST') AS report_month,",
-    "    MIN(s.event_time) AS action_time,",
-    "    COUNT(1) AS cnt",
-    "  FROM l1_web.event_log AS s",
-    "  LEFT JOIN l1_web.user_id_map AS m USING(session_uid)",
-    "  WHERE TD_TIME_RANGE(s.event_time, '2025-12-01', NULL, 'JST') -- 期間変更箇所",
-    "    AND s.hostname = 'shop.example.com'",
-    "    AND m.user_id IS NOT NULL",
-    "    AND cat IS NOT NULL",
+    "      WHEN REGEXP_LIKE(genre_tag, 'pop|rock|hiphop') THEN 'mainstream'",
+    "      WHEN REGEXP_LIKE(genre_tag, 'classical|jazz|ambient') THEN 'niche'",
+    "    END AS taste_segment,",
+    "    TD_TIME_STRING(MIN(s.played_at), 'M!', 'JST') AS report_month,",
+    "    MIN(s.played_at) AS action_time,",
+    "    COUNT(1) AS play_cnt",
+    "  FROM raw_streams.play_events AS s",
+    "  LEFT JOIN acct_data.device_account_mapping AS m USING(device_token)",
+    "  WHERE TD_TIME_RANGE(s.played_at, '2025-12-01', NULL, 'JST') -- 期間変更箇所",
+    "    AND s.app_platform IN ('ios', 'android')",
+    "    AND m.account_id IS NOT NULL",
+    "    AND genre_tag IS NOT NULL",
     "  GROUP BY 1, 2, 3, 4",
     "),",
-    "chat_log AS (",
-    "  SELECT user_id, 'AI chat' AS channel,",
+    "rec_chat_log AS (",
+    "  SELECT account_id, 'rec_chat' AS channel,",
     "    CASE",
-    "      WHEN REGEXP_LIKE(intent_tags, 'price|discount|budget') THEN 'consideration'",
-    "      WHEN REGEXP_LIKE(intent_tags, 'brand|model') THEN 'awareness'",
-    "      WHEN conversation_completed IS NULL THEN 'no conversation'",
+    "      WHEN REGEXP_LIKE(query_text, 'similar|more like|recommend') THEN 'discovery'",
+    "      WHEN REGEXP_LIKE(query_text, 'chart|top|popular') THEN 'mainstream'",
+    "      WHEN conversation_ended IS NULL THEN 'no response'",
     "      ELSE 'other'",
-    "    END AS stage,",
-    "    TD_TIME_STRING(TD_TIME_PARSE(session_date, 'JST'), 'M!', 'JST') AS report_month,",
-    "    MIN(TD_TIME_PARSE(session_date, 'JST')) AS action_time,",
-    "    COUNT(1) AS cnt",
-    "  FROM l1_store.ai_chat_sessions",
-    "  WHERE TD_TIME_RANGE(TD_TIME_PARSE(session_date, 'JST'), '2026-01-01', NULL, 'JST')",
-    "    AND user_id IS NOT NULL",
+    "    END AS taste_segment,",
+    "    TD_TIME_STRING(TD_TIME_PARSE(chat_date, 'JST'), 'M!', 'JST') AS report_month,",
+    "    MIN(TD_TIME_PARSE(chat_date, 'JST')) AS action_time,",
+    "    COUNT(1) AS chat_cnt",
+    "  FROM catalog_db.rec_chat_sessions",
+    "  WHERE TD_TIME_RANGE(TD_TIME_PARSE(chat_date, 'JST'), '2026-01-01', NULL, 'JST')",
+    "    AND account_id IS NOT NULL",
     "  GROUP BY 1, 2, 3, 4",
     ")",
-    "SELECT * FROM web_log",
+    "SELECT * FROM app_play_log",
     "UNION ALL",
-    "SELECT * FROM chat_log",
+    "SELECT * FROM rec_chat_log",
     sep = "\n"
   )
   expect_false(prestoStatementReturnsRows(sql))
@@ -675,21 +671,21 @@ test_that("prestoStatementReturnsRows: CREATE TABLE AS WITH multi-CTE is not row
 test_that("prestoStatementReturnsRows: SELECT with CASE, REGEXP_LIKE, TD functions is row-returning", {
   sql <- paste(
     "SELECT",
-    "  user_id,",
+    "  listener_id,",
     "  CASE",
-    "    WHEN REGEXP_LIKE(behavior_tags, 'purchase|checkout|payment') THEN 'converted'",
-    "    WHEN REGEXP_LIKE(behavior_tags, 'wishlist|cart|compare') THEN 'considering'",
-    "    WHEN REGEXP_LIKE(behavior_tags, 'view|search|browse') THEN 'browsing'",
+    "    WHEN REGEXP_LIKE(action_tags, 'subscribe|upgrade|purchase') THEN 'converted'",
+    "    WHEN REGEXP_LIKE(action_tags, 'playlist|save|follow') THEN 'engaged'",
+    "    WHEN REGEXP_LIKE(action_tags, 'play|search|browse') THEN 'exploring'",
     "    ELSE 'unknown'",
     "  END AS funnel_stage,",
-    "  TD_TIME_STRING(MIN(event_time), 'yyyy-MM-dd', 'JST') AS first_event_date,",
-    "  TD_TIME_STRING(MAX(event_time), 'yyyy-MM-dd', 'JST') AS last_event_date,",
+    "  TD_TIME_STRING(MIN(played_at), 'yyyy-MM-dd', 'JST') AS first_action_date,",
+    "  TD_TIME_STRING(MAX(played_at), 'yyyy-MM-dd', 'JST') AS last_action_date,",
     "  COUNT(DISTINCT session_id) AS session_cnt,",
     "  COUNT(1) AS event_cnt",
-    "FROM l1_web.event_log",
-    "WHERE TD_TIME_RANGE(event_time, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
-    "  AND hostname = 'shop.example.com'",
-    "  AND user_id IS NOT NULL",
+    "FROM raw_streams.play_events",
+    "WHERE TD_TIME_RANGE(played_at, '2026-01-01', NULL, 'JST') -- 期間変更箇所",
+    "  AND app_platform = 'ios'",
+    "  AND listener_id IS NOT NULL",
     "GROUP BY 1, 2",
     "ORDER BY session_cnt DESC",
     sep = "\n"

--- a/tests/testthat/test_presto.R
+++ b/tests/testthat/test_presto.R
@@ -207,7 +207,15 @@ test_that("prestoStatementReturnsRows: SHOW family", {
   expect_true(prestoStatementReturnsRows("SHOW FUNCTIONS"))
   expect_true(prestoStatementReturnsRows("SHOW SESSION"))
   expect_true(prestoStatementReturnsRows("SHOW STATS FOR t"))
+  expect_true(prestoStatementReturnsRows("SHOW STATS FOR TABLE t"))
   expect_true(prestoStatementReturnsRows("SHOW CREATE TABLE t"))
+  expect_true(prestoStatementReturnsRows("SHOW CREATE VIEW v"))
+  expect_true(prestoStatementReturnsRows("SHOW CREATE SCHEMA s"))
+  expect_true(prestoStatementReturnsRows("SHOW CREATE FUNCTION f"))
+  expect_true(prestoStatementReturnsRows("SHOW CREATE MATERIALIZED VIEW mv"))
+  expect_true(prestoStatementReturnsRows("SHOW GRANTS ON TABLE t"))
+  expect_true(prestoStatementReturnsRows("SHOW ROLES"))
+  expect_true(prestoStatementReturnsRows("SHOW ROLE GRANTS"))
 })
 
 test_that("prestoStatementReturnsRows: DESCRIBE / DESC / EXPLAIN", {
@@ -246,12 +254,22 @@ test_that("prestoStatementReturnsRows: DDL is not row-returning", {
   expect_false(prestoStatementReturnsRows("CREATE OR REPLACE VIEW v AS SELECT 1"))
   expect_false(prestoStatementReturnsRows("CREATE SCHEMA s"))
   expect_false(prestoStatementReturnsRows("CREATE MATERIALIZED VIEW mv AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("CREATE FUNCTION f(x INT) RETURNS INT RETURN x + 1"))
+  expect_false(prestoStatementReturnsRows("CREATE VECTOR INDEX ON t (c)"))
+  expect_false(prestoStatementReturnsRows("CREATE ROLE admin"))
   expect_false(prestoStatementReturnsRows("DROP TABLE foo"))
   expect_false(prestoStatementReturnsRows("DROP TABLE IF EXISTS foo"))
   expect_false(prestoStatementReturnsRows("DROP VIEW v"))
   expect_false(prestoStatementReturnsRows("DROP SCHEMA s"))
+  expect_false(prestoStatementReturnsRows("DROP MATERIALIZED VIEW mv"))
+  expect_false(prestoStatementReturnsRows("DROP FUNCTION f"))
+  expect_false(prestoStatementReturnsRows("DROP ROLE admin"))
   expect_false(prestoStatementReturnsRows("ALTER TABLE foo ADD COLUMN x INT"))
   expect_false(prestoStatementReturnsRows("ALTER TABLE foo RENAME TO bar"))
+  expect_false(prestoStatementReturnsRows("ALTER SCHEMA s RENAME TO s2"))
+  expect_false(prestoStatementReturnsRows("ALTER VIEW v RENAME TO v2"))
+  expect_false(prestoStatementReturnsRows("ALTER FUNCTION f RETURNS NULL ON NULL INPUT"))
+  expect_false(prestoStatementReturnsRows("REFRESH MATERIALIZED VIEW mv"))
   expect_false(prestoStatementReturnsRows("COMMENT ON TABLE foo IS 'note'"))
 })
 
@@ -274,15 +292,17 @@ test_that("prestoStatementReturnsRows: session / transaction / admin are not row
   expect_false(prestoStatementReturnsRows("COMMIT"))
   expect_false(prestoStatementReturnsRows("ROLLBACK"))
   expect_false(prestoStatementReturnsRows("GRANT SELECT ON t TO u"))
+  expect_false(prestoStatementReturnsRows("GRANT ROLES admin TO u"))
   expect_false(prestoStatementReturnsRows("REVOKE SELECT ON t FROM u"))
-  expect_false(prestoStatementReturnsRows("DENY SELECT ON t TO u"))
+  expect_false(prestoStatementReturnsRows("REVOKE ROLES admin FROM u"))
   expect_false(prestoStatementReturnsRows("CALL system.runtime.kill_query('q')"))
   expect_false(prestoStatementReturnsRows("ANALYZE t"))
   expect_false(prestoStatementReturnsRows("PREPARE my_query FROM SELECT 1"))
   expect_false(prestoStatementReturnsRows("DEALLOCATE PREPARE my_query"))
-  # EXECUTE may return rows when the prepared statement is a SELECT, but the
-  # keyword whitelist does not include it -- classified as non-row-returning.
+  # EXECUTE returns rows when the prepared statement is SELECT, but the keyword
+  # whitelist does not include EXECUTE -- classified conservatively as non-row-returning.
   expect_false(prestoStatementReturnsRows("EXECUTE my_query"))
+  expect_false(prestoStatementReturnsRows("EXECUTE my_query USING 1, 'foo'"))
 })
 
 test_that("prestoStatementReturnsRows: keyword-prefixed words must not false-positive", {

--- a/tests/testthat/test_presto.R
+++ b/tests/testthat/test_presto.R
@@ -1,0 +1,90 @@
+context("test presto helpers")
+
+test_that("splitPrestoStatements: empty / null / whitespace", {
+  expect_equal(splitPrestoStatements(NULL), character(0))
+  expect_equal(splitPrestoStatements(""), character(0))
+  expect_equal(splitPrestoStatements("   \n  "), character(0))
+  expect_equal(splitPrestoStatements(";"), character(0))
+  expect_equal(splitPrestoStatements(";;;"), character(0))
+})
+
+test_that("splitPrestoStatements: single statement with and without trailing semicolon", {
+  expect_equal(splitPrestoStatements("SELECT 1"), c("SELECT 1"))
+  expect_equal(splitPrestoStatements("SELECT 1;"), c("SELECT 1"))
+  expect_equal(splitPrestoStatements("  SELECT 1  ;  "), c("SELECT 1"))
+})
+
+test_that("splitPrestoStatements: multiple statements", {
+  expect_equal(
+    splitPrestoStatements("DROP TABLE foo; CREATE TABLE foo AS SELECT 1; SELECT * FROM foo"),
+    c("DROP TABLE foo", "CREATE TABLE foo AS SELECT 1", "SELECT * FROM foo")
+  )
+  expect_equal(
+    splitPrestoStatements("SELECT 1;\nSELECT 2;\nSELECT 3;"),
+    c("SELECT 1", "SELECT 2", "SELECT 3")
+  )
+})
+
+test_that("splitPrestoStatements: ; inside single-quoted literal does not split", {
+  expect_equal(splitPrestoStatements("SELECT 'a;b;c'"), c("SELECT 'a;b;c'"))
+  expect_equal(
+    splitPrestoStatements("SELECT 'a;b'; SELECT 2"),
+    c("SELECT 'a;b'", "SELECT 2")
+  )
+  # escaped quote ('') inside literal
+  expect_equal(
+    splitPrestoStatements("SELECT 'it''s; ok'; SELECT 2"),
+    c("SELECT 'it''s; ok'", "SELECT 2")
+  )
+})
+
+test_that("splitPrestoStatements: ; inside double-quoted identifier does not split", {
+  expect_equal(
+    splitPrestoStatements("SELECT \"a;b\" FROM t; SELECT 2"),
+    c("SELECT \"a;b\" FROM t", "SELECT 2")
+  )
+})
+
+test_that("splitPrestoStatements: ; inside line comment does not split", {
+  expect_equal(
+    splitPrestoStatements("SELECT 1 -- comment ; not a split\n; SELECT 2"),
+    c("SELECT 1 -- comment ; not a split", "SELECT 2")
+  )
+})
+
+test_that("splitPrestoStatements: ; inside block comment does not split", {
+  expect_equal(
+    splitPrestoStatements("SELECT 1 /* a;b;c */; SELECT 2"),
+    c("SELECT 1 /* a;b;c */", "SELECT 2")
+  )
+})
+
+test_that("prestoStatementReturnsRows: positive cases", {
+  expect_true(prestoStatementReturnsRows("SELECT 1"))
+  expect_true(prestoStatementReturnsRows("  SELECT 1"))
+  expect_true(prestoStatementReturnsRows("WITH t AS (SELECT 1) SELECT * FROM t"))
+  expect_true(prestoStatementReturnsRows("show schemas"))
+  expect_true(prestoStatementReturnsRows("DESCRIBE foo"))
+  expect_true(prestoStatementReturnsRows("DESC foo"))
+  expect_true(prestoStatementReturnsRows("EXPLAIN SELECT 1"))
+  expect_true(prestoStatementReturnsRows("VALUES (1), (2)"))
+  expect_true(prestoStatementReturnsRows("TABLE foo"))
+  expect_true(prestoStatementReturnsRows("(SELECT 1)"))
+  expect_true(prestoStatementReturnsRows("-- leading comment\nSELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* block */ SELECT 1"))
+  expect_true(prestoStatementReturnsRows("/* multi\nline\nblock */ SELECT 1"))
+  expect_true(prestoStatementReturnsRows("  /* a */ -- b\n /* c */ \n  SELECT 1"))
+})
+
+test_that("prestoStatementReturnsRows: negative cases", {
+  expect_false(prestoStatementReturnsRows("DROP TABLE foo"))
+  expect_false(prestoStatementReturnsRows("CREATE TABLE foo AS SELECT 1"))
+  expect_false(prestoStatementReturnsRows("INSERT INTO foo VALUES (1)"))
+  expect_false(prestoStatementReturnsRows("UPDATE foo SET x = 1"))
+  expect_false(prestoStatementReturnsRows("DELETE FROM foo"))
+  expect_false(prestoStatementReturnsRows("ALTER TABLE foo ADD COLUMN x INT"))
+  expect_false(prestoStatementReturnsRows("USE catalog.schema"))
+  expect_false(prestoStatementReturnsRows("CALL system.runtime.kill_query('q')"))
+  expect_false(prestoStatementReturnsRows(""))
+  expect_false(prestoStatementReturnsRows(NULL))
+})


### PR DESCRIPTION
## Description

Add multi-statement support to `queryPresto` / `queryTreasureData` so a single query string containing multiple `;`-separated SQL statements executes correctly against Presto/Trino's HTTP API, which only accepts one statement per request.

## Implementation Details

**New helpers (pure R, no external deps):**

- `splitPrestoStatements(sql)` — single-pass character-level scanner (state machine: `normal | sq | dq | lc | bc`) that splits on top-level `;` while respecting single-quoted string literals (`''` escape), double-quoted identifiers (`""` escape), line comments (`-- … \n`), and block comments (`/* … */`). Returns a character vector of trimmed, non-empty statements.

- `prestoStatementReturnsRows(sql)` — strips leading whitespace / line comments / block comments / `(`, then checks the first keyword against a whitelist: `SELECT`, `WITH`, `SHOW`, `DESCRIBE`, `DESC`, `EXPLAIN`, `VALUES`, `TABLE`. Returns `TRUE` when the statement is expected to produce a result set.

**`queryPresto` execution flow:**
- 0 statements → `data.frame()` immediately
- 1 statement → existing fast path (no behavior change)
- N statements → non-final statements run via `DBI::dbExecute`; final statement classified by `prestoStatementReturnsRows`: row-returning → `dbSendQuery` + `dbFetch`; DDL/DML → `DBI::dbExecute` + `data.frame()`

All error paths clear the pooled connection before re-throwing, with messages formatted as `Statement i of N failed: <original message>`.

## Build Impact

- R package version bumped: `15.1.2` → `15.1.3`
- No new package dependencies
- No JS/webpack changes

## How to Test

1. Connect to a Presto/Trino data source in Exploratory
2. Enter a multi-statement query separated by `;`, e.g.:
   ```sql
   SHOW SCHEMAS FROM system;
   SELECT table_schema, table_name FROM system.information_schema.tables ORDER BY table_schema
   ```
3. Verify the result of the final `SELECT` is returned as a data frame
4. Test DDL-only multi-statement (last statement is not row-returning) — verify empty data frame returned without error

## Screenshots/Videos

N/A - No UI changes in this PR.

## Exit Criteria

- [x] `splitPrestoStatements` correctly handles all SQL token types (quoted strings, identifiers, line/block comments)
- [x] `prestoStatementReturnsRows` correctly classifies all Presto statement types
- [x] Multi-statement queries execute non-final statements via `DBI::dbExecute`
- [x] Single-statement queries use existing fast path (no regression)
- [x] All unit tests pass (`tests/testthat/test_presto.R` — 21 test groups, 135+ assertions)
- [x] Integration verified against live Presto (`collabdev2.exploratory.io`)

## Sign-Off Checklist

- [x] Code reviewed for correctness — state machine edge cases tested exhaustively
- [x] No private repository URLs in committed content
  - **Verified**: `git filter-branch` used to scrub one commit body that contained a private URL before PR creation
- [x] Version bumped in `DESCRIPTION`
  - **Verified**: `15.1.2` → `15.1.3`
- [x] No new R package dependencies added
  - **Verified**: `DBI` was already in `Suggests`; no new entries
- [x] Tests cover the new code paths
  - **Verified**: 21 test groups covering all state machine transitions, all keyword classifications, realistic multi-statement TD scripts
