### PR TITLE
Support Silhouette Method for K-Means Clustering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.6
-Date: 2026-05-25
+Version: 15.1.7
+Date: 2026-05-26
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     zoo,
     snakecase,
     textshape,
-    V8
+    V8,
+    cluster
 Suggests:
     testthat,
     twitteR,

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -33,6 +33,42 @@ iterate_kmeans <- function(df, max_centers = 10,
   ret %>% rowwise(center) %>% glance_rowwise(model)
 }
 
+# internal function to iterate number of centers (k) from 2 to max_centers for silhouette method to find optimal k.
+iterate_silhouette <- function(df, max_centers = 10,
+                               iter.max = 10,
+                               nstart = 1,
+                               algorithm = "Hartigan-Wong",
+                               trace = FALSE,
+                               normalize_data = TRUE,
+                               seed = NULL) {
+  mat <- as_numeric_matrix_(df, columns = colnames(df))
+  if (normalize_data) {
+    mat <- scale(mat)
+    mat[is.nan(mat)] <- 0
+  }
+  upper <- min(max_centers, nrow(mat) - 1)
+  if (upper < 2) {
+    return(data.frame(center = integer(0), avg_silhouette = numeric(0),
+                      min_silhouette = numeric(0), pct_negative = numeric(0)))
+  }
+  d <- stats::dist(mat)
+  purrr::map_dfr(seq(2, upper), function(k) {
+    if (!is.null(seed)) {
+      set.seed(seed)
+    }
+    km <- stats::kmeans(mat, centers = k, iter.max = iter.max,
+                        nstart = nstart, algorithm = algorithm, trace = trace)
+    sil <- cluster::silhouette(km$cluster, d)
+    widths <- sil[, "sil_width"]
+    data.frame(
+      center = k,
+      avg_silhouette = mean(widths, na.rm = TRUE),
+      min_silhouette = min(widths, na.rm = TRUE),
+      pct_negative = mean(widths < 0, na.rm = TRUE)
+    )
+  })
+}
+
 #' analytics function for K-means view
 #' @export
 exp_kmeans <- function(df, ...,
@@ -51,6 +87,13 @@ exp_kmeans <- function(df, ...,
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
 
   grouped_cols <- grouped_by(df)
+
+  # Normalize elbow_method_mode: accept logical (legacy) or character enum.
+  optimal_method <- if (is.logical(elbow_method_mode)) {
+    if (isTRUE(elbow_method_mode)) "elbow" else "none"
+  } else {
+    match.arg(as.character(elbow_method_mode), c("none", "silhouette", "elbow"))
+  }
 
   # Set seed just once.
   if(!is.null(seed)) { # Set seed before starting to call sample_n.
@@ -102,9 +145,10 @@ exp_kmeans <- function(df, ...,
                    !!!rlang::syms(selected_cols))
   ret <- dplyr::ungroup(ret) # ungroup once so that the following mutate with purrr::map2 works.
 
-  # If elbow_method_mode is TRUE, also compute the elbow method results and attach to model
+  # Compute elbow or silhouette results depending on optimal_method.
   elbow_result <- NULL
-  if (elbow_method_mode) {
+  silhouette_result <- NULL
+  if (optimal_method == "elbow") {
     kmeans_df <- df %>% dplyr::select(!!!rlang::syms(selected_cols))
     elbow_result <- iterate_kmeans(kmeans_df,
                                    max_centers = max_centers,
@@ -113,7 +157,17 @@ exp_kmeans <- function(df, ...,
                                    algorithm = algorithm,
                                    trace = trace,
                                    normalize_data = normalize_data,
-                                   seed=NULL) # Seed is already done in do_prcomp. Skip it.
+                                   seed = NULL) # Seed is already done in do_prcomp. Skip it.
+  } else if (optimal_method == "silhouette") {
+    kmeans_df <- df %>% dplyr::select(!!!rlang::syms(selected_cols))
+    silhouette_result <- iterate_silhouette(kmeans_df,
+                                            max_centers = max_centers,
+                                            iter.max = iter.max,
+                                            nstart = nstart,
+                                            algorithm = algorithm,
+                                            trace = trace,
+                                            normalize_data = normalize_data,
+                                            seed = NULL) # Seed is already done in do_prcomp. Skip it.
   }
 
   ret <- ret %>% dplyr::mutate(model = purrr::imap(model, function(x, idx) {
@@ -124,6 +178,9 @@ exp_kmeans <- function(df, ...,
       x$excluded_nrow <- excluded_nrow
       if (!is.null(elbow_result)) {
         x$elbow_result <- elbow_result
+      }
+      if (!is.null(silhouette_result)) {
+        x$silhouette_result <- silhouette_result
       }
       x
     }, error = function(e) {

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -46,7 +46,10 @@ iterate_silhouette <- function(df, max_centers = 10,
     mat <- scale(mat)
     mat[is.nan(mat)] <- 0
   }
-  upper <- min(max_centers, nrow(mat) - 1)
+  # Cap k by the number of distinct data points, not just the row count:
+  # stats::kmeans() errors with "more cluster centers than distinct data points"
+  # when centers exceed distinct points (same constraint build_kmeans.cols() guards against).
+  upper <- min(max_centers, nrow(unique(mat)) - 1)
   if (upper < 2) {
     return(data.frame(center = integer(0), avg_silhouette = numeric(0),
                       min_silhouette = numeric(0), pct_negative = numeric(0)))
@@ -56,8 +59,14 @@ iterate_silhouette <- function(df, max_centers = 10,
     if (!is.null(seed)) {
       set.seed(seed)
     }
-    km <- stats::kmeans(mat, centers = k, iter.max = iter.max,
-                        nstart = nstart, algorithm = algorithm, trace = trace)
+    km <- tryCatch({
+      stats::kmeans(mat, centers = k, iter.max = iter.max,
+                    nstart = nstart, algorithm = algorithm, trace = trace)
+    }, error = function(e) {
+      # Surface a clear error that names the offending k, mirroring iterate_kmeans().
+      stop(paste0(e$message, " (while computing silhouette with centers=", k, ")"),
+           call. = FALSE)
+    })
     sil <- cluster::silhouette(km$cluster, d)
     widths <- sil[, "sil_width"]
     data.frame(
@@ -157,7 +166,7 @@ exp_kmeans <- function(df, ...,
                                    algorithm = algorithm,
                                    trace = trace,
                                    normalize_data = normalize_data,
-                                   seed = NULL) # Seed is already done in do_prcomp. Skip it.
+                                   seed = NULL) # Seed is already set once at the top of exp_kmeans(). Skip it.
   } else if (optimal_method == "silhouette") {
     kmeans_df <- df %>% dplyr::select(!!!rlang::syms(selected_cols))
     silhouette_result <- iterate_silhouette(kmeans_df,
@@ -167,7 +176,7 @@ exp_kmeans <- function(df, ...,
                                             algorithm = algorithm,
                                             trace = trace,
                                             normalize_data = normalize_data,
-                                            seed = NULL) # Seed is already done in do_prcomp. Skip it.
+                                            seed = NULL) # Seed is already set once at the top of exp_kmeans(). Skip it.
   }
 
   ret <- ret %>% dplyr::mutate(model = purrr::imap(model, function(x, idx) {

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -73,6 +73,52 @@ test_that("exp_kmeans elbow method mode", {
   expect_equal(nrow(res), 8)
 })
 
+test_that("exp_kmeans silhouette method mode", {
+  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+
+  # silhouette_result is attached with correct columns and value ranges
+  model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = "silhouette")
+  res <- model_df$model[[1]]$silhouette_result
+  expect_equal(colnames(res), c("center", "avg_silhouette", "min_silhouette", "pct_negative"))
+  expect_true(min(res$center) == 2)
+  expect_true(all(res$avg_silhouette >= -1 & res$avg_silhouette <= 1))
+  expect_true(all(res$min_silhouette >= -1 & res$min_silhouette <= 1))
+  expect_true(all(res$pct_negative >= 0 & res$pct_negative <= 1))
+  # elbow_result should NOT be attached when silhouette mode is used
+  expect_null(model_df$model[[1]]$elbow_result)
+})
+
+test_that("exp_kmeans elbow_method_mode = 'elbow' attaches elbow_result only", {
+  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+  model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = "elbow")
+  expect_false(is.null(model_df$model[[1]]$elbow_result))
+  expect_null(model_df$model[[1]]$silhouette_result)
+})
+
+test_that("exp_kmeans elbow_method_mode = 'none' attaches neither", {
+  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+  model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = "none")
+  expect_null(model_df$model[[1]]$elbow_result)
+  expect_null(model_df$model[[1]]$silhouette_result)
+})
+
+test_that("exp_kmeans elbow_method_mode backward compatibility: logical TRUE/FALSE", {
+  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+
+  # TRUE should behave the same as "elbow"
+  model_df_logical <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = TRUE, seed = 42)
+  model_df_enum   <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = "elbow", seed = 42)
+  expect_false(is.null(model_df_logical$model[[1]]$elbow_result))
+  expect_null(model_df_logical$model[[1]]$silhouette_result)
+  expect_equal(model_df_logical$model[[1]]$elbow_result,
+               model_df_enum$model[[1]]$elbow_result)
+
+  # FALSE should behave the same as "none"
+  model_df_false <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = FALSE)
+  expect_null(model_df_false$model[[1]]$elbow_result)
+  expect_null(model_df_false$model[[1]]$silhouette_result)
+})
+
 # group_by for elbow method is not currently supported. Revive this test when it is.
 #test_that("exp_kmeans elbow method mode with group_by", {
 #  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -88,6 +88,18 @@ test_that("exp_kmeans silhouette method mode", {
   expect_null(model_df$model[[1]]$elbow_result)
 })
 
+test_that("exp_kmeans silhouette mode caps k by distinct data points", {
+  # Only 3 distinct rows across many duplicates; max_centers default is 10.
+  # k must be capped at distinct points - 1 so stats::kmeans() does not error.
+  df <- data.frame(
+    x = rep(c(1, 2, 3), times = 20),
+    y = rep(c(10, 20, 30), times = 20)
+  )
+  model_df <- exp_kmeans(df, x, y, elbow_method_mode = "silhouette")
+  res <- model_df$model[[1]]$silhouette_result
+  expect_true(max(res$center) <= 2) # distinct points (3) - 1
+})
+
 test_that("exp_kmeans elbow_method_mode = 'elbow' attaches elbow_result only", {
   df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
   model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode = "elbow")


### PR DESCRIPTION
## Description

Adds silhouette method support for selecting the optimal number of clusters (k) in K-Means clustering.


### Changes

- **`DESCRIPTION`**: Added `cluster` to `Imports` (provides `cluster::silhouette()`).
- **`R/kmeans.R`**:
  - Added `iterate_silhouette()` — iterates k from 2 to `max_centers`, computes per-k average silhouette width, minimum silhouette width, and proportion of negative widths using `cluster::silhouette()`.
  - Extended `exp_kmeans()` to normalize `elbow_method_mode` from the legacy `logical` (TRUE/FALSE) into a character enum (`"none"`, `"silhouette"`, `"elbow"`) for backward compatibility.
  - When `elbow_method_mode = "silhouette"`, a `silhouette_result` data frame (columns: `center`, `avg_silhouette`, `min_silhouette`, `pct_negative`) is attached to the model.
  - Only the relevant result (`elbow_result` or `silhouette_result`) is attached; the other remains absent.
- **`tests/testthat/test_kmeans_1.R`**: Added tests for silhouette mode, elbow mode, none mode, and logical backward-compatibility.

## Checklist

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test()
- [ ] Test installing from github
- [ ] Tested with Exploratory

---
_Generated by [Claude Code](https://claude.ai/code/session_011UNnLgzNLeoFUKz8DzL4H6)_