### PR TITLE
Support L1/L2 regularization for XGBoost

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.14
+Version: 15.1.15
 Date: 2026-06-03
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -1092,6 +1092,10 @@ cleanup_df_for_test <- function(df_test, df_train, c_cols) {
 }
 
 #' Build XGBoost model for Analytics View.
+#' @param alpha L1 regularization term on weights (XGBoost "alpha", alias "reg_alpha").
+#'   Larger values make the model more conservative. Default 0 (no L1 regularization).
+#' @param lambda L2 regularization term on weights (XGBoost "lambda", alias "reg_lambda").
+#'   Larger values make the model more conservative. Default 1 (XGBoost tree-booster default).
 #' @export
 exp_xgboost <- function(df,
                         target,
@@ -1113,6 +1117,8 @@ exp_xgboost <- function(df,
                         eta = 0.3, # We used to set learning_rate parameter here for Analytics Step. Corrected it while 6.2 development.
                                    # Either xgboost package changed parameter name at some point,
                                    # or we might have been wrong about the parameter name in the first place.
+                        alpha = 0,  # L1 regularization term on weights (XGBoost "alpha"/"reg_alpha"). 0 = no L1.
+                        lambda = 1, # L2 regularization term on weights (XGBoost "lambda"/"reg_lambda"). XGBoost tree-booster default = 1.
                         output_type_regression = "linear",
                         eval_metric_regression = "rmse",
                         output_type_binary = "logistic",
@@ -1327,7 +1333,9 @@ exp_xgboost <- function(df,
                         subsample = subsample,
                         colsample_bytree = colsample_bytree,
                         eta = eta,
-                        output_type = output_type_binary, 
+                        alpha = alpha,
+                        lambda = lambda,
+                        output_type = output_type_binary,
                         eval_metric = eval_metric_binary)
       }
       else if(is_target_numeric) {
@@ -1343,7 +1351,9 @@ exp_xgboost <- function(df,
                         subsample = subsample,
                         colsample_bytree = colsample_bytree,
                         eta = eta,
-                        output_type = output_type_regression, 
+                        alpha = alpha,
+                        lambda = lambda,
+                        output_type = output_type_regression,
                         eval_metric = eval_metric_regression)
       }
       else {
@@ -1359,7 +1369,9 @@ exp_xgboost <- function(df,
                         subsample = subsample,
                         colsample_bytree = colsample_bytree,
                         eta = eta,
-                        output_type = output_type_multiclass, 
+                        alpha = alpha,
+                        lambda = lambda,
+                        output_type = output_type_multiclass,
                         eval_metric = eval_metric_multiclass)
       }
       class(model) <- c("xgboost_exp", class(model))

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -633,3 +633,100 @@ test_that("exp_xgboost uses XGBoost default alpha=0 / lambda=1 when not specifie
   expect_equal(as.numeric(model$params$alpha), 0)
   expect_equal(as.numeric(model$params$lambda), 1)
 })
+
+test_that("exp_xgboost with alpha and lambda produces valid prediction outputs", {
+  set.seed(1)
+  n <- 100
+  # Binary: predicted probabilities must be in [0, 1]
+  bin_data <- data.frame(
+    target = rep(c(TRUE, FALSE), n / 2),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  model_df <- bin_data %>% exp_xgboost(target, x1, x2, alpha = 1, lambda = 2, nrounds = 5)
+  probs <- model_df$model[[1]]$prediction_training
+  expect_true(is.numeric(probs))
+  expect_true(all(dplyr::between(probs, 0, 1), na.rm = TRUE))
+
+  # Regression: predicted values must be finite numerics
+  reg_data <- data.frame(y = rnorm(n), x1 = rnorm(n), x2 = rnorm(n))
+  model_df_reg <- reg_data %>% exp_xgboost(y, x1, x2, alpha = 0.5, lambda = 3, nrounds = 5)
+  preds <- model_df_reg$model[[1]]$prediction_training
+  expect_true(is.numeric(preds))
+  expect_true(all(is.finite(preds)))
+
+  # Multiclass: probability matrix with values in [0, 1]
+  multi_data <- data.frame(
+    label = rep(c("A", "B", "C"), length.out = n),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  model_df_multi <- multi_data %>% exp_xgboost(label, x1, x2, alpha = 0.5, lambda = 2, nrounds = 5)
+  prob_mat <- model_df_multi$model[[1]]$prediction_training
+  expect_true(is.matrix(prob_mat))
+  expect_true(all(dplyr::between(as.numeric(prob_mat), 0, 1), na.rm = TRUE))
+})
+
+test_that("exp_xgboost handles highly imbalanced binary target", {
+  set.seed(1)
+  n <- 100
+  test_data <- data.frame(
+    target = c(rep(TRUE, 5), rep(FALSE, 95)),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  model_df <- test_data %>% exp_xgboost(target, x1, x2, nrounds = 5)
+  model <- model_df$model[[1]]
+  expect_false("error" %in% class(model))
+  expect_true(is.numeric(model$prediction_training))
+  expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
+})
+
+test_that("exp_xgboost handles NA values in predictors", {
+  set.seed(1)
+  n <- 100
+  x1 <- rnorm(n)
+  x1[sample(n, 10)] <- NA
+  test_data <- data.frame(
+    target = rep(c(TRUE, FALSE), n / 2),
+    x1 = x1,
+    x2 = rnorm(n)
+  )
+  model_df <- test_data %>% exp_xgboost(target, x1, x2, nrounds = 5)
+  model <- model_df$model[[1]]
+  expect_false("error" %in% class(model))
+  expect_true(is.numeric(model$prediction_training))
+  expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
+})
+
+test_that("exp_xgboost handles column names with spaces", {
+  set.seed(1)
+  n <- 100
+  test_data <- data.frame(
+    target = rep(c(TRUE, FALSE), n / 2),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  colnames(test_data) <- c("Is Target", "Feature 1", "Feature 2")
+  model_df <- test_data %>%
+    exp_xgboost(`Is Target`, `Feature 1`, `Feature 2`, nrounds = 5)
+  model <- model_df$model[[1]]
+  expect_false("error" %in% class(model))
+  expect_true(is.numeric(model$prediction_training))
+  expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
+})
+
+test_that("exp_xgboost works with grouped data (repeat-by)", {
+  set.seed(1)
+  test_data <- dplyr::tibble(
+    group = rep(c("A", "B"), each = 50),
+    target = c(rep(c(TRUE, FALSE), 25), rep(c(FALSE, TRUE), 25)),
+    x1 = rnorm(100),
+    x2 = rnorm(100)
+  )
+  model_df <- test_data %>%
+    dplyr::group_by(group) %>%
+    exp_xgboost(target, x1, x2, nrounds = 5)
+  expect_equal(nrow(model_df), 2)
+  expect_true(all(sapply(model_df$model, function(m) !("error" %in% class(m)))))
+})

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -728,6 +728,33 @@ if (Sys.info()["sysname"] != "Windows") {
   })
 }
 
+test_that("exp_xgboost handles column names with ASCII special characters", {
+  set.seed(1)
+  n <- 100
+  test_data <- data.frame(
+    col1 = rep(c(TRUE, FALSE), n / 2),
+    col2 = rep(c("DL", "MQ", "AA", "WN"), length.out = n),
+    col3 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+  colnames(test_data) <- c(
+    "Is Delayed !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x",
+    "Airline !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x",
+    "Flight Time !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x"
+  )
+  model_df <- test_data %>%
+    exp_xgboost(
+      `Is Delayed !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x`,
+      `Airline !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x`,
+      `Flight Time !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ x`,
+      nrounds = 5
+    )
+  model <- model_df$model[[1]]
+  expect_false("error" %in% class(model))
+  expect_true(is.numeric(model$prediction_training))
+  expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
+})
+
 test_that("exp_xgboost works with grouped data (repeat-by)", {
   set.seed(1)
   test_data <- dplyr::tibble(

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -599,8 +599,9 @@ test_that("new data prediction without response column", {
   expect_equal(as.integer(prediction_ret$predicted_label)+1, as.integer(prediction_ret2$predicted_label))
 })
 
-# #36153 - XGBoost L1 (alpha) / L2 (lambda) regularization support.
-# These params are forwarded through ... from exp_xgboost -> xgboost_*() -> fml_xgboost() ->
+# exp_xgboost coverage: L1/L2 regularization (alpha/lambda), prediction output validity,
+# imbalanced targets, NA handling, and complex column names.
+# alpha/lambda are forwarded through ... from exp_xgboost -> xgboost_*() -> fml_xgboost() ->
 # xgboost::xgb.train(), exactly like `objective` (which is read back at model$params$objective).
 xgb_l1l2_test_data <- structure(
   list(

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -699,22 +699,34 @@ test_that("exp_xgboost handles NA values in predictors", {
   expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
 })
 
-test_that("exp_xgboost handles column names with spaces", {
-  set.seed(1)
-  n <- 100
-  test_data <- data.frame(
-    target = rep(c(TRUE, FALSE), n / 2),
-    x1 = rnorm(n),
-    x2 = rnorm(n)
-  )
-  colnames(test_data) <- c("Is Target", "Feature 1", "Feature 2")
-  model_df <- test_data %>%
-    exp_xgboost(`Is Target`, `Feature 1`, `Feature 2`, nrounds = 5)
-  model <- model_df$model[[1]]
-  expect_false("error" %in% class(model))
-  expect_true(is.numeric(model$prediction_training))
-  expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
-})
+if (Sys.info()["sysname"] != "Windows") {
+  test_that("exp_xgboost handles column names with Japanese and many special characters", {
+    set.seed(1)
+    n <- 100
+    test_data <- data.frame(
+      col1 = rep(c(TRUE, FALSE), n / 2),
+      col2 = rep(c("DL", "MQ", "AA", "WN"), length.out = n),
+      col3 = rnorm(n),
+      stringsAsFactors = FALSE
+    )
+    colnames(test_data) <- c(
+      "遅れ た !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表",
+      "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表",
+      "飛行 時間 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
+    )
+    model_df <- test_data %>%
+      exp_xgboost(
+        `遅れ た !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`,
+        `航空 会社 !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`,
+        `飛行 時間 !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`,
+        nrounds = 5
+      )
+    model <- model_df$model[[1]]
+    expect_false("error" %in% class(model))
+    expect_true(is.numeric(model$prediction_training))
+    expect_true(all(dplyr::between(model$prediction_training, 0, 1), na.rm = TRUE))
+  })
+}
 
 test_that("exp_xgboost works with grouped data (repeat-by)", {
   set.seed(1)

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -598,3 +598,38 @@ test_that("new data prediction without response column", {
     prediction_binary(data = "newdata", data_frame = test_data, threshold = 0.2)
   expect_equal(as.integer(prediction_ret$predicted_label)+1, as.integer(prediction_ret2$predicted_label))
 })
+
+# #36153 - XGBoost L1 (alpha) / L2 (lambda) regularization support.
+# These params are forwarded through ... from exp_xgboost -> xgboost_*() -> fml_xgboost() ->
+# xgboost::xgb.train(), exactly like `objective` (which is read back at model$params$objective).
+xgb_l1l2_test_data <- structure(
+  list(
+    CANCELLED = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+    CARRIER = c("DL", "MQ", "AA", "DL", "MQ", "AA", "DL", "DL", "MQ", "AA", "AA", "WN", "US", "US", "DL", "EV", "9E", "EV", "DL", "DL"),
+    DISTANCE = c(1587, 173, 646, 187, 273, 1062, 583, 240, 1123, 851, 852, 862, 361, 507, 1020, 1092, 342, 489, 1184, 545)),
+  row.names = c(NA, -20L),
+  class = c("tbl_df", "tbl", "data.frame"))
+
+test_that("exp_xgboost forwards alpha (L1) and lambda (L2) to the booster", {
+  set.seed(1)
+  # Regression target (numeric) - non-default alpha/lambda must reach xgb.train params.
+  model_df <- xgb_l1l2_test_data %>% exp_xgboost(DISTANCE, CARRIER, alpha = 0.5, lambda = 2, nrounds = 5)
+  model <- model_df$model[[1]]
+  expect_equal(as.numeric(model$params$alpha), 0.5)
+  expect_equal(as.numeric(model$params$lambda), 2)
+
+  # Binary target (logical) - same forwarding through the binary branch.
+  bin_data <- xgb_l1l2_test_data %>% dplyr::mutate(is_cancelled = CANCELLED == 1)
+  model_df_bin <- bin_data %>% exp_xgboost(is_cancelled, CARRIER, alpha = 0.3, lambda = 4, nrounds = 5)
+  model_bin <- model_df_bin$model[[1]]
+  expect_equal(as.numeric(model_bin$params$alpha), 0.3)
+  expect_equal(as.numeric(model_bin$params$lambda), 4)
+})
+
+test_that("exp_xgboost uses XGBoost default alpha=0 / lambda=1 when not specified", {
+  set.seed(1)
+  model_df <- xgb_l1l2_test_data %>% exp_xgboost(DISTANCE, CARRIER, nrounds = 5)
+  model <- model_df$model[[1]]
+  expect_equal(as.numeric(model$params$alpha), 0)
+  expect_equal(as.numeric(model$params$lambda), 1)
+})


### PR DESCRIPTION
# Description

Expose XGBoost's L1 (`alpha`) and L2 (`lambda`) weight-regularization parameters on `exp_xgboost`.

- Added `alpha` (default `0`) and `lambda` (default `1`) as formal arguments of `exp_xgboost`, documented in the roxygen block (`alpha` -> L1, `lambda` -> L2).
- The values are forwarded through `...` to `xgboost::xgb.train` at all three fit sites (binary / regression / multiclass).
- Defaults match XGBoost's tree-booster defaults, so existing models keep their current behavior (no value emitted -> formal default applies).
- Added unit tests in `tests/testthat/test_build_xgboost.R` covering (a) `alpha`/`lambda` reaching the trained booster params for both regression and binary targets, and (b) the defaults (`alpha = 0`, `lambda = 1`) when the arguments are omitted.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [ ] Pass devtools::test() (please run in an environment with `xgboost` installed)
- [ ] Test installing from github
- [x] Tested with Exploratory
