### PR TITLE
Support data_summary type in One-Sample t Test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.15
-Date: 2026-06-03
+Version: 15.1.16
+Date: 2026-06-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -3597,7 +3597,7 @@ exp_one_sample_t_test <- function(df, var, mu = 0, alternative = "two.sided",
 }
 
 #' @export
-tidy.one_sample_t_test_exploratory <- function(x, type = "model") {
+tidy.one_sample_t_test_exploratory <- function(x, type = "model", conf_level = 0.95) {
   if ("error" %in% class(x)) return(tibble::tibble(Note = x$message))
   if (type == "model") {
     diff <- x$observed_mean - x$mu
@@ -3623,6 +3623,24 @@ tidy.one_sample_t_test_exploratory <- function(x, type = "model") {
       `Power`             = x$power,
       `Test Direction`    = direction,
       `Result`            = result_label
+    )
+  } else if (type == "data_summary") {
+    conf_threshold <- 1 - (1 - conf_level) / 2
+    vec <- x$data[[x$var_col]]
+    vec <- vec[!is.na(vec)]
+    n <- length(vec)
+    mean_val <- mean(vec)
+    sd_val <- sd(vec)
+    se_val <- sd_val / sqrt(n)
+    tibble::tibble(
+      `Rows`              = n,
+      `Mean`              = mean_val,
+      `Conf Low`          = mean_val - se_val * qt(p = conf_threshold, df = n - 1),
+      `Conf High`         = mean_val + se_val * qt(p = conf_threshold, df = n - 1),
+      `Std Error of Mean` = se_val,
+      `Std Deviation`     = sd_val,
+      `Minimum`           = min(vec),
+      `Maximum`           = max(vec)
     )
   } else if (type == "prob_dist") {
     generate_ttest_density_data(t = unname(x$htest$statistic), p.value = x$htest$p.value,

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -3619,6 +3619,8 @@ tidy.one_sample_t_test_exploratory <- function(x, type = "model", conf_level = 0
       `P Value`           = x$htest$p.value,
       `Conf Low`          = x$htest$conf.int[1],
       `Conf High`         = x$htest$conf.int[2],
+      `Diff Conf Low`     = x$htest$conf.int[1] - x$mu,
+      `Diff Conf High`    = x$htest$conf.int[2] - x$mu,
       `Cohen's d`         = x$cohens_d,
       `Power`             = x$power,
       `Test Direction`    = direction,

--- a/tests/testthat/test_one_sample_t_test.R
+++ b/tests/testthat/test_one_sample_t_test.R
@@ -412,6 +412,58 @@ test_that("tidy prob_dist_mean no-ops (0-row tibble) when stderr is degenerate",
   expect_equal(nrow(pd), 0)
 })
 
+# --- tidy(type = "data_summary") ---
+
+test_that("tidy data_summary type returns summary statistics with confidence intervals", {
+  set.seed(42)
+  vec <- rnorm(50, mean = 5, sd = 2)
+  df <- data.frame(x = vec)
+  model <- exp_one_sample_t_test(df, x, mu = 4.5)$model[[1]]
+  result <- tidy(model, type = "data_summary", conf_level = 0.95)
+
+  expected_cols <- c("Rows", "Mean", "Conf Low", "Conf High",
+                     "Std Error of Mean", "Std Deviation", "Minimum", "Maximum")
+  expect_true(all(expected_cols %in% names(result)))
+  expect_equal(nrow(result), 1)
+
+  n <- length(vec)
+  conf_threshold <- 1 - (1 - 0.95) / 2
+  expected_se <- sd(vec) / sqrt(n)
+  expect_equal(result$Rows, n)
+  expect_equal(result$Mean, mean(vec))
+  expect_equal(result$`Std Deviation`, sd(vec))
+  expect_equal(result$`Std Error of Mean`, expected_se)
+  expect_equal(result$`Conf Low`,  mean(vec) - expected_se * qt(p = conf_threshold, df = n - 1))
+  expect_equal(result$`Conf High`, mean(vec) + expected_se * qt(p = conf_threshold, df = n - 1))
+  expect_equal(result$Minimum, min(vec))
+  expect_equal(result$Maximum, max(vec))
+})
+
+test_that("tidy data_summary conf_level parameter changes confidence intervals", {
+  set.seed(42)
+  vec <- rnorm(50, mean = 5, sd = 2)
+  df <- data.frame(x = vec)
+  model <- exp_one_sample_t_test(df, x, mu = 4.5)$model[[1]]
+
+  result_95 <- tidy(model, type = "data_summary", conf_level = 0.95)
+  result_90 <- tidy(model, type = "data_summary", conf_level = 0.90)
+
+  expect_true(result_95$`Conf Low`  < result_90$`Conf Low`)
+  expect_true(result_95$`Conf High` > result_90$`Conf High`)
+})
+
+test_that("tidy_rowwise with type=data_summary works for one sample t-test", {
+  set.seed(42)
+  vec <- rnorm(50, mean = 5, sd = 2)
+  df <- data.frame(x = vec)
+  result <- exp_one_sample_t_test(df, x, mu = 4.5) %>%
+    tidy_rowwise(model, type = "data_summary", conf_level = 0.95)
+
+  expect_true("Rows" %in% names(result))
+  expect_true("Mean" %in% names(result))
+  expect_equal(result$Rows, 50)
+})
+
 # --- tidy(type = "data") ---
 
 test_that("tidy data type returns the raw data with the target column", {

--- a/tests/testthat/test_one_sample_t_test.R
+++ b/tests/testthat/test_one_sample_t_test.R
@@ -211,8 +211,8 @@ test_that("tidy model type returns the expected column set", {
   expected_cols <- c(
     "Number of Rows", "Mean", "Std Deviation", "Std Error",
     "Hypothesized Mean", "Difference", "t Value", "DF", "P Value",
-    "Conf Low", "Conf High", "Cohen's d", "Power",
-    "Test Direction", "Result"
+    "Conf Low", "Conf High", "Diff Conf Low", "Diff Conf High",
+    "Cohen's d", "Power", "Test Direction", "Result"
   )
   for (col in expected_cols) {
     expect_true(col %in% names(tidied), info = paste("Missing column:", col))
@@ -237,6 +237,8 @@ test_that("tidy model values are numerically correct", {
   expect_equal(tidied$`P Value`, expected$p.value)
   expect_equal(tidied$`Conf Low`, expected$conf.int[1])
   expect_equal(tidied$`Conf High`, expected$conf.int[2])
+  expect_equal(tidied$`Diff Conf Low`,  expected$conf.int[1] - 4.5)
+  expect_equal(tidied$`Diff Conf High`, expected$conf.int[2] - 4.5)
 })
 
 test_that("tidy model Test Direction maps correctly from alternative", {


### PR DESCRIPTION
# Description
Add `tidy(type="data_summary", conf_level=0.95)` support to `exp_one_sample_t_test`, making it consistent with `exp_ttest`. Returns a one-row summary tibble with Rows, Mean, Conf Low, Conf High, Std Error of Mean, Std Deviation, Minimum, and Maximum. The `conf_level` parameter controls the width of the confidence interval using the t-distribution.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.  

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass devtools::test()
- [ ] Test installing from github
- [x] Tested with Exploratory