### PR TITLE
GA: drop obsolete V3 account list, keep V4 with legacy LOV field names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.19
+Version: 15.1.20
 Date: 2026-06-11
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -20,17 +20,16 @@ getGoogleProfile <- function(tokenFileId = ""){
     }
   })
 
-  if (nrow(v4df) > 0) {
-    # Keep the legacy field names (webPropertyId / webPropertyName / accountName) in the
-    # response so Exploratory Desktop, which reads those keys from the tableId LOV (and from
-    # the cached ga_metadata connection attribute), does not need any change.
-    # any_of() guards the empty / changed-schema cases so the rename never errors.
-    v4df <- v4df %>% dplyr::rename(
-      accountName = dplyr::any_of("account_name"),
-      webPropertyId = dplyr::any_of("propertyId"),
-      webPropertyName = dplyr::any_of("property_name")
-    )
-  }
+  # Keep the legacy field names (webPropertyId / webPropertyName / accountName) in the
+  # response so Exploratory Desktop, which reads those keys from the tableId LOV (and from
+  # the cached ga_metadata connection attribute), does not need any change.
+  # any_of() no-ops missing columns, so this is safe for the empty init frame and for any
+  # GA4 schema change (no nrow guard needed).
+  v4df <- v4df %>% dplyr::rename(
+    accountName = dplyr::any_of("account_name"),
+    webPropertyId = dplyr::any_of("propertyId"),
+    webPropertyName = dplyr::any_of("property_name")
+  )
 
   v4df
 }
@@ -78,7 +77,7 @@ getGoogleAnalyticsTimeZoneInfo <- function(accountId, webPropertyId, viewId = ""
     res <- exploratory:::getGoogleAnalyticsV4Property(accountId)
     df <- data.frame(res)
     # Make sure to filter the result by webPropertyId. (NOTE: name column contains property id as properties/123345 style.)
-    if (!is.null(webPropertyId) && length(webPropertyId) > 0 && webPropertyId != "") {
+    if (!is.null(webPropertyId) && length(webPropertyId) > 0 && !is.na(webPropertyId) && webPropertyId != "") {
       df <- df %>% dplyr::filter(stringr::str_detect(name, webPropertyId))
     }
     # for V4, timezone is stored in timeZone

--- a/R/google_analytics.R
+++ b/R/google_analytics.R
@@ -6,14 +6,6 @@ getGoogleProfile <- function(tokenFileId = ""){
 
   token <- getGoogleTokenForAnalytics(tokenFileId);
   googleAuthR::gar_auth(token = token, skip_fetch = TRUE)
-  # Get V3 account list.
-  df <- googleAnalyticsR::ga_account_list()
-  if (nrow(df) > 0) { # if there are V3 accounts, only select below columns.
-    df <- df %>% dplyr::select(accountId, accountName, viewId, viewName, webPropertyId, webPropertyName)
-  } else {
-    # It means there are no v3 accounts, so create an empty data frame without columns and bind this to a v4 account data frame.
-    df <- tibble::tibble()
-  }
   # get V4 Account
   v4df <- data.frame()
   tryCatch({
@@ -27,12 +19,20 @@ getGoogleProfile <- function(tokenFileId = ""){
       stop(err)
     }
   })
+
   if (nrow(v4df) > 0) {
-    v4df <- v4df %>% dplyr::rename(accountName = account_name, webPropertyId = propertyId, webPropertyName = property_name)
-    df <- df %>% dplyr::bind_rows(v4df)
+    # Keep the legacy field names (webPropertyId / webPropertyName / accountName) in the
+    # response so Exploratory Desktop, which reads those keys from the tableId LOV (and from
+    # the cached ga_metadata connection attribute), does not need any change.
+    # any_of() guards the empty / changed-schema cases so the rename never errors.
+    v4df <- v4df %>% dplyr::rename(
+      accountName = dplyr::any_of("account_name"),
+      webPropertyId = dplyr::any_of("propertyId"),
+      webPropertyName = dplyr::any_of("property_name")
+    )
   }
 
-  df
+  v4df
 }
 #' Helper API to get properites from response.
 parse_webproperty_list <- function(x) {
@@ -78,7 +78,9 @@ getGoogleAnalyticsTimeZoneInfo <- function(accountId, webPropertyId, viewId = ""
     res <- exploratory:::getGoogleAnalyticsV4Property(accountId)
     df <- data.frame(res)
     # Make sure to filter the result by webPropertyId. (NOTE: name column contains property id as properties/123345 style.)
-    df <- df %>% dplyr::filter(stringr::str_detect(name, webPropertyId))
+    if (!is.null(webPropertyId) && length(webPropertyId) > 0 && webPropertyId != "") {
+      df <- df %>% dplyr::filter(stringr::str_detect(name, webPropertyId))
+    }
     # for V4, timezone is stored in timeZone
     df$timeZone
   } else {


### PR DESCRIPTION
## Problem

`getGoogleProfile` (source for the Google Analytics `tableId` LOV) started returning the GA4-native field names `propertyId` / `property_name` / `account_name`. Exploratory Desktop reads the legacy keys `webPropertyId` / `webPropertyName` / `accountName` (from the LOV and from the cached `ga_metadata` connection attribute), so the V4 property resolved to `undefined` — empty property/account dropdowns and an empty `webPropertyId` passed to `getGoogleAnalyticsTimeZoneInfo`.

## Fix (R-only, Desktop untouched)

- Drop the obsolete V3 `ga_account_list()` branch — Universal Analytics is sunset.
- Keep the V4 `ga_account_list("ga4")` fetch.
- Rename the V4 columns back to the legacy names so Desktop needs no change:
  - `account_name` → `accountName`
  - `propertyId` → `webPropertyId`
  - `property_name` → `webPropertyName`
  - `dplyr::any_of()` guards empty / schema-changed results so the rename never errors.
- Guard the V4 timezone `str_detect` filter against an empty `webPropertyId`.

## Behavior change

The response no longer carries V3 accounts (`viewId` / `viewName`). Intended — UA is retired.

## Notes

- No unit test: `getGoogleProfile` hits the live Google API; the change is a pure column rename of previously-shipped behavior.
- **Deploy:** must reach every runtime that returns this LOV — bundled R (Desktop), scheduler docker, and server — via the usual `exploratory` package version bump + rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)