### PR TITLE
fix: Oracle connection 'external pointer is not valid' on 2nd query

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.20
-Date: 2026-06-11
+Version: 15.1.21
+Date: 2026-06-16
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -1575,7 +1575,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope 
         # fall through to getting new connection.
       })
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1257,7 +1257,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
       driverstr = driver;
     }
     key <- paste(type, subType, dsn, hoststr, username, additionalParams, driverstr, timezone, connectionString, sep = ":")
-    conn <- connection_pool[[key]]
+    # Only reuse a pooled connection when pooling is on; otherwise queryODBC() may have already closed
+    # this connection, leaving a dead external pointer in the pool. (tam#36429)
+    conn <- NULL
+    if (user_env$pool_connection) {
+      conn <- connection_pool[[key]]
+    }
     if (!is.null(conn)){
       tryCatch({
         # test connection
@@ -1284,7 +1289,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <- NULL
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
         # fall through to getting new connection.
       })
     }
@@ -1430,7 +1435,9 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
       }
       conn
     }
-    if (is.null(conn)) {
+    # Guard dbIsValid() in tryCatch: a dead external pointer throws instead of returning FALSE, so treat
+    # any error as invalid and reconnect rather than returning a closed connection. (tam#36429)
+    if (is.null(conn) || !isTRUE(tryCatch(DBI::dbIsValid(conn), error = function(e) FALSE))) {
       conn <- connect()
       if (user_env$pool_connection) { # pool connection if connection pooling is on.
         connection_pool[[key]] <- conn
@@ -1543,7 +1550,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
     if(!requireNamespace("odbc")){stop("package odbc must be installed.")}
     key <- paste("mssqlserver", host, port, databaseName, username, timezone, additionalParams, sep = ":")
-    conn <- connection_pool[[key]]
+    # Only reuse a pooled connection when pooling is on; otherwise queryODBC() may have already closed
+    # this connection, leaving a dead external pointer in the pool. (tam#36429)
+    conn <- NULL
+    if (user_env$pool_connection) {
+      conn <- connection_pool[[key]]
+    }
     if (!is.null(conn)){
       tryCatch({
         # test connection
@@ -1563,12 +1575,13 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <- NULL
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
         # fall through to getting new connection.
       })
     }
     # if the connection is null or the connection is invalid, create a new one.
-    if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    # Guard dbIsValid() in tryCatch: a dead external pointer throws instead of returning FALSE. (tam#36429)
+    if (is.null(conn) || !isTRUE(tryCatch(DBI::dbIsValid(conn), error = function(e) FALSE))) {
       # For Windows, set encoding to make sure non-ascii data is handled properly.
       # ref: https://github.com/r-dbi/odbc/issues/153
       if (timezone == "") {
@@ -1603,7 +1616,9 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
                                bigint = "numeric"
         )
       }
-      connection_pool[[key]] <- conn
+      if (user_env$pool_connection) {
+        connection_pool[[key]] <- conn
+      }
     }
   } else if (type == "snowflake") {
     # If the platform is Linux, set the below predefined driver installed on Collaboration Server
@@ -1633,7 +1648,12 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     }
 
     key <- paste("snowflake", host, port, catalog, databaseName, username, timezone, additionalParams, role, secretKeyFile, secretKeyFilePassword, sep = ":")
-    conn <- connection_pool[[key]]
+    # Only reuse a pooled connection when pooling is on; otherwise queryODBC() may have already closed
+    # this connection, leaving a dead external pointer in the pool. (tam#36429)
+    conn <- NULL
+    if (user_env$pool_connection) {
+      conn <- connection_pool[[key]]
+    }
     if (!is.null(conn)) {
       tryCatch({
         # test connection
@@ -1653,12 +1673,13 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <- NULL
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
         # fall through to getting new connection.
       })
     }
     # if the connection is null or the connection is invalid, create a new one.
-    if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    # Guard dbIsValid() in tryCatch: a dead external pointer throws instead of returning FALSE. (tam#36429)
+    if (is.null(conn) || !isTRUE(tryCatch(DBI::dbIsValid(conn), error = function(e) FALSE))) {
 
       loc <- Sys.getlocale(category = "LC_CTYPE")
       # loc looks like "Japanese_Japan.932", so split it with dot ".".
@@ -1703,7 +1724,9 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
                                bigint = "numeric"
         )
       }
-      connection_pool[[key]] <- conn
+      if (user_env$pool_connection) {
+        connection_pool[[key]] <- conn
+      }
     }
   }  else if (type == "oracle") {
     # If the platform is Linux, set the below predefined driver installed on Collaboration Server
@@ -1725,7 +1748,14 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     }
 
     key <- paste("oracle", host, port,databaseName, username, timezone, additionalParams, sep = ":")
-    conn <- connection_pool[[key]]
+    # Only reuse a pooled connection when connection pooling is on (e.g. while the data source dialog
+    # is open). During an import/refresh job pooling is off, so each query gets a fresh connection and
+    # we never reuse a connection that queryODBC() already closed -- which used to leave a dead external
+    # pointer in the pool and make the 2nd query fail with "external pointer is not valid". (tam#36429)
+    conn <- NULL
+    if (user_env$pool_connection) {
+      conn <- connection_pool[[key]]
+    }
     if (!is.null(conn)) {
       tryCatch({
         # test connection
@@ -1745,12 +1775,14 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <- NULL
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
         # fall through to getting new connection.
       })
     }
     # if the connection is null or the connection is invalid, create a new one.
-    if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    # Guard dbIsValid() in tryCatch: on a dead external pointer it throws instead of returning FALSE,
+    # so treat any error as invalid and reconnect. (tam#36429)
+    if (is.null(conn) || !isTRUE(tryCatch(DBI::dbIsValid(conn), error = function(e) FALSE))) {
 
       loc <- Sys.getlocale(category = "LC_CTYPE")
       # loc looks like "Japanese_Japan.932", so split it with dot ".".
@@ -1781,7 +1813,9 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
                                bigint = "numeric"
         )
       }
-      connection_pool[[key]] <- conn
+      if (user_env$pool_connection) {
+        connection_pool[[key]] <- conn
+      }
     }
   }
   conn

--- a/R/system.R
+++ b/R/system.R
@@ -1289,7 +1289,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope 
         # fall through to getting new connection.
       })
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1775,7 +1775,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope 
         # fall through to getting new connection.
       })
     }

--- a/R/system.R
+++ b/R/system.R
@@ -1751,7 +1751,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     # Only reuse a pooled connection when connection pooling is on (e.g. while the data source dialog
     # is open). During an import/refresh job pooling is off, so each query gets a fresh connection and
     # we never reuse a connection that queryODBC() already closed -- which used to leave a dead external
-    # pointer in the pool and make the 2nd query fail with "external pointer is not valid". (tam#36429)
+    # pointer in the pool and make the 2nd query fail with "external pointer is not valid". 
     conn <- NULL
     if (user_env$pool_connection) {
       conn <- connection_pool[[key]]

--- a/R/system.R
+++ b/R/system.R
@@ -1436,7 +1436,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
       conn
     }
     # Guard dbIsValid() in tryCatch: a dead external pointer throws instead of returning FALSE, so treat
-    # any error as invalid and reconnect rather than returning a closed connection. (tam#36429)
+    # any error as invalid and reconnect rather than returning a closed connection. 
     if (is.null(conn) || !isTRUE(tryCatch(DBI::dbIsValid(conn), error = function(e) FALSE))) {
       conn <- connect()
       if (user_env$pool_connection) { # pool connection if connection pooling is on.

--- a/R/system.R
+++ b/R/system.R
@@ -1673,7 +1673,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         }, warning = function(w) {
         }, error = function(e) {
         })
-        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope (tam#36429)
+        conn <<- NULL  # <<- so the outer conn is reset; the handler is a separate function scope
         # fall through to getting new connection.
       })
     }


### PR DESCRIPTION
## Issue
exploratory-io/tam#36429 — ODBC (Oracle) data source: connection becomes invalid after the first query (`external pointer is not valid`) since Exploratory v15.6.1.

## Root cause (confirmed from the customer log)
The Oracle data source connects via a **system DSN** (`dsn = 'test'`), so the query runs through `getDBConnection()`'s **`dbiodbc`** branch (`type='dbiodbc'`) — **not** the dedicated `oracle` branch.

```
exploratory::queryODBC(dsn='hanbai', ..., type='dbiodbc', timezone="Asia/Tokyo", ...)
-> Error : external pointer is not valid
```

While the data source / SQL editor is open, connection pooling is **on**, so the connection from the **1st** run is kept in `connection_pool`. On the **2nd** run that pooled connection is reused and probed with `DBI::dbGetQuery(conn, "select 1")` — which on **Oracle** fails with `ORA-00923` (FROM keyword required). The probe's `error = function(err) { ...; conn <- NULL }` assigns in the **handler's own function scope**, so the outer `conn` is never reset; the `dbiodbc` branch's final guard is only `if (is.null(conn))`, so it returns the just-**disconnected** connection and the subsequent `dbSendQuery()` fails with `external pointer is not valid`. (Non-Oracle dbiodbc engines are fine because `select 1` succeeds, so the error handler never fires.)

The dedicated `oracle` / `mssqlserver` / `snowflake` branches share the same scope bug **and** additionally pool **unconditionally** (ignoring `user_env$pool_connection`), so a connection closed by `queryODBC()` during a non-pooled import is left dead in the pool — the same class of failure on those paths.

Latent since Oracle support was added (commit `56957383a`, PR #1330, 2023-03-29); exposed at v15.6.1 by the tam SQL-job change that runs a job's queries in one persistent R session.

## Fix (oracle / mssqlserver / snowflake / dbiodbc)
- `conn <- NULL` → `conn <<- NULL` in the test-connection error handlers, so the outer `conn` is actually reset and a fresh connection is created.
- Gate the pool **read** and **write** on `user_env$pool_connection` (oracle/mssql/snowflake did neither; dbiodbc gated only the write).
- Guard the final `DBI::dbIsValid(conn)` in `tryCatch(..., error = function(e) FALSE)` so a dead external pointer → reconnect instead of propagating.

`teradata` / `access` already null the pooled conn before use, so they are unaffected.

## Verification
- `parse("R/system.R")` OK.
- Manual / live Oracle DSN on Windows: connection test passes; run the same query **twice** in the editor → both succeed; dashboard **re-import** succeeds; no `external pointer is not valid`.

Bundled via tam (exploratory 15.1.20 → **15.1.21**).