### PR TITLE
Bump exploratory to 15.1.23

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.22
-Date: 2026-06-20
+Version: 15.1.23
+Date: 2026-06-29
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/tests/testthat/test_pdf.R
+++ b/tests/testthat/test_pdf.R
@@ -48,6 +48,19 @@ stub_docling_resolver <- function() {
   }
 }
 
+test_that("resolve_docling_python quotes the Python -c probe as one argument", {
+  source_candidates <- c(file.path("R", "pdf.R"),
+                         file.path("..", "..", "R", "pdf.R"))
+  source_path <- source_candidates[file.exists(source_candidates)][1]
+  if (is.na(source_path)) {
+    skip("R/pdf.R source file is not available")
+  }
+
+  src <- readLines(source_path, warn = FALSE)
+  expect_true(any(grepl("system2\\(resolved, c\\(\"-c\", shQuote\\(check_code\\)\\)",
+                        src)))
+})
+
 test_that("read_pdf_table validates a negative / non-integer table_index before running", {
   pdf <- tempfile(fileext = ".pdf")
   writeLines("dummy", pdf)


### PR DESCRIPTION
## Summary
- bump exploratory package version/date to 15.1.23
- add a regression assertion that the docling Python `-c` probe uses `shQuote(check_code)` so Windows does not split the probe at spaces

## Why
The AI Data PDF flow can list PDF tables via exp-cli/docling, but loading through `exploratory::read_pdf_table()` depends on the R package resolver. Version 15.1.23 should include the Windows-safe docling probe behavior.

## Validation
- `Rscript -e 'stopifnot(read.dcf("DESCRIPTION")[1,"Version"] == "15.1.23"); parse(file="R/pdf.R"); parse(file="tests/testthat/test_pdf.R"); cat("R parse/version checks passed\\n")'`\n- `git diff --check`\n\nFull `testthat` execution was not run locally because `testthat` is not installed in this R environment.