### PR TITLE
fix: count_if/count_if_ratio/count_if_pct accept 1-arg condition-only form (#36705)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.22
+Version: 15.1.23
 Date: 2026-06-20
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/util.R
+++ b/R/util.R
@@ -2844,18 +2844,30 @@ sum_if_pct <- function(x, ..., na.rm = TRUE) {
 }
 
 #' export
-count_if <- function(x, ..., na.rm = TRUE) {
-  aggregate_if(x, "count", ..., na.rm = na.rm)
+count_if <- function(cond, ..., na.rm = TRUE) {
+  if (...length() == 0) {
+    sum(cond, na.rm = na.rm)
+  } else {
+    aggregate_if(cond, "count", ..., na.rm = na.rm)
+  }
 }
 
 #' export
-count_if_ratio <- function(x, ..., na.rm = TRUE) {
-  aggregate_if(x, "count_ratio", ..., na.rm = na.rm)
+count_if_ratio <- function(cond, ..., na.rm = TRUE) {
+  if (...length() == 0) {
+    mean(cond, na.rm = na.rm)
+  } else {
+    aggregate_if(cond, "count_ratio", ..., na.rm = na.rm)
+  }
 }
 
 #' export
-count_if_pct <- function(x, ..., na.rm = TRUE) {
-  aggregate_if(x, "count_pct", ..., na.rm = na.rm)
+count_if_pct <- function(cond, ..., na.rm = TRUE) {
+  if (...length() == 0) {
+    mean(cond, na.rm = na.rm) * 100
+  } else {
+    aggregate_if(cond, "count_pct", ..., na.rm = na.rm)
+  }
 }
 
 #' export

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -1536,14 +1536,29 @@ test_that("count_if", {
   expect_equal(df %>% dplyr::pull(custom), c(11, 7, 8))
 })
 
+test_that("count_if - 1-arg form (condition only)", {
+  df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl"), group_funs = c("none"),  custom = exploratory::count_if(mpg > 15))
+  expect_equal(df %>% dplyr::pull(custom), c(11, 7, 8))
+})
+
 test_that("count_if_ratio", {
   df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl"), group_funs = c("none"),  custom = exploratory::count_if_ratio(hp, mpg > 15, na.rm = F))
+  expect_equal(df %>% dplyr::pull(custom), c(1, 1, 8/14)) # 11/11, 7/7, 8/14
+})
+
+test_that("count_if_ratio - 1-arg form (condition only)", {
+  df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl"), group_funs = c("none"),  custom = exploratory::count_if_ratio(mpg > 15))
   expect_equal(df %>% dplyr::pull(custom), c(1, 1, 8/14)) # 11/11, 7/7, 8/14
 })
 
 test_that("count_if_pct", {
   df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl"), group_funs = c("none"),  custom = exploratory::count_if_pct(hp, mpg > 15, na.rm = F))
   expect_equal(df %>% dplyr::pull(custom), c(100, 100, 800/14)) # 100 *11/11, 100*7/7, 100*8/14
+})
+
+test_that("count_if_pct - 1-arg form (condition only)", {
+  df <- mtcars %>% exploratory::summarize_group(group_cols = c(cyl="cyl"), group_funs = c("none"),  custom = exploratory::count_if_pct(mpg > 15))
+  expect_equal(df %>% dplyr::pull(custom), c(100, 100, 800/14)) # 100*11/11, 100*7/7, 100*8/14
 })
 
 test_that("count_unique_if", {


### PR DESCRIPTION
## Description

Fixes https://github.com/exploratory-io/tam/issues/36705

Makes `count_if`, `count_if_ratio`, and `count_if_pct` work with just a condition argument, without requiring a dummy column:

```r
# New 1-arg form (now works):
count_if(column_a > 3)          # sum(column_a > 3, na.rm=TRUE)
count_if_ratio(column_a > 3)    # mean(column_a > 3, na.rm=TRUE)
count_if_pct(column_a > 3)      # mean(column_a > 3, na.rm=TRUE) * 100

# Old 2-arg form still works (backward compat):
count_if(hp, mpg > 15)          # unchanged
```

## Implementation

Uses `...length()` to detect 1-arg vs 2-arg call shape:
- 0 extra args → direct `sum(cond)` / `mean(cond)` / `mean(cond)*100`
- 1+ extra args → delegate to existing `aggregate_if()` (backward compat)

## Tests

Added 3 new tests for 1-arg form. Existing 2-arg tests unchanged and passing.

## Screenshots/Videos

N/A - Pure R function change.