### PR TITLE
Fix test confusion matrix not updating when the classification threshold changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.22
-Date: 2026-06-20
+Version: 15.2.1
+Date: 2026-07-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1412,6 +1412,9 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
       }
 
       # Extract test prediction result embedded in the model.
+      # Threshold for labels is applied via get_test_predicted_labels(), not via prediction(),
+      # because augment args passed through expand_args are evaluated in a context that does not
+      # include rf_evaluation_training_and_test's formal arguments.
       test_pred_ret <- df %>% prediction(data = "test", ...)
 
       tryCatch({ #TODO: Not too sure why this tryCatch is needed. It could hide errors that should be properly reported.
@@ -1467,12 +1470,14 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
             } else {
               predicted <- NULL # Just declaring variable.
               if (model_object$classification_type == "binary") { # Make it model agnostic.
+                predicted <- get_test_predicted_labels(model_object, binary_classification_threshold)
+                if (is.null(predicted)) {
+                  predicted <- test_pred_ret$predicted_label
+                }
                 if ("xgboost_exp" %in% class(model_object)) {
-                  predicted <- extract_predicted_binary_labels(model_object, type = "test", threshold = binary_classification_threshold) # If threshold is specified in ..., take it.
                   predicted_probability <- extract_predicted(model_object, type = "test")
                 }
                 else {
-                  predicted <- test_pred_ret$predicted_label
                   predicted_probability <- test_pred_ret$predicted_probability
                 }
                 is_rpart <- "rpart" %in% class(model_object)
@@ -1505,16 +1510,8 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
             dplyr::bind_rows(lapply(levels(actual), per_level))
           },
           conf_mat = {
-            model_object <- df$model[[1]]
-            if ("xgboost_exp" %in% class(model_object)) {
-              if (get_prediction_type(model_object) == "binary") {
-                predicted <- extract_predicted_binary_labels(model_object, type = "test", threshold = binary_classification_threshold)
-              }
-              else {
-                predicted <- extract_predicted_multiclass_labels(model_object, type = "test")
-              }
-            }
-            else {
+            predicted <- get_test_predicted_labels(model_object, binary_classification_threshold)
+            if (is.null(predicted)) {
               predicted <- test_pred_ret$predicted_label
             }
             ret <- calc_conf_mat(actual, predicted)
@@ -3707,6 +3704,49 @@ get_class_levels_rpart <- function(x) {
     ylevels <- attr(x,"ylevels")
   }
   ylevels
+}
+
+# Returns threshold-aware predicted labels for test data embedded in the model.
+# Returns NULL for model types / classification types handled via test_pred_ret fallback.
+get_test_predicted_labels <- function(model_object, binary_classification_threshold = 0.5) {
+  if ("xgboost_exp" %in% class(model_object)) {
+    if (get_prediction_type(model_object) == "binary") {
+      return(extract_predicted_binary_labels(
+        model_object, type = "test", threshold = binary_classification_threshold
+      ))
+    }
+    return(extract_predicted_multiclass_labels(model_object, type = "test"))
+  }
+  if (("lightgbm_exp" %in% class(model_object) || "catboost_exp" %in% class(model_object)) &&
+      model_object$classification_type == "binary") {
+    predicted_nona <- extract_predicted_binary_labels(
+      model_object, type = "test", threshold = binary_classification_threshold
+    )
+    predicted_nona <- restore_na(predicted_nona, attr(model_object$prediction_test, "unknown_category_rows_index"))
+    return(restore_na(predicted_nona, attr(model_object$prediction_test, "na.action")))
+  }
+  if ("ranger" %in% class(model_object) &&
+      !is.null(model_object$classification_type) &&
+      model_object$classification_type == "binary") {
+    predicted_nona <- predict_value_from_prob(
+      NULL,
+      model_object$prediction_test$predictions,
+      NULL,
+      threshold = binary_classification_threshold
+    )
+    predicted_nona <- restore_na(predicted_nona, attr(model_object$prediction_test, "unknown_category_rows_index"))
+    return(restore_na(predicted_nona, attr(model_object$prediction_test, "na.action")))
+  }
+  if ("rpart" %in% class(model_object) && model_object$classification_type == "binary") {
+    predicted_nona <- get_predicted_class_rpart(
+      model_object,
+      data_type = "test",
+      binary_classification_threshold = binary_classification_threshold
+    )
+    predicted_nona <- restore_na(predicted_nona, model_object$unknown_category_rows_index_test)
+    return(restore_na(predicted_nona, model_object$na_row_numbers_test))
+  }
+  NULL
 }
 
 get_predicted_class_rpart <- function(x, data_type = "training", binary_classification_threshold = 0.5) {

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -3781,7 +3781,7 @@ get_predicted_probability_rpart <- function(x, data_type = "training") {
 
 #' @export
 #' @param type "importance", "evaluation" or "conf_mat". Feature importance, evaluated scores or confusion matrix of training data.
-tidy.rpart <- function(x, type = "importance", pretty.name = FALSE, ...) {
+tidy.rpart <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     ret <- data.frame()
     return(ret)
@@ -3810,7 +3810,12 @@ tidy.rpart <- function(x, type = "importance", pretty.name = FALSE, ...) {
         glance(x, pretty.name = pretty.name, ...)
       } else {
         actual <- get_actual_class_rpart(x)
-        predicted <- x$predicted_class
+        predicted <- if (x$classification_type == "binary") {
+          get_predicted_class_rpart(x, data_type = "training",
+                                    binary_classification_threshold = binary_classification_threshold)
+        } else {
+          x$predicted_class
+        }
         # unlike ranger, x$y of rpart in this case is integer. convert it to factor to make use of common functions.
         if (x$classification_type == "binary") {
           if (class(x$y) == "logical") {
@@ -3838,7 +3843,12 @@ tidy.rpart <- function(x, type = "importance", pretty.name = FALSE, ...) {
       # get evaluation scores from training data
 
       actual <- get_actual_class_rpart(x)
-      predicted <- x$predicted_class
+      predicted <- if (x$classification_type == "binary") {
+        get_predicted_class_rpart(x, data_type = "training",
+                                  binary_classification_threshold = binary_classification_threshold)
+      } else {
+        x$predicted_class
+      }
       ylevels <- get_class_levels_rpart(x)
 
       per_level <- function(level) {
@@ -3855,7 +3865,12 @@ tidy.rpart <- function(x, type = "importance", pretty.name = FALSE, ...) {
     conf_mat = {
       # return confusion matrix
       actual <- get_actual_class_rpart(x)
-      predicted <- x$predicted_class
+      predicted <- if (x$classification_type == "binary") {
+        get_predicted_class_rpart(x, data_type = "training",
+                                  binary_classification_threshold = binary_classification_threshold)
+      } else {
+        x$predicted_class
+      }
 
       # for rpart, factor levels for logical case is kept in FALSE, TRUE order not to mess up rpart.plot.
       # so need to revert it now, right before visualization.

--- a/tests/testthat/test_conf_mat_threshold_test_mode.R
+++ b/tests/testthat/test_conf_mat_threshold_test_mode.R
@@ -25,19 +25,39 @@ if (!testdata_filename %in% list.files(testdata_dir)) {
   write.csv(flight, testdata_file_path)
 }
 
-expect_test_conf_mat_changes_with_threshold <- function(model_df, eval_fn,
-                                                        threshold_high = 0.5,
-                                                        threshold_low = 0.1) {
+expect_conf_mat_changes_with_threshold <- function(model_df, eval_fn,
+                                                    data_type = c("test", "training"),
+                                                    threshold_high = 0.5,
+                                                    threshold_low = 0.1) {
+  data_type <- match.arg(data_type)
   cm_high <- eval_fn(model_df, threshold_high)
   cm_low <- eval_fn(model_df, threshold_low)
 
-  test_high <- cm_high %>% dplyr::filter(is_test_data == TRUE)
-  test_low <- cm_low %>% dplyr::filter(is_test_data == TRUE)
+  if (data_type == "test") {
+    subset_high <- cm_high %>% dplyr::filter(is_test_data == TRUE)
+    subset_low <- cm_low %>% dplyr::filter(is_test_data == TRUE)
+    info_msg <- "Test confusion matrix should change when threshold changes"
+  } else {
+    subset_high <- cm_high %>% dplyr::filter(is_test_data == FALSE)
+    subset_low <- cm_low %>% dplyr::filter(is_test_data == FALSE)
+    info_msg <- "Training confusion matrix should change when threshold changes"
+  }
 
-  expect_gt(nrow(test_high), 0)
-  expect_gt(nrow(test_low), 0)
-  expect_false(identical(test_high, test_low),
-               info = "Test confusion matrix should change when threshold changes")
+  expect_gt(nrow(subset_high), 0)
+  expect_gt(nrow(subset_low), 0)
+  expect_false(identical(subset_high, subset_low), info = info_msg)
+}
+
+# Backward-compatible alias for existing test-data checks.
+expect_test_conf_mat_changes_with_threshold <- function(model_df, eval_fn,
+                                                        threshold_high = 0.5,
+                                                        threshold_low = 0.1) {
+  expect_conf_mat_changes_with_threshold(
+    model_df, eval_fn,
+    data_type = "test",
+    threshold_high = threshold_high,
+    threshold_low = threshold_low
+  )
 }
 
 rf_conf_mat_eval <- function(model_df, threshold) {
@@ -180,4 +200,70 @@ test_that("rf test conf_mat matches threshold-aware labels at same threshold", {
   manual <- manual %>% dplyr::arrange(actual_value, predicted_value)
 
   expect_equal(test_cm, manual)
+})
+
+test_that("conf_mat training data respects threshold - Decision Tree (rpart)", {
+  set.seed(1)
+  df <- data.frame(
+    y = sample(c(TRUE, FALSE), 500, replace = TRUE, prob = c(0.55, 0.45)),
+    x1 = rnorm(500),
+    x2 = rnorm(500),
+    x3 = rnorm(500)
+  )
+  model_df <- df %>% exp_rpart(y, x1, x2, x3, test_rate = 0.3, binary_classification_threshold = 0.5)
+  expect_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval, data_type = "training")
+})
+
+test_that("conf_mat training data respects threshold - LightGBM", {
+  skip_if_not_installed("lightgbm")
+  set.seed(1)
+  data <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`))
+  model_df <- data %>% exp_lightgbm(
+    is_delayed, `DIS TANCE`, `DEP TIME`,
+    predictor_funs = list(`DIS TANCE` = "none", `DEP TIME` = "none"),
+    test_rate = 0.3,
+    max_pd_vars = 0,
+    pd_with_bin_means = FALSE,
+    importance_measure = "lightgbm"
+  )
+  expect_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval, data_type = "training")
+})
+
+test_that("rpart training conf_mat matches threshold-aware labels at same threshold", {
+  set.seed(1)
+  df <- data.frame(
+    y = sample(c(TRUE, FALSE), 500, replace = TRUE, prob = c(0.55, 0.45)),
+    x1 = rnorm(500),
+    x2 = rnorm(500),
+    x3 = rnorm(500)
+  )
+  model_df <- df %>% exp_rpart(y, x1, x2, x3, test_rate = 0.3, binary_classification_threshold = 0.5)
+  threshold <- 0.3
+  model_object <- model_df$model[[1]]
+
+  actual <- get_actual_class_rpart(model_object)
+  predicted <- get_predicted_class_rpart(
+    model_object,
+    data_type = "training",
+    binary_classification_threshold = threshold
+  )
+  if (is.factor(actual) && length(levels(actual)) == 2 && all(levels(actual) == c("FALSE", "TRUE"))) {
+    actual <- forcats::fct_rev(actual)
+  }
+  if (is.factor(predicted) && length(levels(predicted)) == 2 && all(levels(predicted) == c("FALSE", "TRUE"))) {
+    predicted <- forcats::fct_rev(predicted)
+  }
+  manual <- calc_conf_mat(actual, predicted)
+
+  cm <- rf_evaluation_training_and_test(
+    model_df,
+    type = "conf_mat",
+    binary_classification_threshold = threshold
+  )
+  train_cm <- cm %>% dplyr::filter(is_test_data == FALSE) %>%
+    dplyr::select(actual_value, predicted_value, count) %>%
+    dplyr::arrange(actual_value, predicted_value)
+  manual <- manual %>% dplyr::arrange(actual_value, predicted_value)
+
+  expect_equal(train_cm, manual)
 })

--- a/tests/testthat/test_conf_mat_threshold_test_mode.R
+++ b/tests/testthat/test_conf_mat_threshold_test_mode.R
@@ -1,0 +1,183 @@
+# how to run this test:
+# devtools::test(filter="conf_mat_threshold_test_mode")
+
+context("confusion matrix threshold sensitivity in test mode")
+
+testdata_dir <- tempdir()
+testdata_filename <- "airline_2013_10_tricky_v3_5k.csv"
+testdata_file_path <- paste0(testdata_dir, '/', testdata_filename)
+
+filepath <- if (!testdata_filename %in% list.files(testdata_dir)) {
+  "https://exploratory-download.s3.us-west-2.amazonaws.com/test/airline_2013_10_tricky_v3.csv"
+} else {
+  testdata_file_path
+}
+
+flight <- exploratory::read_delim_file(
+  filepath, ",", quote = "\"", skip = 0, col_names = TRUE, na = c("", "NA"),
+  locale = readr::locale(encoding = "UTF-8", decimal_mark = "."),
+  trim_ws = FALSE, progress = FALSE
+) %>% exploratory::clean_data_frame()
+
+if (!testdata_filename %in% list.files(testdata_dir)) {
+  set.seed(1)
+  flight <- flight %>% slice_sample(n = 5000)
+  write.csv(flight, testdata_file_path)
+}
+
+expect_test_conf_mat_changes_with_threshold <- function(model_df, eval_fn,
+                                                        threshold_high = 0.5,
+                                                        threshold_low = 0.1) {
+  cm_high <- eval_fn(model_df, threshold_high)
+  cm_low <- eval_fn(model_df, threshold_low)
+
+  test_high <- cm_high %>% dplyr::filter(is_test_data == TRUE)
+  test_low <- cm_low %>% dplyr::filter(is_test_data == TRUE)
+
+  expect_gt(nrow(test_high), 0)
+  expect_gt(nrow(test_low), 0)
+  expect_false(identical(test_high, test_low),
+               info = "Test confusion matrix should change when threshold changes")
+}
+
+rf_conf_mat_eval <- function(model_df, threshold) {
+  rf_evaluation_training_and_test(
+    model_df,
+    type = "conf_mat",
+    binary_classification_threshold = threshold
+  )
+}
+
+glm_conf_mat_eval <- function(model_df, threshold) {
+  prediction_training_and_test(
+    model_df,
+    prediction_type = "conf_mat",
+    threshold = threshold
+  )
+}
+
+test_that("conf_mat test data respects threshold - Random Forest", {
+  set.seed(1)
+  df <- data.frame(
+    y = sample(c(TRUE, FALSE), 300, replace = TRUE, prob = c(0.7, 0.3)),
+    x1 = rnorm(300),
+    x2 = rnorm(300)
+  )
+  model_df <- df %>% calc_feature_imp(y, x1, x2, test_rate = 0.3)
+  expect_test_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - Decision Tree (rpart)", {
+  set.seed(1)
+  df <- data.frame(
+    y = sample(c(TRUE, FALSE), 500, replace = TRUE, prob = c(0.55, 0.45)),
+    x1 = rnorm(500),
+    x2 = rnorm(500),
+    x3 = rnorm(500)
+  )
+  model_df <- df %>% exp_rpart(y, x1, x2, x3, test_rate = 0.3, binary_classification_threshold = 0.5)
+  expect_test_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - XGBoost", {
+  set.seed(1)
+  data <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`))
+  model_df <- data %>% exp_xgboost(
+    is_delayed, `DIS TANCE`, `DEP TIME`,
+    predictor_funs = list(`DIS TANCE` = "none", `DEP TIME` = "none"),
+    test_rate = 0.3,
+    max_pd_vars = 0,
+    pd_with_bin_means = FALSE
+  )
+  expect_test_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - LightGBM", {
+  skip_if_not_installed("lightgbm")
+  set.seed(1)
+  data <- flight %>% dplyr::mutate(is_delayed = as.logical(`is delayed`))
+  model_df <- data %>% exp_lightgbm(
+    is_delayed, `DIS TANCE`, `DEP TIME`,
+    predictor_funs = list(`DIS TANCE` = "none", `DEP TIME` = "none"),
+    test_rate = 0.3,
+    max_pd_vars = 0,
+    pd_with_bin_means = FALSE,
+    importance_measure = "lightgbm"
+  )
+  expect_test_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - CatBoost", {
+  skip_if_not_installed("catboost")
+  set.seed(1)
+  df <- data.frame(
+    y = rep(c(TRUE, FALSE), 150),
+    num = rnorm(300),
+    grp = factor(rep(letters[1:3], length.out = 300)),
+    stringsAsFactors = FALSE
+  )
+  model_df <- df %>% exp_catboost(
+    y, num, grp,
+    iterations = 10,
+    depth = 3,
+    learning_rate = 0.2,
+    test_rate = 0.3,
+    max_pd_vars = 0,
+    eval_metric_binary = "Logloss"
+  )
+  expect_test_conf_mat_changes_with_threshold(model_df, rf_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - Logistic Regression", {
+  set.seed(1)
+  model_df <- flight %>%
+    build_lm.fast(
+      `is delayed`, `DIS TANCE`, `DEP TIME`,
+      model_type = "glm",
+      test_rate = 0.3
+    )
+  expect_test_conf_mat_changes_with_threshold(model_df, glm_conf_mat_eval)
+})
+
+test_that("conf_mat test data respects threshold - Binomial GLM", {
+  set.seed(1)
+  model_df <- flight %>%
+    build_lm.fast(
+      `is delayed`, `DIS TANCE`, `DEP TIME`,
+      model_type = "glm",
+      family = "binomial",
+      test_rate = 0.3
+    )
+  expect_test_conf_mat_changes_with_threshold(model_df, glm_conf_mat_eval)
+})
+
+test_that("rf test conf_mat matches threshold-aware labels at same threshold", {
+  set.seed(1)
+  df <- data.frame(
+    y = sample(c(TRUE, FALSE), 300, replace = TRUE, prob = c(0.7, 0.3)),
+    x1 = rnorm(300),
+    x2 = rnorm(300)
+  )
+  model_df <- df %>% calc_feature_imp(y, x1, x2, test_rate = 0.3)
+  threshold <- 0.3
+
+  pred <- prediction(model_df, data = "test")
+  actual_col <- model_df$model[[1]]$terms_mapping[
+    all.vars(model_df$model[[1]]$formula_terms)[1]
+  ]
+  actual <- pred[[actual_col]]
+  predicted <- get_test_predicted_labels(model_df$model[[1]], threshold)
+  manual <- calc_conf_mat(actual, predicted)
+
+  cm <- rf_evaluation_training_and_test(
+    model_df,
+    type = "conf_mat",
+    binary_classification_threshold = threshold
+  )
+  test_cm <- cm %>% dplyr::filter(is_test_data == TRUE) %>%
+    dplyr::select(actual_value, predicted_value, count) %>%
+    dplyr::arrange(actual_value, predicted_value)
+  manual <- manual %>% dplyr::arrange(actual_value, predicted_value)
+
+  expect_equal(test_cm, manual)
+})


### PR DESCRIPTION
# Description

Test-data confusion matrix and binary Summary metrics did not reflect changes to the classification threshold for tree-based classifiers (ranger / Random Forest, rpart, lightgbm, catboost). The test evaluation path used augment's precomputed `predicted_label` (fixed at the build-time threshold, effectively 0.5) instead of recomputing labels from the stored test probabilities the way the training path and xgboost already do. As a result, changing the threshold updated prediction tables but not the test confusion matrix.

## Changes

- Add internal helper `get_test_predicted_labels()` in `R/randomForest_tidiers.R` that computes threshold-aware predicted labels for test data per model class (ranger, rpart, lightgbm, catboost), consolidating the pre-existing xgboost logic. Returns `NULL` for multiclass / other model types so callers fall back to `test_pred_ret$predicted_label`.
- Wire the helper into the `conf_mat` and binary `evaluation` branches of `rf_evaluation_training_and_test()`.
- For non-xgboost models, keep `predicted_probability` from the full-length prediction output so AUC row alignment (NA-restored rows) is preserved. xgboost behavior is unchanged.

## Tests

New `tests/testthat/test_conf_mat_threshold_test_mode.R`:

- Asserts the test confusion matrix changes when the threshold changes, across Random Forest, rpart, xgboost, lightgbm, catboost, logistic regression, and binomial GLM.
- Verifies the Random Forest test confusion matrix matches the prediction table computed at the same threshold.

# Checklist

Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check() 
- [x] Pass devtools::test() 
- [ ] Test installing from github 
- [x] Tested with Exploratory 

