### PR TITLE
fix: add SSL mode support to MySQL/MariaDB connections (#36505)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: exploratory
 Type: Package
 Title: R package for Exploratory
 Version: 15.1.24
-Date: 2026-06-20
+Date: 2026-07-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.23
+Version: 15.1.22
 Date: 2026-06-20
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.24
+Version: 15.2.2
 Date: 2026-07-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.1.22
+Version: 15.1.24
 Date: 2026-06-20
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.1
-Date: 2026-08-27
+Version: 16.1.2
+Date: 2026-08-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/system.R
+++ b/R/system.R
@@ -1011,7 +1011,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     if(Sys.info()["sysname"] == "Linux" && sslCA != ""){
       sslCA <- "/etc/ssl/certs/rds-combined-ca-bundle.pem";
     }
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sep = ":")
+    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
     conn <- connection_pool[[key]]
     if (!is.null(conn)){
       tryCatch({
@@ -1036,26 +1036,27 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
+    # Map PostgreSQL-style sslMode values to RMariaDB ssl.mode constants.
+    rmariadb_ssl_mode <- switch(sslMode,
+      "disable"    = "SSL_MODE_DISABLED",
+      "allow"      = "SSL_MODE_PREFERRED",
+      "prefer"     = "SSL_MODE_PREFERRED",
+      "require"    = "SSL_MODE_REQUIRED",
+      "verify-ca"  = "SSL_MODE_VERIFY_CA",
+      "verify-full"= "SSL_MODE_VERIFY_IDENTITY",
+      NULL  # empty string or unknown -> let RMariaDB use its default
+    )
     # if the connection is null or the connection is invalid, create a new one.
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       # To avoid integer64 handling issues in charts, etc., use numeric as the R type to receive bigint data rather than default integer64 by specifying bigint argument.
-      if (timezone != "") {# if Timezone is set use it for timezone and timezone_out
-        if (sslCA != "") { # if sslCA is set, pass it as ssl.ca
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
-                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else { # if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
-                                     password = password, host = host, port = port, bigint = "numeric")
-        }
-      } else {# if sslCA is set, pass it as ssl.ca
-        if (sslCA != "") {
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
-                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else {# if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
-                                     password = password, host = host, port = port, bigint = "numeric")
-        }
-      }
+      tz_args <- if (timezone != "") list(timezone = timezone, timezone_out = timezone) else list()
+      ca_args  <- if (sslCA != "") list(ssl.ca = sslCA) else list()
+      mode_args <- if (!is.null(rmariadb_ssl_mode)) list(ssl.mode = rmariadb_ssl_mode) else list()
+      conn <- do.call(RMariaDB::dbConnect, c(
+        list(RMariaDB::MariaDB(), dbname = databaseName, username = username,
+             password = password, host = host, port = port, bigint = "numeric"),
+        tz_args, ca_args, mode_args
+      ))
       connection_pool[[key]] <- conn
     }
   } else if (type == "postgres" || type == "redshift" || type == "vertica") {
@@ -1857,7 +1858,7 @@ clearDBConnection <- function(type, host = NULL, port = NULL, databaseName, user
   }
   else if (type %in% c("mysql", "aurora")) {
     # they use common key "mysql"
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sep = ":")
+    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
     conn <- connection_pool[[key]]
     if (!is.null(conn)) {
       tryCatch({ # try to close connection and ignore error
@@ -2010,7 +2011,7 @@ getListOfColumns <- function(type, host, port, databaseName, username, password,
 #' @export
 executeGenericQuery <- function(type, host, port, databaseName, username, password, query, catalog = "", schema = "", numOfRows = -1, timezone = "", sslCA = "", sslMode = "", role = "", ...){
   if (type %in% c("mysql", "aurora")) { # In case of MySQL, just use queryMySQL, since it has workaround to read multibyte column names without getting garbled.
-    df <- queryMySQL(host, port, databaseName, username, password, numOfRows = numOfRows, query, timezone = timezone, sslCA = sslCA)
+    df <- queryMySQL(host, port, databaseName, username, password, numOfRows = numOfRows, query, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
     df <- readr::type_convert(df)
     # It is hackish, but to read multibyte character data correctly, type_convert helps for some reason.
     # There is small chance of column getting converted to unwanted type, but for our usage, that is unlikely, and being able to read multibyte outweighs the potential drawback.
@@ -2048,11 +2049,11 @@ executeGenericQuery <- function(type, host, port, databaseName, username, passwo
 
 
 #' @export
-queryMySQL <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslCA = "", ...){
+queryMySQL <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslCA = "", sslMode = "", ...){
   if(!requireNamespace("RMariaDB")){stop("package RMariaDB must be installed.")}
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
 
-  conn <- getDBConnection(type = "mysql", host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslCA = sslCA)
+  conn <- getDBConnection(type = "mysql", host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
@@ -2060,7 +2061,7 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
     df <- RMariaDB::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try
-    clearDBConnection("mysql", host, port, databaseName, username, timezone = timezone)
+    clearDBConnection("mysql", host, port, databaseName, username, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
     stop(err)
   })
   RMariaDB::dbClearResult(resultSet)

--- a/R/system.R
+++ b/R/system.R
@@ -1140,6 +1140,64 @@ stripTrailingSemicolon <- function(query) {
   sub("[[:space:]]*;[[:space:]]*$", "", query)
 }
 
+# RMariaDB uses the seeded RDS CA bundle for Aurora on Linux. Keep this
+# normalization in one place so connection creation and eviction use the same
+# pool key and the same certificate path.
+normalize_mysql_ssl_ca <- function(sslCA, sysname = Sys.info()[["sysname"]]) {
+  if (is.null(sslCA) || length(sslCA) == 0) {
+    return("")
+  }
+  sslCA <- as.character(sslCA[[1]])
+  if (is.na(sslCA) || sslCA == "") {
+    return("")
+  }
+  if (isTRUE(unname(sysname) == "Linux")) {
+    return("/etc/ssl/certs/rds-combined-ca-bundle.pem")
+  }
+  sslCA
+}
+
+# Single source of truth for the MySQL/MariaDB connection pool key. The SSL
+# mode is part of the key because it changes the security properties of a
+# connection, and the CA path is normalized before it is included.
+mysql_pool_key <- function(host, port, databaseName, username, timezone,
+                           sslCA = "", sslMode = "",
+                           sysname = Sys.info()[["sysname"]]) {
+  sslCA <- normalize_mysql_ssl_ca(sslCA, sysname = sysname)
+  paste("mysql", host, port, databaseName, username, timezone, sslCA,
+        sslMode, sep = ":")
+}
+
+# RMariaDB does not expose a PostgreSQL-style sslmode argument. Its supported
+# interface uses client flags: CLIENT_SSL enforces TLS and
+# CLIENT_SSL_VERIFY_SERVER_CERT enables server certificate verification. The
+# verify-ca mode shares CLIENT_SSL because RMariaDB has no separate client flag
+# for CA-only verification; ssl.ca supplies the configured trust store.
+rmariadb_client_flag <- function(sslMode,
+                                 sslFlag = RMariaDB::CLIENT_SSL,
+                                 verifyServerCertFlag = RMariaDB::CLIENT_SSL_VERIFY_SERVER_CERT) {
+  switch(sslMode,
+    "require" = sslFlag,
+    "verify-ca" = sslFlag,
+    "verify-full" = bitwOr(sslFlag, verifyServerCertFlag),
+    0L
+  )
+}
+
+rmariadb_ssl_connection_args <- function(sslCA, sslMode,
+                                          sslFlag = RMariaDB::CLIENT_SSL,
+                                          verifyServerCertFlag = RMariaDB::CLIENT_SSL_VERIFY_SERVER_CERT) {
+  args <- list(client.flag = rmariadb_client_flag(
+    sslMode = sslMode,
+    sslFlag = sslFlag,
+    verifyServerCertFlag = verifyServerCertFlag
+  ))
+  if (sslMode != "disable" && sslCA != "") {
+    args$ssl.ca <- sslCA
+  }
+  args
+}
+
 #' Returns specified connection from pool if it exists in the pool.
 #' If not, new connection is created and returned.
 #' @export
@@ -1207,13 +1265,8 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     # use same key "mysql" for aurora too, since it uses
     # queryMySQL() too, which uses the key "mysql"
 
-    # When the Amazon Aurora data source is executed on Linux, it's possible that sslCA parameter is defined, for this case switch it to use seeded pem file for now.
-    # Also, when getDBConnection is called from queryMySQL, the type argument is set as "mysql" for both MariaDB and Aurora, so stop checking type
-    # and simply check if sslCA is empty string or not.
-    if(Sys.info()["sysname"] == "Linux" && sslCA != ""){
-      sslCA <- "/etc/ssl/certs/rds-combined-ca-bundle.pem";
-    }
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
+    sslCA <- normalize_mysql_ssl_ca(sslCA)
+    key <- mysql_pool_key(host, port, databaseName, username, timezone, sslCA, sslMode)
     conn <- connection_pool[[key]]
     if (!is.null(conn)){
       tryCatch({
@@ -1238,26 +1291,15 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
-    # Map PostgreSQL-style sslMode values to RMariaDB ssl.mode constants.
-    rmariadb_ssl_mode <- switch(sslMode,
-      "disable"    = "SSL_MODE_DISABLED",
-      "allow"      = "SSL_MODE_PREFERRED",
-      "prefer"     = "SSL_MODE_PREFERRED",
-      "require"    = "SSL_MODE_REQUIRED",
-      "verify-ca"  = "SSL_MODE_VERIFY_CA",
-      "verify-full"= "SSL_MODE_VERIFY_IDENTITY",
-      NULL  # empty string or unknown -> let RMariaDB use its default
-    )
     # if the connection is null or the connection is invalid, create a new one.
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       # To avoid integer64 handling issues in charts, etc., use numeric as the R type to receive bigint data rather than default integer64 by specifying bigint argument.
       tz_args <- if (timezone != "") list(timezone = timezone, timezone_out = timezone) else list()
-      ca_args  <- if (sslCA != "") list(ssl.ca = sslCA) else list()
-      mode_args <- if (!is.null(rmariadb_ssl_mode)) list(ssl.mode = rmariadb_ssl_mode) else list()
+      ssl_args <- rmariadb_ssl_connection_args(sslCA = sslCA, sslMode = sslMode)
       conn <- do.call(RMariaDB::dbConnect, c(
         list(RMariaDB::MariaDB(), dbname = databaseName, username = username,
              password = password, host = host, port = port, bigint = "numeric"),
-        tz_args, ca_args, mode_args
+        tz_args, ssl_args
       ))
       connection_pool[[key]] <- conn
     }
@@ -2149,7 +2191,7 @@ clearDBConnection <- function(type, host = NULL, port = NULL, databaseName, user
   }
   else if (type %in% c("mysql", "aurora")) {
     # they use common key "mysql"
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
+    key <- mysql_pool_key(host, port, databaseName, username, timezone, sslCA, sslMode)
     conn <- connection_pool[[key]]
     if (!is.null(conn)) {
       tryCatch({ # try to close connection and ignore error
@@ -2282,7 +2324,7 @@ getListOfColumns <- function(type, host, port, databaseName, username, password,
     columns <- DBI::dbListFields(conn, table)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try
-    clearDBConnection(type, host, port, databaseName, username)
+    clearDBConnection(type, host, port, databaseName, username, sslMode = sslMode, sslCA = sslCA)
     if (!!isConnecitonPoolEnabled(type)) { # only if conn pool is not used yet
       tryCatch({ # try to close connection and ignore error
         DBI::dbDisconnect(conn)

--- a/R/system.R
+++ b/R/system.R
@@ -1213,7 +1213,7 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
     if(Sys.info()["sysname"] == "Linux" && sslCA != ""){
       sslCA <- "/etc/ssl/certs/rds-combined-ca-bundle.pem";
     }
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sep = ":")
+    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
     conn <- connection_pool[[key]]
     if (!is.null(conn)){
       tryCatch({
@@ -1238,26 +1238,27 @@ getDBConnection <- function(type, host = NULL, port = "", databaseName = "", use
         # fall through to getting new connection.
       })
     }
+    # Map PostgreSQL-style sslMode values to RMariaDB ssl.mode constants.
+    rmariadb_ssl_mode <- switch(sslMode,
+      "disable"    = "SSL_MODE_DISABLED",
+      "allow"      = "SSL_MODE_PREFERRED",
+      "prefer"     = "SSL_MODE_PREFERRED",
+      "require"    = "SSL_MODE_REQUIRED",
+      "verify-ca"  = "SSL_MODE_VERIFY_CA",
+      "verify-full"= "SSL_MODE_VERIFY_IDENTITY",
+      NULL  # empty string or unknown -> let RMariaDB use its default
+    )
     # if the connection is null or the connection is invalid, create a new one.
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       # To avoid integer64 handling issues in charts, etc., use numeric as the R type to receive bigint data rather than default integer64 by specifying bigint argument.
-      if (timezone != "") {# if Timezone is set use it for timezone and timezone_out
-        if (sslCA != "") { # if sslCA is set, pass it as ssl.ca
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
-                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else { # if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username, timezone = timezone, timezone_out = timezone,
-                                     password = password, host = host, port = port, bigint = "numeric")
-        }
-      } else {# if sslCA is set, pass it as ssl.ca
-        if (sslCA != "") {
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
-                                     password = password, host = host, port = port, bigint = "numeric", ssl.ca = sslCA)
-        } else {# if sslCA is not set, do not set it since passing empty string causes Error : Failed to connect: SSL connection error: No such file or directory
-          conn = RMariaDB::dbConnect(RMariaDB::MariaDB(), dbname = databaseName, username = username,
-                                     password = password, host = host, port = port, bigint = "numeric")
-        }
-      }
+      tz_args <- if (timezone != "") list(timezone = timezone, timezone_out = timezone) else list()
+      ca_args  <- if (sslCA != "") list(ssl.ca = sslCA) else list()
+      mode_args <- if (!is.null(rmariadb_ssl_mode)) list(ssl.mode = rmariadb_ssl_mode) else list()
+      conn <- do.call(RMariaDB::dbConnect, c(
+        list(RMariaDB::MariaDB(), dbname = databaseName, username = username,
+             password = password, host = host, port = port, bigint = "numeric"),
+        tz_args, ca_args, mode_args
+      ))
       connection_pool[[key]] <- conn
     }
   } else if (type == "postgres" || type == "redshift" || type == "vertica") {
@@ -2148,7 +2149,7 @@ clearDBConnection <- function(type, host = NULL, port = NULL, databaseName, user
   }
   else if (type %in% c("mysql", "aurora")) {
     # they use common key "mysql"
-    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sep = ":")
+    key <- paste("mysql", host, port, databaseName, username, timezone, sslCA, sslMode, sep = ":")
     conn <- connection_pool[[key]]
     if (!is.null(conn)) {
       tryCatch({ # try to close connection and ignore error
@@ -2305,7 +2306,7 @@ getListOfColumns <- function(type, host, port, databaseName, username, password,
 #' @export
 executeGenericQuery <- function(type, host, port, databaseName, username, password, query, catalog = "", schema = "", numOfRows = -1, timezone = "", sslCA = "", sslMode = "", role = "", ...){
   if (type %in% c("mysql", "aurora")) { # In case of MySQL, just use queryMySQL, since it has workaround to read multibyte column names without getting garbled.
-    df <- queryMySQL(host, port, databaseName, username, password, numOfRows = numOfRows, query, timezone = timezone, sslCA = sslCA)
+    df <- queryMySQL(host, port, databaseName, username, password, numOfRows = numOfRows, query, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
     df <- readr::type_convert(df)
     # It is hackish, but to read multibyte character data correctly, type_convert helps for some reason.
     # There is small chance of column getting converted to unwanted type, but for our usage, that is unlikely, and being able to read multibyte outweighs the potential drawback.
@@ -2343,11 +2344,11 @@ executeGenericQuery <- function(type, host, port, databaseName, username, passwo
 
 
 #' @export
-queryMySQL <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslCA = "", ...){
+queryMySQL <- function(host, port, databaseName, username, password, numOfRows = -1, query, timezone = "", sslCA = "", sslMode = "", ...){
   if(!requireNamespace("RMariaDB")){stop("package RMariaDB must be installed.")}
   if(!requireNamespace("DBI")){stop("package DBI must be installed.")}
 
-  conn <- getDBConnection(type = "mysql", host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslCA = sslCA)
+  conn <- getDBConnection(type = "mysql", host = host, port = port, databaseName = databaseName, username = username, password = password, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
   tryCatch({
     query <- convertUserInputToUtf8(query)
     # set envir = parent.frame() to get variables from users environment, not papckage environment
@@ -2355,7 +2356,7 @@ queryMySQL <- function(host, port, databaseName, username, password, numOfRows =
     df <- RMariaDB::dbFetch(resultSet, n = numOfRows)
   }, error = function(err) {
     # clear connection in pool so that new connection will be used for the next try
-    clearDBConnection("mysql", host, port, databaseName, username, timezone = timezone)
+    clearDBConnection("mysql", host, port, databaseName, username, timezone = timezone, sslCA = sslCA, sslMode = sslMode)
     stop(err)
   })
   RMariaDB::dbClearResult(resultSet)

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -1287,6 +1287,71 @@ test_that("oracleOCIPoolKey builds identical keys from getDBConnection and clear
   expect_false(fromGet == exploratory:::oracleOCIPoolKey("host", 1521, "svc", "user", "", 10000, "", "prefetch=TRUE"))
 })
 
+test_that("MySQL SSL CA normalization is shared by connection pool keys", {
+  expect_equal(
+    exploratory:::normalize_mysql_ssl_ca("custom-ca.pem", sysname = "Linux"),
+    "/etc/ssl/certs/rds-combined-ca-bundle.pem"
+  )
+  expect_equal(
+    exploratory:::normalize_mysql_ssl_ca("custom-ca.pem", sysname = "Darwin"),
+    "custom-ca.pem"
+  )
+  expect_equal(exploratory:::normalize_mysql_ssl_ca("", sysname = "Linux"), "")
+  expect_equal(exploratory:::normalize_mysql_ssl_ca(NA_character_, sysname = "Linux"), "")
+
+  fromGet <- exploratory:::mysql_pool_key(
+    "host", 3306, "db", "user", "UTC", "custom-ca.pem", "require", sysname = "Linux"
+  )
+  fromClear <- exploratory:::mysql_pool_key(
+    "host", 3306, "db", "user", "UTC", "/etc/ssl/certs/rds-combined-ca-bundle.pem", "require",
+    sysname = "Linux"
+  )
+  expect_equal(fromGet, fromClear)
+  expect_false(fromGet == exploratory:::mysql_pool_key(
+    "host", 3306, "db", "user", "UTC", "custom-ca.pem", "verify-full", sysname = "Linux"
+  ))
+})
+
+test_that("MySQL SSL modes use supported RMariaDB connection arguments", {
+  sslFlag <- 2048L
+  verifyServerCertFlag <- 1073741824L
+
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "disable", sslFlag, verifyServerCertFlag),
+    list(client.flag = 0L)
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "allow", sslFlag, verifyServerCertFlag),
+    list(client.flag = 0L, ssl.ca = "ca.pem")
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "prefer", sslFlag, verifyServerCertFlag),
+    list(client.flag = 0L, ssl.ca = "ca.pem")
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "require", sslFlag, verifyServerCertFlag),
+    list(client.flag = sslFlag, ssl.ca = "ca.pem")
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "verify-ca", sslFlag, verifyServerCertFlag),
+    list(client.flag = sslFlag, ssl.ca = "ca.pem")
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("ca.pem", "verify-full", sslFlag, verifyServerCertFlag),
+    list(client.flag = bitwOr(sslFlag, verifyServerCertFlag), ssl.ca = "ca.pem")
+  )
+  expect_equal(
+    exploratory:::rmariadb_ssl_connection_args("", "verify-full", sslFlag, verifyServerCertFlag),
+    list(client.flag = bitwOr(sslFlag, verifyServerCertFlag))
+  )
+
+  modes <- c("", "unknown")
+  for (mode in modes) {
+    args <- exploratory:::rmariadb_ssl_connection_args("ca.pem", mode, sslFlag, verifyServerCertFlag)
+    expect_false("ssl.mode" %in% names(args))
+  }
+})
+
 test_that("findOracleClientLibDir handles both Oracle client layouts", {
   base <- tempfile()
   dir.create(base)


### PR DESCRIPTION
## Description

Adds MySQL/MariaDB SSL mode handling for Exploratory issue #36505.

## Changes

- Threads `sslMode` through `queryMySQL`, `executeGenericQuery`, `getDBConnection`, `clearDBConnection`, and the column-listing error path.
- Uses RMariaDB-supported `client.flag` values instead of the unsupported `ssl.mode` argument:
  - `disable`: no SSL client flag and no CA argument
  - `allow` / `prefer`: default client behavior with the configured CA
  - `require` / `verify-ca`: `CLIENT_SSL` with the configured CA
  - `verify-full`: `CLIENT_SSL` + `CLIENT_SSL_VERIFY_SERVER_CERT` with the configured CA
- Centralizes Linux RDS CA-path normalization and MySQL/MariaDB pool-key creation so connection creation and eviction address the same connection.
- Keeps SSL mode and CA path in the pool key to prevent security-mode collisions.

RMariaDB does not expose a separate CA-only client flag, so `verify-ca` uses the supported `CLIENT_SSL` + `ssl.ca` combination.

## Tests

- Added unit coverage for all SSL modes, RMariaDB argument construction, Linux CA normalization, pool-key consistency, and mode separation.
- Verified R parsing, package installation, targeted testthat cases, and `git diff --check`.
