### PR TITLE
Bump version to 16.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 15.2.3
+Version: 16.0.1
 Date: 2026-07-09
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func


### PR DESCRIPTION
## Summary

Bump package version `15.2.3` → `16.0.1` in `DESCRIPTION`.

Follows the merge of the R 4.6 build_model compatibility fixes (#1529, #1530, #1531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)