### PR TITLE
Factor Analysis report: suitability / parallel-analysis / judgment outputs (tam#37018)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.1
+Version: 16.0.2
 Date: 2026-07-09
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -461,14 +461,15 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     if (any(improper)) {
       var_labels[improper] <- paste0(var_labels[improper], "  ⚠ ", format(round(comm[improper], 2), nsmall = 2))
     }
-    # Order the bars by communality (ascending -> highest communality at the TOP of the horizontal
-    # bar chart). Ratios are on a 0-100 percentage scale for the 100%-style bar. Component is
-    # Communality-first so it stacks/colors/legends before Uniqueness.
-    var_factor <- forcats::fct_reorder(var_labels, comm)
+    # Order the bars by communality DESCENDING (highest communality at the TOP of the horizontal
+    # bar chart). Ratios are kept as 0-1 proportions; the chart renders them as percentages via the
+    # viz's percentage number formatting. Component is Communality-first so it
+    # stacks/colors/legends before Uniqueness.
+    var_factor <- forcats::fct_reorder(var_labels, comm, .desc = TRUE)
     res <- tibble::tibble(
       variable = var_factor,
-      Communality = pmin(comm, 1) * 100,
-      Uniqueness = pmax(1 - comm, 0) * 100
+      Communality = pmin(comm, 1),
+      Uniqueness = pmax(1 - comm, 0)
     ) %>%
       tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%
       dplyr::mutate(Component = forcats::fct_relevel(as.factor(Component), "Communality", "Uniqueness"))

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -61,6 +61,10 @@ judge_bartlett <- function(p_value, cfg = factanal_report_config()) {
 
 judge_communality <- function(communality, cfg = factanal_report_config()) {
   if (is.na(communality)) return(list(label = "Not Available", status = "na"))
+  # A communality > 1 (i.e. negative uniqueness) is a Heywood case: NOT "explained more than
+  # 100%", but a sign that the estimation is unstable / the solution is improper. Flag it before
+  # the "too high" check so it gets its own, more serious judgment. (issue #37018)
+  if (communality > 1) return(list(label = "Possibly improper solution", status = "improper"))
   if (communality >= cfg$communality_too_high) list(label = "Too high (caution)", status = "too_high")
   else if (communality >= cfg$communality_good) list(label = "Well explained", status = "good")
   else if (communality >= cfg$communality_low) list(label = "Moderately explained", status = "moderate")

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -446,9 +446,17 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     ) %>% dplyr::arrange(dplyr::desc(Communality))
   }
   else if (type == "communalities_long") {
-    # Long form for the 100%-stacked communality/uniqueness bar chart. The two components sum to 1.
-    comm <- x$communality
-    res <- tibble::tibble(variable = names(comm), Communality = as.numeric(comm), Uniqueness = 1 - as.numeric(comm)) %>%
+    # Long form for the 100%-stacked communality/uniqueness bar chart. Normally the two components
+    # sum to 1. In a Heywood case (communality > 1) uniqueness goes negative, which would break the
+    # 100%-stacked bar. Cap the DISPLAYED ratios -- communality at 1, uniqueness at 0 -- so the bar
+    # stays a clean 100% stack. The exact communality and the improper-solution warning are surfaced
+    # in the Communality table (judge_communality "Possibly improper solution"). (#37018)
+    comm <- as.numeric(x$communality)
+    res <- tibble::tibble(
+      variable = names(x$communality),
+      Communality = pmin(comm, 1),
+      Uniqueness = pmax(1 - comm, 0)
+    ) %>%
       tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%
       dplyr::mutate(Component = forcats::fct_relevel(as.factor(Component), "Communality", "Uniqueness"))
   }

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -438,10 +438,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   }
   else if (type == "communalities") {
     comm <- x$communality
-    # Wrap the variable names in backticks so the table presents them as data-column identifiers
-    # (e.g. `サイズ`), consistent with how Exploratory shows column references. The client strips the
-    # backticks when it reuses these names in the rule-based summary. (#37018)
-    res <- tibble::tibble(variable = paste0("`", names(comm), "`"), Communality = as.numeric(comm), Uniqueness = as.numeric(x$uniquenesses))
+    res <- tibble::tibble(variable = names(comm), Communality = as.numeric(comm), Uniqueness = as.numeric(x$uniquenesses))
     judgements <- purrr::map(res$Communality, judge_communality)
     res <- res %>% dplyr::mutate(
       Judgement = purrr::map_chr(judgements, "label"),

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -447,28 +447,18 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   }
   else if (type == "communalities_long") {
     # Long form for the 100%-stacked communality/uniqueness bar chart. Normally the two components
-    # sum to 1. In a Heywood case (communality > 1) uniqueness goes negative, which would break the
-    # 100%-stacked bar. Cap the DISPLAYED ratios -- communality at 1, uniqueness at 0 -- so the bar
-    # stays a clean 100% stack. (#37018)
+    # sum to 1. In a Heywood case (communality > 1) uniqueness would go negative, which would break
+    # the stack. Per spec: the bar is CLIPPED at 100% (via the chart's 0-100 value-axis range) but
+    # the numeric label shows the ACTUAL communality (e.g. 101%), so communality is left UNCAPPED
+    # here; uniqueness is clamped to 0 so it is never negative. (#37018)
     comm <- as.numeric(x$communality)
-    # For a Heywood-case variable, flag its bar on the chart with a warning marker + the actual
-    # (uncapped) communality value, appended to the category label. This is language-neutral (a
-    # symbol + a number, no translated text) so it is safe for both EN and JA, and it renders
-    # reliably on the axis / hover without any chart-code change. The full explanation is in the
-    # Communality table judgment ("Possibly improper solution") and the report warning.
-    var_labels <- names(x$communality)
-    improper <- !is.na(comm) & comm > 1
-    if (any(improper)) {
-      var_labels[improper] <- paste0(var_labels[improper], "  ⚠ ", format(round(comm[improper], 2), nsmall = 2))
-    }
     # Order the bars by communality DESCENDING (highest communality at the TOP of the horizontal
-    # bar chart). Ratios are on a 0-100 percentage scale so the bar fills a 0-100 axis; the "%"
-    # suffix is added by the chart. Component is Communality-first so it stacks/colors/legends
-    # before Uniqueness.
-    var_factor <- forcats::fct_reorder(var_labels, comm, .desc = TRUE)
+    # bar chart). Ratios are on a 0-100 percentage scale. Component is Communality-first so it
+    # stacks/colors/legends before Uniqueness.
+    var_factor <- forcats::fct_reorder(names(x$communality), comm, .desc = TRUE)
     res <- tibble::tibble(
       variable = var_factor,
-      Communality = pmin(comm, 1) * 100,
+      Communality = comm * 100,
       Uniqueness = pmax(1 - comm, 0) * 100
     ) %>%
       tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -438,7 +438,10 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   }
   else if (type == "communalities") {
     comm <- x$communality
-    res <- tibble::tibble(variable = names(comm), Communality = as.numeric(comm), Uniqueness = as.numeric(x$uniquenesses))
+    # Wrap the variable names in backticks so the table presents them as data-column identifiers
+    # (e.g. `サイズ`), consistent with how Exploratory shows column references. The client strips the
+    # backticks when it reuses these names in the rule-based summary. (#37018)
+    res <- tibble::tibble(variable = paste0("`", names(comm), "`"), Communality = as.numeric(comm), Uniqueness = as.numeric(x$uniquenesses))
     judgements <- purrr::map(res$Communality, judge_communality)
     res <- res %>% dplyr::mutate(
       Judgement = purrr::map_chr(judgements, "label"),

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -28,6 +28,122 @@ preprocess_factanal_data_before_sample <- function(df, predictor_cols) {
   df
 }
 
+# Threshold configuration for the Factor Analysis report judgments (issue #37018).
+# Kept as an internal function (not a mutable global) so helpers can pick it up by default.
+factanal_report_config <- function() {
+  list(
+    loading_salient = 0.40, loading_strong = 0.60, loading_crossload_diff = 0.20,
+    loading_near = 0.30, loading_near_diff = 0.25,
+    communality_low = 0.40, communality_good = 0.60, communality_too_high = 0.95,
+    kmo_poor = 0.50, kmo_min = 0.60, kmo_good = 0.70, kmo_great = 0.80,
+    factor_corr_medium = 0.30, factor_corr_high = 0.50,
+    p_value_threshold = 0.05
+  )
+}
+
+# All judge_* helpers emit English-canonical labels and a language-neutral `status` token.
+# The desktop/server client translates the label (VizUtil message tables) and composes tooltips
+# from the token + params. No natural language for translation lives in R output. (issue #37018)
+judge_kmo <- function(kmo, cfg = factanal_report_config()) {
+  if (is.na(kmo)) return(list(label = "Not Available", status = "na", description = "KMO could not be computed."))
+  if (kmo >= cfg$kmo_great) list(label = "Very Suitable", status = "great", description = "The variables have a correlation structure well suited for factor analysis.")
+  else if (kmo >= cfg$kmo_good) list(label = "Suitable", status = "good", description = "The variables have a correlation structure suited for factor analysis.")
+  else if (kmo >= cfg$kmo_min) list(label = "Marginally Suitable", status = "min", description = "Factor analysis is possible, but interpret the results with care.")
+  else if (kmo >= cfg$kmo_poor) list(label = "Somewhat Weak", status = "poor", description = "The correlation structure is somewhat weak for factor analysis.")
+  else list(label = "Possibly Unsuitable", status = "below", description = "Consider reselecting the variables.")
+}
+
+judge_bartlett <- function(p_value, cfg = factanal_report_config()) {
+  if (is.na(p_value)) return(list(label = "Not Available", status = "na", description = "Bartlett's test could not be computed."))
+  if (p_value < cfg$p_value_threshold) list(label = "Suitable", status = "suitable", description = "There is enough correlation among the variables for factor analysis.")
+  else list(label = "Caution", status = "caution", description = "The correlation among the variables may be weak.")
+}
+
+judge_communality <- function(communality, cfg = factanal_report_config()) {
+  if (is.na(communality)) return(list(label = "Not Available", status = "na"))
+  if (communality >= cfg$communality_too_high) list(label = "Too high (caution)", status = "too_high")
+  else if (communality >= cfg$communality_good) list(label = "Well explained", status = "good")
+  else if (communality >= cfg$communality_low) list(label = "Moderately explained", status = "moderate")
+  else list(label = "Weakly explained", status = "weak")
+}
+
+# loadings: named numeric vector, names are "Factor 1", "Factor 2", ...
+# Returns label (English), status token, and params for the client-composed tooltip.
+judge_loading <- function(loadings, cfg = factanal_report_config()) {
+  abs_loadings <- abs(loadings)
+  ord <- order(abs_loadings, decreasing = TRUE)
+  primary_idx <- ord[1]
+  secondary_idx <- ord[2]
+  primary_factor <- names(loadings)[primary_idx]
+  secondary_factor <- names(loadings)[secondary_idx]
+  primary_loading <- loadings[[primary_idx]]
+  secondary_abs <- abs(loadings[[secondary_idx]])
+  primary_abs <- abs(primary_loading)
+  diff <- primary_abs - secondary_abs
+  salient <- names(loadings)[abs_loadings >= cfg$loading_salient]
+  num_salient <- length(salient)
+  direction <- if (primary_loading >= 0) "positive" else "negative"
+  neg_suffix <- if (primary_loading < 0) " (negative)" else ""
+
+  if (primary_abs < cfg$loading_salient) {
+    return(list(label = "Hard to interpret", status = "low_loading",
+                primary_factor = primary_factor, secondary_factors = "", direction = direction))
+  }
+  if (num_salient >= 2 && diff < cfg$loading_crossload_diff) {
+    return(list(label = "Cross-loading / ambiguous", status = "ambiguous_crossload",
+                primary_factor = primary_factor,
+                secondary_factors = paste(salient, collapse = ","), direction = direction))
+  }
+  if (num_salient >= 2) {
+    others <- setdiff(salient, primary_factor)
+    return(list(label = paste0("Leans to ", primary_factor, " / cross-loading"), status = "crossload",
+                primary_factor = primary_factor,
+                secondary_factors = paste(others, collapse = ","), direction = direction))
+  }
+  if (secondary_abs >= cfg$loading_near && diff < cfg$loading_near_diff) {
+    return(list(label = paste0("Leans to ", primary_factor, " / somewhat ambiguous"), status = "near_crossload",
+                primary_factor = primary_factor,
+                secondary_factors = secondary_factor, direction = direction))
+  }
+  if (primary_abs >= cfg$loading_strong) {
+    return(list(label = paste0("Strongly related to ", primary_factor, neg_suffix), status = "strong",
+                primary_factor = primary_factor, secondary_factors = "", direction = direction))
+  }
+  list(label = paste0("Moderately related to ", primary_factor, neg_suffix), status = "moderate",
+       primary_factor = primary_factor, secondary_factors = "", direction = direction)
+}
+
+# Horn's parallel analysis: compares actual correlation-matrix eigenvalues against the
+# quantile of eigenvalues from random normal data of the same shape. (issue #37018 spec 3.4)
+compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95) {
+  x <- as.data.frame(x)
+  n <- nrow(x)
+  p <- ncol(x)
+  actual_eigen <- eigen(cor(x, use = "pairwise.complete.obs"), only.values = TRUE)$values
+  # Snapshot the RNG so this null-distribution draw does not perturb the outer deterministic
+  # stream that later groups' sampling relies on. Restore afterward.
+  old_seed <- if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) get(".Random.seed", envir = .GlobalEnv) else NULL
+  set.seed(1234)
+  random_eigen_mat <- replicate(n_iter, {
+    rd <- matrix(stats::rnorm(n * p), nrow = n, ncol = p)
+    eigen(cor(rd), only.values = TRUE)$values
+  })
+  if (!is.null(old_seed)) {
+    assign(".Random.seed", old_seed, envir = .GlobalEnv)
+  } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+    rm(".Random.seed", envir = .GlobalEnv)
+  }
+  random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
+  list(
+    recommended_n = sum(actual_eigen > random_threshold),
+    table = tibble::tibble(
+      factor_number = seq_along(actual_eigen),
+      actual_eigenvalue = actual_eigen,
+      random_eigenvalue_threshold = random_threshold
+    )
+  )
+}
+
 #' Function for Factor Analysis Analytics View
 #' @export
 exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1) {
@@ -98,10 +214,19 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     }
     fit <- psych::fa(cleaned_df, nfactors = nfactors, fm = fm, scores = scores, rotate = rotate)
 
-    fit$correlation <- cor(cleaned_df) # For creating scree plot later.
+    cor_mat <- cor(cleaned_df)
+    fit$correlation <- cor_mat # For creating scree plot later.
     fit$df <- filtered_df # add filtered df to model so that we can bind_col it for output. It needs to be the filtered one to match row number.
     fit$grouped_cols <- grouped_cols
     fit$sampled_nrow <- sampled_nrow
+    # Suitability / factor-count diagnostics for the redesigned report (issue #37018).
+    # psych is already a hard dependency, so KMO/cortest.bartlett add nothing new. Each is
+    # guarded so a singular/degenerate correlation matrix degrades to NA instead of aborting.
+    fit$n_rows_used <- nrow(cleaned_df)
+    fit$n_variables <- ncol(cleaned_df)
+    fit$kmo <- tryCatch(as.numeric(psych::KMO(cor_mat)$MSA), error = function(e) NA_real_)
+    fit$bartlett <- tryCatch(psych::cortest.bartlett(cor_mat, n = nrow(cleaned_df)), error = function(e) NULL)
+    fit$parallel <- tryCatch(compute_parallel_analysis(cleaned_df), error = function(e) NULL)
     class(fit) <- c("fa_exploratory", class(fit))
     fit
   }
@@ -114,6 +239,18 @@ glance.fa_exploratory <- function(x, pretty.name = FALSE, ...) {
   res <- broom:::glance.factanal(x) %>% dplyr::select(-n, -converged, -method) # But converged is NULL.
   res <- res %>% dplyr::mutate(variance=total.variance*length(x$communality), ratio_variance=total.variance)
   res <- res %>% dplyr::select(`Factors`=n.factors, `Variance Explained (Ratio)`=ratio_variance, `Variance Explained`=variance, `Chi-Square`=statistic, `P Value`=p.value, `DF`=df, `Rows`=nobs)
+  # Append fit-quality columns for the report's supplementary section (issue #37018). NA-safe:
+  # older psych fits may not carry every field. Append-only keeps the client's name-indexed reads working.
+  safe_num <- function(v) if (is.null(v) || length(v) == 0) NA_real_ else suppressWarnings(as.numeric(v)[1])
+  rmsea_val <- if (!is.null(x$RMSEA)) safe_num(x$RMSEA[["RMSEA"]]) else NA_real_
+  res <- res %>% dplyr::mutate(
+    `Method` = x$fm,
+    `Rotation` = if (!is.null(x$rotation)) x$rotation else NA_character_,
+    `RMSR` = safe_num(x$rms),
+    `RMSEA` = rmsea_val,
+    `TLI` = safe_num(x$TLI),
+    `BIC` = safe_num(x$BIC)
+  )
   res
 }
 
@@ -273,6 +410,83 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # Return an empty data frame.
       res <- tibble::tibble()
     }
+  }
+  else if (type == "loadings_wide") {
+    # Wide judged loadings table (issue #37018). One row per variable: Factor 1..N loadings plus a
+    # Judgement label and hidden token/param columns the client uses to compose per-cell tooltips.
+    wide <- broom:::tidy.factanal(x)
+    colnames(wide) <- c("variable", "uniqueness", stringr::str_c(factor_loading_prefix, 1:n_factor))
+    wide <- wide %>% dplyr::select(-uniqueness)
+    new_names <- stringr::str_c("Factor ", 1:n_factor)
+    colnames(wide) <- c("variable", new_names)
+    judgements <- purrr::map(seq_len(nrow(wide)), function(i) {
+      loadings <- unlist(wide[i, new_names], use.names = FALSE)
+      names(loadings) <- new_names
+      judge_loading(loadings)
+    })
+    res <- wide %>% dplyr::mutate(
+      Judgement = purrr::map_chr(judgements, "label"),
+      judgement_status = purrr::map_chr(judgements, "status"),
+      primary_factor = purrr::map_chr(judgements, "primary_factor"),
+      secondary_factors = purrr::map_chr(judgements, "secondary_factors"),
+      direction = purrr::map_chr(judgements, "direction")
+    )
+  }
+  else if (type == "communalities") {
+    comm <- x$communality
+    res <- tibble::tibble(variable = names(comm), Communality = as.numeric(comm), Uniqueness = as.numeric(x$uniquenesses))
+    judgements <- purrr::map(res$Communality, judge_communality)
+    res <- res %>% dplyr::mutate(
+      Judgement = purrr::map_chr(judgements, "label"),
+      judgement_status = purrr::map_chr(judgements, "status")
+    ) %>% dplyr::arrange(dplyr::desc(Communality))
+  }
+  else if (type == "communalities_long") {
+    # Long form for the 100%-stacked communality/uniqueness bar chart. The two components sum to 1.
+    comm <- x$communality
+    res <- tibble::tibble(variable = names(comm), Communality = as.numeric(comm), Uniqueness = 1 - as.numeric(comm)) %>%
+      tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%
+      dplyr::mutate(Component = forcats::fct_relevel(as.factor(Component), "Communality", "Uniqueness"))
+  }
+  else if (type == "suitability") {
+    kmo <- x$kmo
+    bart <- x$bartlett
+    p <- if (is.null(bart)) NA_real_ else bart$p.value
+    kj <- judge_kmo(kmo)
+    bj <- judge_bartlett(p)
+    kmo_val <- if (is.na(kmo)) "N/A" else format(round(kmo, 2), nsmall = 2)
+    bart_val <- if (is.na(p)) "N/A" else if (p < 0.001) "p < 0.001" else paste0("p = ", format(round(p, 3), nsmall = 3))
+    res <- tibble::tibble(
+      Metric = c("KMO", "Bartlett's Test of Sphericity", "Rows Used", "Variables Used"),
+      Value = c(kmo_val, bart_val, as.character(x$n_rows_used), as.character(x$n_variables)),
+      Judgement = c(kj$label, bj$label, "", ""),
+      Description = c(kj$description, bj$description,
+                      "Number of rows used after removing missing values.",
+                      "Number of variables used in the analysis."),
+      status = c(kj$status, bj$status, "", "")
+    )
+  }
+  else if (type == "factor_count") {
+    eig <- eigen(x$correlation, only.values = TRUE)$values
+    kaiser_n <- sum(eig > 1)
+    par <- x$parallel
+    parallel_rec <- if (is.null(par)) "Not available" else as.character(par$recommended_n)
+    res <- tibble::tibble(
+      Method = c("Kaiser Criterion", "Parallel Analysis", "Scree Plot"),
+      `Recommended Number of Factors` = c(as.character(kaiser_n), parallel_rec, "Check the chart"),
+      Description = c(
+        "Number of factors with an eigenvalue greater than 1.",
+        "Number of factors whose eigenvalue exceeds the random-data eigenvalue.",
+        "Look for the point where the eigenvalue drop levels off (the elbow)."
+      )
+    )
+  }
+  else if (type == "parallel_screeplot") {
+    eig <- eigen(x$correlation, only.values = TRUE)$values
+    par <- x$parallel
+    threshold <- if (is.null(par)) rep(NA_real_, length(eig)) else par$table$random_eigenvalue_threshold
+    length(threshold) <- length(eig) # pad/truncate to align with eigenvalue count
+    res <- tibble::tibble(Factor = 1:length(eig), Eigenvalue = eig, `Random Data Eigenvalue` = threshold)
   }
   else { # should be data
     scores_df <- broom:::augment.factanal(x) # This happens to work. Revisit.

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -462,14 +462,14 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       var_labels[improper] <- paste0(var_labels[improper], "  ⚠ ", format(round(comm[improper], 2), nsmall = 2))
     }
     # Order the bars by communality DESCENDING (highest communality at the TOP of the horizontal
-    # bar chart). Ratios are kept as 0-1 proportions; the chart renders them as percentages via the
-    # viz's percentage number formatting. Component is Communality-first so it
-    # stacks/colors/legends before Uniqueness.
+    # bar chart). Ratios are on a 0-100 percentage scale so the bar fills a 0-100 axis; the "%"
+    # suffix is added by the chart. Component is Communality-first so it stacks/colors/legends
+    # before Uniqueness.
     var_factor <- forcats::fct_reorder(var_labels, comm, .desc = TRUE)
     res <- tibble::tibble(
       variable = var_factor,
-      Communality = pmin(comm, 1),
-      Uniqueness = pmax(1 - comm, 0)
+      Communality = pmin(comm, 1) * 100,
+      Uniqueness = pmax(1 - comm, 0) * 100
     ) %>%
       tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%
       dplyr::mutate(Component = forcats::fct_relevel(as.factor(Component), "Communality", "Uniqueness"))

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -449,11 +449,20 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     # Long form for the 100%-stacked communality/uniqueness bar chart. Normally the two components
     # sum to 1. In a Heywood case (communality > 1) uniqueness goes negative, which would break the
     # 100%-stacked bar. Cap the DISPLAYED ratios -- communality at 1, uniqueness at 0 -- so the bar
-    # stays a clean 100% stack. The exact communality and the improper-solution warning are surfaced
-    # in the Communality table (judge_communality "Possibly improper solution"). (#37018)
+    # stays a clean 100% stack. (#37018)
     comm <- as.numeric(x$communality)
+    # For a Heywood-case variable, flag its bar on the chart with a warning marker + the actual
+    # (uncapped) communality value, appended to the category label. This is language-neutral (a
+    # symbol + a number, no translated text) so it is safe for both EN and JA, and it renders
+    # reliably on the axis / hover without any chart-code change. The full explanation is in the
+    # Communality table judgment ("Possibly improper solution") and the report warning.
+    var_labels <- names(x$communality)
+    improper <- !is.na(comm) & comm > 1
+    if (any(improper)) {
+      var_labels[improper] <- paste0(var_labels[improper], "  ⚠ ", format(round(comm[improper], 2), nsmall = 2))
+    }
     res <- tibble::tibble(
-      variable = names(x$communality),
+      variable = var_labels,
       Communality = pmin(comm, 1),
       Uniqueness = pmax(1 - comm, 0)
     ) %>%

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -461,10 +461,14 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     if (any(improper)) {
       var_labels[improper] <- paste0(var_labels[improper], "  ⚠ ", format(round(comm[improper], 2), nsmall = 2))
     }
+    # Order the bars by communality (ascending -> highest communality at the TOP of the horizontal
+    # bar chart). Ratios are on a 0-100 percentage scale for the 100%-style bar. Component is
+    # Communality-first so it stacks/colors/legends before Uniqueness.
+    var_factor <- forcats::fct_reorder(var_labels, comm)
     res <- tibble::tibble(
-      variable = var_labels,
-      Communality = pmin(comm, 1),
-      Uniqueness = pmax(1 - comm, 0)
+      variable = var_factor,
+      Communality = pmin(comm, 1) * 100,
+      Uniqueness = pmax(1 - comm, 0) * 100
     ) %>%
       tidyr::pivot_longer(cols = c("Communality", "Uniqueness"), names_to = "Component", values_to = "Ratio") %>%
       dplyr::mutate(Component = forcats::fct_relevel(as.factor(Component), "Communality", "Uniqueness"))

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -3908,7 +3908,17 @@ build_rpart_tree_nodes <- function(x) {
     if (!is.null(yv) && length(yv) > 0 && !is.null(x$where)) {
       yfin <- yv[is.finite(yv)]
       if (length(yfin) >= 2 && diff(range(yfin)) > 0) {
-        shared_breaks <- seq(min(yfin), max(yfin), length.out = 21) # ~20 equal-width bins
+        y_min <- min(yfin)
+        y_max <- max(yfin)
+        # Integer/discrete target: use one bin per integer value (breaks at n +/- 0.5)
+        # so the histogram shows discrete bars instead of ~20 continuous equal-width
+        # bins that scatter the integers into sparse, empty-gapped bins. Guard the
+        # range so a wide-range integer column (e.g. income) still uses equal-width bins.
+        if (all(yfin == floor(yfin)) && (y_max - y_min) <= 30) {
+          shared_breaks <- seq(y_min - 0.5, y_max + 0.5, by = 1) # one bin per integer
+        } else {
+          shared_breaks <- seq(y_min, y_max, length.out = 21)    # ~20 equal-width bins
+        }
       } else if (length(yfin) >= 1) {
         shared_breaks <- c(yfin[1] - 0.5, yfin[1] + 0.5)             # degenerate: single bin
       }

--- a/docs/superpowers/plans/2026-07-10-chaid-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-chaid-implementation.md
@@ -1,0 +1,450 @@
+# CHAID Classification Tree Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a self-contained, non-weighted classification CHAID engine in the `exploratory` R package with fitting, prediction, category merging, numeric binning, report tables, tree data, and tests.
+
+**Architecture:** Add one focused `R/chaid.R` module containing public CHAID functions and private helpers. The fitter prepares stable categorical training data, recursively grows a multiway tree using chi-square tests and Bonferroni-adjusted p-values, and stores normalized node/edge tables plus traversal metadata. A dedicated testthat file drives each behavior before implementation.
+
+**Tech Stack:** Base R, `stats::chisq.test`, existing package imports, testthat, roxygen2-generated NAMESPACE.
+
+## Global Constraints
+
+- Classification CHAID only; the target must be character or factor.
+- No third-party CHAID dependency.
+- No weighted fitting in this version.
+- Numeric predictors support `quantile`, `equal_width`, and `none` binning.
+- Missing values support `as_category` and `exclude`.
+- Unknown prediction categories stop traversal at the current node.
+- Existing rpart and model-builder behavior must not change.
+- Every production change must follow a failing test first.
+
+---
+
+### Task 1: Add the public contract and validation tests
+
+**Files:**
+- Create: `tests/testthat/test_chaid.R`
+- Create: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: no new code.
+- Produces: failing tests that define `chaid_fit()` validation, stable target levels, and the root-node model shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('chaid_fit rejects invalid targets and predictors', {
+  data <- data.frame(target = c('yes', 'no'), x = c('a', 'b'))
+
+  expect_error(chaid_fit(data, target = 'missing'), 'target')
+  expect_error(chaid_fit(data, target = 'target', predictors = 'missing'), 'predictor')
+  expect_error(chaid_fit(data.frame(target = 1:2, x = 1:2), target = 'target'), 'character or factor')
+  expect_error(chaid_fit(data, target = 'target', min_split = 1, min_bucket = 2), 'min_split')
+})
+
+test_that('chaid_fit returns a terminal root for a single-class target', {
+  data <- data.frame(target = factor(rep('yes', 4)), x = c('a', 'b', 'a', 'b'))
+  model <- chaid_fit(data, target = 'target', min_split = 2, min_bucket = 1)
+
+  expect_s3_class(model, 'exploratory_chaid')
+  expect_true(model$nodes$is_terminal[model$nodes$node_id == 1])
+  expect_equal(model$class_levels, 'yes')
+  expect_equal(model$nodes$n[model$nodes$node_id == 1], 4)
+})
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R')"`
+
+Expected: FAIL because `chaid_fit()` is not defined.
+
+- [ ] **Step 3: Add the minimal public skeleton and validation helper**
+
+Create `R/chaid.R` with a documented `chaid_fit()` signature, validation for column names, target type, predictor names, parameter ranges, and a terminal-root return containing `nodes`, `edges`, `class_levels`, `target`, `predictors`, and `parameters`.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R')"`
+
+Expected: PASS for the validation and single-class tests.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add tests/testthat/test_chaid.R R/chaid.R
+git commit -m "test: define CHAID fit contract"
+```
+
+### Task 2: Implement preprocessing and numeric binning
+
+**Files:**
+- Modify: `tests/testthat/test_chaid.R`
+- Modify: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: `chaid_fit()` validation from Task 1.
+- Produces: private preprocessing helpers that return prepared data and saved `numeric_binning_map` metadata.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('numeric quantile and equal-width binning are saved and reused', {
+  data <- data.frame(target = rep(c('yes', 'no'), 5), x = 1:10)
+  quantile_model <- chaid_fit(data, target = 'target', numeric_binning = 'quantile',
+                              numeric_bins = 3, min_split = 2, min_bucket = 1)
+  equal_model <- chaid_fit(data, target = 'target', numeric_binning = 'equal_width',
+                           numeric_bins = 3, min_split = 2, min_bucket = 1)
+
+  expect_equal(quantile_model$numeric_binning_map$x$method, 'quantile')
+  expect_equal(equal_model$numeric_binning_map$x$method, 'equal_width')
+  expect_length(quantile_model$numeric_binning_map$x$breaks, 4)
+  out_of_range_nodes <- chaid_predict(quantile_model, data.frame(x = c(-10, 100)), type = 'node')
+  expect_length(out_of_range_nodes, 2)
+  expect_true(all(!is.na(out_of_range_nodes)))
+})
+
+test_that('missing values can be represented as a category or excluded', {
+  data <- data.frame(target = c('yes', 'no', 'yes'), x = c('a', NA, 'b'))
+  as_category <- chaid_fit(data, target = 'target', missing = 'as_category',
+                           min_split = 2, min_bucket = 1)
+  excluded <- chaid_fit(data, target = 'target', missing = 'exclude',
+                        min_split = 2, min_bucket = 1)
+
+  expect_true('Missing' %in% as_category$prepared_levels$x)
+  expect_equal(excluded$training_metadata$n_rows, 2)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify the expected failure**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'numeric quantile')"`
+
+Expected: FAIL because preprocessing metadata is not implemented.
+
+- [ ] **Step 3: Implement minimal preprocessing**
+
+Add helpers that validate `numeric_binning`, `numeric_bins`, and `missing`; convert character/factor predictors to character categories; preserve ordered-factor status; create deterministic quantile/equal-width breaks; use `cut()` with saved labels; and apply the same transformations to new data. `numeric_binning = 'none'` excludes numeric predictors.
+
+- [ ] **Step 4: Run focused preprocessing tests**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'numeric')"` and `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'missing')"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R
+git commit -m "feat: prepare CHAID categorical predictors"
+```
+
+### Task 3: Implement chi-square evaluation and category merging
+
+**Files:**
+- Modify: `tests/testthat/test_chaid.R`
+- Modify: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: prepared categorical data from Task 2.
+- Produces: private `compute_chisq_test()`, `merge_categories()`, and predictor-evaluation helpers returning merged groups, raw p-values, adjusted p-values, and merge history.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('CHAID merges similar nominal categories', {
+  data <- data.frame(
+    target = rep(c('yes', 'no'), c(40, 40)),
+    segment = rep(c('a', 'b', 'c'), c(20, 20, 40))
+  )
+  model <- chaid_fit(data, target = 'target', predictors = 'segment',
+                     alpha_merge = 0.05, min_split = 2, min_bucket = 1)
+
+  merge_table <- chaid_category_merge_table(model)
+  expect_true(nrow(merge_table) >= 1)
+  expect_true(any(grepl('a|b', merge_table$original_categories)))
+})
+
+test_that('ordered predictors only merge adjacent categories', {
+  data <- data.frame(
+    target = rep(c('yes', 'no'), 30),
+    ordered_x = ordered(rep(c('low', 'medium', 'high'), 20),
+                        levels = c('low', 'medium', 'high'))
+  )
+  model <- chaid_fit(data, target = 'target', predictors = 'ordered_x',
+                     min_split = 2, min_bucket = 1)
+  merges <- chaid_category_merge_table(model)
+
+  expect_false(any(grepl('low.*high|high.*low', merges$original_categories)))
+})
+
+test_that('alpha_merge controls category merging', {
+  data <- data.frame(target = rep(c('yes', 'no'), 30), x = rep(c('a', 'b', 'c'), 20))
+  conservative <- chaid_fit(data, target = 'target', alpha_merge = 0.001,
+                             min_split = 2, min_bucket = 1)
+  permissive <- chaid_fit(data, target = 'target', alpha_merge = 0.99,
+                          min_split = 2, min_bucket = 1)
+
+  expect_lte(nrow(chaid_category_merge_table(permissive)),
+             nrow(chaid_category_merge_table(conservative)))
+})
+```
+
+- [ ] **Step 2: Run the merging tests and verify they fail**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'merge')"`
+
+Expected: FAIL because category merging and report extraction are not implemented.
+
+- [ ] **Step 3: Implement chi-square and merging helpers**
+
+Use `stats::chisq.test()` on contingency tables, return `NA` for degenerate tables, compare all nominal pairs or adjacent ordered pairs, merge the highest-p pair when it exceeds `alpha_merge`, and repeat until no candidate qualifies. Apply Bonferroni correction to the candidate comparisons and store each merge with node ID, variable, merged group, original categories, and merge p-value.
+
+- [ ] **Step 4: Run the merging tests**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'merge')"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R
+git commit -m "feat: add CHAID category merging"
+```
+
+### Task 4: Implement recursive multiway tree growth
+
+**Files:**
+- Modify: `tests/testthat/test_chaid.R`
+- Modify: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: preprocessing and predictor evaluation from Tasks 2–3.
+- Produces: fitted multiway tree with normalized node/edge tables, split metadata, rules, and stopping-condition metadata.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('CHAID chooses a significant predictor and creates multiple children', {
+  data <- data.frame(
+    target = rep(c('yes', 'no'), each = 60),
+    strong = rep(c('a', 'b', 'c'), each = 40),
+    weak = rep(c('x', 'y'), 60)
+  )
+  model <- chaid_fit(data, target = 'target', predictors = c('strong', 'weak'),
+                     alpha_split = 0.05, max_depth = 2, min_split = 10, min_bucket = 5)
+
+  root <- model$nodes[model$nodes$node_id == 1, ]
+  expect_false(root$is_terminal)
+  expect_equal(root$split_variable, 'strong')
+  expect_gte(sum(model$edges$parent_id == 1), 2)
+  expect_true(all(model$nodes$n[model$nodes$parent_id == 1] >= 5))
+})
+
+test_that('CHAID stops on non-significant data and max depth', {
+  data <- data.frame(target = rep(c('yes', 'no'), 50), x = rep(c('a', 'b'), 50))
+  root_model <- chaid_fit(data, target = 'target', alpha_split = 0.001,
+                          min_split = 10, min_bucket = 5)
+  depth_model <- chaid_fit(data.frame(target = rep(c('yes', 'no'), 100),
+                                      x = rep(c('a', 'b'), 100)),
+                           target = 'target', max_depth = 0,
+                           min_split = 10, min_bucket = 5)
+
+  expect_true(root_model$nodes$is_terminal[1])
+  expect_true(depth_model$nodes$is_terminal[1])
+})
+```
+
+- [ ] **Step 2: Run the growth tests and verify failure**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'significant')"`
+
+Expected: FAIL because recursive growth is not implemented.
+
+- [ ] **Step 3: Implement tree growth**
+
+Add a recursive `grow_chaid_node()` that computes node distributions, evaluates every eligible predictor, adjusts selection p-values by the number of evaluated predictors, rejects invalid child sizes, assigns sequential node IDs, builds human-readable rules, and stores split groups for traversal. Preserve terminal nodes when no valid split exists.
+
+- [ ] **Step 4: Run growth and regression tests**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'significant')"` and `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R')"`
+
+Expected: PASS for all tests added so far.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R
+git commit -m "feat: grow recursive CHAID trees"
+```
+
+### Task 5: Implement prediction and unknown-category handling
+
+**Files:**
+- Modify: `tests/testthat/test_chaid.R`
+- Modify: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: fitted model traversal metadata from Task 4.
+- Produces: `chaid_predict()` and `predict.exploratory_chaid()` with `class`, `prob`, `node`, and `all` output modes.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('CHAID prediction returns class, probabilities, nodes, and rules', {
+  data <- data.frame(target = rep(c('yes', 'no'), each = 30),
+                     x = rep(c('a', 'b', 'c'), each = 20))
+  model <- chaid_fit(data, target = 'target', min_split = 5, min_bucket = 2)
+  new_data <- data.frame(x = c('a', 'b', 'unknown'))
+
+  classes <- chaid_predict(model, new_data, type = 'class')
+  probabilities <- chaid_predict(model, new_data, type = 'prob')
+  nodes <- chaid_predict(model, new_data, type = 'node')
+  all_predictions <- chaid_predict(model, new_data, type = 'all')
+
+  expect_length(classes, 3)
+  expect_equal(nrow(probabilities), 3)
+  expect_equal(rowSums(probabilities), rep(1, 3))
+  expect_equal(length(nodes), 3)
+  expect_true(all(c('.chaid_node_id', '.pred_class', '.chaid_rule') %in%
+                  names(all_predictions)))
+  expect_equal(nodes[3], 1L)
+  expect_equal(predict(model, new_data, type = 'class'), classes)
+})
+```
+
+- [ ] **Step 2: Run the prediction test and verify failure**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'prediction')"`
+
+Expected: FAIL because `chaid_predict()` is not implemented.
+
+- [ ] **Step 3: Implement traversal**
+
+Transform new data with the model’s saved binning/missing metadata, follow known split groups recursively, stop on unknown values, and calculate predictions from the terminal/current node’s stored class distribution. Ensure probability columns are named `.pred_prob_<class>` and rows sum to one even when a class has zero training count at a node.
+
+- [ ] **Step 4: Run prediction tests**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'prediction')"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R
+git commit -m "feat: add CHAID prediction"
+```
+
+### Task 6: Implement report tables and tree data
+
+**Files:**
+- Modify: `tests/testthat/test_chaid.R`
+- Modify: `R/chaid.R`
+
+**Interfaces:**
+- Consumes: normalized tree and merge metadata from Task 4.
+- Produces: all report helpers and `chaid_tree_data()` with stable columns.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+test_that('CHAID report helpers return stable schemas', {
+  data <- data.frame(target = rep(c('yes', 'no'), each = 30),
+                     x = rep(c('a', 'b', 'c'), each = 20))
+  model <- chaid_fit(data, target = 'target', min_split = 5, min_bucket = 2)
+
+  node_summary <- chaid_node_summary(model)
+  rules <- chaid_rule_table(model)
+  merges <- chaid_category_merge_table(model)
+  splits <- chaid_split_summary(model)
+  tree <- chaid_tree_data(model)
+
+  expect_true(all(c('Node', 'Rule', 'Rows', 'Predicted Class', 'Split Variable') %in%
+                  names(node_summary)))
+  expect_true(all(c('Node', 'Rule', 'Prediction', 'Rows') %in% names(rules)))
+  expect_true(all(c('Node', 'Variable', 'Merged Category', 'Original Categories') %in%
+                  names(merges)))
+  expect_true(all(c('Depth', 'Node', 'Split Variable', 'p-value', 'Adjusted p-value') %in%
+                  names(splits)))
+  expect_true(all(c('node_id', 'label', 'depth', 'n', 'is_terminal') %in%
+                  names(tree$nodes)))
+  expect_true(all(c('parent_id', 'child_id', 'label', 'split_variable') %in%
+                  names(tree$edges)))
+})
+```
+
+- [ ] **Step 2: Run the report test and verify failure**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'report helpers')"`
+
+Expected: FAIL because the report helpers are not implemented.
+
+- [ ] **Step 3: Implement report helpers**
+
+Build the requested human-readable columns from model metadata, return zero-row data frames with the same schemas when a model has no merges or splits, and return `list(nodes = ..., edges = ...)` from `chaid_tree_data()`.
+
+- [ ] **Step 4: Run the report test**
+
+Run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R', filter = 'report helpers')"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the task**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R
+git commit -m "feat: expose CHAID report tables"
+```
+
+### Task 7: Export public APIs and verify the package
+
+**Files:**
+- Modify: `R/chaid.R`
+- Modify: `NAMESPACE` through roxygen2
+- Modify: `tests/testthat/test_chaid.R`
+
+**Interfaces:**
+- Consumes: complete CHAID implementation from Tasks 1–6.
+- Produces: installable package API and full focused test coverage.
+
+- [ ] **Step 1: Add export tags and an API smoke test**
+
+Add roxygen `@export` tags to each public function and add:
+
+```r
+test_that('CHAID public functions are exported', {
+  expect_true('chaid_fit' %in% getNamespaceExports('exploratory'))
+  expect_true('chaid_predict' %in% getNamespaceExports('exploratory'))
+  expect_true('chaid_tree_data' %in% getNamespaceExports('exploratory'))
+})
+```
+
+- [ ] **Step 2: Regenerate NAMESPACE and run package checks**
+
+Run: `Rscript -e "devtools::document(roclets = 'namespace')"`
+
+Then run: `Rscript -e "testthat::test_file('tests/testthat/test_chaid.R')"`
+
+Expected: exported functions resolve and all CHAID tests pass.
+
+- [ ] **Step 3: Run broader verification**
+
+Run: `Rscript tests/testthat.R`
+
+Expected: the package test suite passes, or any unrelated pre-existing failures are recorded without changing unrelated files.
+
+- [ ] **Step 4: Review generated and changed files**
+
+Run: `git diff --check` and `git status --short`.
+
+Confirm only `R/chaid.R`, `tests/testthat/test_chaid.R`, `NAMESPACE`, and the approved design/plan documents are changed or committed; do not stage the repository’s unrelated untracked files.
+
+- [ ] **Step 5: Commit the completed feature**
+
+```bash
+git add R/chaid.R tests/testthat/test_chaid.R NAMESPACE
+git commit -m "feat: implement classification CHAID engine"
+```

--- a/docs/superpowers/specs/2026-07-10-chaid-design.md
+++ b/docs/superpowers/specs/2026-07-10-chaid-design.md
@@ -1,0 +1,87 @@
+# CHAID Classification Tree Design
+
+**Goal:** Add a self-contained, non-weighted classification CHAID engine to the `exploratory` R package without adding a third-party CHAID dependency or changing existing CART/rpart behavior.
+
+## Scope
+
+This change targets the R package layer only. It includes fitting, prediction, category merging, numeric binning, model metadata, report tables, tree data, and unit tests. Exploratory UI integration, weighted fitting, exhaustive CHAID, pruning, regression CHAID, survival CHAID, and advanced ordinal-target logic are out of scope.
+
+## Architecture
+
+The implementation will live in a new `R/chaid.R` file and expose a small public API:
+
+- `chaid_fit()`
+- `chaid_predict()`
+- `predict.exploratory_chaid()`
+- `chaid_node_summary()`
+- `chaid_rule_table()`
+- `chaid_category_merge_table()`
+- `chaid_split_summary()`
+- `chaid_tree_data()`
+
+The engine will use base R and packages already imported by `exploratory`, primarily `stats` and `tibble`. It will not depend on an external CHAID implementation. Existing rpart and model-builder behavior will remain unchanged.
+
+## Data preparation
+
+- The target must be a character or factor column and will be represented by stable training factor levels.
+- Character and factor predictors are categorical. Ordered factors merge only adjacent categories.
+- Numeric predictors are converted to categorical bins during fitting. Supported methods are `quantile`, `equal_width`, and `none`; training breaks and labels are saved for prediction.
+- `missing = "as_category"` represents missing values as the `"Missing"` category.
+- `missing = "exclude"` removes incomplete training rows. Missing values in prediction data are treated as unknown traversal values.
+- Weight columns are not accepted in this version.
+
+## Tree-growth algorithm
+
+At each node, the engine will:
+
+1. Check purity, depth, minimum split size, and predictor availability.
+2. Merge statistically similar predictor categories using pairwise chi-square tests. Nominal predictors may merge any pair; ordered predictors may merge adjacent pairs only.
+3. Apply Bonferroni correction to category-comparison p-values and predictor-selection p-values.
+4. Evaluate the merged predictor-by-target contingency table with Pearson or likelihood-ratio chi-square.
+5. Select the predictor with the smallest adjusted p-value.
+6. Create a multiway child for each merged category group only when the adjusted p-value meets `alpha_split` and every child satisfies `min_bucket` and `min_node_proportion`.
+
+Predictor levels unseen during prediction stop traversal at the current node. The current node’s target distribution is used for the prediction.
+
+Predictors with more than `max_categories` levels are skipped with a warning. The model records raw and adjusted split p-values and the category merge history.
+
+## Model representation
+
+`chaid_fit()` returns an S3 object with class `c("exploratory_chaid", "list")`. It stores:
+
+- normalized node and edge tables;
+- internal split-group metadata used for traversal;
+- category merge history;
+- numeric binning metadata;
+- target levels, target/predictor names, parameters, and training metadata.
+
+Node tables include node ID, parent, depth, terminal state, row counts, predicted class, target distribution, split variable, raw/adjusted p-values, and rule. Edge tables include parent/child IDs, split variable, child label, and original categories.
+
+## Public outputs
+
+- `chaid_predict(type = "class")` returns predicted classes.
+- `chaid_predict(type = "prob")` returns one probability column per target class.
+- `chaid_predict(type = "node")` returns terminal node IDs.
+- `chaid_predict(type = "all")` returns node ID, predicted class, rule, and class probabilities.
+- Report helpers return stable data frames for node summaries, terminal rules, category merges, and split summaries.
+- `chaid_tree_data()` returns `nodes` and `edges` data frames suitable for a tree renderer.
+
+## Testing strategy
+
+`tests/testthat/test_chaid.R` will test behavior rather than private implementation details:
+
+- input validation and single-class targets;
+- nominal versus ordered category merging and alpha controls;
+- significant/non-significant splits and stopping conditions;
+- numeric binning and reuse of training boundaries;
+- missing values and unknown prediction categories;
+- class, probability, node, and all prediction modes;
+- report and tree-data schemas;
+- probability normalization and stable target levels.
+
+## Self-review
+
+- No placeholders or deferred implementation steps are required inside this design.
+- The tree-growth algorithm, model representation, and public outputs are consistent with one another.
+- Scope is limited to one independently testable package-layer feature.
+- Weighted fitting and UI integration are explicitly excluded rather than left ambiguous.

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -232,15 +232,21 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   expect_equal(moderate$status, "moderate")
 
   # Communality bar capping: a Heywood case (communality > 1) must be capped so the 100%-stacked
-  # communality/uniqueness bar stays valid (communality <= 1, uniqueness >= 0). (#37018)
+  # communality/uniqueness bar stays valid (communality <= 1, uniqueness >= 0), and the affected
+  # bar's label carries a warning marker + the actual value. (#37018)
   fake_fa <- list(communality = c(A = 0.70, B = 1.05, C = 0.30))
   class(fake_fa) <- "fa_exploratory"
   clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
   expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
   bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
-  expect_equal(bwide$Communality[bwide$variable == "B"], 1)      # capped from 1.05
-  expect_equal(bwide$Uniqueness[bwide$variable == "B"], 0)       # clamped from -0.05
-  expect_equal(bwide$Communality[bwide$variable == "A"], 0.70)   # normal case unchanged
+  # Heywood variable (B): capped values, label flagged with the warning marker + actual value.
+  b_row <- bwide[grepl("⚠", bwide$variable), ]
+  expect_equal(nrow(b_row), 1)
+  expect_true(grepl("1.05", b_row$variable))
+  expect_equal(b_row$Communality, 1)      # capped from 1.05
+  expect_equal(b_row$Uniqueness, 0)       # clamped from -0.05
+  # Normal variables are unchanged (label and values).
+  expect_equal(bwide$Communality[bwide$variable == "A"], 0.70)
   expect_true(all(bwide$Communality + bwide$Uniqueness <= 1 + 1e-9))
 
   # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -239,18 +239,20 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
   expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
   bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
-  # Ratios are on a 0-100 percentage scale. Heywood variable (B): capped values, label flagged
-  # with the warning marker + actual (raw, un-scaled) communality value.
+  # Ratios are 0-1 proportions (the chart renders them as %). Heywood variable (B): capped values,
+  # label flagged with the warning marker + actual communality value.
   b_row <- bwide[grepl("⚠", as.character(bwide$variable)), ]
   expect_equal(nrow(b_row), 1)
   expect_true(grepl("1.05", as.character(b_row$variable)))
-  expect_equal(b_row$Communality, 100)    # capped from 1.05 -> 1 * 100
-  expect_equal(b_row$Uniqueness, 0)        # clamped from -0.05 -> 0
-  # Normal variables unchanged in value (70% communality) and label.
-  expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 70)
-  expect_true(all(bwide$Communality + bwide$Uniqueness <= 100 + 1e-9))
+  expect_equal(b_row$Communality, 1)      # capped from 1.05
+  expect_equal(b_row$Uniqueness, 0)        # clamped from -0.05
+  # Normal variables unchanged in value and label.
+  expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 0.70)
+  expect_true(all(bwide$Communality + bwide$Uniqueness <= 1 + 1e-9))
   # Component is Communality-first (stack/color/legend order).
   expect_equal(levels(clong$Component), c("Communality", "Uniqueness"))
+  # Variables ordered by communality DESCENDING: the highest (Heywood B) is the first level.
+  expect_true(grepl("⚠", levels(clong$variable)[1]))
 
   # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.
   set.seed(1)

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -239,15 +239,18 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
   expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
   bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
-  # Heywood variable (B): capped values, label flagged with the warning marker + actual value.
-  b_row <- bwide[grepl("⚠", bwide$variable), ]
+  # Ratios are on a 0-100 percentage scale. Heywood variable (B): capped values, label flagged
+  # with the warning marker + actual (raw, un-scaled) communality value.
+  b_row <- bwide[grepl("⚠", as.character(bwide$variable)), ]
   expect_equal(nrow(b_row), 1)
-  expect_true(grepl("1.05", b_row$variable))
-  expect_equal(b_row$Communality, 1)      # capped from 1.05
-  expect_equal(b_row$Uniqueness, 0)       # clamped from -0.05
-  # Normal variables are unchanged (label and values).
-  expect_equal(bwide$Communality[bwide$variable == "A"], 0.70)
-  expect_true(all(bwide$Communality + bwide$Uniqueness <= 1 + 1e-9))
+  expect_true(grepl("1.05", as.character(b_row$variable)))
+  expect_equal(b_row$Communality, 100)    # capped from 1.05 -> 1 * 100
+  expect_equal(b_row$Uniqueness, 0)        # clamped from -0.05 -> 0
+  # Normal variables unchanged in value (70% communality) and label.
+  expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 70)
+  expect_true(all(bwide$Communality + bwide$Uniqueness <= 100 + 1e-9))
+  # Component is Communality-first (stack/color/legend order).
+  expect_equal(levels(clong$Component), c("Communality", "Uniqueness"))
 
   # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.
   set.seed(1)

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -195,7 +195,9 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   expect_equal(judge_bartlett(0.20)$status, "caution")
   expect_equal(judge_bartlett(NA_real_)$status, "na")
 
-  # Communality thresholds.
+  # Communality thresholds. A communality > 1 (Heywood case) is flagged before "too high".
+  expect_equal(judge_communality(1.05)$status, "improper")
+  expect_equal(judge_communality(1.0)$status, "too_high")
   expect_equal(judge_communality(0.97)$status, "too_high")
   expect_equal(judge_communality(0.70)$status, "good")
   expect_equal(judge_communality(0.50)$status, "moderate")

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -239,16 +239,16 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
   expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
   bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
-  # Ratios are 0-1 proportions (the chart renders them as %). Heywood variable (B): capped values,
-  # label flagged with the warning marker + actual communality value.
+  # Ratios are on a 0-100 percentage scale. Heywood variable (B): capped values, label flagged
+  # with the warning marker + actual communality value.
   b_row <- bwide[grepl("⚠", as.character(bwide$variable)), ]
   expect_equal(nrow(b_row), 1)
   expect_true(grepl("1.05", as.character(b_row$variable)))
-  expect_equal(b_row$Communality, 1)      # capped from 1.05
+  expect_equal(b_row$Communality, 100)    # capped from 1.05 -> 1 * 100
   expect_equal(b_row$Uniqueness, 0)        # clamped from -0.05
   # Normal variables unchanged in value and label.
-  expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 0.70)
-  expect_true(all(bwide$Communality + bwide$Uniqueness <= 1 + 1e-9))
+  expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 70)
+  expect_true(all(bwide$Communality + bwide$Uniqueness <= 100 + 1e-9))
   # Component is Communality-first (stack/color/legend order).
   expect_equal(levels(clong$Component), c("Communality", "Uniqueness"))
   # Variables ordered by communality DESCENDING: the highest (Heywood B) is the first level.

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -153,7 +153,7 @@ test_that("exp_factanal with strange column name and all-NA column", {
   model_df <- exp_factanal(df, `Cy l`, mpg, hp, na_col)
   res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
   expect_equal(colnames(res),
-               c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows"))
+               c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows", "Method", "Rotation", "RMSR", "RMSEA", "TLI", "BIC"))
   res <- model_df %>% tidy_rowwise(model, type="variances")
   expect_equal(colnames(res),
                c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))
@@ -231,28 +231,26 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   moderate <- judge_loading(c(`Factor 1` = 0.45, `Factor 2` = 0.05))
   expect_equal(moderate$status, "moderate")
 
-  # Communality bar capping: a Heywood case (communality > 1) must be capped so the 100%-stacked
-  # communality/uniqueness bar stays valid (communality <= 1, uniqueness >= 0), and the affected
-  # bar's label carries a warning marker + the actual value. (#37018)
+  # Communality bar (#37018): a Heywood case (communality > 1) leaves communality UNCAPPED so the
+  # numeric label shows the actual value (e.g. 105); the chart's 0-100 value-axis range clips the
+  # bar at 100. Uniqueness is clamped to 0 (never negative). Variable names stay clean (no marker).
   fake_fa <- list(communality = c(A = 0.70, B = 1.05, C = 0.30))
   class(fake_fa) <- "fa_exploratory"
   clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
   expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
   bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
-  # Ratios are on a 0-100 percentage scale. Heywood variable (B): capped values, label flagged
-  # with the warning marker + actual communality value.
-  b_row <- bwide[grepl("⚠", as.character(bwide$variable)), ]
-  expect_equal(nrow(b_row), 1)
-  expect_true(grepl("1.05", as.character(b_row$variable)))
-  expect_equal(b_row$Communality, 100)    # capped from 1.05 -> 1 * 100
-  expect_equal(b_row$Uniqueness, 0)        # clamped from -0.05
-  # Normal variables unchanged in value and label.
+  # Ratios are on a 0-100 percentage scale. Heywood variable (B): uncapped communality (105) so the
+  # label shows the actual value; uniqueness clamped to 0.
+  expect_equal(bwide$Communality[as.character(bwide$variable) == "B"], 105)
+  expect_equal(bwide$Uniqueness[as.character(bwide$variable) == "B"], 0)
+  # Normal variable unchanged.
   expect_equal(bwide$Communality[as.character(bwide$variable) == "A"], 70)
-  expect_true(all(bwide$Communality + bwide$Uniqueness <= 100 + 1e-9))
+  # No warning marker appended to any variable name.
+  expect_false(any(grepl("⚠", as.character(bwide$variable))))
   # Component is Communality-first (stack/color/legend order).
   expect_equal(levels(clong$Component), c("Communality", "Uniqueness"))
   # Variables ordered by communality DESCENDING: the highest (Heywood B) is the first level.
-  expect_true(grepl("⚠", levels(clong$variable)[1]))
+  expect_equal(levels(clong$variable)[1], "B")
 
   # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.
   set.seed(1)

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -231,6 +231,18 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   moderate <- judge_loading(c(`Factor 1` = 0.45, `Factor 2` = 0.05))
   expect_equal(moderate$status, "moderate")
 
+  # Communality bar capping: a Heywood case (communality > 1) must be capped so the 100%-stacked
+  # communality/uniqueness bar stays valid (communality <= 1, uniqueness >= 0). (#37018)
+  fake_fa <- list(communality = c(A = 0.70, B = 1.05, C = 0.30))
+  class(fake_fa) <- "fa_exploratory"
+  clong <- tidy.fa_exploratory(fake_fa, type = "communalities_long")
+  expect_equal(colnames(clong), c("variable", "Component", "Ratio"))
+  bwide <- tidyr::pivot_wider(clong, names_from = Component, values_from = Ratio)
+  expect_equal(bwide$Communality[bwide$variable == "B"], 1)      # capped from 1.05
+  expect_equal(bwide$Uniqueness[bwide$variable == "B"], 0)       # clamped from -0.05
+  expect_equal(bwide$Communality[bwide$variable == "A"], 0.70)   # normal case unchanged
+  expect_true(all(bwide$Communality + bwide$Uniqueness <= 1 + 1e-9))
+
   # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.
   set.seed(1)
   pa <- compute_parallel_analysis(mtcars[, c("mpg","cyl","disp","hp","drat","wt","qsec")], n_iter = 20)

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -8,7 +8,7 @@ test_that("exp_factanal with default orthogonal varimax rotation", {
   check_output <- function(model_df) {
     res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(colnames(res),
-                 c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows"))
+                 c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows", "Method", "Rotation", "RMSR", "RMSEA", "TLI", "BIC"))
     res <- model_df %>% tidy_rowwise(model, type="variances")
     expect_equal(colnames(res),
                  c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))
@@ -32,6 +32,25 @@ test_that("exp_factanal with default orthogonal varimax rotation", {
     res <- model_df %>% tidy_rowwise(model, type="data")
     expect_equal(colnames(res),
                  c("mpg","cyl","disp","hp","drat","wt","qsec","vs","am","gear","carb","new_col","Factor 1","Factor 2","Factor 3"))
+    # New report tidy types (issue #37018).
+    res <- model_df %>% tidy_rowwise(model, type="suitability")
+    expect_equal(colnames(res), c("Metric", "Value", "Judgement", "Description", "status"))
+    expect_equal(res$Metric, c("KMO", "Bartlett's Test of Sphericity", "Rows Used", "Variables Used"))
+    res <- model_df %>% tidy_rowwise(model, type="factor_count")
+    expect_equal(colnames(res), c("Method", "Recommended Number of Factors", "Description"))
+    expect_equal(res$Method, c("Kaiser Criterion", "Parallel Analysis", "Scree Plot"))
+    expect_equal(res$`Recommended Number of Factors`[3], "Check the chart")
+    res <- model_df %>% tidy_rowwise(model, type="parallel_screeplot")
+    expect_equal(colnames(res), c("Factor", "Eigenvalue", "Random Data Eigenvalue"))
+    res <- model_df %>% tidy_rowwise(model, type="loadings_wide")
+    expect_equal(colnames(res), c("variable", "Factor 1", "Factor 2", "Factor 3", "Judgement", "judgement_status", "primary_factor", "secondary_factors", "direction"))
+    # Every status token must be one of the known set (guards against a typo drifting from the client tooltip keys).
+    expect_true(all(res$judgement_status %in% c("strong", "moderate", "near_crossload", "crossload", "ambiguous_crossload", "low_loading")))
+    res <- model_df %>% tidy_rowwise(model, type="communalities")
+    expect_equal(colnames(res), c("variable", "Communality", "Uniqueness", "Judgement", "judgement_status"))
+    res <- model_df %>% tidy_rowwise(model, type="communalities_long")
+    expect_equal(colnames(res), c("variable", "Component", "Ratio"))
+    expect_equal(levels(res$Component), c("Communality", "Uniqueness"))
   }
 
   model_df <- exp_factanal(df, cyl, mpg, hp, max_nrow=30, nfactors=3, fm="minres") 
@@ -62,7 +81,7 @@ test_that("exp_factanal with oblique Promax rotation", {
   check_output <- function(model_df) {
     res <- model_df %>% glance_rowwise(model, pretty.name=TRUE)
     expect_equal(colnames(res),
-                 c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows"))
+                 c("Factors", "Variance Explained (Ratio)", "Variance Explained", "Chi-Square", "P Value", "DF", "Rows", "Method", "Rotation", "RMSR", "RMSEA", "TLI", "BIC"))
     res <- model_df %>% tidy_rowwise(model, type="variances")
     expect_equal(colnames(res),
                  c("SS loadings", "Proportion Var", "Cumulative Var", "Proportion Explained", "Cumulative Proportion", "Factor", "% Variance", "Cummulated % Variance"))
@@ -150,4 +169,69 @@ test_that("exp_factanal with strange column name and all-NA column", {
   res <- model_df %>% tidy_rowwise(model, type="data")
   expect_equal(colnames(res),
                c("mpg","Cy l","disp","hp","drat","wt","qsec","vs","am","gear","carb","new_col","Factor 1","Factor 2"))
+  # New tidy types must also survive a strange column name + all-NA column (issue #37018).
+  res <- model_df %>% tidy_rowwise(model, type="suitability")
+  expect_equal(colnames(res), c("Metric", "Value", "Judgement", "Description", "status"))
+  res <- model_df %>% tidy_rowwise(model, type="loadings_wide")
+  expect_true(all(c("variable", "Judgement", "judgement_status") %in% colnames(res)))
+  res <- model_df %>% tidy_rowwise(model, type="communalities")
+  expect_equal(colnames(res), c("variable", "Communality", "Uniqueness", "Judgement", "judgement_status"))
+})
+
+test_that("factor analysis report judgment helpers (issue #37018)", {
+  cfg <- factanal_report_config()
+
+  # KMO thresholds + NA handling. Labels are English-canonical; status is the language-neutral token.
+  expect_equal(judge_kmo(0.85)$status, "great")
+  expect_equal(judge_kmo(0.75)$status, "good")
+  expect_equal(judge_kmo(0.65)$status, "min")
+  expect_equal(judge_kmo(0.55)$status, "poor")
+  expect_equal(judge_kmo(0.40)$status, "below")
+  expect_equal(judge_kmo(NA_real_)$status, "na")
+  expect_equal(judge_kmo(0.85)$label, "Very Suitable")
+
+  # Bartlett p-value.
+  expect_equal(judge_bartlett(0.001)$status, "suitable")
+  expect_equal(judge_bartlett(0.20)$status, "caution")
+  expect_equal(judge_bartlett(NA_real_)$status, "na")
+
+  # Communality thresholds.
+  expect_equal(judge_communality(0.97)$status, "too_high")
+  expect_equal(judge_communality(0.70)$status, "good")
+  expect_equal(judge_communality(0.50)$status, "moderate")
+  expect_equal(judge_communality(0.30)$status, "weak")
+  expect_equal(judge_communality(NA_real_)$status, "na")
+
+  # Loading judgment: strong, negative direction, hard-to-interpret, cross-loading.
+  strong <- judge_loading(c(`Factor 1` = 0.75, `Factor 2` = 0.10))
+  expect_equal(strong$status, "strong")
+  expect_equal(strong$primary_factor, "Factor 1")
+  expect_equal(strong$direction, "positive")
+  expect_equal(strong$label, "Strongly related to Factor 1")
+
+  strong_neg <- judge_loading(c(`Factor 1` = 0.10, `Factor 2` = -0.75))
+  expect_equal(strong_neg$status, "strong")
+  expect_equal(strong_neg$direction, "negative")
+  expect_equal(strong_neg$label, "Strongly related to Factor 2 (negative)")
+
+  low <- judge_loading(c(`Factor 1` = 0.20, `Factor 2` = 0.15))
+  expect_equal(low$status, "low_loading")
+  expect_equal(low$label, "Hard to interpret")
+
+  ambiguous <- judge_loading(c(`Factor 1` = 0.55, `Factor 2` = 0.50))
+  expect_equal(ambiguous$status, "ambiguous_crossload")
+
+  crossload <- judge_loading(c(`Factor 1` = 0.70, `Factor 2` = 0.45))
+  expect_equal(crossload$status, "crossload")
+  expect_equal(crossload$primary_factor, "Factor 1")
+  expect_equal(crossload$secondary_factors, "Factor 2")
+
+  moderate <- judge_loading(c(`Factor 1` = 0.45, `Factor 2` = 0.05))
+  expect_equal(moderate$status, "moderate")
+
+  # Parallel analysis returns a recommended count and per-factor threshold table, deterministically.
+  set.seed(1)
+  pa <- compute_parallel_analysis(mtcars[, c("mpg","cyl","disp","hp","drat","wt","qsec")], n_iter = 20)
+  expect_true(is.numeric(pa$recommended_n))
+  expect_equal(colnames(pa$table), c("factor_number", "actual_eigenvalue", "random_eigenvalue_threshold"))
 })

--- a/tests/testthat/test_rpart_tree_nodes.R
+++ b/tests/testthat/test_rpart_tree_nodes.R
@@ -111,6 +111,24 @@ test_that("tree_nodes regression - predicted mean, class_json NA, sd/rmse/dist (
   }
 })
 
+test_that("tree_nodes regression - integer/discrete target uses one bin per integer", {
+  set.seed(7)
+  n <- 400
+  df <- tibble::tibble(x1 = rnorm(n), x2 = rnorm(n))
+  # discrete integer target, small range (<= 30) so it should get per-integer bins
+  df$level <- as.integer(pmin(5L, pmax(1L, round(3 + df$x1))))
+  model_df <- df %>% exp_rpart(level, x1, x2)
+  nodes <- model_df %>% tidy_rowwise(model, type = "tree_nodes")
+
+  root <- jsonlite::fromJSON(nodes$dist_json[nodes$node_id == 1])
+  # one bin per integer: breaks are consecutive half-integers (width 1, at n +/- 0.5)
+  expect_true(all(abs(diff(root$breaks) - 1) < 1e-9))
+  expect_true(all(abs((root$breaks %% 1) - 0.5) < 1e-9))
+  rng <- range(df$level)
+  expect_equal(length(root$counts), as.integer(diff(rng)) + 1L)
+  expect_equal(sum(root$counts), nodes$n[nodes$node_id == 1])
+})
+
 test_that("tree_nodes multibyte/symbol column with categorical + numeric split", {
   set.seed(42)
   n <- 400


### PR DESCRIPTION
Part of the Factor Analysis Analytics Report redesign ([tam#37018](https://github.com/exploratory-io/tam/issues/37018)). This is the **R side**; the desktop (tam) side is a separate PR.

## What this adds

New statistics and judgment outputs for `exp_factanal` so the report can help users answer: is the data suited for factor analysis, is the factor count valid, how to interpret each factor, which variables drive them, which need caution.

- **Fit-time diagnostics** attached to the `fa_exploratory` model: KMO (`psych::KMO`), Bartlett's test of sphericity (`psych::cortest.bartlett`), and Horn's parallel analysis (implemented in-repo, ~30 lines, deterministically seeded). `psych` is already a hard dependency, so no new deps. Each is wrapped so a singular/degenerate correlation matrix degrades to `NA` instead of aborting.
- **Six new `tidy(type=…)` branches**: `suitability`, `factor_count`, `parallel_screeplot`, `loadings_wide`, `communalities`, `communalities_long`.
- **`glance` extended** (append-only): `Method`, `Rotation`, `RMSR`, `RMSEA`, `TLI`, `BIC`. Append-only keeps the client's name-indexed reads working.
- **Judgment helpers** (`judge_kmo` / `judge_bartlett` / `judge_loading` / `judge_communality`) + threshold config + parallel analysis.

## Translation-safe by design

Every judgment emits an **English-canonical label plus a language-neutral `status` token** (and param columns like `primary_factor`). No natural language for translation lives in R output — the desktop/server client owns all localization. This is the core requirement from the issue (the spec was Japanese-only; we need EN + future languages).

## Existing outputs unchanged

Only `else if` branches were added; the existing `loadings` / `biplot` / `variances` / `screeplot` / `correlation` / `data` tidy types and the base `glance` columns are untouched, so saved analytics keep working.

## Tests

`tests/testthat/test_factanal.R`:
- `check_output` extended to assert colnames of all 6 new tidy types across every `fm` (minres/ml/ols/wls/gls/minchi/minrank), plus the strange-column-name / all-NA case.
- New `test_that` for the judgment helpers (every threshold boundary, NA handling, negative loading direction, cross-loading list ordering) and `compute_parallel_analysis`.

Verified on live `psych::fa` fits (ungrouped, grouped/Repeat By, orthogonal + oblique Promax) — all 6 outputs produce the expected columns and localizable tokens.

## Deploy note

New tidy types run server-side for scheduled refresh / published notes, so this needs the usual package rebuild + scheduler/server deploy after merge. Version bumped 16.0.1 → 16.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
