### PR TITLE
PCA report: coefficients tidy type — re-land after #1540 branch-delete race (tam #37019)

### DIFF
--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -550,6 +550,22 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
         dplyr::mutate(Component = forcats::fct_inorder(Component)) # PC2 before PC10 on chart
     }
   }
+  else if (type == "coefficients") {
+    # PCA report: raw principal-component coefficients (主成分係数 = fit$rotation, the eigenvector
+    # weights that construct each PC) in long format for ALL components (issue #37019). Unlike
+    # "loadings_signed" (cor(cleaned_df, fit$x) correlations) or "contributions" (rotation^2 share),
+    # these are the sign-stabilized rotation values themselves -- signed weights, negatives expected
+    # on non-dominant variables. rotation is already sign-stabilized (A2) -- do NOT re-flip. Empty
+    # typed tibble for k-means / old saved models.
+    if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
+      res <- tibble::tibble(Variable = character(0), Component = character(0), Coefficient = numeric(0))
+    }
+    else {
+      res <- tibble::as_tibble(x$rotation, rownames = "Variable") %>%
+        tidyr::gather(Component, Coefficient, dplyr::starts_with("PC"), convert = TRUE) %>%
+        dplyr::mutate(Component = forcats::fct_inorder(Component)) # PC2 before PC10 on chart
+    }
+  }
   else if (type == "variable_map") {
     # PCA report: variable-vector rows for a 2D correlation-circle chart (issue #37019).
     # The tam side renders this like the biplot's VARIABLE vectors only (no observation points),

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -294,3 +294,16 @@ test_that("all 8 report tidy types return 0-row typed tibbles for an old saved m
     expect_true(all(PRCOMP_REPORT_TYPE_COLS[[ty]] %in% colnames(res)), info = ty)
   }
 })
+
+test_that("coefficients tidy type returns rotation weights (long, signed)", {
+  model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
+  res <- model_df %>% tidy_rowwise(model, type = "coefficients")
+  expect_equal(colnames(res), c("Variable", "Component", "Coefficient"))
+  expect_true(any(res$Coefficient < 0))            # signed eigenvector weights
+  expect_true(nrow(res) == 6 * length(unique(res$Component)))  # vars x components
+  # kmeans fit -> empty
+  km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
+  r2 <- km %>% tidy_rowwise(model, type = "coefficients")
+  expect_equal(nrow(r2), 0)
+  expect_equal(colnames(r2), c("Variable", "Component", "Coefficient"))
+})


### PR DESCRIPTION
## Summary

Follow-up to #1540 (PCA report redesign). #1540 merged before this commit was pushed to the same source branch, so it never made it into the merge — GitHub deleted the source branch on merge, silently dropping this commit. Re-landing it here off current `master`.

Adds the `coefficients` tidy type (raw `fit$rotation` weights, i.e. 主成分係数) to `do_prcomp`, distinguishing it from the already-shipped `loadings_signed` (correlation-based) and `contributions` (rotation²-based) types. Required by the tam PR (exploratory-io/tam#37051), which adds a "Coefficients" report tab consuming this type — building `exploratory_16.0.4` from `master` without this commit would ship a package that 404s that tab.

## Test plan
- `devtools::test(filter="prcomp")` — 139 passing, 0 failing (full suite incl. sibling types, no regressions)
- Reinstalled locally and confirmed `tidy_rowwise(model, type="coefficients")` returns `Variable, Component, Coefficient` with correct signed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
