### PR TITLE
fix: add variance-scaled contribution column for PCA contribution chart (#37132)

### DIFF
--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -537,16 +537,33 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     }
   }
   else if (type == "contributions") {
-    # PCA report: each variable's percent contribution to each component (issue #37019).
-    # rotation^2 per column normalized to sum 100 (%). Long format. Empty typed tibble for k-means.
+    # PCA report: variable contributions to each component in long format, for the stacked-bar
+    # contribution chart (issue #37132). Two value columns:
+    #   Contribution           - the variable's share of that component (rotation^2 per column
+    #                            normalized to sum 100 (%)); each component sums to 100.
+    #   `Variance Contribution` - that share scaled by the component's explained-variance ratio,
+    #                            i.e. the variable's contribution to the TOTAL data variance (%):
+    #                            height = pc_explained_variance_ratio * variable_contribution_to_pc.
+    #                            Summing a component's segments gives that component's % variance;
+    #                            summing every segment gives the cumulative variance explained.
+    # Long format. Empty typed tibble for k-means.
     if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
-      res <- tibble::tibble(Variable = character(0), Component = character(0), Contribution = numeric(0))
+      res <- tibble::tibble(Variable = character(0), Component = character(0),
+                            Contribution = numeric(0), `Variance Contribution` = numeric(0))
     }
     else {
-      contribution <- x$rotation^2
-      contribution <- sweep(contribution, 2, colSums(contribution), "/") * 100 # each column sums to 100
-      res <- tibble::as_tibble(contribution, rownames = "Variable") %>%
-        tidyr::gather(Component, Contribution, dplyr::starts_with("PC"), convert = TRUE) %>%
+      contribution_fraction <- x$rotation^2
+      contribution_fraction <- sweep(contribution_fraction, 2, colSums(contribution_fraction), "/") # each column sums to 1
+      pct_variance_ratio <- x$sdev^2 / sum(x$sdev^2) # explained-variance ratio per component (fraction)
+      variance_contribution <- sweep(contribution_fraction, 2,
+                                     pct_variance_ratio[seq_len(ncol(contribution_fraction))], "*") * 100 # % of total variance
+      contribution <- contribution_fraction * 100 # each column sums to 100 (%)
+      res_contribution <- tibble::as_tibble(contribution, rownames = "Variable") %>%
+        tidyr::gather(Component, Contribution, dplyr::starts_with("PC"), convert = TRUE)
+      res_variance <- tibble::as_tibble(variance_contribution, rownames = "Variable") %>%
+        tidyr::gather(Component, `Variance Contribution`, dplyr::starts_with("PC"), convert = TRUE)
+      res <- res_contribution %>%
+        dplyr::left_join(res_variance, by = c("Variable", "Component")) %>%
         dplyr::mutate(Component = forcats::fct_inorder(Component)) # PC2 before PC10 on chart
     }
   }

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -134,9 +134,15 @@ test_that("component_profiles / loadings_signed / contributions", {
   expect_equal(colnames(res), c("Variable","Component","Loading"))
   expect_true(any(res$Loading < 0))
   res <- model_df %>% tidy_rowwise(model, type = "contributions")
-  expect_equal(colnames(res), c("Variable","Component","Contribution"))
+  expect_equal(colnames(res), c("Variable","Component","Contribution","Variance Contribution"))
   sums <- res %>% dplyr::group_by(Component) %>% dplyr::summarize(s = sum(Contribution)) %>% dplyr::pull(s)
   expect_true(all(abs(sums - 100) < 1e-6))
+  # Each component's Variance Contribution segments sum to that component's % variance, and all
+  # segments together sum to the cumulative variance explained (issue #37132).
+  var_ratio <- model_df$model[[1]]$sdev^2 / sum(model_df$model[[1]]$sdev^2) * 100
+  vc_sums <- res %>% dplyr::group_by(Component) %>%
+    dplyr::summarize(s = sum(`Variance Contribution`)) %>% dplyr::pull(s)
+  expect_true(all(abs(vc_sums - var_ratio[seq_along(vc_sums)]) < 1e-6))
 })
 
 test_that("component_profiles / loadings_signed / contributions empty for kmeans fits", {
@@ -150,7 +156,7 @@ test_that("component_profiles / loadings_signed / contributions empty for kmeans
   expect_equal(colnames(ls), c("Variable","Component","Loading"))
   expect_equal(nrow(ls), 0)
   ct <- km %>% tidy_rowwise(model, type = "contributions")
-  expect_equal(colnames(ct), c("Variable","Component","Contribution"))
+  expect_equal(colnames(ct), c("Variable","Component","Contribution","Variance Contribution"))
   expect_equal(nrow(ct), 0)
 })
 

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -202,7 +202,7 @@ PRCOMP_REPORT_TYPE_COLS <- list(
                           "Related Variables", "Pattern",
                           "pattern_status", "dominant_variable", "positive_variables", "negative_variables"),
   loadings_signed     = c("Variable", "Component", "Loading"),
-  contributions       = c("Variable", "Component", "Contribution"),
+  contributions       = c("Variable", "Component", "Contribution", "Variance Contribution"),
   variable_map        = c("measure_name", "PC1", "PC2", "Measures", "Representation 2D"),
   representation       = c("Variable", "Retained", "Judgement", "judgement_status")
 )


### PR DESCRIPTION
## What
`tidy(model, type="contributions")` now returns an additional column
`Variance Contribution` = each variable's contribution to the **total** data variance (%):

```
height = pc_explained_variance_ratio * variable_contribution_to_pc
```

where `variable_contribution_to_pc` = normalized `rotation^2` (per-PC column sums to 1) and
`pc_explained_variance_ratio` = `sdev^2 / sum(sdev^2)`. Summing a component's segments gives
that component's % variance; summing all segments gives the cumulative variance explained.

The existing per-PC `Contribution` column (sums to 100 per component) is kept for backward
compatibility. Empty typed tibble (k-means / old models) gains the new column too.

tam consumes this to render the Contributions tab as a stacked bar chart (X = PC, Y = % of
total variance, stacked by variable) instead of the old heatmap pivot.

## Test
`tests/testthat/test_prcomp.R` — asserts the new colname and that per-component
`Variance Contribution` sums equal each PC's % variance; k-means empty case updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)