### PR TITLE
feat: loadings_signed_wide tidy for PCA report bar loading table (#37130)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.5
+Version: 16.0.6
 Date: 2026-07-17
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -536,6 +536,28 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
         dplyr::mutate(Component = forcats::fct_inorder(Component)) # PC2 before PC10 on chart
     }
   }
+  else if (type == "loadings_signed_wide") {
+    # PCA report: signed loadings (主成分負荷量 = cor(cleaned_df, fit$x)) as a WIDE table -- one
+    # row per variable, one column per component -- for the in-cell diverging bar table (issue
+    # #37130). Each PC column header carries that component's % variance (sdev^2 / sum(sdev^2) * 100,
+    # the SAME basis as the "variances_judged" / "component_profiles" branches, so the numbers match
+    # the Variance (%) tab exactly), e.g. "PC1 (43.1%)". Row order = cor() rownames = original
+    # variable order (no reorder). Empty typed tibble for k-means / old saved models.
+    if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
+      res <- tibble::tibble(Variable = character(0))
+    }
+    else {
+      cleaned_df <- x$df[, names(x$input_diagnostics$variable_sd), drop = FALSE]
+      signed_loadings <- cor(cleaned_df, x$x) # variables x components
+      n_comp <- ncol(signed_loadings)
+      eigenvalue <- x$sdev^2
+      pct_variance <- eigenvalue / sum(eigenvalue) * 100
+      pc_labels <- paste0("PC", seq_len(n_comp), " (",
+                          format(round(pct_variance[seq_len(n_comp)], 1), nsmall = 1, trim = TRUE), "%)")
+      res <- tibble::as_tibble(signed_loadings, rownames = "Variable")
+      colnames(res) <- c("Variable", pc_labels)
+    }
+  }
   else if (type == "contributions") {
     # PCA report: each variable's percent contribution to each component (issue #37019).
     # rotation^2 per column normalized to sum 100 (%). Long format. Empty typed tibble for k-means.

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -154,6 +154,31 @@ test_that("component_profiles / loadings_signed / contributions empty for kmeans
   expect_equal(nrow(ct), 0)
 })
 
+test_that("loadings_signed_wide returns a wide table with %-labeled PC headers (#37130)", {
+  model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
+  res <- model_df %>% tidy_rowwise(model, type = "loadings_signed_wide")
+  # One row per input variable; first column is Variable, rest are the PC columns.
+  expect_equal(res$Variable, c("mpg","cyl","disp","hp","drat","wt"))
+  pc_cols <- setdiff(colnames(res), "Variable")
+  expect_equal(length(pc_cols), 6L) # 6 variables -> 6 components
+  # Headers carry the contribution % e.g. "PC1 (43.1%)".
+  expect_true(all(grepl("^PC[0-9]+ \\([0-9]+\\.[0-9]%\\)$", pc_cols)))
+  # The %-labels use the SAME basis as variances_judged (sdev^2 / sum * 100).
+  vj <- model_df %>% tidy_rowwise(model, type = "variances_judged")
+  expected_labels <- paste0("PC", seq_len(nrow(vj)), " (",
+                            format(round(vj$`% Variance`, 1), nsmall = 1, trim = TRUE), "%)")
+  expect_equal(pc_cols, expected_labels)
+  # Signed loadings: negatives are expected on non-dominant variables.
+  expect_true(any(unlist(res[, pc_cols]) < 0))
+})
+
+test_that("loadings_signed_wide is empty for kmeans fits (#37130)", {
+  km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
+  lw <- km %>% tidy_rowwise(model, type = "loadings_signed_wide")
+  expect_equal(colnames(lw), "Variable")
+  expect_equal(nrow(lw), 0)
+})
+
 test_that("variable_map / representation", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, retained_components = 2)
   res <- model_df %>% tidy_rowwise(model, type = "variable_map")


### PR DESCRIPTION
Paired with tam#37130.

Adds `tidy.prcomp_exploratory(type="loadings_signed_wide")`: the signed principal-component loadings (`cor(cleaned_df, fit\$x)`) as a **wide** table — one row per variable, one column per component — with each PC column header carrying that component's % variance (`sdev^2 / sum(sdev^2) * 100`, the same basis as `variances_judged` / `component_profiles`), e.g. `PC1 (43.1%)`.

The tam side renders this as an in-cell diverging bar table (red = positive, blue = negative, length = |loading|), replacing the old bgcolor heatmap.

- Row order = `cor()` rownames = original variable order (no reorder).
- Empty typed tibble (`Variable` only) for k-means / old saved models.
- Existing long `loadings_signed` type left intact for backward compatibility.
- Version 16.0.5 → 16.0.6.

## Test
`devtools::test(filter="prcomp")` — new wide-shape + %-label-matches-variances_judged + empty-kmeans tests, all prcomp tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)