### PR TITLE
fix(corresp): drop variable prefix from dimension-summary categories (#37133)

### DIFF
--- a/R/corresp_report.R
+++ b/R/corresp_report.R
@@ -626,9 +626,11 @@ ca_build_dimension_summary <- function(metrics, max_dimensions = 5, analysis_typ
   dimensions <- sort(unique(metrics$dimension))
   dimensions <- dimensions[dimensions <= max_dimensions]
 
+  # #37133: show the category value only (no "variable: " prefix) in the dimension
+  # summary's positive/negative category lists.
   join_labels <- function(x) {
     if (nrow(x) == 0) return("")
-    paste(paste0(x$variable, ": ", x$category), collapse = ", ")
+    paste(x$category, collapse = ", ")
   }
 
   purrr::map_dfr(dimensions, function(current_dimension) {


### PR DESCRIPTION
drop variable prefix from dimension-summary categories

## Change
The dimension summary's positive/negative category lists (`One Side` / `Other Side`, i.e. `positive_categories` / `negative_categories`) rendered as `variable: category` (e.g. `要素: 味わい, 年代: 40代`). Per issue item 13, show the category value only (`味わい, 40代`).

`join_labels()` is local to `ca_build_dimension_summary()`, so only the dimension summary is affected. The category-map label prefix (item 2) is handled separately on the tam side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)