### PR TITLE
fix(cronbach): report one alpha scale everywhere (tam#37175)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.7
+Version: 16.0.8
 Date: 2026-07-17
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -234,12 +234,42 @@ reliability_standardized_item_total <- function(r) {
   }, numeric(1)), items)
 }
 
-reliability_alpha_if_deleted <- function(correlation_matrix, current_alpha) {
+# Alpha for each "this item removed" subset.
+#
+# The alpha reported to the user (display_alpha) is the RAW (covariance-based)
+# alpha for the pearson method and the correlation-matrix alpha otherwise. The
+# if-dropped alphas must be produced by the SAME estimator, or the report shows
+# two different scales side by side (issue #37175: the prose said 0.798 while the
+# table said 0.791). Pass `raw_data` for the pearson case to get raw alpha.
+reliability_alpha_if_deleted <- function(correlation_matrix, current_alpha,
+                                         raw_data = NULL, check_keys = FALSE) {
   item_names <- colnames(correlation_matrix)
+  raw_alpha_for_subset <- function(keep_names) {
+    if (is.null(raw_data) || length(keep_names) < 2) {
+      return(NA_real_)
+    }
+    subset_data <- raw_data[, keep_names, drop = FALSE]
+    subset_object <- tryCatch(
+      suppressWarnings(psych::alpha(subset_data, check.keys = check_keys,
+                                    warnings = FALSE)),
+      error = function(e) NULL)
+    if (is.null(subset_object)) {
+      return(NA_real_)
+    }
+    reliability_safe_number(subset_object$total$raw_alpha)
+  }
   purrr::map_dfr(item_names, function(item) {
     keep <- colnames(correlation_matrix) != item
     reduced <- correlation_matrix[keep, keep, drop = FALSE]
-    deleted_alpha <- reliability_alpha_from_correlation(reduced)
+    deleted_alpha <- if (is.null(raw_data)) {
+      reliability_alpha_from_correlation(reduced)
+    } else {
+      raw_alpha_for_subset(item_names[keep])
+    }
+    if (is.na(deleted_alpha)) {
+      # Never leave a hole in the table: fall back to the matrix-based estimate.
+      deleted_alpha <- reliability_alpha_from_correlation(reduced)
+    }
     difference <- deleted_alpha - current_alpha
     tibble::tibble(
       removed_item = item,
@@ -374,7 +404,10 @@ reliability_scale_candidates <- function(current_alpha, alpha_if_deleted, item_c
       recommendation = dplyr::if_else(difference_from_current >= 0.05,
                                       "Recommended", "Consider")
     )
-  dplyr::bind_rows(base, improvements) %>% dplyr::arrange(dplyr::desc(alpha))
+  # "Use all items" is the baseline the user compares against, so it always leads
+  # the table (issue #37175); the drop candidates follow, best alpha first.
+  improvements <- improvements %>% dplyr::arrange(dplyr::desc(alpha))
+  dplyr::bind_rows(base, improvements)
 }
 
 # ------------------------------------------------------------
@@ -546,7 +579,11 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
       dplyr::select(variable, r.drop, raw.r, std.r, r.cor, n, missing_n, mean, sd,
                     interpretation)
 
-    alpha_if_deleted <- reliability_alpha_if_deleted(r, standardized_alpha)
+    # Same estimator as the alpha we display, so the report never mixes scales.
+    alpha_if_deleted <- reliability_alpha_if_deleted(
+      r, display_alpha,
+      raw_data = if (selected_method == "pearson") cleaned_df else NULL,
+      check_keys = check_keys)
 
     response_distribution <- reliability_response_distribution(cleaned_df)
 
@@ -593,7 +630,7 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
       summary_table <- summary_table %>% dplyr::filter(Metric != "95% CI")
     }
 
-    scale_candidates <- reliability_scale_candidates(standardized_alpha, alpha_if_deleted,
+    scale_candidates <- reliability_scale_candidates(display_alpha, alpha_if_deleted,
                                                      ncol(cleaned_df))
 
     correlation_long <- tibble::as_tibble(as.data.frame(r), rownames = "variable_1") %>%

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -69,6 +69,46 @@ test_that("exp_cronbach_alpha Pearson report sections", {
   expect_true(all(colnames(df) %in% colnames(res)))
 })
 
+test_that("alpha-if-dropped and scale candidates use the reported alpha's estimator (#37175)", {
+  df <- make_reliability_df()
+
+  model_df <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson")
+  reported_alpha <- (model_df %>% glance_rowwise(model, pretty.name = TRUE))$Alpha
+
+  candidates <- model_df %>% tidy_rowwise(model, type = "scale_candidates")
+  # "Use all items" always leads the table, and its alpha is the alpha we report.
+  expect_equal(candidates$Candidate[[1]], "Use all items")
+  expect_equal(candidates$Alpha[[1]], reported_alpha, tolerance = 1e-8)
+  # Drop candidates stay sorted best-alpha-first behind the base row.
+  if (nrow(candidates) > 2) {
+    expect_equal(candidates$Alpha[-1], sort(candidates$Alpha[-1], decreasing = TRUE))
+  }
+
+  dropped <- model_df %>% tidy_rowwise(model, type = "alpha_if_dropped")
+  # Each if-dropped alpha is the RAW alpha of the remaining items, not the
+  # correlation-matrix (standardized) alpha, and the difference is measured
+  # against the same reported alpha.
+  for (i in seq_len(nrow(dropped))) {
+    item <- dropped$`Dropped Item`[[i]]
+    remaining <- as.data.frame(df[, setdiff(colnames(df), item), drop = FALSE])
+    ref <- suppressWarnings(psych::alpha(remaining))$total$raw_alpha
+    expect_equal(dropped$`Alpha if Dropped`[[i]], ref, tolerance = 1e-6)
+    expect_equal(dropped$`Difference from Current`[[i]], ref - reported_alpha,
+                 tolerance = 1e-6)
+  }
+
+  # Polychoric/mixed keep the correlation-matrix estimator, and stay consistent
+  # with the ordinal alpha reported for them.
+  ordinal_df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(),
+                                                   ~ factor(.x, ordered = TRUE)))
+  ordinal_model <- exp_cronbach_alpha(ordinal_df, dplyr::everything(),
+                                      correlation_method = "polychoric")
+  ordinal_reported <- (ordinal_model %>% glance_rowwise(model, pretty.name = TRUE))$Alpha
+  ordinal_candidates <- ordinal_model %>% tidy_rowwise(model, type = "scale_candidates")
+  expect_equal(ordinal_candidates$Candidate[[1]], "Use all items")
+  expect_equal(ordinal_candidates$Alpha[[1]], ordinal_reported, tolerance = 1e-8)
+})
+
 test_that("response distribution uses Summary View numeric binning", {
   df <- list(
     low_cardinality = c(1L, 1L, 2L, 4L, 4L),


### PR DESCRIPTION
## Problem

The Cronbach's Alpha analytics report showed two different alphas for the same
thing. The summary table and the "next steps" prose use the reported alpha —
raw / covariance-based for the pearson method — while `alpha_if_deleted` and the
scale-score candidates were computed from the correlation matrix (standardized).
So "Use all items" read **0.791** right under a sentence saying **0.798**
(tam#37175, img `64b4af53`).

## Fix

`reliability_alpha_if_deleted` / `reliability_scale_candidates` now use the SAME
estimator as the alpha the report displays:

- **pearson** → raw alpha (`psych::alpha(...)$total$raw_alpha`) over the
  remaining items;
- **polychoric / mixed** → the correlation-matrix alpha (unchanged).

`reliability_scale_candidates` also always puts "Use all items" first, with the
drop candidates sorted best-alpha-first behind it (tam#37175, img `05699ddd`).

## Verification

- New testthat cases assert each if-dropped alpha equals
  `psych::alpha(remaining_items)$total$raw_alpha`, the difference is measured
  against the reported alpha, "Use all items" leads the candidates table with the
  reported alpha, and the polychoric path stays on the matrix estimator.
- Full `test_reliability.R`: `PASS 56`.
- Live end-to-end: summary display alpha == candidates base alpha (0.587 == 0.587
  on a synthetic pearson scale).

Version bumped 16.0.7 → 16.0.8. Paired tam PR wires the report (tam#37175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)