### PR TITLE
feat(chaid): readable conditions, collapsed ranges, final merges for the report (tam#37177)

### DIFF
--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -100,6 +100,11 @@ exp_chaid <- function(df,
   is_target_ordered <- is.ordered(df[[target_col]])
   target_ordered_levels <- if (is_target_ordered) levels(df[[target_col]]) else NULL
 
+  # tam #37177: cleanup_df() turns every character predictor into a factor whose
+  # levels are just data-appearance order, so factor-ness has to be captured from
+  # the ORIGINAL frame. Report tables keep a real factor's declared level order
+  # and sort everything else alphabetically.
+  original_factor_levels <- lapply(Filter(is.factor, df), levels)
   clean_ret <- cleanup_df(df, target_col, selected_cols, grouped_cols,
                           target_n, predictor_n, map_name = FALSE)
   clean_df <- clean_ret$clean_df
@@ -150,6 +155,7 @@ exp_chaid <- function(df,
         max_categories = max_categories
       )
       model$classification_type <- if (model$target_type == "logical") "binary" else "multi"
+      model$original_factor_levels <- original_factor_levels
 
       # Store training actual / predicted so tidy() evaluation and conf_mat can
       # reuse the shared model-agnostic evaluation helpers.

--- a/R/chaid.R
+++ b/R/chaid.R
@@ -1362,7 +1362,9 @@ chaid_node_summary <- function(model) {
   root.n <- model$nodes$n[model$nodes$node_id == 1L]
   data.frame(
     Node = model$nodes$node_id,
-    Rule = model$nodes$rule,
+    # tam #37177: readable form -- no "Root & " prefix, contiguous numeric bins
+    # collapsed to one inequality. The root row reads "All".
+    Rule = chaid_readable_condition(model$nodes$rule),
     Rows = model$nodes$n,
     `%` = model$nodes$n / root.n * 100,
     `Predicted Class` = model$nodes$predicted_class,
@@ -1389,7 +1391,8 @@ chaid_rule_table <- function(model) {
   terminal <- model$nodes$is_terminal
   data.frame(
     Node = model$nodes$node_id[terminal],
-    Rule = model$nodes$rule[terminal],
+    # tam #37177: see chaid_node_summary().
+    Rule = chaid_readable_condition(model$nodes$rule[terminal]),
     Prediction = model$nodes$predicted_class[terminal],
     Probability = vapply(
       model$nodes$class_distribution[terminal],
@@ -1409,6 +1412,24 @@ chaid_rule_table <- function(model) {
 chaid_category_merge_table <- function(model) {
   validate_chaid_model(model)
   merge.data <- model$category_merge_map
+  # tam #37177: a merge chain records every intermediate step, so keep only the
+  # group that survived to the split, and give both category columns a stable
+  # member order (factor level order, else alphabetical). The surviving merged
+  # group additionally collapses contiguous numeric bins into a single range.
+  merge.data <- chaid_keep_final_merges(merge.data)
+  if (nrow(merge.data) > 0) {
+    level.order <- lapply(merge.data$variable, function(variable) {
+      chaid_group_level_order(model, variable)
+    })
+    merge.data$merged_group <- vapply(seq_len(nrow(merge.data)), function(i) {
+      chaid_normalize_group_label(merge.data$merged_group[i], level.order[[i]],
+                                  collapse = TRUE)
+    }, character(1))
+    merge.data$original_categories <- vapply(seq_len(nrow(merge.data)), function(i) {
+      chaid_normalize_group_label(merge.data$original_categories[i], level.order[[i]],
+                                  collapse = FALSE, separator = ' | ')
+    }, character(1))
+  }
   data.frame(
     Node = merge.data$node_id,
     Variable = merge.data$variable,
@@ -1457,7 +1478,7 @@ chaid_split_summary <- function(model) {
 #' no numeric predictor was binned. (#37155 §4-5)
 #'
 #' @param model A fitted `exploratory_chaid` model.
-#' @return A data frame with `Node`, `Variable`, `Initial Binning`,
+#' @return A data frame with `Node`, `Variable`, `Binning Method`, `Initial Bins`,
 #'   `Final Intervals`.
 #' @export
 chaid_numeric_intervals <- function(model) {
@@ -1465,7 +1486,8 @@ chaid_numeric_intervals <- function(model) {
   empty <- data.frame(
     Node = integer(),
     Variable = character(),
-    `Initial Binning` = character(),
+    `Binning Method` = character(),
+    `Initial Bins` = integer(),
     `Final Intervals` = character(),
     check.names = FALSE,
     stringsAsFactors = FALSE
@@ -1487,11 +1509,17 @@ chaid_numeric_intervals <- function(model) {
       return(NULL)
     }
     child_labels <- edges$label[edges$parent_id == node_id]
+    # tam #37177: each child edge's label is a " + "-joined run of bins; show the
+    # range it actually covers. Binning method and bin count are separate columns.
+    child_labels <- vapply(child_labels, function(label) {
+      chaid_normalize_group_label(label, chaid_group_level_order(model, variable),
+                                  collapse = TRUE)
+    }, character(1), USE.NAMES = FALSE)
     data.frame(
       Node = node_id,
       Variable = variable,
-      `Initial Binning` = paste0(binmap[[variable]]$method, ", ",
-                                 length(binmap[[variable]]$labels), " bins"),
+      `Binning Method` = binmap[[variable]]$method,
+      `Initial Bins` = length(binmap[[variable]]$labels),
       `Final Intervals` = paste(child_labels, collapse = " / "),
       check.names = FALSE,
       stringsAsFactors = FALSE

--- a/R/chaid_report_format.R
+++ b/R/chaid_report_format.R
@@ -1,0 +1,319 @@
+# Report-formatting helpers for CHAID analytics report tables (tam #37177).
+#
+# These are display-only transformations of strings that the CHAID engine
+# already produces (node rules, merged category-group labels, child-edge
+# interval labels). They never change how the tree is fitted.
+#
+# Two primitives cover five separate spec bullets:
+#   P1 chaid_readable_condition()  - "Root & X in {(3, 5] + (5, 6.7]}" -> "3 < X <= 6.7"
+#   P2 chaid_collapse_intervals()  - c("(3, 5]", "(5, 6.7]")           -> "(3, 6.7]"
+#
+# Numeric bin labels produced by create_numeric_bins() have exactly three
+# shapes: "<= b1", "(b1, b2]", "> bk". Anything else (a category name, the
+# "Missing" level) is passed through untouched and acts as a barrier that
+# collapsing never crosses.
+
+CHAID_GROUP_SEPARATOR <- ' + '
+CHAID_CONDITION_SEPARATOR <- ' & '
+CHAID_ROOT_LABEL <- 'Root'
+# Emitted for the root row once the "Root & " prefix is stripped (tam #37177).
+# Localized on the tam side via the ANALYTICS.UI pass-through namespace.
+CHAID_ALL_LABEL <- 'All'
+
+#' Parse a numeric bin label into an interval.
+#'
+#' @param label A single bin label, e.g. `"<= 3"`, `"(3, 5]"`, `"> 23"`.
+#' @return A list with `lower` / `upper` (character bound text, `NA` when the
+#'   side is unbounded) and `lower_value` / `upper_value` (numeric, `-Inf` /
+#'   `Inf` when unbounded), or `NULL` when `label` is not an interval.
+chaid_parse_interval <- function(label) {
+  if (length(label) != 1 || is.na(label)) {
+    return(NULL)
+  }
+  label <- trimws(label)
+  m <- regmatches(label, regexec('^<=[[:space:]]*(.+)$', label))[[1]]
+  if (length(m) == 2) {
+    upper <- trimws(m[2])
+    upper.value <- suppressWarnings(as.numeric(upper))
+    if (is.na(upper.value)) {
+      return(NULL)
+    }
+    return(list(lower = NA_character_, upper = upper,
+                lower_value = -Inf, upper_value = upper.value))
+  }
+  m <- regmatches(label, regexec('^>[[:space:]]*(.+)$', label))[[1]]
+  if (length(m) == 2) {
+    lower <- trimws(m[2])
+    lower.value <- suppressWarnings(as.numeric(lower))
+    if (is.na(lower.value)) {
+      return(NULL)
+    }
+    return(list(lower = lower, upper = NA_character_,
+                lower_value = lower.value, upper_value = Inf))
+  }
+  m <- regmatches(label, regexec('^\\([[:space:]]*([^,]+),[[:space:]]*(.+)\\]$', label))[[1]]
+  if (length(m) == 3) {
+    lower <- trimws(m[2])
+    upper <- trimws(m[3])
+    lower.value <- suppressWarnings(as.numeric(lower))
+    upper.value <- suppressWarnings(as.numeric(upper))
+    if (is.na(lower.value) || is.na(upper.value)) {
+      return(NULL)
+    }
+    return(list(lower = lower, upper = upper,
+                lower_value = lower.value, upper_value = upper.value))
+  }
+  NULL
+}
+
+#' Render an interval back to a bin label.
+#'
+#' @param interval A list as returned by [chaid_parse_interval()].
+#' @return A single label string.
+chaid_format_interval <- function(interval) {
+  if (is.na(interval$lower) && is.na(interval$upper)) {
+    return(CHAID_ALL_LABEL)
+  }
+  if (is.na(interval$lower)) {
+    return(paste0('<= ', interval$upper))
+  }
+  if (is.na(interval$upper)) {
+    return(paste0('> ', interval$lower))
+  }
+  paste0('(', interval$lower, ', ', interval$upper, ']')
+}
+
+#' Collapse a run of adjacent numeric bin labels into single ranges.
+#'
+#' Only CONTIGUOUS labels are collapsed: the upper bound of one must equal the
+#' lower bound of the next. A gap keeps the pieces enumerated (tam #37177 —
+#' collapsing across a gap would claim values the branch does not contain).
+#' Non-interval entries (category names, `"Missing"`) pass through in place.
+#'
+#' @param labels Character vector of bin labels, in bin order.
+#' @return Character vector, same order, with adjacent intervals merged.
+chaid_collapse_intervals <- function(labels) {
+  labels <- as.character(labels)
+  if (length(labels) <= 1) {
+    return(labels)
+  }
+  out <- character()
+  pending <- NULL
+  flush <- function() {
+    if (!is.null(pending)) {
+      out <<- c(out, chaid_format_interval(pending))
+      pending <<- NULL
+    }
+  }
+  for (label in labels) {
+    interval <- chaid_parse_interval(label)
+    if (is.null(interval)) {
+      flush()
+      out <- c(out, label)
+      next
+    }
+    if (is.null(pending)) {
+      pending <- interval
+      next
+    }
+    contiguous <- is.finite(pending$upper_value) &&
+      is.finite(interval$lower_value) &&
+      isTRUE(all.equal(pending$upper_value, interval$lower_value))
+    if (contiguous) {
+      pending$upper <- interval$upper
+      pending$upper_value <- interval$upper_value
+    } else {
+      flush()
+      pending <- interval
+    }
+  }
+  flush()
+  out
+}
+
+#' Split a rule string into its top-level conditions.
+#'
+#' Splitting on `" & "` alone is unsafe because a category value may itself
+#' contain `" & "` (e.g. `"R & D"`). Fragments are re-joined until the
+#' `{...}` group of the condition is balanced.
+#'
+#' @param rule A rule string.
+#' @return Character vector of conditions.
+chaid_split_conditions <- function(rule) {
+  fragments <- strsplit(rule, CHAID_CONDITION_SEPARATOR, fixed = TRUE)[[1]]
+  out <- character()
+  buffer <- NULL
+  for (fragment in fragments) {
+    buffer <- if (is.null(buffer)) fragment else paste0(buffer, CHAID_CONDITION_SEPARATOR, fragment)
+    opens <- lengths(regmatches(buffer, gregexpr('\\{', buffer)))
+    closes <- lengths(regmatches(buffer, gregexpr('\\}', buffer)))
+    if (opens <= closes) {
+      out <- c(out, buffer)
+      buffer <- NULL
+    }
+  }
+  if (!is.null(buffer)) {
+    out <- c(out, buffer)
+  }
+  out
+}
+
+#' Rewrite one `<variable> in {<group>}` condition in readable form.
+#'
+#' @param condition A single condition string.
+#' @return A readable condition string.
+chaid_readable_one_condition <- function(condition) {
+  m <- regmatches(condition, regexec('^(.*) in \\{(.*)\\}$', condition))[[1]]
+  if (length(m) != 3) {
+    return(condition)
+  }
+  variable <- m[2]
+  parts <- strsplit(m[3], CHAID_GROUP_SEPARATOR, fixed = TRUE)[[1]]
+  collapsed <- chaid_collapse_intervals(parts)
+  if (length(collapsed) == 1) {
+    interval <- chaid_parse_interval(collapsed)
+    if (!is.null(interval)) {
+      if (is.na(interval$lower)) {
+        return(paste0(variable, ' <= ', interval$upper))
+      }
+      if (is.na(interval$upper)) {
+        return(paste0(variable, ' > ', interval$lower))
+      }
+      return(paste0(interval$lower, ' < ', variable, ' <= ', interval$upper))
+    }
+  }
+  paste0(variable, ' in (', paste(collapsed, collapse = CHAID_GROUP_SEPARATOR), ')')
+}
+
+#' Rewrite a CHAID node rule in readable form.
+#'
+#' Drops the leading `Root` term, collapses contiguous numeric bin groups into
+#' a single inequality, and renders categorical groups as `X in (a + b)`.
+#' The root node's own rule becomes [CHAID_ALL_LABEL].
+#'
+#' @param rule Character vector of rule strings.
+#' @return Character vector of readable rules.
+chaid_readable_condition <- function(rule) {
+  vapply(rule, function(one) {
+    if (is.na(one)) {
+      return(NA_character_)
+    }
+    one <- trimws(one)
+    if (!nzchar(one)) {
+      return(CHAID_ALL_LABEL)
+    }
+    conditions <- chaid_split_conditions(one)
+    conditions <- conditions[trimws(conditions) != CHAID_ROOT_LABEL]
+    if (length(conditions) == 0) {
+      return(CHAID_ALL_LABEL)
+    }
+    paste(vapply(conditions, chaid_readable_one_condition, character(1)),
+          collapse = CHAID_CONDITION_SEPARATOR)
+  }, character(1), USE.NAMES = FALSE)
+}
+
+#' Order the members of a category group.
+#'
+#' Factor (and binned-numeric / ordinal) predictors keep their original level
+#' order; every other predictor is sorted alphabetically, so the same merged
+#' group always reads the same way (tam #37177 — `離婚 | 既婚` vs `既婚 | 離婚`).
+#'
+#' @param parts Character vector of category names.
+#' @param levels Original level order, or `NULL` for alphabetical.
+#' @return Reordered character vector.
+chaid_order_group_parts <- function(parts, levels = NULL) {
+  parts <- as.character(parts)
+  if (length(parts) <= 1) {
+    return(parts)
+  }
+  if (is.null(levels) || length(levels) == 0) {
+    return(sort(parts))
+  }
+  position <- match(parts, levels)
+  # Anything not in the declared levels keeps its relative order at the end.
+  position[is.na(position)] <- length(levels) + seq_len(sum(is.na(position)))
+  parts[order(position)]
+}
+
+#' Level order to use when ordering a predictor's category group.
+#'
+#' @param model A fitted `exploratory_chaid` model.
+#' @param variable Predictor name.
+#' @return Character vector of levels, or `NULL` when alphabetical order applies.
+chaid_group_level_order <- function(model, variable) {
+  # A predictor that was a factor in the USER's data frame keeps its declared
+  # level order. This has to come from the pre-cleanup frame: cleanup_df() turns
+  # every character predictor into a factor whose levels are merely
+  # data-appearance order, so `predictor_info` cannot tell the two apart.
+  declared <- model$original_factor_levels[[variable]]
+  if (!is.null(declared) && length(declared) > 0) {
+    return(declared)
+  }
+  info <- model$predictor_info[[variable]]
+  # Binned numerics and ordinal predictors carry a real order too; anything
+  # else (a plain character column) is displayed alphabetically.
+  if (!is.null(info) && isTRUE(info$ordered)) {
+    return(info$levels)
+  }
+  NULL
+}
+
+#' Normalize a merged category-group label for display.
+#'
+#' Orders the members ([chaid_order_group_parts()]) and then collapses
+#' contiguous numeric intervals ([chaid_collapse_intervals()]).
+#'
+#' @param label A `" + "`-joined group label.
+#' @param levels Original level order, or `NULL`.
+#' @param collapse Whether to collapse contiguous intervals.
+#' @param separator Separator used by `label`.
+#' @return A normalized label string.
+chaid_normalize_group_label <- function(label, levels = NULL, collapse = TRUE,
+                                        separator = CHAID_GROUP_SEPARATOR) {
+  if (is.na(label)) {
+    return(label)
+  }
+  parts <- strsplit(label, separator, fixed = TRUE)[[1]]
+  parts <- chaid_order_group_parts(parts, levels)
+  if (isTRUE(collapse)) {
+    parts <- chaid_collapse_intervals(parts)
+  }
+  paste(parts, collapse = separator)
+}
+
+#' Keep only the final merge row for each (node, variable) merge chain.
+#'
+#' CHAID records every intermediate step of a merge, so the same group appears
+#' repeatedly as it grows. A row is dropped when a LATER row for the same node
+#' and variable covers a strict superset of its original categories — leaving
+#' exactly the groups that survived to the split (tam #37177).
+#'
+#' @param merges Category-merge data frame.
+#' @param node_col,variable_col,categories_col Column names to key on.
+#' @param separator Separator used by `categories_col`.
+#' @return The filtered data frame.
+chaid_keep_final_merges <- function(merges, node_col = 'node_id',
+                                    variable_col = 'variable',
+                                    categories_col = 'original_categories',
+                                    separator = ' | ') {
+  if (is.null(merges) || nrow(merges) == 0) {
+    return(merges)
+  }
+  category.sets <- lapply(merges[[categories_col]], function(value) {
+    if (is.na(value)) character() else trimws(strsplit(value, separator, fixed = TRUE)[[1]])
+  })
+  keep <- rep(TRUE, nrow(merges))
+  for (i in seq_len(nrow(merges))) {
+    later <- which(seq_len(nrow(merges)) > i &
+                     merges[[node_col]] == merges[[node_col]][i] &
+                     merges[[variable_col]] == merges[[variable_col]][i])
+    for (j in later) {
+      if (length(category.sets[[i]]) < length(category.sets[[j]]) &&
+          all(category.sets[[i]] %in% category.sets[[j]])) {
+        keep[i] <- FALSE
+        break
+      }
+    }
+  }
+  merges[keep, , drop = FALSE]
+}

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -213,11 +213,13 @@ test_that("numeric_intervals reports initial binning + final intervals per numer
                                          min_split = 30, min_bucket = 15,
                                          max_depth = 3))
   ni <- model_df %>% tidy_rowwise(model, type = "numeric_intervals")
+  # tam #37177: "Initial Binning" was split into method + bin count.
   expect_equal(colnames(ni),
-               c("Node", "Variable", "Initial Binning", "Final Intervals"))
+               c("Node", "Variable", "Binning Method", "Initial Bins", "Final Intervals"))
   # Only numeric predictors appear.
   expect_true(all(ni$Variable %in% c("age", "salary")))
-  expect_true(all(grepl("bins$", ni[["Initial Binning"]])))
+  expect_true(all(ni[["Binning Method"]] %in% c("quantile", "equal_width")))
+  expect_true(all(ni[["Initial Bins"]] > 0))
   expect_true(all(nchar(ni[["Final Intervals"]]) > 0))
 })
 
@@ -234,7 +236,7 @@ test_that("numeric_intervals is empty when no numeric predictor is binned", {
   ni <- model_df %>% tidy_rowwise(model, type = "numeric_intervals")
   expect_equal(nrow(ni), 0)
   expect_equal(colnames(ni),
-               c("Node", "Variable", "Initial Binning", "Final Intervals"))
+               c("Node", "Variable", "Binning Method", "Initial Bins", "Final Intervals"))
 })
 
 test_that("category_error_distribution is empty for a non-ordered target", {

--- a/tests/testthat/test_chaid_report_format.R
+++ b/tests/testthat/test_chaid_report_format.R
@@ -1,0 +1,148 @@
+context('chaid report formatting helpers (tam #37177)')
+
+test_that('chaid_parse_interval recognizes the three bin label shapes', {
+  expect_equal(chaid_parse_interval('<= 3')$upper, '3')
+  expect_equal(chaid_parse_interval('<= 3')$lower_value, -Inf)
+  expect_equal(chaid_parse_interval('> 23')$lower, '23')
+  expect_equal(chaid_parse_interval('> 23')$upper_value, Inf)
+  i <- chaid_parse_interval('(3, 6.7]')
+  expect_equal(i$lower, '3')
+  expect_equal(i$upper, '6.7')
+  expect_null(chaid_parse_interval('Missing'))
+  expect_null(chaid_parse_interval('研究開発'))
+  expect_null(chaid_parse_interval('<= abc'))
+})
+
+test_that('chaid_collapse_intervals collapses contiguous runs only', {
+  # Spec examples (#37177).
+  expect_equal(chaid_collapse_intervals(c('(3, 5]', '(5, 6.7]', '(6.7, 8]')), '(3, 8]')
+  expect_equal(
+    chaid_collapse_intervals(c('(8, 10]', '(10, 13]', '(13, 17]', '(17, 23]', '> 23')),
+    '> 8')
+  expect_equal(
+    chaid_collapse_intervals(c('<= 26', '(26, 29]', '(29, 31]', '(31, 34]')),
+    '<= 34')
+  expect_equal(
+    chaid_collapse_intervals(c('(38, 41]', '(41, 45]', '(45, 50]', '> 50')),
+    '> 38')
+})
+
+test_that('a gap keeps the pieces enumerated', {
+  # User decision (#37177): never collapse across a gap.
+  expect_equal(chaid_collapse_intervals(c('(34, 36]', '(41, 45]')),
+               c('(34, 36]', '(41, 45]'))
+  expect_equal(chaid_collapse_intervals(c('(3, 5]', '(5, 6.7]', '(10, 13]')),
+               c('(3, 6.7]', '(10, 13]'))
+})
+
+test_that('non-interval members pass through and act as barriers', {
+  expect_equal(chaid_collapse_intervals(c('(3, 5]', '(5, 8]', 'Missing')),
+               c('(3, 8]', 'Missing'))
+  expect_equal(chaid_collapse_intervals(c('研究開発', '人事')), c('研究開発', '人事'))
+  expect_equal(chaid_collapse_intervals(character()), character())
+  expect_equal(chaid_collapse_intervals('<= 3'), '<= 3')
+})
+
+test_that('chaid_readable_condition rewrites the spec examples', {
+  expect_equal(
+    chaid_readable_condition('Root & 勤続年数 in {(3, 5] + (5, 6.7] + (6.7, 8]}'),
+    '3 < 勤続年数 <= 8')
+  expect_equal(
+    chaid_readable_condition(
+      'Root & 勤続年数 in {(8, 10] + (10, 13] + (13, 17] + (17, 23] + > 23} & 部署 in {研究開発 + 人事}'),
+    '勤続年数 > 8 & 部署 in (研究開発 + 人事)')
+})
+
+test_that('chaid_readable_condition handles the root and edge shapes', {
+  expect_equal(chaid_readable_condition('Root'), 'All')
+  expect_equal(chaid_readable_condition(''), 'All')
+  expect_true(is.na(chaid_readable_condition(NA_character_)))
+  expect_equal(chaid_readable_condition('Root & 年齢 in {<= 26}'), '年齢 <= 26')
+  expect_equal(chaid_readable_condition('Root & 年齢 in {> 50}'), '年齢 > 50')
+  expect_equal(chaid_readable_condition('Root & 部署 in {営業}'), '部署 in (営業)')
+  expect_equal(chaid_readable_condition(c('Root', 'Root & 年齢 in {<= 26}')),
+               c('All', '年齢 <= 26'))
+})
+
+test_that('a category value containing " & " does not break condition splitting', {
+  expect_equal(
+    chaid_readable_condition('Root & 部署 in {R & D + 人事} & 年齢 in {<= 26}'),
+    '部署 in (R & D + 人事) & 年齢 <= 26')
+})
+
+test_that('chaid_order_group_parts sorts alphabetically without levels', {
+  expect_equal(chaid_order_group_parts(c('b', 'a', 'c')), c('a', 'b', 'c'))
+  expect_equal(chaid_order_group_parts('a'), 'a')
+})
+
+test_that('chaid_order_group_parts honors declared level order', {
+  levels <- c('既婚', '離婚', '独身')
+  expect_equal(chaid_order_group_parts(c('離婚', '既婚'), levels), c('既婚', '離婚'))
+  expect_equal(chaid_order_group_parts(c('既婚', '離婚'), levels), c('既婚', '離婚'))
+  # Unknown members keep their relative order, after the declared ones.
+  expect_equal(chaid_order_group_parts(c('不明', '離婚'), levels), c('離婚', '不明'))
+})
+
+test_that('chaid_normalize_group_label orders then collapses', {
+  expect_equal(
+    chaid_normalize_group_label('(5, 6.7] + (3, 5]', levels = c('(3, 5]', '(5, 6.7]')),
+    '(3, 6.7]')
+  expect_equal(chaid_normalize_group_label('離婚 + 既婚'), '既婚 + 離婚')
+  expect_equal(
+    chaid_normalize_group_label('離婚 + 既婚', levels = c('既婚', '離婚', '独身')),
+    '既婚 + 離婚')
+  expect_equal(
+    chaid_normalize_group_label('(3, 5] + (5, 6.7]', collapse = FALSE,
+                                levels = c('(3, 5]', '(5, 6.7]')),
+    '(3, 5] + (5, 6.7]')
+})
+
+test_that('chaid_keep_final_merges keeps the last row of each merge chain', {
+  merges <- data.frame(
+    node_id = c(1, 1, 1, 1, 6, 6, 2),
+    variable = c('t', 't', 't', 't', 'a', 'a', 'm'),
+    original_categories = c(
+      '(3, 5] | (5, 6.7]',
+      '(3, 5] | (5, 6.7] | (6.7, 8]',
+      '(8, 10] | (10, 13]',
+      '(8, 10] | (10, 13] | (13, 17]',
+      '<= 26 | (26, 29]',
+      '(34, 36] | (36, 38]',
+      '離婚 | 既婚'),
+    stringsAsFactors = FALSE
+  )
+  kept <- chaid_keep_final_merges(merges)
+  expect_equal(kept$original_categories, c(
+    '(3, 5] | (5, 6.7] | (6.7, 8]',
+    '(8, 10] | (10, 13] | (13, 17]',
+    '<= 26 | (26, 29]',
+    '(34, 36] | (36, 38]',
+    '離婚 | 既婚'))
+})
+
+test_that('chaid_keep_final_merges is a no-op on empty input', {
+  empty <- data.frame(node_id = integer(), variable = character(),
+                      original_categories = character(), stringsAsFactors = FALSE)
+  expect_equal(nrow(chaid_keep_final_merges(empty)), 0)
+})
+
+test_that('chaid_group_level_order prefers the user-declared factor levels', {
+  model <- list(
+    original_factor_levels = list(部署 = c('営業', '研究開発', '人事')),
+    predictor_info = list(
+      部署 = list(ordered = FALSE, levels = c('研究開発', '人事', '営業')),
+      婚姻ステータス = list(ordered = FALSE, levels = c('離婚', '既婚', '独身')),
+      年齢 = list(ordered = TRUE, levels = c('<= 26', '(26, 29]', '> 29'))
+    )
+  )
+  # Declared factor order wins over the post-cleanup appearance order.
+  expect_equal(chaid_group_level_order(model, '部署'), c('営業', '研究開発', '人事'))
+  # A character predictor has no meaningful order -> alphabetical.
+  expect_null(chaid_group_level_order(model, '婚姻ステータス'))
+  # A binned numeric / ordinal keeps its bin order.
+  expect_equal(chaid_group_level_order(model, '年齢'), c('<= 26', '(26, 29]', '> 29'))
+  expect_null(chaid_group_level_order(model, '存在しない列'))
+  expect_equal(
+    chaid_normalize_group_label('人事 + 営業', chaid_group_level_order(model, '部署')),
+    '営業 + 人事')
+})


### PR DESCRIPTION
R-side half of **tam#37177** — "Analytics: CHAID: Updates for Analytics report".
Paired tam PR to follow (JSON template, column renames, bars, % formatting, JA labels).

Display-only formatting for the CHAID report tables. **Nothing here changes how the tree is fitted** — only how already-computed rules, merged category groups and bin labels are presented.

## Two primitives, five spec bullets

New `R/chaid_report_format.R`. The issue asks for "readable conditions" twice (§2 group column, §4-3 condition column) and "collapse to the final range" three times (§4-4 merged categories, §4-5 final intervals, and inside the readable condition) — all of it reduces to two functions.

**`chaid_readable_condition()`**
```
Root & 勤続年数 in {(3, 5] + (5, 6.7] + (6.7, 8]}   ->  3 < 勤続年数 <= 8
… & 部署 in {研究開発 + 人事}                        ->  … & 部署 in (研究開発 + 人事)
Root                                                 ->  All
```
Condition splitting is brace-aware, so a category value containing `" & "` (e.g. `"R & D"`) does not break the parse.

**`chaid_collapse_intervals()`** merges only **adjacent** bins:
```
(3, 5] + (5, 6.7] + (6.7, 8]                       ->  (3, 8]
(8, 10] + (10, 13] + (13, 17] + (17, 23] + > 23    ->  > 8
<= 26 + (26, 29] + (29, 31] + (31, 34]             ->  <= 34
(34, 36] + (41, 45]                                ->  unchanged (gap)
```
A gap keeps the pieces enumerated — collapsing across one would claim values the branch does not contain. Non-interval members (`Missing`, category names) pass through and act as barriers.

## Wired into the tidy layer

| tidy type | change |
|---|---|
| `node_summary`, `rules` | `Rule` is now the readable form |
| `category_merges` | intermediate merge-chain rows dropped; both category columns get a stable member order; merged group collapses contiguous bins |
| `numeric_intervals` | `Initial Binning` split into `Binning Method` + `Initial Bins`; each child edge collapses to the range it covers |

`chaid_keep_final_merges()` drops a row when a **later** row for the same node+variable covers a strict superset of its original categories — leaving exactly the groups that survived to the split. Note a node/variable normally keeps **several** rows (one per surviving group), not one.

## The non-obvious part

Category ordering is "alphabetical, but a Factor keeps its original order". That distinction cannot be made where the merge table is built: `cleanup_df()` turns **every** character predictor into a factor whose levels are merely data-appearance order, so `predictor_info` sees a factor either way. `exp_chaid()` therefore captures `original_factor_levels` from the **pre-cleanup** frame.

This was found by running a real fit (`離婚 + 既婚` stayed unsorted) — the unit tests were all green against the standalone helper. Live execution, not string assertions, per the repo's R-codegen rule.

## Testing

- **45 new assertions** in `test_chaid_report_format.R` — every verbatim example in the issue, plus gap / barrier / root / `"&"`-in-category / declared-factor-order edge cases.
- `test_build_chaid.R` updated for the `numeric_intervals` column split.
- **213 assertions pass** across `test_chaid_report_format.R` (45), `test_build_chaid.R` (96), `test_chaid.R` (72) — 0 failures, 0 errors.
- End-to-end live fits (logical + multiclass targets, Japanese column names, mixed factor/character/numeric predictors) inspected for all four report tables.

## Not in this PR

- **No version bump.** Following the repo pattern (`bd654497` feat → `b08ccaa3` chore: bump), the `DESCRIPTION` bump + installer manifest regen is a separate release step.
- The tam-side rendering (bars, `%` formatting, JA labels) is a separate PR; its render/visual verification is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)