### PR TITLE
feat(cronbach): tidy(type="correlation_method") for the report (tam#37175)

### DIFF
--- a/R/reliability.R
+++ b/R/reliability.R
@@ -728,6 +728,34 @@ tidy.cronbach_alpha_exploratory <- function(x, type = "summary", pretty.name = F
                       `Standardized Item-Total`, `Corrected Correlation`, `Rows`,
                       `Missing`, `Mean`, `Standard Deviation`, `Interpretation`)
     }
+  } else if (type == "correlation_method") {
+    # The "which correlation was used and why" table. English labels only -- the
+    # Analytics report localizes them through the usual translation path.
+    method_label <- switch(x$selected_method,
+      pearson = "Pearson Correlation",
+      polychoric = "Polychoric Correlation",
+      mixed = "Mixed Correlation",
+      x$selected_method)
+    requested <- if (is.null(x$requested_method)) "auto" else x$requested_method
+    reason <- if (requested != "auto") {
+      switch(requested,
+        pearson = "Pearson was specified in the settings.",
+        polychoric = "Polychoric was specified in the settings.",
+        mixed = "Mixed Correlation was specified in the settings.",
+        "Specified in the settings.")
+    } else {
+      unique_types <- unique(unname(x$item_types))
+      if (all(unique_types == "continuous")) {
+        "All variables are Numeric."
+      } else if (all(unique_types %in% c("ordinal", "dichotomous"))) {
+        "All variables are Factor or Logical."
+      } else {
+        "Numeric and Factor/Logical variables are mixed."
+      }
+    }
+    res <- tibble::tibble(
+      `Item` = c("Correlation Type", "Primary Metric", "Selection Reason"),
+      `Value` = c(method_label, x$coefficient_name, reason))
   } else if (type == "correlation") {
     res <- x$correlation_long
   } else if (type == "response_distribution") {

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -109,6 +109,32 @@ test_that("alpha-if-dropped and scale candidates use the reported alpha's estima
   expect_equal(ordinal_candidates$Alpha[[1]], ordinal_reported, tolerance = 1e-8)
 })
 
+test_that("correlation_method reports the method and why it was chosen (#37175)", {
+  df <- make_reliability_df()
+
+  auto_numeric <- exp_cronbach_alpha(df, dplyr::everything()) %>%
+    tidy_rowwise(model, type = "correlation_method")
+  expect_equal(colnames(auto_numeric), c("Item", "Value"))
+  expect_equal(auto_numeric$Item, c("Correlation Type", "Primary Metric", "Selection Reason"))
+  expect_equal(auto_numeric$Value,
+               c("Pearson Correlation", "Cronbach's Alpha", "All variables are Numeric."))
+
+  ordinal_df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(),
+                                                   ~ factor(.x, ordered = TRUE)))
+  auto_ordinal <- exp_cronbach_alpha(ordinal_df, dplyr::everything()) %>%
+    tidy_rowwise(model, type = "correlation_method")
+  expect_equal(auto_ordinal$Value,
+               c("Polychoric Correlation", "Ordinal Alpha",
+                 "All variables are Factor or Logical."))
+
+  # An explicitly requested method reports the request as the reason.
+  explicit <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "mixed") %>%
+    tidy_rowwise(model, type = "correlation_method")
+  expect_equal(explicit$Value,
+               c("Mixed Correlation", "Mixed-Correlation Alpha",
+                 "Mixed Correlation was specified in the settings."))
+})
+
 test_that("response distribution uses Summary View numeric binning", {
   df <- list(
     low_cardinality = c(1L, 1L, 2L, 4L, 4L),


### PR DESCRIPTION
Follow-up to #1553, which merged only its first commit — the `correlation_method` tidy type was pushed to the branch after the merge and never landed on master.

## What this adds

`tidy(type = "correlation_method")` returns the three Item / Value rows behind the Cronbach report's 「選択された相関係数のタイプとその理由」 table:

| Item | Value |
|---|---|
| Correlation Type | Pearson Correlation / Polychoric Correlation / Mixed Correlation |
| Primary Metric | Cronbach's Alpha / Ordinal Alpha / Mixed-Correlation Alpha |
| Selection Reason | the requested method when one was specified, else the item-type rule |

English only — the Analytics report localizes it through the usual translation path.

## Why

tam#37180 turns that table into a real chart table (it was a markdown spec-table built from JS bind variables, so it didn't match the rest of the report). Without this tidy type the table falls through to the `data` branch and renders the raw dataset, so **tam#37180 cannot ship until this merges**.

## Verification

New testthat cases cover auto→pearson, auto→ordinal, and an explicitly requested method. `test_reliability.R`: `PASS 61`. Verified live against the installed package for all three branches.

Version stays 16.0.8 (unreleased — the binaries for it have not been built yet, so this rides the same bump rather than adding another).

🤖 Generated with [Claude Code](https://claude.com/claude-code)