### PR TITLE
fix: guard biplot/variances tidy types against nfactors=1 in exp_factanal (tam#30798)

### DIFF
--- a/R/factanal.R
+++ b/R/factanal.R
@@ -341,7 +341,22 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)
   }
   else if (type == "variances") {
-    res <- tibble::as_tibble(t(x$Vaccounted)) %>% dplyr::mutate(Factor=as.factor(1:n()), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
+    res <- tibble::as_tibble(t(x$Vaccounted))
+    # With a single factor (nfactors=1), psych::fa()'s Vaccounted matrix only reports "SS
+    # loadings" and "Proportion Var" -- "Cumulative Var" / "Proportion Explained" / "Cumulative
+    # Proportion" are omitted since they are trivially equal to (or 100% for) the one and only
+    # factor. Backfill them with those trivial single-factor values so the mutate below (and the
+    # column shape callers rely on) does not depend on nfactors. (issue #30798)
+    if (!"Cumulative Var" %in% colnames(res)) {
+      res <- res %>% dplyr::mutate(`Cumulative Var` = `Proportion Var`)
+    }
+    if (!"Proportion Explained" %in% colnames(res)) {
+      res <- res %>% dplyr::mutate(`Proportion Explained` = 1)
+    }
+    if (!"Cumulative Proportion" %in% colnames(res)) {
+      res <- res %>% dplyr::mutate(`Cumulative Proportion` = 1)
+    }
+    res <- res %>% dplyr::mutate(Factor=as.factor(1:n()), `% Variance`=100*`Proportion Var`, `Cummulated % Variance`=100*`Cumulative Var`)
   }
   else if (type == "loadings") {
     res <- broom:::tidy.factanal(x) # TODO: This just happens to work. Revisit.
@@ -363,6 +378,15 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     }, .desc=TRUE))
   }
   else if (type == "biplot") {
+    if (n_factor < 2) {
+      # Biplot plots Factor 1 against Factor 2, so it needs at least 2 factors. With nfactors=1
+      # there is no "Factor 2" to build factor_2_loading_col/factor_2_score_col from below.
+      # Degrade gracefully -- mirroring the type=="correlation" branch's handling of an
+      # unavailable x$Phi below -- instead of erroring on a missing column. Keep the same column
+      # shape the client's `tidy_rowwise(model, type="biplot") %>% dplyr::rename(...)` expects, so
+      # the rename does not itself fail on a missing column. (issue #30798)
+      return(tibble::tibble(.factor_1 = numeric(0), .factor_2 = numeric(0), .factor_2_variable = numeric(0)))
+    }
     factor_1_loading_col <- paste0(factor_loading_prefix, "1")
     factor_2_loading_col <- paste0(factor_loading_prefix, "2")
     factor_1_score_col <- paste0(factor_score_prefix, "1")

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -178,6 +178,49 @@ test_that("exp_factanal with strange column name and all-NA column", {
   expect_equal(colnames(res), c("variable", "Communality", "Uniqueness", "Judgement", "judgement_status"))
 })
 
+test_that("exp_factanal with nfactors=1 (issue #30798)", {
+  # Biplot plots Factor 1 vs Factor 2, so it is the only tidy type that structurally cannot
+  # support a single factor. It must degrade gracefully to an empty result with the same column
+  # shape the client expects, instead of erroring on a missing "Factor 2" column. Every other
+  # tidy type must keep working normally with nfactors=1 -- exercise every type used elsewhere in
+  # this test file to guard against a similar nfactors>=2 assumption lurking anywhere else.
+  df <- mtcars %>% mutate(new_col = c(rep("A", n() - 10), rep("B", 10)))
+  model_df <- exp_factanal(df, cyl, mpg, hp, drat, max_nrow=30, nfactors=1, fm="minres")
+
+  res <- model_df %>% tidy_rowwise(model, type="biplot")
+  expect_equal(nrow(res), 0)
+  expect_true(all(c(".factor_1", ".factor_2", ".factor_2_variable") %in% colnames(res)))
+  expect_true(is.numeric(res$.factor_1))
+  expect_true(is.numeric(res$.factor_2))
+  expect_true(is.numeric(res$.factor_2_variable))
+
+  # "variances" needs its own value-level check: psych::fa()'s Vaccounted matrix omits
+  # "Cumulative Var" / "Proportion Explained" / "Cumulative Proportion" when nfactors=1 (they are
+  # trivial for a single factor), and factanal.R backfills them. For one factor: cumulative
+  # variance up through "the only factor" equals that factor's own proportion, and that one
+  # factor explains 100% of whatever is explained.
+  variances_res <- model_df %>% tidy_rowwise(model, type="variances")
+  expect_equal(nrow(variances_res), 1)
+  expect_equal(variances_res$`Cumulative Var`, variances_res$`Proportion Var`)
+  expect_equal(variances_res$`Proportion Explained`, 1)
+  expect_equal(variances_res$`Cumulative Proportion`, 1)
+  expect_equal(variances_res$`Cummulated % Variance`, variances_res$`% Variance`)
+
+  # Every other tidy/glance type must run cleanly with nfactors=1 (no other nfactors>=2
+  # assumption should exist elsewhere in this file besides biplot/variances).
+  expect_no_error(model_df %>% glance_rowwise(model, pretty.name=TRUE))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="loadings"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="correlation"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="screeplot"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="data"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="suitability"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="factor_count"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="parallel_screeplot"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="loadings_wide"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="communalities"))
+  expect_no_error(model_df %>% tidy_rowwise(model, type="communalities_long"))
+})
+
 test_that("factor analysis report judgment helpers (issue #37018)", {
   cfg <- factanal_report_config()
 


### PR DESCRIPTION
## Description

Companion fix for exploratory-io/tam#30798 (Analytics: Factor Analysis: Supports a factor count of 1).

`exp_factanal` wraps `psych::fa()`, which fully supports `nfactors=1` with no library-level restriction. The tam-side PR (exploratory-io/tam#37197) relaxes the UI floor from 2 to 1. This PR fixes the two R-side tidy-dispatch branches that crash for `nfactors=1`:

1. `type=="biplot"` — plots Factor 1 vs Factor 2, hardcodes access to a "Factor 2" column that doesn't exist with only one factor.
2. `type=="variances"` — `psych::fa()`'s `Vaccounted` matrix omits the `Cumulative Var` / `Proportion Explained` / `Cumulative Proportion` rows when there's only one factor, so the existing `mutate()` throws `object 'Cumulative Var' not found`. Found via this task's own mandatory "verify no other tidy type breaks" step, not part of the original report.

**⚠️ Release note:** the tam PR (#37197) is held as a draft specifically because it depends on this fix landing and the `exploratory` package being version-bumped + rebuilt first — see that PR's description for the coordination note. Please merge/release this before tam#37197 goes out.

## Implementation Details

- `R/factanal.R`, `type=="biplot"` branch: added an early guard — when `n_factor < 2`, returns `tibble::tibble(.factor_1=numeric(0), .factor_2=numeric(0), .factor_2_variable=numeric(0))` before any code that would reference a nonexistent "Factor 2" column. Shape verified against the tam-side consumer (`exp_factanal.json`'s Biplot preprocessor does an UNCONDITIONAL `dplyr::rename(\`Factor 1\`=.factor_1, \`Factor 2\`=.factor_2, Variables=.factor_2_variable)`, unlike the Correlation tab's guarded rename), so all 3 columns must be present even with 0 rows.
- `R/factanal.R`, `type=="variances"` branch: backfills `Cumulative Var` / `Proportion Explained` / `Cumulative Proportion` with their mathematically-correct single-factor values (`Cumulative Var = Proportion Var`; `Proportion Explained = 1`; `Cumulative Proportion = 1` — confirmed via live comparison against `psych::fa()`'s own nfactors=2 output that "Proportion Explained" is defined relative to *explained* variance, not total, so `=1` is correct even when total variance explained is well under 100%), using the `!"X" %in% colnames(res)`-style guard already established elsewhere in this codebase (`google_drive.R`, `prophet.R`, `randomForest_tidiers.R`, etc.).
- `tests/testthat/test_factanal.R`: new `test_that("exp_factanal with nfactors=1 (issue #30798)", ...)` — asserts the biplot empty-shape, the variances backfill values, and `expect_no_error()` across every other tidy-dispatch branch in this file (loadings, correlation, screeplot, data, suitability, factor_count, parallel_screeplot, loadings_wide, communalities, communalities_long) plus `glance_rowwise`.

## Build Impact

No new dependencies. Two functions in `R/factanal.R` gain defensive guards; no signature changes.

## How to Test

```r
devtools::load_all(".")
df <- data.frame(a=rnorm(50), b=rnorm(50), c=rnorm(50), d=rnorm(50))
result <- df %>% exp_factanal(a, b, c, d, nfactors = 1)
result %>% tidy_rowwise(model, type = "biplot") %>% print()    # 0 rows, 3 columns, no error
result %>% tidy_rowwise(model, type = "variances") %>% print() # Proportion Explained = 1, no error
```

```bash
Rscript -e 'devtools::test(filter = "factanal")'
```

## Test Results

`[FAIL 0 | WARN 1 | SKIP 0 | PASS 289]` — 21 new passing assertions, 0 regressions. The one warning ("ultra-Heywood case detected") is pre-existing and identical on `origin/master` (`[FAIL 0 | WARN 1 | SKIP 0 | PASS 268]`), confirmed by diffing both runs.

## Documents

- [tam design doc](https://github.com/exploratory-io/tam/blob/fix/bug-fix-session-daab09/docs/plans/design/30798_design.md)
- [tam implementation plan](https://github.com/exploratory-io/tam/blob/fix/bug-fix-session-daab09/docs/plans/design/30798_plan.md)
- Paired tam PR: exploratory-io/tam#37197
