### PR TITLE
Factor Analysis: support polychoric correlation (tam#26623)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.9
+Version: 16.0.10
 Date: 2026-07-21
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -224,8 +224,9 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
 #'        Tetrachoric / Polychoric / Mixed from the variable types and response distributions,
 #'        "pearson" and "polychoric" force that correlation. The SAME matrix drives fa(), KMO,
 #'        Bartlett, the eigenvalues, the parallel analysis and the factor scores. (issue #26623)
-#' @param parallel_n_iter Iterations of the parallel analysis null distribution. Polychoric-family
-#'        correlations are far more expensive per iteration, so they use a smaller default.
+#' @param parallel_n_iter Iterations of the parallel analysis null distribution (default 100 for
+#'        every correlation type). Polychoric-family correlations re-estimate the correlation on
+#'        each iteration, so this is the dominant cost of a polychoric run.
 exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1,
                          cor_type = "auto", parallel_n_iter = NULL) {
   # this evaluates select arguments like starts_with
@@ -298,12 +299,19 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # (e.g. a polychoric fa() next to a Pearson KMO or parallel analysis). (issue #26623)
     selection <- select_factor_correlation_type(cleaned_df)
     resolved <- resolve_factanal_correlation_type(cor_type, selection)
-    if (identical(resolved$type, "unsupported")) {
+    # An unsupported variable combination (a nominal category, a constant column) is unsupported
+    # whichever correlation was asked for -- picking Pearson manually must not smuggle a nominal
+    # column in as arbitrary integer codes. So gate on the SELECTION, not the resolved type.
+    if (identical(selection$selected_method, "unsupported") || identical(resolved$type, "unsupported")) {
       stop(paste0("EXP-ANA-6 :: [] :: ", selection$reason))
     }
     # Category-ordered numeric coding. For an all-numeric data frame this is a no-op, so the
     # Pearson path stays bit-for-bit what it was before this change.
     encoded_df <- encode_factanal_data(cleaned_df, selection)
+    # The correlation family that was ASKED for. It differs from resolved$type only when the
+    # estimation fails and we degrade to Pearson, and the diagnostics table needs the asked-for
+    # one so the failure is reported instead of silently disappearing with the table.
+    requested_family <- resolved$type
 
     if (identical(resolved$type, "pearson")) {
       fit <- psych::fa(encoded_df, nfactors = nfactors, fm = fm, scores = scores, rotate = rotate)
@@ -313,17 +321,25 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     } else {
       # Correlation-matrix based fit. n.obs is mandatory here: without it psych assumes 100 rows
       # and every sample-size dependent fit index would be wrong.
-      cor_result <- build_factor_correlation(encoded_df, resolved$type)
+      cor_result <- build_factor_correlation(encoded_df, requested_family)
       cor_mat <- cor_result$correlation
       if (isTRUE(cor_result$failed)) {
         # build_factor_correlation already degraded to Pearson; keep the reported type honest.
+        # requested_family stays as asked so the diagnostics table can still REPORT the failure.
         resolved$type <- "pearson"
       }
       fit <- psych::fa(cor_mat, nfactors = nfactors, n.obs = nrow(encoded_df), fm = fm, rotate = rotate)
-      # fa() on a correlation matrix never returns scores, so compute them from the same matrix.
+      # fa() on a correlation matrix never returns scores, so compute them from the same matrix,
+      # honoring the "Type of Scores" property instead of hardcoding one method.
       fit$scores <- tryCatch({
-        psych::factor.scores(as.matrix(encoded_df), fit, rho = cor_mat, method = "Thurstone")$scores
+        psych::factor.scores(as.matrix(encoded_df), fit, rho = cor_mat,
+                             method = factanal_score_method(scores))$scores
       }, error = function(e) NULL)
+      if (is.null(fit$scores)) {
+        # Keep the shape so the score-consuming outputs (Data tab, biplot) degrade to NA columns
+        # instead of aborting inside broom's augment().
+        fit$scores <- matrix(NA_real_, nrow = nrow(encoded_df), ncol = nfactors)
+      }
     }
 
     fit$correlation <- cor_mat # For creating scree plot later.
@@ -350,7 +366,9 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     fit$parallel <- tryCatch(compute_parallel_analysis(encoded_df, n_iter = n_iter,
                                                        cor_type = resolved$type, cor_matrix = cor_mat),
                              error = function(e) NULL)
-    fit$cor_diagnostics <- if (identical(resolved$type, "pearson")) NULL else {
+    # Keyed off the REQUESTED family, so a failed polychoric estimation still shows the table with
+    # its "Estimation failed" row rather than hiding the only signal the user has.
+    fit$cor_diagnostics <- if (identical(requested_family, "pearson")) NULL else {
       tryCatch(compute_polychoric_diagnostics(encoded_df, cor_result, selection), error = function(e) NULL)
     }
     class(fit) <- c("fa_exploratory", class(fit))
@@ -630,7 +648,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       Value = c(
         factanal_correlation_label(cor_type),
         factanal_extraction_method_label(x$fm),
-        stringr::str_to_title(as.character(rotation)),
+        factanal_rotation_label(rotation),
         if (length(x$n_variables) == 1L && !is.na(x$n_variables)) as.character(x$n_variables) else "N/A",
         if (length(x$n_rows_used) == 1L && !is.na(x$n_rows_used)) as.character(x$n_rows_used) else "N/A"
       ),
@@ -638,6 +656,9 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # part of the rendered Item/Value table.
       correlation_type = cor_type,
       correlation_is_auto = isTRUE(x$correlation_is_auto),
+      # TRUE also when a polychoric estimation failed and the fit degraded to Pearson, so the
+      # report still shows the diagnostics table that reports the failure.
+      has_diagnostics = !is.null(x$cor_diagnostics) && nrow(x$cor_diagnostics) > 0,
       reason = if (is.null(x$correlation_reason)) "" else x$correlation_reason
     )
   }

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -138,7 +138,13 @@ judge_loading <- function(loadings, cfg = factanal_report_config()) {
 
 # Horn's parallel analysis: compares actual correlation-matrix eigenvalues against the
 # quantile of eigenvalues from random normal data of the same shape. (issue #37018 spec 3.4)
-compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95) {
+#' @param cor_type Correlation type the whole analysis uses. For anything other than "pearson" both the
+#'        actual and the random-data eigenvalues are computed with that same correlation, so the parallel
+#'        analysis never silently falls back to Pearson. (issue #26623)
+#' @param cor_matrix Correlation matrix already built for the analysis. Reused for the actual eigenvalues
+#'        so the scree/parallel chart matches the matrix `fa()` was fitted on.
+compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
+                                      cor_type = "pearson", cor_matrix = NULL) {
   if (length(n_iter) != 1L || is.na(n_iter) || n_iter < 1 || n_iter != as.integer(n_iter)) {
     stop("n_iter must be a positive integer")
   }
@@ -149,6 +155,41 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95) {
   x <- as.data.frame(x)
   n <- nrow(x)
   p <- ncol(x)
+  if (!identical(cor_type, "pearson")) {
+    # Polychoric/tetrachoric/mixed: the null distribution is built by shuffling each column
+    # independently, which keeps every variable's category marginals but destroys the association,
+    # and the SAME correlation method is applied to it. Drawing normal deviates instead would
+    # compare a polychoric eigenvalue against a Pearson one.
+    actual_eigen <- if (!is.null(cor_matrix)) {
+      eigen(cor_matrix, symmetric = TRUE, only.values = TRUE)$values
+    } else {
+      eigen(build_factor_correlation(x, cor_type)$correlation, symmetric = TRUE, only.values = TRUE)$values
+    }
+    had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    old_seed <- if (had_seed) get(".Random.seed", envir = .GlobalEnv) else NULL
+    set.seed(1234)
+    on.exit({
+      if (had_seed) {
+        assign(".Random.seed", old_seed, envir = .GlobalEnv)
+      } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+        rm(".Random.seed", envir = .GlobalEnv)
+      }
+    }, add = TRUE)
+    random_eigen_mat <- replicate(n_iter, {
+      shuffled <- as.data.frame(lapply(x, function(col) col[sample.int(n)]))
+      res <- build_factor_correlation(shuffled, cor_type)
+      eigen(res$correlation, symmetric = TRUE, only.values = TRUE)$values
+    })
+    random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
+    return(list(
+      recommended_n = sum(actual_eigen > random_threshold),
+      table = tibble::tibble(
+        factor_number = seq_along(actual_eigen),
+        actual_eigenvalue = actual_eigen,
+        random_eigenvalue_threshold = random_threshold
+      )
+    ))
+  }
   actual_eigen <- eigen(cor(x, use = "pairwise.complete.obs"), only.values = TRUE)$values
   # Snapshot the RNG so this null-distribution draw does not perturb the outer deterministic
   # stream that later groups' sampling relies on. Restore afterward.
@@ -179,7 +220,14 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95) {
 
 #' Function for Factor Analysis Analytics View
 #' @export
-exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1) {
+#' @param cor_type Correlation used for the whole analysis. "auto" (default) picks Pearson /
+#'        Tetrachoric / Polychoric / Mixed from the variable types and response distributions,
+#'        "pearson" and "polychoric" force that correlation. The SAME matrix drives fa(), KMO,
+#'        Bartlett, the eigenvalues, the parallel analysis and the factor scores. (issue #26623)
+#' @param parallel_n_iter Iterations of the parallel analysis null distribution. Polychoric-family
+#'        correlations are far more expensive per iteration, so they use a smaller default.
+exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1,
+                         cor_type = "auto", parallel_n_iter = NULL) {
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
   if (length(selected_cols) < nfactors) {
@@ -245,10 +293,46 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
         return(NULL)
       }
     }
-    fit <- psych::fa(cleaned_df, nfactors = nfactors, fm = fm, scores = scores, rotate = rotate)
+    # Decide which correlation the whole analysis runs on, and build that ONE matrix. Every
+    # downstream computation below reads it, so the report can never mix Pearson and Polychoric
+    # (e.g. a polychoric fa() next to a Pearson KMO or parallel analysis). (issue #26623)
+    selection <- select_factor_correlation_type(cleaned_df)
+    resolved <- resolve_factanal_correlation_type(cor_type, selection)
+    if (identical(resolved$type, "unsupported")) {
+      stop(paste0("EXP-ANA-6 :: [] :: ", selection$reason))
+    }
+    # Category-ordered numeric coding. For an all-numeric data frame this is a no-op, so the
+    # Pearson path stays bit-for-bit what it was before this change.
+    encoded_df <- encode_factanal_data(cleaned_df, selection)
 
-    cor_mat <- cor(cleaned_df)
+    if (identical(resolved$type, "pearson")) {
+      fit <- psych::fa(encoded_df, nfactors = nfactors, fm = fm, scores = scores, rotate = rotate)
+      cor_result <- list(correlation = cor(encoded_df), thresholds = NULL, type = "pearson",
+                         smoothed = FALSE, warnings = character(), failed = FALSE)
+      cor_mat <- cor_result$correlation
+    } else {
+      # Correlation-matrix based fit. n.obs is mandatory here: without it psych assumes 100 rows
+      # and every sample-size dependent fit index would be wrong.
+      cor_result <- build_factor_correlation(encoded_df, resolved$type)
+      cor_mat <- cor_result$correlation
+      if (isTRUE(cor_result$failed)) {
+        # build_factor_correlation already degraded to Pearson; keep the reported type honest.
+        resolved$type <- "pearson"
+      }
+      fit <- psych::fa(cor_mat, nfactors = nfactors, n.obs = nrow(encoded_df), fm = fm, rotate = rotate)
+      # fa() on a correlation matrix never returns scores, so compute them from the same matrix.
+      fit$scores <- tryCatch({
+        psych::factor.scores(as.matrix(encoded_df), fit, rho = cor_mat, method = "Thurstone")$scores
+      }, error = function(e) NULL)
+    }
+
     fit$correlation <- cor_mat # For creating scree plot later.
+    fit$correlation_type <- resolved$type
+    fit$correlation_is_auto <- isTRUE(resolved$auto)
+    fit$correlation_reason <- resolved$reason
+    fit$correlation_selection <- selection
+    fit$correlation_result <- cor_result[setdiff(names(cor_result), "correlation")]
+    fit$nfactors_requested <- nfactors
     fit$df <- filtered_df # add filtered df to model so that we can bind_col it for output. It needs to be the filtered one to match row number.
     fit$grouped_cols <- grouped_cols
     fit$sampled_nrow <- sampled_nrow
@@ -257,9 +341,18 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # guarded so a singular/degenerate correlation matrix degrades to NA instead of aborting.
     fit$n_rows_used <- nrow(cleaned_df)
     fit$n_variables <- ncol(cleaned_df)
+    # KMO and Bartlett take the correlation MATRIX (never the raw data): passing raw data would
+    # make psych recompute a Pearson correlation internally and silently contradict a polychoric
+    # fit. cortest.bartlett also needs n explicitly, or it assumes n = 100. (issue #26623)
     fit$kmo <- tryCatch(as.numeric(psych::KMO(cor_mat)$MSA), error = function(e) NA_real_)
-    fit$bartlett <- tryCatch(psych::cortest.bartlett(cor_mat, n = nrow(cleaned_df)), error = function(e) NULL)
-    fit$parallel <- tryCatch(compute_parallel_analysis(cleaned_df), error = function(e) NULL)
+    fit$bartlett <- tryCatch(psych::cortest.bartlett(cor_mat, n = nrow(encoded_df)), error = function(e) NULL)
+    n_iter <- if (!is.null(parallel_n_iter)) parallel_n_iter else 100
+    fit$parallel <- tryCatch(compute_parallel_analysis(encoded_df, n_iter = n_iter,
+                                                       cor_type = resolved$type, cor_matrix = cor_mat),
+                             error = function(e) NULL)
+    fit$cor_diagnostics <- if (identical(resolved$type, "pearson")) NULL else {
+      tryCatch(compute_polychoric_diagnostics(encoded_df, cor_result, selection), error = function(e) NULL)
+    }
     class(fit) <- c("fa_exploratory", class(fit))
     fit
   }
@@ -363,6 +456,15 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     }, .desc=TRUE))
   }
   else if (type == "biplot") {
+    if (n_factor < 2) {
+      # Biplot plots Factor 1 against Factor 2, so it needs at least 2 factors. With nfactors=1
+      # there is no "Factor 2" to build factor_2_loading_col/factor_2_score_col from below.
+      # Degrade gracefully -- mirroring the type=="correlation" branch's handling of an
+      # unavailable x$Phi above -- instead of erroring on a missing column. Keep the same column
+      # shape the client's `tidy_rowwise(model, type="biplot") %>% dplyr::rename(...)` expects, so
+      # the rename does not itself fail on a missing column. (issue #30798)
+      return(tibble::tibble(.factor_1 = numeric(0), .factor_2 = numeric(0), .factor_2_variable = numeric(0)))
+    }
     factor_1_loading_col <- paste0(factor_loading_prefix, "1")
     factor_2_loading_col <- paste0(factor_loading_prefix, "2")
     factor_1_score_col <- paste0(factor_score_prefix, "1")
@@ -515,6 +617,39 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
                       "Number of variables used in the analysis."),
       status = c(kj$status, bj$status, "", "")
     )
+  }
+  else if (type == "analysis_method") {
+    # Report header table: what the numbers below were actually computed with. (issue #26623)
+    cor_type <- if (is.null(x$correlation_type)) "pearson" else x$correlation_type
+    rotation <- if (!is.null(x$rotation)) x$rotation else "none"
+    res <- tibble::tibble(
+      # NOTE: "Target Variables" / "Data Rows" instead of the shorter "Variables" / "Rows":
+      # the client's shared translation map already binds those two keys to different wordings
+      # for other tables, and a direct-map key can only have one translation. (issue #26623)
+      Item = c("Correlation", "Factor Extraction Method", "Rotation", "Target Variables", "Data Rows"),
+      Value = c(
+        factanal_correlation_label(cor_type),
+        factanal_extraction_method_label(x$fm),
+        stringr::str_to_title(as.character(rotation)),
+        if (length(x$n_variables) == 1L && !is.na(x$n_variables)) as.character(x$n_variables) else "N/A",
+        if (length(x$n_rows_used) == 1L && !is.na(x$n_rows_used)) as.character(x$n_rows_used) else "N/A"
+      ),
+      # Hidden columns. The client reads them to bind the report's explanation text; they are not
+      # part of the rendered Item/Value table.
+      correlation_type = cor_type,
+      correlation_is_auto = isTRUE(x$correlation_is_auto),
+      reason = if (is.null(x$correlation_reason)) "" else x$correlation_reason
+    )
+  }
+  else if (type == "cor_diagnostics") {
+    # Polychoric-family data suitability diagnostics. Empty tibble (with the same columns) when
+    # the analysis ran on Pearson, so the client can hide the section. (issue #26623)
+    res <- if (is.null(x$cor_diagnostics)) {
+      tibble::tibble(Diagnostic = character(), Judgement = character(),
+                     Description = character(), status = character())
+    } else {
+      x$cor_diagnostics
+    }
   }
   else if (type == "factor_count") {
     eig <- eigen(x$correlation, only.values = TRUE)$values

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -341,6 +341,12 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # whichever correlation was asked for -- picking Pearson manually must not smuggle a nominal
     # column in as arbitrary integer codes. So gate on the SELECTION, not the resolved type.
     if (identical(selection$selected_method, "unsupported") || identical(resolved$type, "unsupported")) {
+      if (length(grouped_cols) > 0) {
+        # With Repeat By, skip just this group -- mirroring the not-enough-columns guard above.
+        # One facet whose columns degenerate (e.g. a single observed value plus NAs) must not
+        # abort every other facet. (issue #26623)
+        return(NULL)
+      }
       # EXP-ANA-35 carries the offending column names as its params, so the client can name them.
       # (EXP-ANA-6 is PCA's reserved-column-name error -- do not reuse it here.)
       unsupported_vars <- selection$variable_summary$variable[
@@ -527,15 +533,6 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     }, .desc=TRUE))
   }
   else if (type == "biplot") {
-    if (n_factor < 2) {
-      # Biplot plots Factor 1 against Factor 2, so it needs at least 2 factors. With nfactors=1
-      # there is no "Factor 2" to build factor_2_loading_col/factor_2_score_col from below.
-      # Degrade gracefully -- mirroring the type=="correlation" branch's handling of an
-      # unavailable x$Phi above -- instead of erroring on a missing column. Keep the same column
-      # shape the client's `tidy_rowwise(model, type="biplot") %>% dplyr::rename(...)` expects, so
-      # the rename does not itself fail on a missing column. (issue #30798)
-      return(tibble::tibble(.factor_1 = numeric(0), .factor_2 = numeric(0), .factor_2_variable = numeric(0)))
-    }
     factor_1_loading_col <- paste0(factor_loading_prefix, "1")
     factor_2_loading_col <- paste0(factor_loading_prefix, "2")
     factor_1_score_col <- paste0(factor_score_prefix, "1")

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -220,7 +220,7 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
   }, add = TRUE)
   random_eigen_mat <- replicate(n_iter, {
     rd <- matrix(stats::rnorm(n * p), nrow = n, ncol = p)
-    eigen(cor(rd), only.values = TRUE)$values
+    eigen(cor(rd), symmetric = TRUE, only.values = TRUE)$values
   })
   random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
   list(

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -190,7 +190,13 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
       )
     ))
   }
-  actual_eigen <- eigen(cor(x, use = "pairwise.complete.obs"), only.values = TRUE)$values
+  # Reuse the analysis's own matrix when it was handed one, so the scree/parallel chart and the
+  # fit can never be based on two separately-computed Pearson matrices. (issue #26623)
+  actual_eigen <- if (!is.null(cor_matrix)) {
+    eigen(cor_matrix, only.values = TRUE)$values
+  } else {
+    eigen(cor(x, use = "pairwise.complete.obs"), only.values = TRUE)$values
+  }
   # Snapshot the RNG so this null-distribution draw does not perturb the outer deterministic
   # stream that later groups' sampling relies on. Restore afterward.
   had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
@@ -303,7 +309,13 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # whichever correlation was asked for -- picking Pearson manually must not smuggle a nominal
     # column in as arbitrary integer codes. So gate on the SELECTION, not the resolved type.
     if (identical(selection$selected_method, "unsupported") || identical(resolved$type, "unsupported")) {
-      stop(paste0("EXP-ANA-6 :: [] :: ", selection$reason))
+      # EXP-ANA-35 carries the offending column names as its params, so the client can name them.
+      # (EXP-ANA-6 is PCA's reserved-column-name error -- do not reuse it here.)
+      unsupported_vars <- selection$variable_summary$variable[
+        selection$variable_summary$detected_type %in% c("nominal", "invalid")]
+      stop(paste0("EXP-ANA-35 :: ",
+                  jsonlite::toJSON(paste(unsupported_vars, collapse = ", ")),
+                  " :: ", selection$reason))
     }
     # Category-ordered numeric coding. For an all-numeric data frame this is a no-op, so the
     # Pearson path stays bit-for-bit what it was before this change.
@@ -325,8 +337,13 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
       cor_mat <- cor_result$correlation
       if (isTRUE(cor_result$failed)) {
         # build_factor_correlation already degraded to Pearson; keep the reported type honest.
-        # requested_family stays as asked so the diagnostics table can still REPORT the failure.
+        # requested_family stays as asked so the diagnostics table can still REPORT the failure,
+        # and degraded_from lets the report say WHICH correlation failed instead of claiming the
+        # variables were treated as continuous on purpose.
         resolved$type <- "pearson"
+        resolved$degraded_from <- requested_family
+        resolved$reason <- sprintf("%s could not be estimated, so Pearson correlation was used instead.",
+                                   factanal_correlation_label(requested_family))
       }
       fit <- psych::fa(cor_mat, nfactors = nfactors, n.obs = nrow(encoded_df), fm = fm, rotate = rotate)
       # fa() on a correlation matrix never returns scores, so compute them from the same matrix,
@@ -346,6 +363,7 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     fit$correlation_type <- resolved$type
     fit$correlation_is_auto <- isTRUE(resolved$auto)
     fit$correlation_reason <- resolved$reason
+    fit$correlation_degraded_from <- if (is.null(resolved$degraded_from)) "" else resolved$degraded_from
     fit$correlation_selection <- selection
     fit$correlation_result <- cor_result[setdiff(names(cor_result), "correlation")]
     fit$nfactors_requested <- nfactors
@@ -656,6 +674,13 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # part of the rendered Item/Value table.
       correlation_type = cor_type,
       correlation_is_auto = isTRUE(x$correlation_is_auto),
+      # Non-empty when the requested correlation could not be estimated and the fit fell back to
+      # Pearson, so the report can say so instead of inventing a rationale.
+      degraded_from = if (is.null(x$correlation_degraded_from)) "" else x$correlation_degraded_from,
+      # Whether suggesting Polychoric makes sense for this data at all.
+      polychoric_available = factanal_polychoric_available(x$correlation_selection),
+      # Language-neutral tokens for the selector's warnings; the client renders the localized text.
+      warning_tokens = paste(factanal_selection_warning_tokens(x$correlation_selection), collapse = ","),
       # TRUE also when a polychoric estimation failed and the fit degraded to Pearson, so the
       # report still shows the diagnostics table that reports the failure.
       has_diagnostics = !is.null(x$cor_diagnostics) && nrow(x$cor_diagnostics) > 0,

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -175,11 +175,20 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
         rm(".Random.seed", envir = .GlobalEnv)
       }
     }, add = TRUE)
-    random_eigen_mat <- replicate(n_iter, {
+    random_eigen_list <- lapply(seq_len(n_iter), function(i) {
       shuffled <- as.data.frame(lapply(x, function(col) col[sample.int(n)]))
       res <- build_factor_correlation(shuffled, cor_type)
+      # build_factor_correlation degrades to Pearson when the estimation fails. Comparing a
+      # polychoric eigenvalue against a Pearson threshold is exactly the mix-up this whole change
+      # exists to prevent, so drop the iteration instead.
+      if (isTRUE(res$failed)) return(NULL)
       eigen(res$correlation, symmetric = TRUE, only.values = TRUE)$values
     })
+    random_eigen_list <- random_eigen_list[!vapply(random_eigen_list, is.null, logical(1))]
+    if (length(random_eigen_list) == 0) {
+      return(NULL) # no usable null distribution; the caller reports the parallel analysis as unavailable
+    }
+    random_eigen_mat <- do.call(cbind, random_eigen_list)
     random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
     return(list(
       recommended_n = sum(actual_eigen > random_threshold),
@@ -193,9 +202,9 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
   # Reuse the analysis's own matrix when it was handed one, so the scree/parallel chart and the
   # fit can never be based on two separately-computed Pearson matrices. (issue #26623)
   actual_eigen <- if (!is.null(cor_matrix)) {
-    eigen(cor_matrix, only.values = TRUE)$values
+    eigen(cor_matrix, symmetric = TRUE, only.values = TRUE)$values
   } else {
-    eigen(cor(x, use = "pairwise.complete.obs"), only.values = TRUE)$values
+    eigen(cor(x, use = "pairwise.complete.obs"), symmetric = TRUE, only.values = TRUE)$values
   }
   # Snapshot the RNG so this null-distribution draw does not perturb the outer deterministic
   # stream that later groups' sampling relies on. Restore afterward.
@@ -344,6 +353,7 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
         resolved$degraded_from <- requested_family
         resolved$reason <- sprintf("%s could not be estimated, so Pearson correlation was used instead.",
                                    factanal_correlation_label(requested_family))
+        # degraded_from stays the TOKEN ("polychoric"/...), which the client renders per language.
       }
       fit <- psych::fa(cor_mat, nfactors = nfactors, n.obs = nrow(encoded_df), fm = fm, rotate = rotate)
       # fa() on a correlation matrix never returns scores, so compute them from the same matrix,
@@ -365,6 +375,8 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     fit$correlation_reason <- resolved$reason
     fit$correlation_degraded_from <- if (is.null(resolved$degraded_from)) "" else resolved$degraded_from
     fit$correlation_selection <- selection
+    # Computed here, while the data is in hand: whether Polychoric is worth offering for this data.
+    fit$correlation_polychoric_available <- factanal_polychoric_available(selection, encoded_df)
     fit$correlation_result <- cor_result[setdiff(names(cor_result), "correlation")]
     fit$nfactors_requested <- nfactors
     fit$df <- filtered_df # add filtered df to model so that we can bind_col it for output. It needs to be the filtered one to match row number.
@@ -466,7 +478,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   n_factor <- x$factors # Number of factors.
 
   if (type == "screeplot") {
-    eigen_res <- eigen(x$correlation, only.values = TRUE) # Cattell's scree plot is eigenvalues of correlation/covariance matrix.
+    eigen_res <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE) # Cattell's scree plot is eigenvalues of correlation/covariance matrix.
     res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)
   }
   else if (type == "variances") {
@@ -678,7 +690,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # Pearson, so the report can say so instead of inventing a rationale.
       degraded_from = if (is.null(x$correlation_degraded_from)) "" else x$correlation_degraded_from,
       # Whether suggesting Polychoric makes sense for this data at all.
-      polychoric_available = factanal_polychoric_available(x$correlation_selection),
+      polychoric_available = isTRUE(x$correlation_polychoric_available),
       # Language-neutral tokens for the selector's warnings; the client renders the localized text.
       warning_tokens = paste(factanal_selection_warning_tokens(x$correlation_selection), collapse = ","),
       # TRUE also when a polychoric estimation failed and the fit degraded to Pearson, so the
@@ -698,7 +710,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     }
   }
   else if (type == "factor_count") {
-    eig <- eigen(x$correlation, only.values = TRUE)$values
+    eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     kaiser_n <- sum(eig > 1)
     par <- x$parallel
     parallel_rec <- if (is.null(par)) "Not available" else as.character(par$recommended_n)
@@ -713,7 +725,7 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     )
   }
   else if (type == "parallel_screeplot") {
-    eig <- eigen(x$correlation, only.values = TRUE)$values
+    eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     par <- x$parallel
     threshold <- if (is.null(par)) rep(NA_real_, length(eig)) else par$table$random_eigenvalue_threshold
     length(threshold) <- length(eig) # pad/truncate to align with eigenvalue count

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -271,6 +271,22 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     set.seed(seed)
   }
 
+  # Resolve the correlation ONCE, from the whole data, and reuse it for every group. Selecting per
+  # group would let one facet run on Polychoric and another on Pearson while the report describes a
+  # single method, and would make the groups' loadings incomparable. (issue #26623)
+  overall_type <- NULL
+  overall_reason <- NULL
+  if (identical(tolower(trimws(as.character(cor_type))), "auto")) {
+    overall_selection <- tryCatch({
+      candidate_cols <- intersect(selected_cols, colnames(df))
+      if (length(candidate_cols) >= 2) select_factor_correlation_type(as.data.frame(df)[, candidate_cols, drop = FALSE]) else NULL
+    }, error = function(e) NULL)
+    if (!is.null(overall_selection) && !identical(overall_selection$selected_method, "unsupported")) {
+      overall_type <- overall_selection$selected_method
+      overall_reason <- overall_selection$reason
+    }
+  }
+
   each_func <- function(df) {
     # sample the data for quicker turn around on UI,
     # if data size is larger than specified max_nrow.
@@ -314,6 +330,13 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # (e.g. a polychoric fa() next to a Pearson KMO or parallel analysis). (issue #26623)
     selection <- select_factor_correlation_type(cleaned_df)
     resolved <- resolve_factanal_correlation_type(cor_type, selection)
+    # Auto: keep the whole-analysis choice made above, so every group uses the same correlation.
+    # The per-group selection is still what drives the category coding and the diagnostics.
+    if (isTRUE(resolved$auto) && !is.null(overall_type) &&
+        !identical(selection$selected_method, "unsupported")) {
+      resolved$type <- overall_type
+      resolved$reason <- overall_reason
+    }
     # An unsupported variable combination (a nominal category, a constant column) is unsupported
     # whichever correlation was asked for -- picking Pearson manually must not smuggle a nominal
     # column in as arbitrary integer codes. So gate on the SELECTION, not the resolved type.

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -476,7 +476,7 @@ resolve_factanal_correlation_type <- function(requested, selection) {
   }
   if (requested != "auto") {
     return(list(type = requested, auto = FALSE,
-                reason = sprintf("%s correlation was selected manually.",
+                reason = sprintf("%s was selected manually.",
                                  factanal_correlation_label(requested))))
   }
   list(type = selection$selected_method, auto = TRUE, reason = selection$reason)
@@ -490,6 +490,42 @@ factanal_correlation_label <- function(type) {
          tetrachoric = "Tetrachoric Correlation",
          mixed = "Mixed Correlation",
          "Unsupported")
+}
+
+# The "Type of Scores" property values are psych::fa() `scores` values. When the fit is built from
+# a correlation matrix the scores come from psych::factor.scores(), whose `method` uses a different
+# spelling for the default: fa()'s "regression" is factor.scores()'s "Thurstone". Everything else
+# passes through, and anything unknown falls back to the default rather than erroring.
+factanal_score_method <- function(scores) {
+  scores <- if (is.null(scores) || length(scores) != 1L || is.na(scores)) "regression" else as.character(scores)
+  switch(scores,
+         regression = "Thurstone",
+         Thurstone = "Thurstone",
+         Bartlett = "Bartlett",
+         tenBerge = "tenBerge",
+         Anderson = "Anderson",
+         "Thurstone")
+}
+
+# Rotation names for the report's Analysis Method table. A generic title-case would turn the
+# camel-cased psych names into non-words ("bentlerT" -> "Bentlert"), so they are mapped explicitly.
+factanal_rotation_label <- function(rotate) {
+  rotate <- if (is.null(rotate) || length(rotate) != 1L || is.na(rotate)) "none" else as.character(rotate)
+  switch(rotate,
+         none = "None",
+         varimax = "Varimax",
+         Promax = "Promax",
+         promax = "Promax with Kaiser Normalization",
+         oblimin = "Oblimin",
+         quartimax = "Quartimax",
+         bentlerT = "Bentler (Orthogonal)",
+         bentlerQ = "Bentler (Oblique)",
+         equamax = "Equamax",
+         geominT = "Geomin (Orthogonal)",
+         geomin = "Geomin (Oblique)",
+         simplimax = "Simplimax",
+         cluster = "Cluster (Oblique)",
+         rotate)
 }
 
 factanal_extraction_method_label <- function(fm) {
@@ -514,7 +550,19 @@ factanal_extraction_method_label <- function(fm) {
 compute_polychoric_diagnostics <- function(data, cor_result, selection,
                                            rare_category_prop_cutoff = 0.05) {
   data <- as.data.frame(data)
-  variables <- colnames(data)
+  # Category-shape diagnostics only make sense for the CATEGORICAL variables. In a mixed analysis
+  # a continuous column would otherwise report one "category" per distinct value, flag every one
+  # of them as sparse, and make every pair look like it has empty combinations. (issue #26623)
+  categorical_variables <- if (!is.null(selection) && !is.null(selection$variable_summary)) {
+    summary_df <- selection$variable_summary
+    summary_df$variable[summary_df$detected_type %in% c("binary", "ordinal")]
+  } else {
+    colnames(data)
+  }
+  variables <- intersect(colnames(data), categorical_variables)
+  if (length(variables) == 0) {
+    variables <- colnames(data)
+  }
 
   # 1. Number of categories
   category_counts <- vapply(variables, function(v) {

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -603,9 +603,10 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     colnames(data)
   }
   variables <- intersect(colnames(data), categorical_variables)
-  if (length(variables) == 0) {
-    variables <- colnames(data)
-  }
+  # No categorical variable at all (e.g. Polychoric forced onto continuous columns): the category
+  # diagnostics have nothing to describe. Reporting them over continuous columns would invent
+  # "400 categories", flag every variable sparse and every pair empty.
+  no_categorical <- length(variables) == 0
 
   # 1. Number of categories
   # Defined categories, not observed ones: the auto-selection branched on n_defined_categories, so
@@ -616,11 +617,14 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   } else {
     NULL
   }
-  category_counts <- vapply(variables, function(v) {
+  category_counts <- if (no_categorical) numeric() else vapply(variables, function(v) {
     defined <- if (!is.null(defined_counts) && v %in% names(defined_counts)) defined_counts[[v]] else NA_real_
     if (is.na(defined)) length(unique(data[[v]][!is.na(data[[v]])])) else as.numeric(defined)
   }, numeric(1))
-  if (length(unique(category_counts)) == 1) {
+  if (no_categorical) {
+    category_value <- "Not Available"
+    category_status <- "na"
+  } else if (length(unique(category_counts)) == 1) {
     # "categorical variables", not "variables": in a mixed analysis the continuous columns are not
     # counted here, and saying "all variables" would contradict the Target Variables count above.
     category_value <- sprintf("All categorical variables have %d categories", as.integer(category_counts[[1]]))
@@ -631,20 +635,28 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   }
 
   # 2. Sparse categories (a category holding less than the cutoff share of responses)
-  sparse_variables <- variables[vapply(variables, function(v) {
+  defined_levels <- if (!is.null(selection) && !is.null(selection$category_levels)) selection$category_levels else NULL
+  sparse_variables <- if (no_categorical) character() else variables[vapply(variables, function(v) {
     x <- data[[v]][!is.na(data[[v]])]
     if (length(x) == 0) return(FALSE)
-    props <- as.numeric(table(x)) / length(x)
-    any(props < rare_category_prop_cutoff)
+    counts <- as.numeric(table(x))
+    # A declared level with zero responses never shows up in table(), yet it is the sparsest case
+    # there is. Pad the counts out to the number of DEFINED categories so it is caught.
+    n_defined <- if (!is.null(defined_levels) && !is.null(defined_levels[[v]])) length(defined_levels[[v]]) else length(counts)
+    if (n_defined > length(counts)) {
+      counts <- c(counts, rep(0, n_defined - length(counts)))
+    }
+    any(counts / length(x) < rare_category_prop_cutoff)
   }, logical(1))]
-  sparse_value <- if (length(sparse_variables) == 0) "None"
+  sparse_value <- if (no_categorical) "Not Available"
+    else if (length(sparse_variables) == 0) "None"
     else if (length(sparse_variables) == 1) "Detected in 1 variable"
     else sprintf("Detected in %d variables", length(sparse_variables))
-  sparse_status <- if (length(sparse_variables) == 0) "ok" else "caution"
+  sparse_status <- if (no_categorical) "na" else if (length(sparse_variables) == 0) "ok" else "caution"
 
   # 3. Empty category combinations (a zero cell in a pair's cross tabulation)
   empty_pairs <- 0L
-  if (length(variables) >= 2) {
+  if (!no_categorical && length(variables) >= 2) {
     for (i in seq_len(length(variables) - 1)) {
       for (j in seq(i + 1, length(variables))) {
         tab <- table(data[[variables[[i]]]], data[[variables[[j]]]])
@@ -652,10 +664,11 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
       }
     }
   }
-  empty_value <- if (empty_pairs == 0) "None"
+  empty_value <- if (no_categorical) "Not Available"
+    else if (empty_pairs == 0) "None"
     else if (empty_pairs == 1) "Detected in 1 variable pair"
     else sprintf("Detected in %d variable pairs", empty_pairs)
-  empty_status <- if (empty_pairs == 0) "ok" else "caution"
+  empty_status <- if (no_categorical) "na" else if (empty_pairs == 0) "ok" else "caution"
 
   # 4. Correlation estimation failures (NA in the off-diagonal of the matrix)
   R <- cor_result$correlation

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -513,17 +513,17 @@ factanal_rotation_label <- function(rotate) {
   rotate <- if (is.null(rotate) || length(rotate) != 1L || is.na(rotate)) "none" else as.character(rotate)
   switch(rotate,
          none = "None",
-         varimax = "Varimax",
-         Promax = "Promax",
+         varimax = "Varimax (Orthogonal)",
+         Promax = "Promax (Oblique)",
          promax = "Promax with Kaiser Normalization",
-         oblimin = "Oblimin",
-         quartimax = "Quartimax",
+         oblimin = "Oblimin (Oblique)",
+         quartimax = "Quartimax (Orthogonal)",
          bentlerT = "Bentler (Orthogonal)",
          bentlerQ = "Bentler (Oblique)",
-         equamax = "Equamax",
+         equamax = "Equamax (Orthogonal)",
          geominT = "Geomin (Orthogonal)",
          geomin = "Geomin (Oblique)",
-         simplimax = "Simplimax",
+         simplimax = "Simplimax (Oblique)",
          cluster = "Cluster (Oblique)",
          rotate)
 }
@@ -535,11 +535,36 @@ factanal_extraction_method_label <- function(fm) {
          pa = "Principal Axis",
          ols = "Ordinary Least Squares",
          wls = "Weighted Least Squares",
-         gls = "Generalized Least Squares",
+         gls = "Generalized Weighted Least Squares",
          minchi = "Minimum Chi-Square",
          minrank = "Minimum Rank",
          alpha = "Alpha Factoring",
          as.character(fm))
+}
+
+
+# Language-neutral tokens for the selector's warnings, so the client can render localized text
+# instead of the English sentences the selector composes for logs. (issue #26623)
+factanal_selection_warning_tokens <- function(selection) {
+  if (is.null(selection) || is.null(selection$warnings) || length(selection$warnings) == 0) {
+    return(character())
+  }
+  tokens <- character()
+  if (any(grepl("less than", selection$warnings, fixed = TRUE))) {
+    tokens <- c(tokens, "sparse_categories")
+  }
+  if (any(grepl("Alphabetical order will be used", selection$warnings, fixed = TRUE))) {
+    tokens <- c(tokens, "alphabetical_category_order")
+  }
+  unique(tokens)
+}
+
+# Is Polychoric a legitimate alternative for this data? Used to decide whether the report should
+# suggest it. All-numeric data has `available_options` of just "pearson", so the suggestion is
+# suppressed there rather than pointing the user at a meaningless (and slow) re-run.
+factanal_polychoric_available <- function(selection) {
+  !is.null(selection) && !is.null(selection$available_options) &&
+    any(c("polychoric", "tetrachoric", "mixed") %in% selection$available_options)
 }
 
 # -----------------------------------------------------------------------------
@@ -569,7 +594,9 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     length(unique(data[[v]][!is.na(data[[v]])]))
   }, numeric(1))
   if (length(unique(category_counts)) == 1) {
-    category_value <- sprintf("All variables have %d categories", as.integer(category_counts[[1]]))
+    # "categorical variables", not "variables": in a mixed analysis the continuous columns are not
+    # counted here, and saying "all variables" would contradict the Target Variables count above.
+    category_value <- sprintf("All categorical variables have %d categories", as.integer(category_counts[[1]]))
     category_status <- "uniform"
   } else {
     category_value <- sprintf("%d to %d categories", as.integer(min(category_counts)), as.integer(max(category_counts)))
@@ -618,10 +645,16 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   }
 
   # 5. Positive definiteness of the correlation matrix
+  # psych::polychoric()/tetrachoric() smooth the matrix automatically when it is not positive
+  # definite, so testing the RETURNED matrix would always pass and contradict the "Smoothing
+  # Applied" row below. The smoothing itself is the evidence that the raw estimate was not
+  # positive definite.
   min_eigen <- tryCatch({
     if (is.null(R) || anyNA(R)) NA_real_ else min(eigen(R, symmetric = TRUE, only.values = TRUE)$values)
   }, error = function(e) NA_real_)
-  if (is.na(min_eigen)) {
+  if (isTRUE(cor_result$smoothed)) {
+    definite_value <- "Not positive definite"; definite_status <- "caution"
+  } else if (is.na(min_eigen)) {
     definite_value <- "Not Available"; definite_status <- "na"
   } else if (min_eigen > 1e-8) {
     definite_value <- "No problem"; definite_status <- "ok"
@@ -639,11 +672,11 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
                    "Smoothing Applied"),
     Judgement = c(category_value, sparse_value, empty_value, failure_value, definite_value, smoothed_value),
     Description = c(
-      "Number of categories in the selected variables.",
-      "Variables that have a category holding less than 5% of the responses. Polychoric correlations may become unstable when categories are sparse.",
+      "Number of categories in the categorical variables used for the correlation.",
+      "Categorical variables that have a category holding less than 5% of the responses. Polychoric correlations may become unstable when categories are sparse.",
       "Variable pairs that have a category combination with no observations.",
       "Variable pairs whose correlation could not be estimated.",
-      "Whether the correlation matrix is positive definite, which factor analysis assumes.",
+      "Whether the estimated correlation matrix was positive definite, which factor analysis assumes, before any smoothing.",
       "Whether the correlation matrix had to be smoothed to become positive definite."
     ),
     status = c(category_status, sparse_status, empty_status, failure_status, definite_status, smoothed_status)

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -362,7 +362,7 @@ select_factor_correlation_type <- function(data, variables = names(data),
       sparse_variables <- five_category_diagnostics$variable[five_category_diagnostics$rare_category]
       if (length(sparse_variables) > 0) {
         all_warnings <- c(all_warnings, sprintf(
-          "Some categories contain less than %.1f%% of responses: %s. Polychoric correlations may become unstable when categories are sparse.",
+          "Some categories contain less than %.1f%% of responses: %s. Correlations estimated from categories may become unstable when categories are sparse.",
           rare_category_prop_cutoff * 100, paste(sparse_variables, collapse = ", ")))
       }
       if (use_polychoric) {
@@ -471,7 +471,7 @@ resolve_factanal_correlation_type <- function(requested, selection) {
   }
   requested <- tolower(trimws(as.character(requested)))
   if (!requested %in% c("auto", "pearson", "polychoric", "tetrachoric", "mixed")) {
-    stop(sprintf("Unknown correlation type: '%s'. Allowed values are auto, pearson, and polychoric.", requested),
+    stop(sprintf("Unknown correlation type: '%s'. Allowed values are auto, pearson, polychoric, tetrachoric, and mixed.", requested),
          call. = FALSE)
   }
   if (requested != "auto") {
@@ -562,9 +562,27 @@ factanal_selection_warning_tokens <- function(selection) {
 # Is Polychoric a legitimate alternative for this data? Used to decide whether the report should
 # suggest it. All-numeric data has `available_options` of just "pearson", so the suggestion is
 # suppressed there rather than pointing the user at a meaningless (and slow) re-run.
-factanal_polychoric_available <- function(selection) {
-  !is.null(selection) && !is.null(selection$available_options) &&
-    any(c("polychoric", "tetrachoric", "mixed") %in% selection$available_options)
+factanal_polychoric_available <- function(selection, data = NULL) {
+  if (!is.null(selection) && !is.null(selection$available_options) &&
+      any(c("polychoric", "tetrachoric", "mixed") %in% selection$available_options)) {
+    return(TRUE)
+  }
+  # A 1-10 scale, or a 1-5 scale with an unobserved middle value, is classified numeric by the
+  # rating-scale heuristic -- but polychoric is still a legitimate manual choice there, so the
+  # report must keep pointing at it. Genuinely continuous measurements (non-integer values, or
+  # many distinct values) are the only case where the suggestion is dropped.
+  if (is.null(data)) {
+    return(FALSE)
+  }
+  data <- as.data.frame(data)
+  any(vapply(colnames(data), function(col) {
+    values <- data[[col]]
+    if (!is.numeric(values)) return(FALSE)
+    values <- values[is.finite(values)]
+    if (length(values) == 0) return(FALSE)
+    if (any(values != floor(values))) return(FALSE)
+    length(unique(values)) <= 20
+  }, logical(1)))
 }
 
 # -----------------------------------------------------------------------------
@@ -590,8 +608,17 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   }
 
   # 1. Number of categories
+  # Defined categories, not observed ones: the auto-selection branched on n_defined_categories, so
+  # counting observed codes here would let this row contradict the reason for the method choice
+  # (a declared-but-unobserved level).
+  defined_counts <- if (!is.null(selection) && !is.null(selection$variable_summary)) {
+    stats::setNames(selection$variable_summary$n_defined_categories, selection$variable_summary$variable)
+  } else {
+    NULL
+  }
   category_counts <- vapply(variables, function(v) {
-    length(unique(data[[v]][!is.na(data[[v]])]))
+    defined <- if (!is.null(defined_counts) && v %in% names(defined_counts)) defined_counts[[v]] else NA_real_
+    if (is.na(defined)) length(unique(data[[v]][!is.na(data[[v]])])) else as.numeric(defined)
   }, numeric(1))
   if (length(unique(category_counts)) == 1) {
     # "categorical variables", not "variables": in a mixed analysis the continuous columns are not
@@ -610,7 +637,9 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     props <- as.numeric(table(x)) / length(x)
     any(props < rare_category_prop_cutoff)
   }, logical(1))]
-  sparse_value <- if (length(sparse_variables) == 0) "None" else sprintf("Detected in %d variables", length(sparse_variables))
+  sparse_value <- if (length(sparse_variables) == 0) "None"
+    else if (length(sparse_variables) == 1) "Detected in 1 variable"
+    else sprintf("Detected in %d variables", length(sparse_variables))
   sparse_status <- if (length(sparse_variables) == 0) "ok" else "caution"
 
   # 3. Empty category combinations (a zero cell in a pair's cross tabulation)
@@ -623,7 +652,9 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
       }
     }
   }
-  empty_value <- if (empty_pairs == 0) "None" else sprintf("Detected in %d variable pairs", empty_pairs)
+  empty_value <- if (empty_pairs == 0) "None"
+    else if (empty_pairs == 1) "Detected in 1 variable pair"
+    else sprintf("Detected in %d variable pairs", empty_pairs)
   empty_status <- if (empty_pairs == 0) "ok" else "caution"
 
   # 4. Correlation estimation failures (NA in the off-diagonal of the matrix)
@@ -640,7 +671,8 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     failure_value <- "None"
     failure_status <- "ok"
   } else {
-    failure_value <- sprintf("Detected in %d variable pairs", failed_cells)
+    failure_value <- if (failed_cells == 1) "Detected in 1 variable pair"
+      else sprintf("Detected in %d variable pairs", failed_cells)
     failure_status <- "caution"
   }
 
@@ -652,7 +684,10 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   min_eigen <- tryCatch({
     if (is.null(R) || anyNA(R)) NA_real_ else min(eigen(R, symmetric = TRUE, only.values = TRUE)$values)
   }, error = function(e) NA_real_)
-  if (isTRUE(cor_result$smoothed)) {
+  if (isTRUE(cor_result$failed)) {
+    # The matrix here is the Pearson fallback, so it describes a different correlation entirely.
+    definite_value <- "Not Available"; definite_status <- "na"
+  } else if (isTRUE(cor_result$smoothed)) {
     definite_value <- "Not positive definite"; definite_status <- "caution"
   } else if (is.na(min_eigen)) {
     definite_value <- "Not Available"; definite_status <- "na"
@@ -663,8 +698,10 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   }
 
   # 6. Whether the matrix had to be smoothed
-  smoothed_value <- if (isTRUE(cor_result$smoothed)) "Applied" else "None"
-  smoothed_status <- if (isTRUE(cor_result$smoothed)) "caution" else "ok"
+  smoothed_value <- if (isTRUE(cor_result$failed)) "Not Available"
+    else if (isTRUE(cor_result$smoothed)) "Applied" else "None"
+  smoothed_status <- if (isTRUE(cor_result$failed)) "na"
+    else if (isTRUE(cor_result$smoothed)) "caution" else "ok"
 
   tibble::tibble(
     Diagnostic = c("Number of Categories", "Sparse Categories", "Empty Category Combinations",
@@ -673,7 +710,7 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     Judgement = c(category_value, sparse_value, empty_value, failure_value, definite_value, smoothed_value),
     Description = c(
       "Number of categories in the categorical variables used for the correlation.",
-      "Categorical variables that have a category holding less than 5% of the responses. Polychoric correlations may become unstable when categories are sparse.",
+      "Categorical variables that have a category holding less than 5% of the responses. Correlations estimated from categories may become unstable when categories are sparse.",
       "Variable pairs that have a category combination with no observations.",
       "Variable pairs whose correlation could not be estimated.",
       "Whether the estimated correlation matrix was positive definite, which factor analysis assumes, before any smoothing.",

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -448,8 +448,10 @@ build_factor_correlation <- function(data, correlation_type = c("pearson", "poly
       invokeRestart("muffleWarning")
     })
 
-  if (is.null(result) || is.null(result$rho)) {
-    # Degrade to Pearson rather than aborting the whole analysis.
+  if (is.null(result) || is.null(result$rho) || anyNA(result$rho)) {
+    # Degrade to Pearson rather than aborting the whole analysis. A partially-NA matrix counts as a
+    # failure too: psych::fa() refuses to run on one ("missing values (NAs) in the correlation
+    # matrix do not allow me to continue"), so keeping it would abort with a raw psych error.
     return(list(correlation = stats::cor(data, use = use), thresholds = NULL,
                 type = "pearson", smoothed = FALSE, warnings = captured, failed = TRUE))
   }
@@ -657,9 +659,20 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
   # 3. Empty category combinations (a zero cell in a pair's cross tabulation)
   empty_pairs <- 0L
   if (!no_categorical && length(variables) >= 2) {
+    # Cross-tabulate over the DEFINED levels: a level nobody chose makes every pair involving it
+    # structurally empty, but a raw table() never materializes a row/column for it.
+    as_defined_factor <- function(v) {
+      values <- data[[v]]
+      levels_for_v <- if (!is.null(defined_levels) && !is.null(defined_levels[[v]])) {
+        seq_len(length(defined_levels[[v]]))
+      } else {
+        sort(unique(values[!is.na(values)]))
+      }
+      factor(values, levels = levels_for_v)
+    }
     for (i in seq_len(length(variables) - 1)) {
       for (j in seq(i + 1, length(variables))) {
-        tab <- table(data[[variables[[i]]]], data[[variables[[j]]]])
+        tab <- table(as_defined_factor(variables[[i]]), as_defined_factor(variables[[j]]))
         if (any(tab == 0)) empty_pairs <- empty_pairs + 1L
       }
     }
@@ -723,7 +736,7 @@ compute_polychoric_diagnostics <- function(data, cor_result, selection,
     Judgement = c(category_value, sparse_value, empty_value, failure_value, definite_value, smoothed_value),
     Description = c(
       "Number of categories in the categorical variables used for the correlation.",
-      "Categorical variables that have a category holding less than 5% of the responses. Correlations estimated from categories may become unstable when categories are sparse.",
+      "Categorical variables that have a category holding a very small share of the responses. Correlations estimated from categories may become unstable when categories are sparse.",
       "Variable pairs that have a category combination with no observations.",
       "Variable pairs whose correlation could not be estimated.",
       "Whether the estimated correlation matrix was positive definite, which factor analysis assumes, before any smoothing.",

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -1,0 +1,603 @@
+# =============================================================================
+# Correlation type selection / construction for Factor Analysis (issue #26623)
+#
+# Automatic selection rules (spec):
+#
+#   all numeric                       -> Pearson
+#   all binary                        -> Tetrachoric
+#   all ordinal, at most 4 categories -> Polychoric
+#   all ordinal, 5 categories         -> decided from the response distribution
+#   all ordinal, 6+ categories        -> Pearson by default
+#   numeric / binary / ordinal mix    -> Mixed correlation
+#   any nominal category              -> Unsupported
+#
+# The correlation matrix built here is the single matrix every downstream
+# computation (fa, KMO, Bartlett, eigenvalues, parallel analysis, factor
+# scores) has to use, so that the report never mixes Pearson and Polychoric.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Normalize a declared variable type
+# -----------------------------------------------------------------------------
+normalize_factor_variable_type <- function(x) {
+  aliases <- c(
+    "auto" = "auto",
+    "numeric" = "numeric", "continuous" = "numeric", "number" = "numeric",
+    "binary" = "binary", "dichotomous" = "binary", "logical" = "binary", "boolean" = "binary",
+    "ordinal" = "ordinal", "ordered" = "ordinal", "ordered_factor" = "ordinal",
+    "nominal" = "nominal", "categorical" = "nominal", "unordered" = "nominal"
+  )
+  key <- tolower(trimws(as.character(x)))
+  if (!key %in% names(aliases)) {
+    stop(sprintf("Unknown variable type: '%s'. Allowed values are auto, numeric, binary, ordinal, and nominal.", x),
+         call. = FALSE)
+  }
+  unname(aliases[[key]])
+}
+
+# -----------------------------------------------------------------------------
+# Defined category levels of a variable.
+# Priority: supplied metadata -> factor levels -> observed values.
+# -----------------------------------------------------------------------------
+get_factor_category_levels <- function(x, supplied_levels = NULL) {
+  if (!is.null(supplied_levels)) {
+    return(supplied_levels)
+  }
+  if (is.factor(x)) {
+    return(levels(x))
+  }
+  observed <- x[!is.na(x)]
+  if (is.logical(observed)) {
+    return(c(FALSE, TRUE))
+  }
+  if (is.numeric(observed)) {
+    return(sort(unique(observed)))
+  }
+  sort(unique(as.character(observed)))
+}
+
+# -----------------------------------------------------------------------------
+# Is a numeric column really a rating scale (1-5 survey answer) rather than a
+# continuous measurement?
+#
+# The spec's literal rule calls every numeric column with 3+ distinct values
+# "numeric", which would mean a 1-to-5 survey item imported as an integer -- the
+# exact data the polychoric request is about -- never reaches the ordinal branch.
+# So numeric columns are treated as ordinal only when they look like a rating
+# scale: consecutive integers, 3 to `max_categories` of them, starting at 0 or 1.
+# A measurement like cyl (4, 6, 8) or a count is not consecutive-from-0/1 and
+# stays numeric, so existing all-numeric analyses keep using Pearson.
+# -----------------------------------------------------------------------------
+is_rating_scale_numeric <- function(observed, max_categories = 7) {
+  observed <- observed[is.finite(observed)]
+  if (length(observed) == 0) return(FALSE)
+  if (any(observed != floor(observed))) return(FALSE)
+  values <- sort(unique(observed))
+  n_values <- length(values)
+  if (n_values < 3 || n_values > max_categories) return(FALSE)
+  if (!(min(values) %in% c(0, 1))) return(FALSE)
+  # Consecutive integers only: 1,2,3,4,5 yes; 1,2,5 no.
+  identical(as.numeric(max(values) - min(values) + 1), as.numeric(n_values))
+}
+
+# -----------------------------------------------------------------------------
+# Detect the type of one variable.
+# -----------------------------------------------------------------------------
+inspect_factor_variable <- function(variable_name, x, declared_type = "auto", supplied_levels = NULL) {
+  declared_type <- normalize_factor_variable_type(declared_type)
+
+  observed <- x[!is.na(x)]
+  n_observed_categories <- length(unique(observed))
+  warnings <- character()
+
+  if (n_observed_categories < 2) {
+    return(list(
+      variable = variable_name, declared_type = declared_type, detected_type = "invalid",
+      n_non_missing = length(observed), n_observed_categories = n_observed_categories,
+      n_defined_categories = n_observed_categories,
+      category_levels = get_factor_category_levels(x, supplied_levels),
+      order_source = NA_character_,
+      warnings = sprintf("Variable '%s' has fewer than two observed values.", variable_name)
+    ))
+  }
+
+  if (declared_type != "auto") {
+    detected_type <- declared_type
+  } else if (!is.null(supplied_levels)) {
+    # Supplied levels are treated as ordered-category metadata.
+    detected_type <- if (length(supplied_levels) == 2) "binary" else "ordinal"
+  } else if (is.logical(x)) {
+    detected_type <- "binary"
+  } else if (is.ordered(x)) {
+    detected_type <- if (nlevels(x) == 2) "binary" else "ordinal"
+  } else if (is.factor(x)) {
+    detected_type <- if (nlevels(x) == 2) "binary" else "nominal"
+  } else if (is.numeric(x)) {
+    detected_type <- if (n_observed_categories == 2) "binary"
+      else if (is_rating_scale_numeric(observed)) "ordinal"
+      else "numeric"
+  } else if (is.character(x)) {
+    detected_type <- if (n_observed_categories == 2) "binary" else "nominal"
+  } else {
+    detected_type <- "nominal"
+  }
+
+  is_categorical <- detected_type %in% c("binary", "ordinal", "nominal")
+  if (is_categorical) {
+    category_levels <- get_factor_category_levels(x = x, supplied_levels = supplied_levels)
+    n_defined_categories <- length(category_levels)
+    order_source <- if (!is.null(supplied_levels)) "supplied_metadata"
+      else if (is.ordered(x)) "ordered_factor_levels"
+      else if (is.factor(x)) "factor_levels"
+      else if (is.numeric(x)) "sorted_numeric_values"
+      else "sorted_character_values"
+  } else {
+    category_levels <- get_factor_category_levels(x = x, supplied_levels = supplied_levels)
+    n_defined_categories <- NA_integer_
+    order_source <- NA_character_
+  }
+
+  if (detected_type == "numeric" && !is.numeric(x)) {
+    detected_type <- "invalid"
+    warnings <- c(warnings, sprintf("Variable '%s' is declared numeric but its R data type is not numeric.", variable_name))
+  }
+  if (detected_type == "binary" && !is.na(n_defined_categories) && n_defined_categories != 2) {
+    detected_type <- "invalid"
+    warnings <- c(warnings, sprintf("Variable '%s' is binary but has %d defined categories.", variable_name, n_defined_categories))
+  }
+  if (detected_type == "ordinal" && !is.na(n_defined_categories) && n_defined_categories == 2) {
+    detected_type <- "binary"
+  }
+  if (detected_type == "ordinal" && !is.na(n_defined_categories) && n_defined_categories < 2) {
+    detected_type <- "invalid"
+    warnings <- c(warnings, sprintf("Variable '%s' does not have enough ordered categories.", variable_name))
+  }
+  if (detected_type == "ordinal" && is.character(x) && is.null(supplied_levels)) {
+    warnings <- c(warnings, sprintf(
+      "Variable '%s' is ordinal character data, but no category order was supplied. Alphabetical order will be used.",
+      variable_name))
+  }
+
+  list(
+    variable = variable_name, declared_type = declared_type, detected_type = detected_type,
+    n_non_missing = length(observed), n_observed_categories = n_observed_categories,
+    n_defined_categories = n_defined_categories, category_levels = category_levels,
+    order_source = order_source, warnings = warnings
+  )
+}
+
+# -----------------------------------------------------------------------------
+# Ordered categories -> 1, 2, 3, ... codes
+# -----------------------------------------------------------------------------
+encode_ordered_variable <- function(x, category_levels) {
+  match(as.character(x), as.character(category_levels))
+}
+
+# -----------------------------------------------------------------------------
+# Skewness (standardized 3rd moment, no extra package dependency)
+# -----------------------------------------------------------------------------
+calculate_ordinal_skewness <- function(x) {
+  x <- x[is.finite(x)]
+  if (length(x) < 3) return(NA_real_)
+  center <- mean(x)
+  second_moment <- mean((x - center)^2)
+  if (!is.finite(second_moment) || second_moment <= 0) return(NA_real_)
+  mean((x - center)^3) / second_moment^(3 / 2)
+}
+
+# -----------------------------------------------------------------------------
+# Diagnose the distribution of a 5-category variable.
+# Polychoric is recommended when any of these holds:
+#   - the modal category takes 50% or more
+#   - the lowest or highest category takes 40% or more
+#   - |skewness| is 1 or more
+# A category below 5% only produces a warning by default, because sparse
+# categories can also destabilize the polychoric estimation.
+# -----------------------------------------------------------------------------
+assess_five_category_distribution <- function(variable_name, x, category_levels,
+                                              modal_prop_cutoff = 0.50,
+                                              extreme_prop_cutoff = 0.40,
+                                              skewness_cutoff = 1.00,
+                                              rare_category_prop_cutoff = 0.05,
+                                              rare_category_triggers_poly = FALSE) {
+  if (length(category_levels) != 5) {
+    stop(sprintf("Variable '%s' does not have exactly five defined categories.", variable_name), call. = FALSE)
+  }
+  encoded <- encode_ordered_variable(x = x, category_levels = category_levels)
+  valid <- !is.na(encoded)
+  n_valid <- sum(valid)
+  counts <- tabulate(encoded[valid], nbins = 5)
+  proportions <- if (n_valid > 0) counts / n_valid else rep(NA_real_, 5)
+
+  modal_prop <- max(proportions, na.rm = TRUE)
+  lower_extreme_prop <- proportions[[1]]
+  upper_extreme_prop <- proportions[[5]]
+  max_extreme_prop <- max(lower_extreme_prop, upper_extreme_prop, na.rm = TRUE)
+  min_category_prop <- min(proportions, na.rm = TRUE)
+  skewness <- calculate_ordinal_skewness(encoded[valid])
+
+  dominant_category <- is.finite(modal_prop) && modal_prop >= modal_prop_cutoff
+  extreme_concentration <- is.finite(max_extreme_prop) && max_extreme_prop >= extreme_prop_cutoff
+  strong_skewness <- is.finite(skewness) && abs(skewness) >= skewness_cutoff
+  rare_category <- is.finite(min_category_prop) && min_category_prop < rare_category_prop_cutoff
+
+  trigger_ids <- character()
+  if (dominant_category) trigger_ids <- c(trigger_ids, "dominant_category")
+  if (extreme_concentration) trigger_ids <- c(trigger_ids, "extreme_category_concentration")
+  if (strong_skewness) trigger_ids <- c(trigger_ids, "strong_skewness")
+  if (rare_category && rare_category_triggers_poly) trigger_ids <- c(trigger_ids, "rare_category")
+
+  data.frame(
+    variable = variable_name, n = n_valid,
+    modal_category_prop = modal_prop,
+    lower_extreme_prop = lower_extreme_prop, upper_extreme_prop = upper_extreme_prop,
+    max_extreme_prop = max_extreme_prop, minimum_category_prop = min_category_prop,
+    skewness = skewness,
+    dominant_category = dominant_category, extreme_concentration = extreme_concentration,
+    strong_skewness = strong_skewness, rare_category = rare_category,
+    polychoric_trigger = length(trigger_ids) > 0,
+    trigger_reason = if (length(trigger_ids) == 0) NA_character_ else paste(trigger_ids, collapse = ", "),
+    stringsAsFactors = FALSE
+  )
+}
+
+# -----------------------------------------------------------------------------
+# Main automatic-selection entry point.
+# -----------------------------------------------------------------------------
+select_factor_correlation_type <- function(data, variables = names(data),
+                                           variable_types = NULL, category_levels = NULL,
+                                           modal_prop_cutoff = 0.50, extreme_prop_cutoff = 0.40,
+                                           skewness_cutoff = 1.00, rare_category_prop_cutoff = 0.05,
+                                           rare_category_triggers_poly = FALSE) {
+  if (!is.data.frame(data)) {
+    data <- as.data.frame(data)
+  }
+  missing_variables <- setdiff(variables, names(data))
+  if (length(missing_variables) > 0) {
+    stop(sprintf("The following variables do not exist: %s", paste(missing_variables, collapse = ", ")), call. = FALSE)
+  }
+  if (length(variables) < 2) {
+    stop("At least two variables are required.", call. = FALSE)
+  }
+
+  declared_types <- rep("auto", length(variables))
+  names(declared_types) <- variables
+  if (!is.null(variable_types)) {
+    if (is.null(names(variable_types))) {
+      stop("variable_types must be a named vector.", call. = FALSE)
+    }
+    unknown_type_variables <- setdiff(names(variable_types), variables)
+    if (length(unknown_type_variables) > 0) {
+      stop(sprintf("variable_types contains unknown variables: %s", paste(unknown_type_variables, collapse = ", ")), call. = FALSE)
+    }
+    declared_types[names(variable_types)] <- vapply(variable_types, normalize_factor_variable_type, character(1))
+  }
+  if (is.null(category_levels)) {
+    category_levels <- list()
+  }
+
+  inspections <- lapply(variables, function(variable_name) {
+    inspect_factor_variable(variable_name = variable_name, x = data[[variable_name]],
+                            declared_type = declared_types[[variable_name]],
+                            supplied_levels = category_levels[[variable_name]])
+  })
+  names(inspections) <- variables
+
+  variable_summary <- do.call(rbind, lapply(inspections, function(result) {
+    data.frame(variable = result$variable, declared_type = result$declared_type,
+               detected_type = result$detected_type, n_non_missing = result$n_non_missing,
+               n_observed_categories = result$n_observed_categories,
+               n_defined_categories = result$n_defined_categories,
+               order_source = result$order_source, stringsAsFactors = FALSE)
+  }))
+  rownames(variable_summary) <- NULL
+
+  detected_types <- variable_summary$detected_type
+  detected_category_levels <- lapply(inspections, function(result) result$category_levels)
+  all_warnings <- unlist(lapply(inspections, function(result) result$warnings), use.names = FALSE)
+  five_category_diagnostics <- data.frame()
+
+  build_result <- function(selected_method, selected_label, psych_fa_cor, available_options, reason, warnings) {
+    structure(list(
+      selected_method = selected_method, selected_label = selected_label,
+      psych_fa_cor = psych_fa_cor, available_options = available_options, reason = reason,
+      variables = variables, variable_summary = variable_summary,
+      category_levels = detected_category_levels,
+      five_category_diagnostics = five_category_diagnostics,
+      warnings = unique(warnings),
+      thresholds = list(modal_prop_cutoff = modal_prop_cutoff, extreme_prop_cutoff = extreme_prop_cutoff,
+                        skewness_cutoff = skewness_cutoff, rare_category_prop_cutoff = rare_category_prop_cutoff,
+                        rare_category_triggers_poly = rare_category_triggers_poly)
+    ), class = "factor_correlation_selection")
+  }
+
+  # Invalid variables
+  if (any(detected_types == "invalid")) {
+    invalid_variables <- variable_summary$variable[detected_types == "invalid"]
+    return(build_result("unsupported", "Unsupported", NA_character_, character(),
+                        sprintf("Invalid variables were detected: %s", paste(invalid_variables, collapse = ", ")),
+                        all_warnings))
+  }
+
+  # Nominal categories
+  if (any(detected_types == "nominal")) {
+    nominal_variables <- variable_summary$variable[detected_types == "nominal"]
+    warning_message <- sprintf(
+      "Nominal categorical variables cannot be used directly in this factor analysis: %s",
+      paste(nominal_variables, collapse = ", "))
+    return(build_result("unsupported", "Unsupported", NA_character_, character(),
+                        warning_message, c(all_warnings, warning_message)))
+  }
+
+  if (all(detected_types == "numeric")) {
+    selected_method <- "pearson"; selected_label <- "Pearson"; psych_fa_cor <- "cor"
+    available_options <- c("pearson")
+    reason <- "All selected variables are numeric. Pearson correlation was selected."
+
+  } else if (all(detected_types == "binary")) {
+    selected_method <- "tetrachoric"; selected_label <- "Tetrachoric"; psych_fa_cor <- "tet"
+    available_options <- c("tetrachoric", "pearson")
+    reason <- "All selected variables are binary. Tetrachoric correlation was selected."
+
+  } else if (all(detected_types == "ordinal")) {
+    max_categories <- max(variable_summary$n_defined_categories, na.rm = TRUE)
+
+    if (max_categories <= 4) {
+      selected_method <- "polychoric"; selected_label <- "Polychoric"; psych_fa_cor <- "poly"
+      available_options <- c("polychoric", "pearson")
+      reason <- paste0("All selected variables are ordinal and have no more than four categories. ",
+                       "Polychoric correlation was selected.")
+
+    } else if (max_categories == 5) {
+      five_category_variables <- variable_summary$variable[variable_summary$n_defined_categories == 5]
+      five_category_diagnostics <- do.call(rbind, lapply(five_category_variables, function(variable_name) {
+        assess_five_category_distribution(
+          variable_name = variable_name, x = data[[variable_name]],
+          category_levels = detected_category_levels[[variable_name]],
+          modal_prop_cutoff = modal_prop_cutoff, extreme_prop_cutoff = extreme_prop_cutoff,
+          skewness_cutoff = skewness_cutoff, rare_category_prop_cutoff = rare_category_prop_cutoff,
+          rare_category_triggers_poly = rare_category_triggers_poly)
+      }))
+      use_polychoric <- any(five_category_diagnostics$polychoric_trigger, na.rm = TRUE)
+      sparse_variables <- five_category_diagnostics$variable[five_category_diagnostics$rare_category]
+      if (length(sparse_variables) > 0) {
+        all_warnings <- c(all_warnings, sprintf(
+          "Some categories contain less than %.1f%% of responses: %s. Polychoric correlations may become unstable when categories are sparse.",
+          rare_category_prop_cutoff * 100, paste(sparse_variables, collapse = ", ")))
+      }
+      if (use_polychoric) {
+        selected_method <- "polychoric"; selected_label <- "Polychoric"; psych_fa_cor <- "poly"
+        reason <- paste0("All selected variables are ordinal with no more than five categories. ",
+                         "At least one five-category variable has a concentrated or strongly skewed distribution. ",
+                         "Polychoric correlation was selected.")
+      } else {
+        selected_method <- "pearson"; selected_label <- "Pearson"; psych_fa_cor <- "cor"
+        reason <- paste0("All selected variables are ordinal with no more than five categories, ",
+                         "but their distributions are relatively balanced. Pearson correlation was selected.")
+      }
+      available_options <- c(selected_method, setdiff(c("pearson", "polychoric"), selected_method))
+
+    } else {
+      selected_method <- "pearson"; selected_label <- "Pearson"; psych_fa_cor <- "cor"
+      available_options <- c("pearson", "polychoric")
+      reason <- paste0("All selected variables are ordinal and at least one variable has six or more categories. ",
+                       "Pearson correlation was selected by default. ",
+                       "Polychoric correlation remains available as a manual option.")
+    }
+
+  } else if (all(detected_types %in% c("numeric", "binary", "ordinal"))) {
+    selected_method <- "mixed"; selected_label <- "Mixed correlation"; psych_fa_cor <- "mixed"
+    available_options <- c("mixed", "pearson")
+    reason <- sprintf("The selected variables contain multiple supported types: %s. Mixed correlation was selected.",
+                      paste(unique(detected_types), collapse = ", "))
+
+  } else {
+    return(build_result("unsupported", "Unsupported", NA_character_, character(),
+                        "The selected variable combination is not supported.", all_warnings))
+  }
+
+  build_result(selected_method, selected_label, psych_fa_cor, available_options, reason, all_warnings)
+}
+
+# -----------------------------------------------------------------------------
+# Encode the analysis data as a numeric data frame using the detected category
+# order, so every correlation method sees the same coding.
+# -----------------------------------------------------------------------------
+encode_factanal_data <- function(data, selection) {
+  data <- as.data.frame(data)
+  for (col in colnames(data)) {
+    x <- data[[col]]
+    if (is.numeric(x)) next
+    levels_for_col <- selection$category_levels[[col]]
+    if (is.null(levels_for_col)) {
+      levels_for_col <- get_factor_category_levels(x)
+    }
+    data[[col]] <- as.numeric(encode_ordered_variable(x, levels_for_col))
+  }
+  data
+}
+
+# -----------------------------------------------------------------------------
+# Build the single correlation matrix used across the whole analysis.
+# Returns the matrix, the thresholds (for the polychoric family), whether the
+# matrix had to be smoothed, and any estimation warnings.
+# -----------------------------------------------------------------------------
+build_factor_correlation <- function(data, correlation_type = c("pearson", "polychoric", "tetrachoric", "mixed"),
+                                     use = "pairwise.complete.obs", correct = 0.5) {
+  correlation_type <- match.arg(correlation_type)
+  data <- as.data.frame(data)
+
+  if (correlation_type == "pearson") {
+    return(list(correlation = stats::cor(data, use = use), thresholds = NULL,
+                type = "pearson", smoothed = FALSE, warnings = character(), failed = FALSE))
+  }
+
+  captured <- character()
+  result <- withCallingHandlers(
+    tryCatch({
+      switch(correlation_type,
+        polychoric = psych::polychoric(data, correct = correct),
+        tetrachoric = psych::tetrachoric(data, correct = correct),
+        mixed = psych::mixedCor(data))
+    }, error = function(e) {
+      captured <<- c(captured, conditionMessage(e))
+      NULL
+    }),
+    warning = function(w) {
+      captured <<- c(captured, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    })
+
+  if (is.null(result) || is.null(result$rho)) {
+    # Degrade to Pearson rather than aborting the whole analysis.
+    return(list(correlation = stats::cor(data, use = use), thresholds = NULL,
+                type = "pearson", smoothed = FALSE, warnings = captured, failed = TRUE))
+  }
+
+  list(correlation = result$rho,
+       thresholds = if (!is.null(result$tau)) result$tau else NULL,
+       type = correlation_type,
+       smoothed = any(grepl("smooth", captured, ignore.case = TRUE)),
+       warnings = captured, failed = FALSE)
+}
+
+# -----------------------------------------------------------------------------
+# Resolve the correlation type actually used from the requested UI value
+# ("auto" / "pearson" / "polychoric") and the automatic selection result.
+# -----------------------------------------------------------------------------
+resolve_factanal_correlation_type <- function(requested, selection) {
+  if (is.null(requested) || length(requested) != 1L || is.na(requested)) {
+    requested <- "auto"
+  }
+  requested <- tolower(trimws(as.character(requested)))
+  if (!requested %in% c("auto", "pearson", "polychoric", "tetrachoric", "mixed")) {
+    stop(sprintf("Unknown correlation type: '%s'. Allowed values are auto, pearson, and polychoric.", requested),
+         call. = FALSE)
+  }
+  if (requested != "auto") {
+    return(list(type = requested, auto = FALSE,
+                reason = sprintf("%s correlation was selected manually.",
+                                 factanal_correlation_label(requested))))
+  }
+  list(type = selection$selected_method, auto = TRUE, reason = selection$reason)
+}
+
+# English-canonical label. The client translates it (VizUtil message tables).
+factanal_correlation_label <- function(type) {
+  switch(as.character(type),
+         pearson = "Pearson Correlation",
+         polychoric = "Polychoric Correlation",
+         tetrachoric = "Tetrachoric Correlation",
+         mixed = "Mixed Correlation",
+         "Unsupported")
+}
+
+factanal_extraction_method_label <- function(fm) {
+  switch(as.character(fm),
+         minres = "Minimum Residual",
+         ml = "Maximum Likelihood",
+         pa = "Principal Axis",
+         ols = "Ordinary Least Squares",
+         wls = "Weighted Least Squares",
+         gls = "Generalized Least Squares",
+         minchi = "Minimum Chi-Square",
+         minrank = "Minimum Rank",
+         alpha = "Alpha Factoring",
+         as.character(fm))
+}
+
+# -----------------------------------------------------------------------------
+# Diagnostics for a polychoric-family correlation matrix (issue #26623, report
+# section "Data Suitability Diagnostics"). Values are English-canonical strings
+# the client translates; `status` is a language-neutral token.
+# -----------------------------------------------------------------------------
+compute_polychoric_diagnostics <- function(data, cor_result, selection,
+                                           rare_category_prop_cutoff = 0.05) {
+  data <- as.data.frame(data)
+  variables <- colnames(data)
+
+  # 1. Number of categories
+  category_counts <- vapply(variables, function(v) {
+    length(unique(data[[v]][!is.na(data[[v]])]))
+  }, numeric(1))
+  if (length(unique(category_counts)) == 1) {
+    category_value <- sprintf("All variables have %d categories", as.integer(category_counts[[1]]))
+    category_status <- "uniform"
+  } else {
+    category_value <- sprintf("%d to %d categories", as.integer(min(category_counts)), as.integer(max(category_counts)))
+    category_status <- "mixed"
+  }
+
+  # 2. Sparse categories (a category holding less than the cutoff share of responses)
+  sparse_variables <- variables[vapply(variables, function(v) {
+    x <- data[[v]][!is.na(data[[v]])]
+    if (length(x) == 0) return(FALSE)
+    props <- as.numeric(table(x)) / length(x)
+    any(props < rare_category_prop_cutoff)
+  }, logical(1))]
+  sparse_value <- if (length(sparse_variables) == 0) "None" else sprintf("Detected in %d variables", length(sparse_variables))
+  sparse_status <- if (length(sparse_variables) == 0) "ok" else "caution"
+
+  # 3. Empty category combinations (a zero cell in a pair's cross tabulation)
+  empty_pairs <- 0L
+  if (length(variables) >= 2) {
+    for (i in seq_len(length(variables) - 1)) {
+      for (j in seq(i + 1, length(variables))) {
+        tab <- table(data[[variables[[i]]]], data[[variables[[j]]]])
+        if (any(tab == 0)) empty_pairs <- empty_pairs + 1L
+      }
+    }
+  }
+  empty_value <- if (empty_pairs == 0) "None" else sprintf("Detected in %d variable pairs", empty_pairs)
+  empty_status <- if (empty_pairs == 0) "ok" else "caution"
+
+  # 4. Correlation estimation failures (NA in the off-diagonal of the matrix)
+  R <- cor_result$correlation
+  failed_cells <- if (is.null(R)) NA_integer_ else {
+    off_diagonal <- R
+    diag(off_diagonal) <- 0
+    as.integer(sum(is.na(off_diagonal)) / 2)
+  }
+  if (isTRUE(cor_result$failed)) {
+    failure_value <- "Estimation failed"
+    failure_status <- "failed"
+  } else if (is.na(failed_cells) || failed_cells == 0) {
+    failure_value <- "None"
+    failure_status <- "ok"
+  } else {
+    failure_value <- sprintf("Detected in %d variable pairs", failed_cells)
+    failure_status <- "caution"
+  }
+
+  # 5. Positive definiteness of the correlation matrix
+  min_eigen <- tryCatch({
+    if (is.null(R) || anyNA(R)) NA_real_ else min(eigen(R, symmetric = TRUE, only.values = TRUE)$values)
+  }, error = function(e) NA_real_)
+  if (is.na(min_eigen)) {
+    definite_value <- "Not Available"; definite_status <- "na"
+  } else if (min_eigen > 1e-8) {
+    definite_value <- "No problem"; definite_status <- "ok"
+  } else {
+    definite_value <- "Not positive definite"; definite_status <- "caution"
+  }
+
+  # 6. Whether the matrix had to be smoothed
+  smoothed_value <- if (isTRUE(cor_result$smoothed)) "Applied" else "None"
+  smoothed_status <- if (isTRUE(cor_result$smoothed)) "caution" else "ok"
+
+  tibble::tibble(
+    Diagnostic = c("Number of Categories", "Sparse Categories", "Empty Category Combinations",
+                   "Correlation Estimation Failures", "Positive Definiteness of the Correlation Matrix",
+                   "Smoothing Applied"),
+    Judgement = c(category_value, sparse_value, empty_value, failure_value, definite_value, smoothed_value),
+    Description = c(
+      "Number of categories in the selected variables.",
+      "Variables that have a category holding less than 5% of the responses. Polychoric correlations may become unstable when categories are sparse.",
+      "Variable pairs that have a category combination with no observations.",
+      "Variable pairs whose correlation could not be estimated.",
+      "Whether the correlation matrix is positive definite, which factor analysis assumes.",
+      "Whether the correlation matrix had to be smoothed to become positive definite."
+    ),
+    status = c(category_status, sparse_status, empty_status, failure_status, definite_status, smoothed_status)
+  )
+}

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -592,6 +592,10 @@ factanal_polychoric_available <- function(selection, data = NULL) {
 # section "Data Suitability Diagnostics"). Values are English-canonical strings
 # the client translates; `status` is a language-neutral token.
 # -----------------------------------------------------------------------------
+# NOTE: `rare_category_prop_cutoff` is mirrored in the report templates, which name the percentage
+# in prose ("less than 5% of the responses" / 「回答が全体の5%未満」) in
+# tam/src/js/components/analysis/templates/markdown/exp_factanal{,_ja}.js. Changing the default here
+# means updating that wording too. (issue #26623)
 compute_polychoric_diagnostics <- function(data, cor_result, selection,
                                            rare_category_prop_cutoff = 0.05) {
   data <- as.data.frame(data)

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -436,3 +436,77 @@ test_that("the parallel analysis null distribution never mixes in Pearson eigenv
   # Only the successful iterations (identity matrices) contribute, so every threshold is 1.
   expect_true(all(abs(result$table$random_eigenvalue_threshold - 1) < 1e-8))
 })
+
+test_that("verification pass 4 findings (issue #26623)", {
+  df <- factanal_ordinal_fixture(n = 200)
+
+  # Manual Polychoric on continuous columns: there is no categorical variable to describe, so the
+  # category rows must report Not Available rather than inventing "400 categories" and flagging
+  # every variable and pair.
+  continuous <- data.frame(a = stats::rnorm(200), b = stats::rnorm(200), c = stats::rnorm(200))
+  continuous_selection <- select_factor_correlation_type(continuous)
+  continuous_diagnostics <- compute_polychoric_diagnostics(
+    continuous, list(correlation = diag(3), thresholds = NULL, type = "polychoric",
+                     smoothed = FALSE, warnings = character(), failed = FALSE),
+    continuous_selection)
+  expect_equal(continuous_diagnostics$Judgement[[1]], "Not Available")
+  expect_equal(continuous_diagnostics$Judgement[[2]], "Not Available")
+  expect_equal(continuous_diagnostics$Judgement[[3]], "Not Available")
+  expect_equal(continuous_diagnostics$status[[1]], "na")
+
+  # A DECLARED category with zero responses is the sparsest case there is; table() never shows it,
+  # so it has to be padded in from the defined levels.
+  zero_level_df <- data.frame(
+    a = factor(c("low", "mid", "high")[c(1, 2, 1, 2, 1, 2, 1, 2)], levels = c("low", "mid", "high"), ordered = TRUE),
+    b = factor(c("low", "mid", "high")[c(1, 2, 3, 2, 1, 2, 3, 2)], levels = c("low", "mid", "high"), ordered = TRUE),
+    c = factor(c("low", "mid", "high")[c(3, 2, 1, 2, 3, 2, 1, 2)], levels = c("low", "mid", "high"), ordered = TRUE)
+  )
+  zero_selection <- select_factor_correlation_type(zero_level_df)
+  zero_diagnostics <- compute_polychoric_diagnostics(
+    encode_factanal_data(zero_level_df, zero_selection),
+    list(correlation = diag(3), thresholds = NULL, type = "polychoric",
+         smoothed = FALSE, warnings = character(), failed = FALSE),
+    zero_selection)
+  expect_equal(zero_diagnostics$Judgement[[1]], "All categorical variables have 3 categories")
+  # Column `a` never takes its third level -> 0% of the responses -> sparse.
+  expect_equal(zero_diagnostics$Judgement[[2]], "Detected in 1 variable")
+})
+
+test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
+  # The degrade path mutates `resolved` after construction and re-points the diagnostics and the
+  # parallel analysis; exercise it through exp_factanal, not just the helper.
+  df <- factanal_ordinal_fixture(n = 150)
+  original_build <- build_factor_correlation
+  failing_build <- function(data, correlation_type = c("pearson", "polychoric", "tetrachoric", "mixed"),
+                            use = "pairwise.complete.obs", correct = 0.5) {
+    correlation_type <- match.arg(correlation_type)
+    if (identical(correlation_type, "pearson")) {
+      return(original_build(data, correlation_type, use = use, correct = correct))
+    }
+    list(correlation = stats::cor(data, use = use), thresholds = NULL, type = "pearson",
+         smoothed = FALSE, warnings = "simulated polychoric failure", failed = TRUE)
+  }
+  assign("build_factor_correlation", failing_build, envir = environment(exp_factanal))
+  on.exit(assign("build_factor_correlation", original_build, envir = environment(exp_factanal)), add = TRUE)
+
+  fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                      cor_type = "polychoric", parallel_n_iter = 3)$model[[1]]
+  # The fit itself falls back to Pearson...
+  expect_equal(fit$correlation_type, "pearson")
+  # ...but the report can still say WHICH correlation failed, and still shows the diagnostics.
+  expect_equal(fit$correlation_degraded_from, "polychoric")
+  expect_true(grepl("could not be estimated", fit$correlation_reason))
+  expect_false(is.null(fit$cor_diagnostics))
+  method_tbl <- tidy(fit, type = "analysis_method")
+  expect_equal(method_tbl$Value[[1]], "Pearson Correlation")
+  expect_equal(method_tbl$degraded_from[[1]], "polychoric")
+  expect_true(method_tbl$has_diagnostics[[1]])
+  diagnostics <- tidy(fit, type = "cor_diagnostics")
+  expect_equal(diagnostics$Judgement[[4]], "Estimation failed")
+  # The Pearson fallback matrix says nothing about the correlation that failed.
+  expect_equal(diagnostics$Judgement[[5]], "Not Available")
+  expect_equal(diagnostics$Judgement[[6]], "Not Available")
+  # Scores and the parallel analysis still come out of the fallback matrix, not a half-built one.
+  expect_false(is.null(fit$scores))
+  expect_false(is.null(fit$parallel))
+})

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -537,3 +537,35 @@ test_that("Repeat By groups all use the same correlation (issue #26623)", {
   has_diagnostics <- vapply(model_df$model, function(m) !is.null(m$cor_diagnostics), logical(1))
   expect_equal(length(unique(has_diagnostics)), 1)
 })
+
+test_that("an unsupported facet is skipped, not fatal, under Repeat By (issue #26623)", {
+  # Mirrors the not-enough-columns guard: one degenerate facet must not abort the whole run.
+  # Facet "good" sees only two distinct answers for q1 (binary -> supported); facet "bad" sees
+  # three (nominal -> unsupported), so the unsupported branch is reached per group.
+  set.seed(77)
+  n <- 120
+  latent <- stats::rnorm(n)
+  ordinal_col <- function() {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+  }
+  good <- data.frame(g = "good", q1 = sample(c("yes", "no"), n, TRUE),
+                     q2 = ordinal_col(), q3 = ordinal_col(), stringsAsFactors = FALSE)
+  bad <- data.frame(g = "bad", q1 = sample(c("yes", "no", "maybe"), n, TRUE),
+                    q2 = ordinal_col(), q3 = ordinal_col(), stringsAsFactors = FALSE)
+  grouped <- dplyr::group_by(rbind(good, bad), g)
+
+  model_df <- exp_factanal(grouped, q1, q2, q3, nfactors = 1, rotate = "none", parallel_n_iter = 3)
+  # The good facet still produced a model; the unsupported one was skipped (NULL model, the same
+  # shape the not-enough-columns guard produces), not fatal.
+  expect_true("good" %in% model_df$g)
+  good_model <- model_df$model[[which(model_df$g == "good")]]
+  expect_false(is.null(good_model))
+  if ("bad" %in% model_df$g) {
+    expect_true(is.null(model_df$model[[which(model_df$g == "bad")]]))
+  }
+
+  # Without Repeat By the same unsupported data still raises the error, so nothing is swallowed.
+  expect_error(exp_factanal(dplyr::select(bad, q1, q2, q3), q1, q2, q3, nfactors = 1, parallel_n_iter = 3),
+               "EXP-ANA-35")
+})

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -135,7 +135,7 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
   expect_equal(method_tbl$Item, c("Correlation", "Factor Extraction Method", "Rotation", "Target Variables", "Data Rows"))
   expect_equal(method_tbl$Value[[1]], "Polychoric Correlation")
   expect_equal(method_tbl$Value[[2]], "Minimum Residual")
-  expect_equal(method_tbl$Value[[3]], "Varimax")
+  expect_equal(method_tbl$Value[[3]], "Varimax (Orthogonal)")
   expect_equal(method_tbl$Value[[4]], "6")
   expect_equal(method_tbl$Value[[5]], as.character(nrow(df)))
   # Hidden columns the client binds the report explanation from.
@@ -352,4 +352,87 @@ test_that("an unsupported variable combination uses its own error id with the co
   expect_true(grepl("^EXP-ANA-35 :: ", err))
   expect_false(grepl("EXP-ANA-6", err))
   expect_true(grepl('\\["cat"\\]', err))
+})
+
+test_that("verification pass 3 findings (issue #26623)", {
+  df <- factanal_ordinal_fixture(n = 200)
+  selection <- select_factor_correlation_type(df[, 1:3])
+
+  # A failed estimation leaves the PEARSON fallback matrix in hand, so its positive definiteness
+  # and smoothing say nothing about the correlation that failed.
+  failed_result <- list(correlation = diag(3), thresholds = NULL, type = "pearson",
+                        smoothed = FALSE, warnings = "boom", failed = TRUE)
+  failed_diagnostics <- compute_polychoric_diagnostics(df[, 1:3], failed_result, selection)
+  expect_equal(failed_diagnostics$Judgement[[4]], "Estimation failed")
+  expect_equal(failed_diagnostics$Judgement[[5]], "Not Available")
+  expect_equal(failed_diagnostics$Judgement[[6]], "Not Available")
+  expect_equal(failed_diagnostics$status[[5]], "na")
+
+  # The sparse-category description must not name Polychoric: the same row appears in tetrachoric
+  # and mixed analyses.
+  expect_false(any(grepl("Polychoric correlations may become unstable", failed_diagnostics$Description)))
+  expect_true(any(grepl("Correlations estimated from categories", failed_diagnostics$Description)))
+
+  # Counts are singular when there is exactly one hit. Balanced columns, then one rare category
+  # injected into a single variable.
+  balanced <- data.frame(q1 = rep(1:4, 50), q2 = rep(1:4, 50), q3 = rep(1:4, 50))
+  balanced$q1[balanced$q1 == 4] <- 3
+  balanced$q1[1] <- 4   # a single response in the top category (1 of 200 = below the 5% cutoff)
+  balanced_selection <- select_factor_correlation_type(balanced)
+  single <- compute_polychoric_diagnostics(balanced,
+                                           list(correlation = diag(3), thresholds = NULL,
+                                                type = "polychoric", smoothed = FALSE,
+                                                warnings = character(), failed = FALSE),
+                                           balanced_selection)
+  expect_equal(single$Judgement[[2]], "Detected in 1 variable")
+
+  # Category counts come from the DEFINED levels the selection branched on, not observed codes.
+  ordered_df <- data.frame(
+    a = factor(c("low", "mid", "high")[c(1, 2, 1, 2, 1, 2, 1, 2)], levels = c("low", "mid", "high"), ordered = TRUE),
+    b = factor(c("low", "mid", "high")[c(1, 2, 3, 2, 1, 2, 3, 2)], levels = c("low", "mid", "high"), ordered = TRUE),
+    c = factor(c("low", "mid", "high")[c(3, 2, 1, 2, 3, 2, 1, 2)], levels = c("low", "mid", "high"), ordered = TRUE)
+  )
+  ordered_selection <- select_factor_correlation_type(ordered_df)
+  ordered_diagnostics <- compute_polychoric_diagnostics(encode_factanal_data(ordered_df, ordered_selection),
+                                                        list(correlation = diag(3), thresholds = NULL,
+                                                             type = "polychoric", smoothed = FALSE,
+                                                             warnings = character(), failed = FALSE),
+                                                        ordered_selection)
+  # Column `a` never takes its third level, but it still HAS three defined categories.
+  expect_equal(ordered_diagnostics$Judgement[[1]], "All categorical variables have 3 categories")
+
+  # Polychoric stays offered for scale-like data the rating-scale heuristic classifies numeric
+  # (a 1-10 scale, or a 1-5 scale with a gap), and is dropped only for genuine measurements.
+  wide_scale <- data.frame(a = rep(1:10, 20), b = rep(1:10, 20), c = rep(1:10, 20))
+  expect_true(factanal_polychoric_available(select_factor_correlation_type(wide_scale), wide_scale))
+  continuous <- mtcars[, c("mpg", "disp", "drat", "wt")]
+  expect_false(factanal_polychoric_available(select_factor_correlation_type(continuous), continuous))
+
+  # The unknown-correlation-type error lists what the guard actually accepts.
+  expect_error(resolve_factanal_correlation_type("nonsense", selection),
+               "auto, pearson, polychoric, tetrachoric, and mixed")
+})
+
+test_that("the parallel analysis null distribution never mixes in Pearson eigenvalues (issue #26623)", {
+  # A permutation whose polychoric estimation fails returns the Pearson matrix with failed = TRUE.
+  # Those iterations must be dropped, not compared against polychoric eigenvalues.
+  df <- factanal_ordinal_fixture(n = 150)[, 1:3]
+  calls <- 0
+  fake_build <- function(data, correlation_type, ...) {
+    calls <<- calls + 1
+    if (calls %% 2 == 0) {
+      list(correlation = stats::cor(data), thresholds = NULL, type = "pearson",
+           smoothed = FALSE, warnings = "failed", failed = TRUE)
+    } else {
+      list(correlation = diag(ncol(data)), thresholds = NULL, type = correlation_type,
+           smoothed = FALSE, warnings = character(), failed = FALSE)
+    }
+  }
+  original_build <- build_factor_correlation
+  assign("build_factor_correlation", fake_build, envir = environment(compute_parallel_analysis))
+  on.exit(assign("build_factor_correlation", original_build, envir = environment(compute_parallel_analysis)), add = TRUE)
+  result <- compute_parallel_analysis(df, n_iter = 4, cor_type = "polychoric",
+                                      cor_matrix = diag(ncol(df)))
+  # Only the successful iterations (identity matrices) contribute, so every threshold is 1.
+  expect_true(all(abs(result$table$random_eigenvalue_threshold - 1) < 1e-8))
 })

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -148,7 +148,7 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
                c("Number of Categories", "Sparse Categories", "Empty Category Combinations",
                  "Correlation Estimation Failures", "Positive Definiteness of the Correlation Matrix",
                  "Smoothing Applied"))
-  expect_equal(diagnostics$Judgement[[1]], "All variables have 5 categories")
+  expect_equal(diagnostics$Judgement[[1]], "All categorical variables have 5 categories")
   expect_equal(diagnostics$Judgement[[4]], "None")   # no estimation failure on this fixture
   expect_equal(diagnostics$Judgement[[5]], "No problem")
   expect_equal(diagnostics$Judgement[[6]], "None")
@@ -276,7 +276,80 @@ test_that("mixed-correlation diagnostics only describe the categorical variables
   diagnostics <- tidy(fit, type = "cor_diagnostics")
   # A continuous column has one "category" per distinct value; counting it would report hundreds of
   # categories and flag every variable as sparse and every pair as having empty combinations.
-  expect_equal(diagnostics$Judgement[[1]], "All variables have 5 categories")
+  expect_equal(diagnostics$Judgement[[1]], "All categorical variables have 5 categories")
   expect_equal(diagnostics$Judgement[[2]], "Detected in 3 variables")   # the 3 ordinal ones at most
   expect_false(grepl("Detected in 10 variable pairs", diagnostics$Judgement[[3]]))
+})
+
+test_that("verification pass 2 findings (issue #26623)", {
+  df <- factanal_ordinal_fixture()
+  fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                      parallel_n_iter = 3)$model[[1]]
+  method_tbl <- tidy(fit, type = "analysis_method")
+
+  # Rotation / extraction labels echo the property dropdown's wording, so the report and the
+  # settings panel cannot disagree about what was run.
+  expect_equal(factanal_rotation_label("varimax"), "Varimax (Orthogonal)")
+  expect_equal(factanal_rotation_label("oblimin"), "Oblimin (Oblique)")
+  expect_equal(factanal_extraction_method_label("gls"), "Generalized Weighted Least Squares")
+
+  # Whether Polychoric is worth suggesting is data-dependent.
+  expect_true(factanal_polychoric_available(select_factor_correlation_type(df)))
+  expect_false(factanal_polychoric_available(select_factor_correlation_type(mtcars[, c("mpg", "hp", "drat", "wt")])))
+  expect_true(method_tbl$polychoric_available[[1]])
+  expect_equal(method_tbl$degraded_from[[1]], "")
+
+  # The category-count row says "categorical variables": in a mixed analysis the continuous
+  # columns are not counted, so "all variables" would contradict the Target Variables row.
+  diagnostics <- tidy(fit, type = "cor_diagnostics")
+  expect_true(grepl("^All categorical variables have", diagnostics$Judgement[[1]]))
+
+  # Selector warnings reach the client as language-neutral tokens (never English prose).
+  sparse_df <- df
+  sparse_df$q1[sparse_df$q1 == 5] <- 4       # make the top category nearly empty
+  sparse_df$q1[seq_len(2)] <- 5              # 2 of 300 responses = below the 5% cutoff
+  tokens <- factanal_selection_warning_tokens(select_factor_correlation_type(sparse_df))
+  expect_true("sparse_categories" %in% tokens)
+  expect_equal(factanal_selection_warning_tokens(select_factor_correlation_type(mtcars[, 1:4])), character())
+
+  # The parallel analysis reuses the analysis's own matrix rather than recomputing a second one.
+  parallel_result <- compute_parallel_analysis(mtcars[, c("mpg", "hp", "drat", "wt")], n_iter = 3,
+                                               cor_type = "pearson",
+                                               cor_matrix = cor(mtcars[, c("mpg", "hp", "drat", "wt")]))
+  expect_equal(parallel_result$table$actual_eigenvalue,
+               eigen(cor(mtcars[, c("mpg", "hp", "drat", "wt")]), only.values = TRUE)$values)
+})
+
+test_that("positive definiteness reports the matrix BEFORE psych's smoothing (issue #26623)", {
+  df <- factanal_ordinal_fixture(n = 200)
+  # psych smooths a non-positive-definite matrix automatically, so testing the returned matrix
+  # would always pass and contradict the "Smoothing Applied" row.
+  smoothed_result <- list(correlation = diag(3), thresholds = NULL, type = "polychoric",
+                          smoothed = TRUE, warnings = character(), failed = FALSE)
+  selection <- select_factor_correlation_type(df[, 1:3])
+  diagnostics <- compute_polychoric_diagnostics(df[, 1:3], smoothed_result, selection)
+  expect_equal(diagnostics$Judgement[[5]], "Not positive definite")
+  expect_equal(diagnostics$Judgement[[6]], "Applied")
+  expect_equal(diagnostics$status[[5]], "caution")
+
+  clean_result <- list(correlation = diag(3), thresholds = NULL, type = "polychoric",
+                       smoothed = FALSE, warnings = character(), failed = FALSE)
+  clean_diagnostics <- compute_polychoric_diagnostics(df[, 1:3], clean_result, selection)
+  expect_equal(clean_diagnostics$Judgement[[5]], "No problem")
+  expect_equal(clean_diagnostics$Judgement[[6]], "None")
+})
+
+test_that("an unsupported variable combination uses its own error id with the column names (issue #26623)", {
+  df <- factanal_ordinal_fixture(n = 150)
+  df$cat <- factor(sample(c("a", "b", "c"), nrow(df), TRUE))
+  # EXP-ANA-6 belongs to PCA's reserved-column-name error; reusing it would show the user a
+  # message about renaming PC1/PC2. The params carry the offending column names.
+  err <- tryCatch({
+    exp_factanal(df, q1, q2, cat, nfactors = 1, parallel_n_iter = 3)
+    NULL
+  }, error = function(e) conditionMessage(e))
+  expect_false(is.null(err))
+  expect_true(grepl("^EXP-ANA-35 :: ", err))
+  expect_false(grepl("EXP-ANA-6", err))
+  expect_true(grepl('\\["cat"\\]', err))
 })

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -1,0 +1,220 @@
+# Correlation-type selection and polychoric support for Factor Analysis (issue #26623).
+# how to run this test:
+# devtools::test(filter="factanal_correlation")
+context("test factor analysis correlation type, exp_factanal cor_type")
+
+# =============================================================================
+# Polychoric correlation support (issue #26623)
+# =============================================================================
+
+# Builds ordinal survey-like data: q1-q3 load on one latent factor, q4-q6 on another.
+# `skew=TRUE` concentrates the responses so the 5-category rule picks Polychoric.
+factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
+  set.seed(seed)
+  lat1 <- stats::rnorm(n)
+  lat2 <- stats::rnorm(n)
+  make_col <- function(latent) {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    if (skew) {
+      as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    } else {
+      as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = 6)),
+                     include.lowest = TRUE, labels = FALSE))
+    }
+  }
+  data.frame(q1 = make_col(lat1), q2 = make_col(lat1), q3 = make_col(lat1),
+             q4 = make_col(lat2), q5 = make_col(lat2), q6 = make_col(lat2))
+}
+
+test_that("correlation type auto-selection rules (issue #26623)", {
+  n <- 300
+  set.seed(11)
+  lat <- stats::rnorm(n)
+  ordinal_col <- function(k) {
+    z <- 0.7 * lat + sqrt(1 - 0.7^2) * stats::rnorm(n)
+    as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = k + 1)),
+                   include.lowest = TRUE, labels = FALSE))
+  }
+  method_of <- function(df) select_factor_correlation_type(df)$selected_method
+
+  # All numeric -> Pearson.
+  expect_equal(method_of(data.frame(a = stats::rnorm(n), b = stats::rnorm(n), c = stats::rnorm(n))), "pearson")
+  # All binary -> Tetrachoric (numeric 0/1 and logical alike).
+  expect_equal(method_of(data.frame(a = stats::rbinom(n, 1, .4), b = stats::rbinom(n, 1, .5), c = stats::rbinom(n, 1, .6))), "tetrachoric")
+  expect_equal(method_of(data.frame(a = stats::rbinom(n, 1, .4) == 1, b = stats::rbinom(n, 1, .5) == 1, c = stats::rbinom(n, 1, .6) == 1)), "tetrachoric")
+  # All ordinal with at most 4 categories -> Polychoric.
+  expect_equal(method_of(data.frame(a = ordinal_col(4), b = ordinal_col(4), c = ordinal_col(4))), "polychoric")
+  # Ordered factors are ordinal too.
+  expect_equal(method_of(data.frame(a = factor(ordinal_col(4), ordered = TRUE),
+                                    b = factor(ordinal_col(4), ordered = TRUE),
+                                    c = factor(ordinal_col(4), ordered = TRUE))), "polychoric")
+  # 5 categories: skewed/concentrated -> Polychoric, balanced -> Pearson.
+  expect_equal(method_of(factanal_ordinal_fixture(skew = TRUE)), "polychoric")
+  expect_equal(method_of(factanal_ordinal_fixture(skew = FALSE)), "pearson")
+  # 6 or more ordered categories -> Pearson by default.
+  expect_equal(method_of(data.frame(a = ordinal_col(7), b = ordinal_col(7), c = ordinal_col(7))), "pearson")
+  # Numeric + ordinal mix -> Mixed correlation.
+  expect_equal(method_of(data.frame(a = stats::rnorm(n), b = ordinal_col(5), c = ordinal_col(5))), "mixed")
+  # A nominal category makes the combination unsupported.
+  nominal <- select_factor_correlation_type(data.frame(a = factor(sample(letters[1:4], n, TRUE)),
+                                                       b = ordinal_col(4), c = ordinal_col(4)))
+  expect_equal(nominal$selected_method, "unsupported")
+  expect_true(grepl("Nominal categorical variables", nominal$reason))
+  # A constant column is invalid, not silently analyzed.
+  invalid <- select_factor_correlation_type(data.frame(a = rep(1, n), b = ordinal_col(4), c = ordinal_col(4)))
+  expect_equal(invalid$selected_method, "unsupported")
+  expect_true(grepl("Invalid variables", invalid$reason))
+})
+
+test_that("numeric rating-scale detection does not reclassify ordinary measurements (issue #26623)", {
+  # A 1-5 (or 0-4) consecutive integer scale is treated as ordinal...
+  expect_true(is_rating_scale_numeric(c(1, 2, 3, 4, 5)))
+  expect_true(is_rating_scale_numeric(c(0, 1, 2, 3)))
+  # ...but a measurement with gaps, non-integers, too many levels, or not starting at 0/1 is not.
+  expect_false(is_rating_scale_numeric(c(4, 6, 8)))          # mtcars$cyl
+  expect_false(is_rating_scale_numeric(c(1.5, 2.5, 3.5)))
+  expect_false(is_rating_scale_numeric(1:8))
+  expect_false(is_rating_scale_numeric(c(3, 4, 5)))
+  # So an all-numeric data frame like mtcars keeps using Pearson.
+  expect_equal(select_factor_correlation_type(mtcars[, c("cyl", "mpg", "hp", "drat")])$selected_method, "pearson")
+})
+
+test_that("exp_factanal Pearson results are unchanged by the correlation-type support (issue #26623)", {
+  set.seed(3)
+  n <- 200
+  lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
+  df <- data.frame(a = lat1 + stats::rnorm(n), b = lat1 + stats::rnorm(n),
+                   c = lat2 + stats::rnorm(n), e = lat2 + stats::rnorm(n))
+  fit <- exp_factanal(df, a, b, c, e, nfactors = 2, fm = "minres", rotate = "varimax",
+                      cor_type = "pearson", parallel_n_iter = 5)$model[[1]]
+  reference <- psych::fa(df, nfactors = 2, fm = "minres", scores = "regression", rotate = "varimax")
+  expect_equal(unclass(fit$loadings), unclass(reference$loadings))
+  expect_equal(fit$scores, reference$scores)
+  # Auto on all-numeric data resolves to Pearson, so existing analyses keep their results.
+  auto_fit <- exp_factanal(df, a, b, c, e, nfactors = 2, fm = "minres", rotate = "varimax",
+                           parallel_n_iter = 5)$model[[1]]
+  expect_equal(auto_fit$correlation_type, "pearson")
+  expect_equal(unclass(auto_fit$loadings), unclass(reference$loadings))
+})
+
+test_that("every downstream computation uses the polychoric matrix, not Pearson (issue #26623)", {
+  df <- factanal_ordinal_fixture()
+  poly <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                       parallel_n_iter = 5)$model[[1]]
+  pearson <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                          cor_type = "pearson", parallel_n_iter = 5)$model[[1]]
+  expect_equal(poly$correlation_type, "polychoric")
+  expect_true(poly$correlation_is_auto)
+  expect_false(pearson$correlation_is_auto)
+
+  # The correlation matrix itself, and therefore KMO / Bartlett / eigenvalues, differ.
+  expect_false(isTRUE(all.equal(poly$correlation, pearson$correlation)))
+  expect_false(isTRUE(all.equal(poly$kmo, pearson$kmo)))
+  expect_false(isTRUE(all.equal(poly$bartlett$chisq, pearson$bartlett$chisq)))
+
+  # The parallel analysis compares against the SAME matrix fa() was fitted on.
+  expect_equal(poly$parallel$table$actual_eigenvalue,
+               eigen(poly$correlation, symmetric = TRUE, only.values = TRUE)$values)
+  # The scree plot / Kaiser criterion read the same matrix as well.
+  expect_equal(tidy(poly, type = "screeplot")$eigenvalue,
+               eigen(poly$correlation, only.values = TRUE)$values)
+
+  # fa() on a correlation matrix returns no scores, so they are computed from that matrix.
+  expect_false(is.null(poly$scores))
+  expect_equal(nrow(poly$scores), nrow(df))
+  expect_equal(ncol(poly$scores), 2)
+  expect_equal(nrow(tidy(poly, type = "data")), nrow(df))
+})
+
+test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
+  df <- factanal_ordinal_fixture()
+  poly <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, fm = "minres", rotate = "varimax",
+                       parallel_n_iter = 5)$model[[1]]
+
+  method_tbl <- tidy(poly, type = "analysis_method")
+  expect_equal(method_tbl$Item, c("Correlation", "Factor Extraction Method", "Rotation", "Target Variables", "Data Rows"))
+  expect_equal(method_tbl$Value[[1]], "Polychoric Correlation")
+  expect_equal(method_tbl$Value[[2]], "Minimum Residual")
+  expect_equal(method_tbl$Value[[3]], "Varimax")
+  expect_equal(method_tbl$Value[[4]], "6")
+  expect_equal(method_tbl$Value[[5]], as.character(nrow(df)))
+  # Hidden columns the client binds the report explanation from.
+  expect_equal(unique(method_tbl$correlation_type), "polychoric")
+  expect_true(all(method_tbl$correlation_is_auto))
+  expect_true(nchar(method_tbl$reason[[1]]) > 0)
+
+  diagnostics <- tidy(poly, type = "cor_diagnostics")
+  expect_equal(diagnostics$Diagnostic,
+               c("Number of Categories", "Sparse Categories", "Empty Category Combinations",
+                 "Correlation Estimation Failures", "Positive Definiteness of the Correlation Matrix",
+                 "Smoothing Applied"))
+  expect_equal(diagnostics$Judgement[[1]], "All variables have 5 categories")
+  expect_equal(diagnostics$Judgement[[4]], "None")   # no estimation failure on this fixture
+  expect_equal(diagnostics$Judgement[[5]], "No problem")
+  expect_equal(diagnostics$Judgement[[6]], "None")
+  expect_equal(diagnostics$status[[5]], "ok")
+
+  # On a Pearson analysis the diagnostics table is empty (the report hides the section) but keeps
+  # its column shape.
+  pearson <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                          cor_type = "pearson", parallel_n_iter = 5)$model[[1]]
+  empty <- tidy(pearson, type = "cor_diagnostics")
+  expect_equal(nrow(empty), 0)
+  expect_equal(colnames(empty), c("Diagnostic", "Judgement", "Description", "status"))
+  expect_equal(tidy(pearson, type = "analysis_method")$Value[[1]], "Pearson Correlation")
+})
+
+test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
+  set.seed(5)
+  n <- 250
+  lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
+  binary_col <- function(latent) as.integer(0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n) > 0.3)
+  ordinal_col <- function(latent) {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+  }
+  binary_df <- data.frame(b1 = binary_col(lat1), b2 = binary_col(lat1), b3 = binary_col(lat1),
+                          b4 = binary_col(lat2), b5 = binary_col(lat2), b6 = binary_col(lat2))
+  tet <- exp_factanal(binary_df, b1, b2, b3, b4, b5, b6, nfactors = 2, rotate = "varimax",
+                      parallel_n_iter = 5)$model[[1]]
+  expect_equal(tet$correlation_type, "tetrachoric")
+  expect_equal(tidy(tet, type = "analysis_method")$Value[[1]], "Tetrachoric Correlation")
+  expect_false(is.null(tet$scores))
+
+  mixed_df <- data.frame(x1 = lat1 + stats::rnorm(n, 0, .5), x2 = lat1 + stats::rnorm(n, 0, .5),
+                         q1 = ordinal_col(lat2), q2 = ordinal_col(lat2), q3 = ordinal_col(lat2))
+  mixed <- exp_factanal(mixed_df, x1, x2, q1, q2, q3, nfactors = 2, rotate = "varimax",
+                        parallel_n_iter = 5)$model[[1]]
+  expect_equal(mixed$correlation_type, "mixed")
+  expect_equal(tidy(mixed, type = "analysis_method")$Value[[1]], "Mixed Correlation")
+
+  # A nominal column aborts with the analytics error code, not a raw psych error.
+  nominal_df <- binary_df
+  nominal_df$cat <- factor(sample(c("a", "b", "c"), n, TRUE))
+  expect_error(exp_factanal(nominal_df, b1, b2, cat, nfactors = 1, parallel_n_iter = 5),
+               "Nominal categorical variables")
+})
+
+test_that("build_factor_correlation returns one matrix for the whole analysis (issue #26623)", {
+  df <- factanal_ordinal_fixture(n = 200)
+  pearson <- build_factor_correlation(df, "pearson")
+  expect_equal(pearson$type, "pearson")
+  expect_equal(pearson$correlation, stats::cor(df, use = "pairwise.complete.obs"))
+  expect_null(pearson$thresholds)
+
+  poly <- build_factor_correlation(df, "polychoric")
+  expect_equal(poly$type, "polychoric")
+  expect_equal(dim(poly$correlation), c(ncol(df), ncol(df)))
+  expect_false(is.null(poly$thresholds))
+  expect_false(poly$failed)
+  # Thresholds are what makes it polychoric: the matrix must not equal the Pearson one.
+  expect_false(isTRUE(all.equal(poly$correlation, pearson$correlation)))
+
+  expect_error(build_factor_correlation(df, "nonsense"))
+  expect_error(resolve_factanal_correlation_type("nonsense", select_factor_correlation_type(df)),
+               "Unknown correlation type")
+  # A manual choice wins over the automatic selection.
+  manual <- resolve_factanal_correlation_type("polychoric", select_factor_correlation_type(mtcars[, 1:4]))
+  expect_equal(manual$type, "polychoric")
+  expect_false(manual$auto)
+})

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -218,3 +218,65 @@ test_that("build_factor_correlation returns one matrix for the whole analysis (i
   expect_equal(manual$type, "polychoric")
   expect_false(manual$auto)
 })
+
+test_that("verification pass 1 findings (issue #26623)", {
+  df <- factanal_ordinal_fixture()
+
+  # The "Type of Scores" property must not become a no-op on the correlation-matrix path.
+  expect_equal(factanal_score_method("regression"), "Thurstone")   # fa()'s name for the same method
+  expect_equal(factanal_score_method("Bartlett"), "Bartlett")
+  expect_equal(factanal_score_method("tenBerge"), "tenBerge")
+  expect_equal(factanal_score_method(NULL), "Thurstone")
+  regression_fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                                 scores = "regression", parallel_n_iter = 3)$model[[1]]
+  bartlett_fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
+                               scores = "Bartlett", parallel_n_iter = 3)$model[[1]]
+  expect_false(isTRUE(all.equal(regression_fit$scores, bartlett_fit$scores)))
+
+  # Rotation names are mapped, not title-cased: "bentlerT" must not render as "Bentlert".
+  expect_equal(factanal_rotation_label("bentlerT"), "Bentler (Orthogonal)")
+  expect_equal(factanal_rotation_label("geominT"), "Geomin (Orthogonal)")
+  expect_equal(factanal_rotation_label("promax"), "Promax with Kaiser Normalization")
+  expect_equal(factanal_rotation_label("none"), "None")
+  rotated <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "bentlerT",
+                          cor_type = "polychoric", parallel_n_iter = 3)$model[[1]]
+  expect_equal(tidy(rotated, type = "analysis_method")$Value[[3]], "Bentler (Orthogonal)")
+
+  # A manual choice must not be reported as an automatic one, and must not read "Correlation
+  # correlation".
+  expect_equal(rotated$correlation_reason, "Polychoric Correlation was selected manually.")
+  expect_false(rotated$correlation_is_auto)
+  method_tbl <- tidy(rotated, type = "analysis_method")
+  expect_false(method_tbl$correlation_is_auto[[1]])
+  expect_true(method_tbl$has_diagnostics[[1]])
+
+  # An unsupported variable combination stays unsupported when the correlation is chosen manually:
+  # picking Pearson must not smuggle a nominal column in as arbitrary integer codes.
+  nominal_df <- df
+  nominal_df$cat <- factor(sample(c("a", "b", "c"), nrow(df), TRUE))
+  expect_error(exp_factanal(nominal_df, q1, q2, cat, nfactors = 1, cor_type = "pearson", parallel_n_iter = 3),
+               "Nominal categorical variables")
+  expect_error(exp_factanal(nominal_df, q1, q2, cat, nfactors = 1, cor_type = "polychoric", parallel_n_iter = 3),
+               "Nominal categorical variables")
+})
+
+test_that("mixed-correlation diagnostics only describe the categorical variables (issue #26623)", {
+  set.seed(21)
+  n <- 300
+  lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
+  ordinal_col <- function(latent) {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+  }
+  mixed_df <- data.frame(x1 = lat1 + stats::rnorm(n, 0, .5), x2 = lat1 + stats::rnorm(n, 0, .5),
+                         q1 = ordinal_col(lat2), q2 = ordinal_col(lat2), q3 = ordinal_col(lat2))
+  fit <- exp_factanal(mixed_df, x1, x2, q1, q2, q3, nfactors = 2, rotate = "varimax",
+                      parallel_n_iter = 3)$model[[1]]
+  expect_equal(fit$correlation_type, "mixed")
+  diagnostics <- tidy(fit, type = "cor_diagnostics")
+  # A continuous column has one "category" per distinct value; counting it would report hundreds of
+  # categories and flag every variable as sparse and every pair as having empty combinations.
+  expect_equal(diagnostics$Judgement[[1]], "All variables have 5 categories")
+  expect_equal(diagnostics$Judgement[[2]], "Detected in 3 variables")   # the 3 ordinal ones at most
+  expect_false(grepl("Detected in 10 variable pairs", diagnostics$Judgement[[3]]))
+})

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -510,3 +510,30 @@ test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
   expect_false(is.null(fit$scores))
   expect_false(is.null(fit$parallel))
 })
+
+test_that("Repeat By groups all use the same correlation (issue #26623)", {
+  # Group A is ordinal (would pick Polychoric on its own), group B is continuous (Pearson). One
+  # report describes one correlation, and loadings must be comparable across facets, so the choice
+  # is made once from the whole data.
+  set.seed(31)
+  n <- 200
+  latent_a <- stats::rnorm(n)
+  ordinal_col <- function(latent) {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+  }
+  group_a <- data.frame(g = "A", q1 = ordinal_col(latent_a), q2 = ordinal_col(latent_a),
+                        q3 = ordinal_col(latent_a), stringsAsFactors = FALSE)
+  latent_b <- stats::rnorm(n)
+  group_b <- data.frame(g = "B",
+                        q1 = latent_b + stats::rnorm(n), q2 = latent_b + stats::rnorm(n),
+                        q3 = latent_b + stats::rnorm(n), stringsAsFactors = FALSE)
+  grouped <- dplyr::group_by(rbind(group_a, group_b), g)
+
+  model_df <- exp_factanal(grouped, q1, q2, q3, nfactors = 1, rotate = "none", parallel_n_iter = 3)
+  types <- vapply(model_df$model, function(m) m$correlation_type, character(1))
+  expect_equal(length(unique(types)), 1)
+  # And the per-group diagnostics still reflect that one correlation.
+  has_diagnostics <- vapply(model_df$model, function(m) !is.null(m$cor_diagnostics), logical(1))
+  expect_equal(length(unique(has_diagnostics)), 1)
+})

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -26,6 +26,42 @@ factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
              q4 = make_col(lat2), q5 = make_col(lat2), q6 = make_col(lat2))
 }
 
+# Swaps build_factor_correlation for a stub and returns a restore function.
+#
+# The package namespace is LOCKED when the tests run against an installed build (Jenkins /
+# R CMD check), so a bare assign() fails there with "cannot change value of locked binding".
+# Mirrors the unlockBinding pattern already used in test_pdf.R. The global-environment copy is
+# patched too, so the suite also works when the R files are source()'d for local iteration --
+# in that case exp_factanal()/compute_parallel_analysis() resolve the helper from globalenv,
+# not from the namespace.
+stub_build_factor_correlation <- function(stub) {
+  restorers <- list()
+
+  ns <- tryCatch(asNamespace("exploratory"), error = function(e) NULL)
+  if (!is.null(ns) && exists("build_factor_correlation", envir = ns, inherits = FALSE)) {
+    original_ns <- get("build_factor_correlation", envir = ns)
+    was_locked <- bindingIsLocked("build_factor_correlation", ns)
+    if (was_locked) unlockBinding("build_factor_correlation", ns)
+    assign("build_factor_correlation", stub, envir = ns)
+    restorers <- c(restorers, function() {
+      assign("build_factor_correlation", original_ns, envir = ns)
+      if (was_locked) lockBinding("build_factor_correlation", ns)
+    })
+  }
+
+  if (exists("build_factor_correlation", envir = globalenv(), inherits = FALSE)) {
+    original_global <- get("build_factor_correlation", envir = globalenv())
+    assign("build_factor_correlation", stub, envir = globalenv())
+    restorers <- c(restorers, function() {
+      assign("build_factor_correlation", original_global, envir = globalenv())
+    })
+  }
+
+  function() {
+    for (restore in restorers) restore()
+  }
+}
+
 test_that("correlation type auto-selection rules (issue #26623)", {
   n <- 300
   set.seed(11)
@@ -428,9 +464,8 @@ test_that("the parallel analysis null distribution never mixes in Pearson eigenv
            smoothed = FALSE, warnings = character(), failed = FALSE)
     }
   }
-  original_build <- build_factor_correlation
-  assign("build_factor_correlation", fake_build, envir = environment(compute_parallel_analysis))
-  on.exit(assign("build_factor_correlation", original_build, envir = environment(compute_parallel_analysis)), add = TRUE)
+  restore <- stub_build_factor_correlation(fake_build)
+  on.exit(restore(), add = TRUE)
   result <- compute_parallel_analysis(df, n_iter = 4, cor_type = "polychoric",
                                       cor_matrix = diag(ncol(df)))
   # Only the successful iterations (identity matrices) contribute, so every threshold is 1.
@@ -486,8 +521,8 @@ test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
     list(correlation = stats::cor(data, use = use), thresholds = NULL, type = "pearson",
          smoothed = FALSE, warnings = "simulated polychoric failure", failed = TRUE)
   }
-  assign("build_factor_correlation", failing_build, envir = environment(exp_factanal))
-  on.exit(assign("build_factor_correlation", original_build, envir = environment(exp_factanal)), add = TRUE)
+  restore <- stub_build_factor_correlation(failing_build)
+  on.exit(restore(), add = TRUE)
 
   fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
                       cor_type = "polychoric", parallel_n_iter = 3)$model[[1]]


### PR DESCRIPTION
## Description

Factor Analysis ran everything on a Pearson correlation: `psych::fa()` got the raw data, `KMO()` / `cortest.bartlett()` got `cor()`, and the parallel analysis recomputed its own Pearson matrix. For ordinal survey answers (1-5 scales, 1/0 items) that misstates the factor structure — which is what インテージヘルスケア / インテージ asked us to fix.

The analysis now runs on **one** correlation matrix chosen up front, and every downstream computation reads it.

## Implementation Details

### `exp_factanal(..., cor_type = "auto")`

| `cor_type` | Behavior |
|---|---|
| `auto` (default) | Picks Pearson / Tetrachoric / Polychoric / Mixed from the variable types and, for 5-category items, the response distribution |
| `pearson` | Forces Pearson |
| `polychoric` | Forces Polychoric |

Auto-selection rules (issue COMMENT 3), all verified by live execution:

| Data | Selected |
|---|---|
| all numeric | Pearson |
| all binary | Tetrachoric |
| all ordinal, ≤ 4 categories | Polychoric |
| all ordinal, 5 categories | Distribution-based (modal ≥ 50%, extreme ≥ 40%, or \|skew\| ≥ 1 → Polychoric, else Pearson) |
| all ordinal, 6+ categories | Pearson (Polychoric still selectable manually) |
| numeric / binary / ordinal mix | Mixed |
| any nominal category | Unsupported → `EXP-ANA-35` |

### One matrix everywhere (issue COMMENT 2)

`fa()` (with mandatory `n.obs`), `psych::KMO()`, `psych::cortest.bartlett(n =)`, the scree eigenvalues, the Kaiser count, the parallel analysis and the factor scores all read the same `cor_mat`. `fa()` on a correlation matrix returns no scores, so they come from `psych::factor.scores(rho = cor_mat, method =)` — honoring the existing "Type of Scores" property rather than hardcoding one method.

### New tidy types for the report

- `analysis_method` — correlation / extraction method / rotation / variables / rows, plus hidden columns the client binds its explanation from (`correlation_type`, `correlation_is_auto`, `has_diagnostics`, `degraded_from`, `polychoric_available`, `warning_tokens`, `reason`).
- `cor_diagnostics` — category counts, sparse categories, empty category combinations, estimation failures, positive definiteness, smoothing. Empty (same column shape) on a Pearson analysis.

### Deviations from the spec text

- **Rating-scale heuristic.** The spec's literal rule calls any numeric column with 3+ distinct values "numeric", which would mean a 1-5 survey item imported as an integer never reaches the ordinal branch. A numeric column is treated as ordinal only when it looks like a rating scale: consecutive integers, 3-7 of them, starting at 0 or 1. `mtcars$cyl` (4, 6, 8) and counts stay numeric, so existing all-numeric analyses are unaffected.
- **Parallel analysis** is the existing in-house implementation with the spec's 100 iterations rather than `psych::fa.parallel(cor = "poly")`; for a non-Pearson correlation the null distribution permutes each column and re-estimates the same correlation. Failed permutations are dropped so a Pearson eigenvalue can never enter a polychoric null distribution.

## Backward compatibility

The Pearson path keeps the pre-existing raw-data `fa()` call, asserted identical to `psych::fa()` in the tests. **However**, `cor_type` defaults to `auto`, so a saved analysis over logical or 1-5 integer columns will switch to Tetrachoric/Polychoric on its next run and its loadings/scores/KMO will change. This is intended (Auto is the spec's default and the new choice is the statistically better one) but needs a release note.

## Version

`DESCRIPTION` 16.0.9 → **16.0.10**. The paired tam PR pins 16.0.10; without the bump every Factor Analysis, including saved ones, would fail with `unused argument (cor_type = "auto")`. The per-platform binaries still need to be built and uploaded to download2.

## How to Test

```r
devtools::test(filter = "factanal")
```

`tests/testthat/test_factanal_correlation.R` covers every auto-selection rule, the single-matrix invariant (KMO/Bartlett/eigenvalues/parallel all differ between Pearson and Polychoric on the same data), Pearson-path equivalence, the degrade-to-Pearson path end to end, the diagnostics edge cases, and one-correlation-per-analysis under Repeat By.

## Sign-Off

- [x] Tests pass (`test_factanal_correlation.R` + the pre-existing `test_factanal.R`; the one failure in the latter is an unrelated in-flight #30798 test on master)
- [x] New R functions are internal helpers; the only exported change is the `exp_factanal` signature (new optional args, defaults preserve behavior)
- [x] No new R package dependencies — `psych` / `dplyr` / `jsonlite` / `stats` / `tibble` were already required
- [x] Version bumped
- [ ] Per-platform binaries built and uploaded to download2 (release step)
- [ ] Jenkins test
