### PR TITLE
feat(chaid): partial dependence for Analytics Report (v16.0.16)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.15
+Version: 16.0.16
 Date: 2026-07-25
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_catboost.R
+++ b/R/build_catboost.R
@@ -1377,7 +1377,7 @@ exp_catboost <- function(df,
 }
 
 #' @export
-glance.catboost_exp <- function(x, pretty.name = FALSE, ...) {
+glance.catboost_exp <- function(x, pretty.name = FALSE, report_metrics = FALSE, ...) {
   if ("error" %in% class(x)) {
     return(data.frame(Note = x$message))
   }
@@ -1390,9 +1390,15 @@ glance.catboost_exp <- function(x, pretty.name = FALSE, ...) {
   rsq <- r_squared(actual, predicted)
   n <- length(actual)
   ret <- data.frame(r_squared = rsq, root_mean_square_error = root_mean_square_error, n = n)
+  if (isTRUE(report_metrics)) {
+    ret <- ret %>% dplyr::mutate(mean_absolute_error = mae(actual, predicted))
+  }
   if (pretty.name) {
     map <- list(`R Squared` = as.symbol("r_squared"), `RMSE` = as.symbol("root_mean_square_error"), `Rows` = as.symbol("n"))
     ret <- ret %>% dplyr::rename(!!!map)
+    if (isTRUE(report_metrics)) {
+      ret <- ret %>% dplyr::rename(`MAE` = mean_absolute_error)
+    }
   }
   if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
     ret$Note <- x$inf_removed_message
@@ -1444,7 +1450,7 @@ catboost_prediction_training_and_test <- function(x, binary_classification_thres
 
 #' @export
 #' @param type "importance", "evaluation", "conf_mat", "partial_dependence", "partial_binning", "evaluation_log"
-tidy.catboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, ...) {
+tidy.catboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, report_metrics = FALSE, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     return(data.frame())
   }
@@ -1463,14 +1469,31 @@ tidy.catboost_exp <- function(x, type = "importance", pretty.name = FALSE, binar
       }
       actual <- extract_actual(x)
       if ("catboost_reg" %in% class(x) || identical(x$classification_type, "regression")) {
-        ret <- glance(x, pretty.name = pretty.name, ...)
+        ret <- glance(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
       } else if ("catboost_binary" %in% class(x) || identical(x$classification_type, "binary")) {
         predicted <- extract_predicted_binary_labels(x, threshold = binary_classification_threshold)
         predicted_probability <- extract_predicted(x)
-        ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name)
+        # Pass report_metrics for Analytics Report Summary ROC AUC / PR AUC (#37256).
+        ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name, report_metrics = report_metrics)
       } else {
         predicted <- extract_predicted_multiclass_labels(x)
         ret <- evaluate_multi_(data.frame(predicted = predicted, actual = actual), "predicted", "actual", pretty.name = pretty.name)
+        if (report_metrics) {
+          balanced_accuracy <- multiclass_balanced_accuracy(actual, predicted)
+          auc_by_class <- multiclass_auc_by_class(actual, tryCatch(extract_predicted(x), error = function(e) NULL))
+          macro_roc_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$roc_auc, na.rm = TRUE) else NA_real_
+          macro_pr_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$pr_auc, na.rm = TRUE) else NA_real_
+          extra <- if (pretty.name) {
+            tibble::tibble(`Balanced Accuracy` = balanced_accuracy,
+                           `Macro ROC AUC` = macro_roc_auc,
+                           `Macro PR AUC` = macro_pr_auc)
+          } else {
+            tibble::tibble(balanced_accuracy = balanced_accuracy,
+                           macro_roc_auc = macro_roc_auc,
+                           macro_pr_auc = macro_pr_auc)
+          }
+          ret <- dplyr::bind_cols(ret, extra)
+        }
       }
       if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
         ret$Note <- if ("Note" %in% colnames(ret)) paste(ret$Note, x$inf_removed_message, sep = " ") else x$inf_removed_message
@@ -1487,7 +1510,12 @@ tidy.catboost_exp <- function(x, type = "importance", pretty.name = FALSE, binar
       per_level <- function(level) {
         evaluate_classification(actual, predicted, level, pretty.name = pretty.name)
       }
-      dplyr::bind_rows(lapply(levels(actual), per_level))
+      ret <- dplyr::bind_rows(lapply(levels(actual), per_level))
+      if (report_metrics && nrow(ret) > 0) {
+        ret <- dplyr::bind_cols(ret, evaluate_by_class_report_metrics(
+          actual, predicted, levels(actual), tryCatch(extract_predicted(x), error = function(e) NULL), pretty.name))
+      }
+      ret
     },
     conf_mat = ,
     confusion_matrix = {

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -175,6 +175,11 @@ exp_chaid <- function(df,
         model, train_all, binary_classification_threshold
       )
       model$predicted_prob <- chaid_positive_probability(model, train_all)
+      # Full class-probability matrix for report_metrics (Macro / One-vs-Rest AUCs).
+      # Column names are the raw class levels so multiclass_auc_by_class() can use them.
+      model$predicted_prob_matrix <- chaid_as_probability_matrix(
+        train_all, model$class_levels
+      )
 
       # Metadata expected by the framework.
       model$terms_mapping <- names(group_name_map)
@@ -315,6 +320,37 @@ chaid_positive_probability <- function(model, all_prediction) {
   } else {
     apply(as.matrix(all_prediction[, prob_cols, drop = FALSE]), 1, max)
   }
+}
+
+#' Convert CHAID probability output to a class-named matrix.
+#'
+#' `chaid_predict(type = "prob"|"all")` uses `.pred_prob_<class>` columns. The
+#' shared Decision Tree report helpers (`multiclass_auc_by_class`,
+#' `evaluate_by_class_report_metrics`) expect colnames to be the class levels.
+#'
+#' @param prediction A data frame / matrix from `chaid_predict`, or NULL.
+#' @param class_levels Optional class order; columns are reordered when present.
+#' @return A numeric matrix, or NULL when conversion is not possible.
+chaid_as_probability_matrix <- function(prediction, class_levels = NULL) {
+  if (is.null(prediction)) {
+    return(NULL)
+  }
+  if (is.data.frame(prediction) || is.matrix(prediction)) {
+    mat <- as.matrix(prediction)
+  } else {
+    return(NULL)
+  }
+  if (ncol(mat) == 0) {
+    return(NULL)
+  }
+  colnames(mat) <- sub("^\\.pred_prob_", "", colnames(mat))
+  if (!is.null(class_levels) && length(class_levels) > 0) {
+    if (!all(class_levels %in% colnames(mat))) {
+      return(NULL)
+    }
+    mat <- mat[, class_levels, drop = FALSE]
+  }
+  mat
 }
 
 #' Return an empty CHAID permutation-importance result.
@@ -684,14 +720,17 @@ augment.exploratory_chaid <- function(x, data = NULL, newdata = NULL,
 #'
 #' @param x A fitted `exploratory_chaid` model.
 #' @param pretty.name Whether to use display-friendly column names.
+#' @param report_metrics Whether to include Decision Tree report extras
+#'   (ROC AUC / PR AUC / …).
 #' @param ... Unused.
 #' @return A one-row model summary data frame.
 #' @export
-glance.exploratory_chaid <- function(x, pretty.name = FALSE, ...) {
+glance.exploratory_chaid <- function(x, pretty.name = FALSE, report_metrics = FALSE, ...) {
   if ("error" %in% class(x)) {
     return(data.frame(Note = x$message))
   }
-  tidy.exploratory_chaid(x, type = "evaluation", pretty.name = pretty.name, ...)
+  tidy.exploratory_chaid(x, type = "evaluation", pretty.name = pretty.name,
+                         report_metrics = report_metrics, ...)
 }
 
 #' tidy for a CHAID model (broom S3 method).
@@ -703,6 +742,9 @@ glance.exploratory_chaid <- function(x, pretty.name = FALSE, ...) {
 #'   `partial_dependence`.
 #' @param pretty.name Whether to use display-friendly column names.
 #' @param binary_classification_threshold Positive-class threshold (binary).
+#' @param report_metrics Whether to include Decision Tree report extras
+#'   (ROC AUC / PR AUC / Balanced Accuracy / Specificity for binary;
+#'   Macro AUCs for multiclass; One-vs-Rest AUCs for evaluation_by_class).
 #' @param ... Unused.
 #' @return A data frame whose shape depends on `type`.
 #' @export
@@ -733,12 +775,23 @@ chaid_display_node_ids <- function(df) {
 }
 
 tidy.exploratory_chaid <- function(x, type = "evaluation", pretty.name = FALSE,
-                                   binary_classification_threshold = 0.5, ...) {
+                                   binary_classification_threshold = 0.5,
+                                   report_metrics = FALSE, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     return(data.frame())
   }
   actual <- x$y
-  predicted <- x$predicted_class
+  # Re-threshold binary labels so Settings → cut point updates F1 / Accuracy etc.
+  # (ROC / PR AUC use predicted_prob and are threshold-independent.)
+  predicted <- if (identical(x$classification_type, "binary") &&
+                     !is.null(x$predicted_prob)) {
+    factor(
+      ifelse(x$predicted_prob >= binary_classification_threshold, "TRUE", "FALSE"),
+      levels = x$class_levels
+    )
+  } else {
+    x$predicted_class
+  }
   chaid_display_node_ids(switch(
     type,
     evaluation = {
@@ -747,17 +800,41 @@ tidy.exploratory_chaid <- function(x, type = "evaluation", pretty.name = FALSE,
       }
       if (identical(x$classification_type, "binary")) {
         evaluate_binary_classification(actual, predicted, x$predicted_prob,
-                                       pretty.name = pretty.name, is_rpart = FALSE)
+                                       pretty.name = pretty.name, is_rpart = FALSE,
+                                       report_metrics = report_metrics)
       } else {
-        evaluate_multi_(data.frame(predicted = predicted, actual = actual),
-                        "predicted", "actual", pretty.name = pretty.name)
+        ret <- evaluate_multi_(data.frame(predicted = predicted, actual = actual),
+                               "predicted", "actual", pretty.name = pretty.name)
+        # Mirror tidy.rpart: Macro ROC/PR AUC for the Decision Tree report (#37156).
+        if (report_metrics) {
+          balanced_accuracy <- multiclass_balanced_accuracy(actual, predicted)
+          auc_by_class <- multiclass_auc_by_class(actual, x$predicted_prob_matrix)
+          macro_roc_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$roc_auc, na.rm = TRUE) else NA_real_
+          macro_pr_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$pr_auc, na.rm = TRUE) else NA_real_
+          extra <- if (pretty.name) {
+            tibble::tibble(`Balanced Accuracy` = balanced_accuracy,
+                           `Macro ROC AUC` = macro_roc_auc,
+                           `Macro PR AUC` = macro_pr_auc)
+          } else {
+            tibble::tibble(balanced_accuracy = balanced_accuracy,
+                           macro_roc_auc = macro_roc_auc,
+                           macro_pr_auc = macro_pr_auc)
+          }
+          ret <- dplyr::bind_cols(ret, extra)
+        }
+        ret
       }
     },
     evaluation_by_class = {
       per_level <- function(level) {
         evaluate_classification(actual, predicted, level, pretty.name = pretty.name)
       }
-      dplyr::bind_rows(lapply(x$class_levels, per_level))
+      ret <- dplyr::bind_rows(lapply(x$class_levels, per_level))
+      if (report_metrics && nrow(ret) > 0) {
+        ret <- dplyr::bind_cols(ret, evaluate_by_class_report_metrics(
+          actual, predicted, x$class_levels, x$predicted_prob_matrix, pretty.name))
+      }
+      ret
     },
     conf_mat = {
       calc_conf_mat(actual, predicted)

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -4,10 +4,11 @@
 # per group: `model`, `.test_index`, `source.data`) used by every Analytics View
 # decision-tree/model template, and the augment/tidy/glance S3 methods below let
 # the framework's generic preprocessors (prediction(), rf_evaluation_*,
-# tidy_rowwise()) dispatch on an `exploratory_chaid` model. This mirrors the
-# exp_rpart() pattern in randomForest_tidiers.R, minus regression, SMOTE, and
-# partial dependence. Model-independent permutation importance is calculated
-# from the training or held-out rows and stored as a compact result table.
+# tidy_rowwise(), rf_partial_dependence()) dispatch on an `exploratory_chaid`
+# model. This mirrors the exp_rpart() pattern in randomForest_tidiers.R, minus
+# regression and SMOTE. Model-independent permutation importance is calculated
+# from the training or held-out rows; partial dependence for the report chart
+# is stored on the model the same way as CART.
 
 #' Fit a CHAID classification tree as an Analytics View model data frame.
 #'
@@ -26,6 +27,10 @@
 #' @param max_nrow Row cap; data is sampled down to this before fitting.
 #' @param target_n,predictor_n Category caps; excess categories are lumped into "Other".
 #' @param binary_classification_threshold Probability threshold for the positive class.
+#' @param max_pd_vars Max number of predictors for partial dependence charts.
+#' @param pd_sample_size Row sample size used when computing partial dependence.
+#' @param pd_grid_resolution Grid resolution for numeric partial dependence.
+#' @param pd_with_bin_means Whether to overlay binned actual means on PD charts.
 #' @param seed Random seed for sampling / splitting reproducibility.
 #' @param test_rate Fraction of rows held out as test data.
 #' @param test_split_type `random` or `ordered`.
@@ -53,6 +58,10 @@ exp_chaid <- function(df,
                       target_n = 20,
                       predictor_n = 12,
                       binary_classification_threshold = 0.5,
+                      max_pd_vars = 20,
+                      pd_sample_size = 500,
+                      pd_grid_resolution = 20,
+                      pd_with_bin_means = FALSE,
                       seed = 1,
                       test_rate = 0.0,
                       test_split_type = "random") {
@@ -185,6 +194,28 @@ exp_chaid <- function(df,
         seed = seed,
         repeats = 10L
       )
+
+      # Partial dependence for Analytics Report {{variable_effect}} /
+      # local_importance_binary (same contract as exp_rpart).
+      if (is.null(max_pd_vars) || !is.finite(max_pd_vars) || max_pd_vars < 1) {
+        max_pd_vars_eff <- 20
+      } else {
+        max_pd_vars_eff <- as.integer(max_pd_vars)
+      }
+      imp_vars <- chaid_partial_dependence_vars(
+        model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
+      )
+      model$partial_dependence <- partial_dependence.exploratory_chaid(
+        model, clean_target_col, vars = imp_vars, data = df,
+        n = c(pd_grid_resolution, min(nrow(df), pd_sample_size))
+      )
+      model$imp_vars <- imp_vars
+      if (isTRUE(pd_with_bin_means) && isTRUE(is_target_logical)) {
+        model$partial_binning <- calc_partial_binning_data(
+          df, clean_target_col, imp_vars
+        )
+      }
+
       # formula_terms lets generic evaluation code find the target column name
       # (all.vars(model$formula_terms)[1]) in the test-evaluation path.
       rhs <- paste0("`", c_cols, "`", collapse = " + ")
@@ -464,6 +495,137 @@ chaid_permutation_importance <- function(model, data, target, predictors,
   result
 }
 
+
+
+#' Choose predictor columns for CHAID partial dependence, by importance order.
+#'
+#' @param importance Importance table from `chaid_permutation_importance()`.
+#' @param predictors Clean predictor column names present in the training frame.
+#' @param terms_mapping Named character vector mapping clean -> display names.
+#' @param max_pd_vars Maximum number of variables to keep.
+#' @return Character vector of clean predictor names.
+chaid_partial_dependence_vars <- function(importance, predictors, terms_mapping,
+                                          max_pd_vars = 20L) {
+  predictors <- as.character(predictors)
+  max_pd_vars <- max(1L, as.integer(max_pd_vars))
+  if (length(predictors) == 0L) {
+    return(character())
+  }
+  if (is.null(importance) || !is.data.frame(importance) ||
+      nrow(importance) == 0L || !"variable" %in% names(importance)) {
+    return(predictors[seq_len(min(length(predictors), max_pd_vars))])
+  }
+
+  display_ordered <- as.character(importance$variable)
+  clean_ordered <- vapply(display_ordered, function(display_name) {
+    if (!is.null(terms_mapping) && length(terms_mapping) > 0) {
+      hits <- names(terms_mapping)[terms_mapping == display_name]
+      if (length(hits) >= 1L) {
+        return(hits[[1]])
+      }
+    }
+    display_name
+  }, character(1), USE.NAMES = FALSE)
+  clean_ordered <- unique(clean_ordered[clean_ordered %in% predictors])
+  if (length(clean_ordered) == 0L) {
+    return(predictors[seq_len(min(length(predictors), max_pd_vars))])
+  }
+  clean_ordered[seq_len(min(length(clean_ordered), max_pd_vars))]
+}
+
+#' Build a partial-dependence object for an `exploratory_chaid` model.
+#'
+#' Mirrors `partial_dependence.rpart()` so `handle_partial_dependence()` and
+#' the Analytics View `rf_partial_dependence()` preprocessor work unchanged.
+#'
+#' @param fit A fitted `exploratory_chaid` model.
+#' @param target Clean target column name.
+#' @param vars Predictor column names to evaluate.
+#' @param n Grid / sample sizes passed to `mmpf::marginalPrediction`.
+#' @param interaction Whether to compute interactions (unused; always FALSE).
+#' @param uniform Unused; kept for API parity with the rpart helper.
+#' @param data Training data frame used for the grid and sampling.
+#' @param ... Additional arguments forwarded to `mmpf::marginalPrediction`.
+#' @return A `pd` data frame with attributes, or NULL if mmpf is unavailable.
+partial_dependence.exploratory_chaid <- function(fit, target,
+                                                 vars = colnames(data),
+                                                 n = c(min(nrow(unique(data[, vars, drop = FALSE])), 25L),
+                                                       nrow(data)),
+                                                 interaction = FALSE,
+                                                 uniform = TRUE,
+                                                 data, ...) {
+  if (!requireNamespace("mmpf", quietly = TRUE)) {
+    return(NULL)
+  }
+  if (length(vars) == 0L) {
+    return(NULL)
+  }
+
+  # Default S3 predict() returns class labels; PD needs class probabilities with
+  # the same column names (TRUE/FALSE or class levels) that handle_partial_dependence
+  # expects from rpart/ranger.
+  predict.fun <- function(object, newdata) {
+    prob <- as.data.frame(
+      predict(object, newdata, type = "prob"),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+    colnames(prob) <- sub("^\\.pred_prob_", "", colnames(prob))
+    as.matrix(prob)
+  }
+
+  points <- list()
+  quantile_points <- list()
+  for (cname in vars) {
+    if (is.numeric(data[[cname]])) {
+      coldata <- data[[cname]]
+      minv <- min(coldata, na.rm = TRUE)
+      maxv <- max(coldata, na.rm = TRUE)
+      grid <- minv + (0:20) / 20 * (maxv - minv)
+      quantile_grid <- stats::quantile(coldata, probs = 1:24 / 25)
+      quantile_points[[cname]] <- quantile_grid
+      points[[cname]] <- sort(unique(c(grid, quantile_grid)))
+    } else {
+      points[[cname]] <- unique(data[[cname]])
+    }
+  }
+
+  args <- list(
+    data = data,
+    vars = vars,
+    n = n,
+    model = fit,
+    points = points,
+    predict.fun = predict.fun,
+    ...
+  )
+
+  if (length(vars) > 1L && !isTRUE(interaction)) {
+    pd <- data.table::rbindlist(sapply(vars, function(x) {
+      args$vars <- x
+      if ("points" %in% names(args)) {
+        args$points <- args$points[x]
+      }
+      do.call(mmpf::marginalPrediction, args)
+    }, simplify = FALSE), fill = TRUE)
+    data.table::setcolorder(pd, c(vars, colnames(pd)[!colnames(pd) %in% vars]))
+  } else {
+    pd <- do.call(mmpf::marginalPrediction, args)
+  }
+
+  attr(pd, "class") <- c("pd", "data.frame")
+  attr(pd, "interaction") <- isTRUE(interaction)
+  attr(pd, "target") <- if (identical(fit$classification_type, "binary")) {
+    target
+  } else {
+    fit$class_levels
+  }
+  attr(pd, "vars") <- vars
+  attr(pd, "points") <- points
+  attr(pd, "quantile_points") <- quantile_points
+  pd
+}
+
 #' Augment data with CHAID predictions (broom S3 method).
 #'
 #' Supports both the `data =` and `newdata =` calling conventions used by
@@ -537,7 +699,8 @@ glance.exploratory_chaid <- function(x, pretty.name = FALSE, ...) {
 #' @param x A fitted `exploratory_chaid` model.
 #' @param type One of `evaluation`, `evaluation_by_class`, `conf_mat`,
 #'   `tree_nodes`, `node_summary`, `rules`, `category_merges`, `split_summary`,
-#'   `category_error_distribution`, `numeric_intervals`, or `importance`.
+#'   `category_error_distribution`, `numeric_intervals`, `importance`, or
+#'   `partial_dependence`.
 #' @param pretty.name Whether to use display-friendly column names.
 #' @param binary_classification_threshold Positive-class threshold (binary).
 #' @param ... Unused.
@@ -622,6 +785,9 @@ tidy.exploratory_chaid <- function(x, type = "evaluation", pretty.name = FALSE,
     },
     importance = {
       if (is.null(x$importance)) chaid_empty_permutation_importance() else x$importance
+    },
+    partial_dependence = {
+      handle_partial_dependence(x)
     },
     {
       stop(paste0("type ", type, " is not defined"))

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -847,13 +847,17 @@ build_chaid_tree_nodes <- function(x) {
       original_categories <- strsplit(edges$original_categories[edge_row], " \\| ")[[1]]
       # tam #37177: a branch built from a run of contiguous numeric bins reads
       # as the range it covers ("<= 2317.6, (2317.6, 2695.8]" -> "<= 2695.8").
-      # cond_value is collapsed IN LOCKSTEP because DTreeGenerator rebuilds the
-      # edge label from cond_value, and its Show Detail filter
-      # (binLabelsToRangeConditions, min-lo/max-hi) parses the collapsed labels
-      # to the same range -- CHAID merges only ADJACENT ordered bins, so no gap
-      # can make the two differ. Categorical members pass through untouched.
+      # cond_value stays the collapsed bin/category labels so DTreeGenerator's
+      # Show Detail filter (binLabelsToRangeConditions) can parse them. The
+      # displayed edge_label is rewritten to the same readable inequalities
+      # used by node_summary / rules ("給料 = <= 2695.8" -> "給料 <= 2695.8",
+      # "給料 = (2695.8, 4228.8]" -> "2695.8 < 給料 <= 4228.8") so the
+      # characteristic-groups Condition column and tree chart match CART.
       display_categories <- chaid_collapse_intervals(original_categories)
-      edge_label <- paste0(cond_column, " = ", paste(display_categories, collapse = ", "))
+      edge_label <- chaid_readable_one_condition(
+        paste0(cond_column, " in {",
+               paste(display_categories, collapse = CHAID_GROUP_SEPARATOR), "}")
+      )
       cond_value <- as.character(jsonlite::toJSON(as.character(display_categories)))
     } else {
       cond_column <- NA_character_

--- a/R/build_lightgbm.R
+++ b/R/build_lightgbm.R
@@ -2037,7 +2037,7 @@ exp_lightgbm <- function(df,
 
 # This is used from Analytics View only when classification type is regression.
 #' @export
-glance.lightgbm_exp <- function(x, pretty.name = FALSE, ...) {
+glance.lightgbm_exp <- function(x, pretty.name = FALSE, report_metrics = FALSE, ...) {
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)
@@ -2047,7 +2047,7 @@ glance.lightgbm_exp <- function(x, pretty.name = FALSE, ...) {
   } else {
     stop("glance.lightgbm_exp should not be called for classification")
   }
-  ret <- glance.method(x, pretty.name = pretty.name, ...)
+  ret <- glance.method(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
   
   # Add note about Inf removal if applicable
   if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -2062,23 +2062,29 @@ glance.lightgbm_exp <- function(x, pretty.name = FALSE, ...) {
 }
 
 #' @export
-glance.lightgbm_exp.regression <- function(x, pretty.name, ...) {
+glance.lightgbm_exp.regression <- function(x, pretty.name, report_metrics = FALSE, ...) {
   predicted <- extract_predicted(x)
   actual <- extract_actual(x)
   root_mean_square_error <- rmse(predicted, actual)
   rsq <- r_squared(actual, predicted)
   n <- length(actual)
   ret <- data.frame(r_squared = rsq, root_mean_square_error = root_mean_square_error, n = n)
+  if (isTRUE(report_metrics)) {
+    ret <- ret %>% dplyr::mutate(mean_absolute_error = mae(actual, predicted))
+  }
   if (pretty.name) {
     map <- list(`R Squared` = as.symbol("r_squared"), `RMSE` = as.symbol("root_mean_square_error"), `Rows` = as.symbol("n"))
     ret <- ret %>% dplyr::rename(!!!map)
+    if (isTRUE(report_metrics)) {
+      ret <- ret %>% dplyr::rename(`MAE` = mean_absolute_error)
+    }
   }
   ret
 }
 
 #' @export
 #' @param type "importance", "evaluation", "conf_mat", "partial_dependence", "evaluation_log"
-tidy.lightgbm_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, ...) {
+tidy.lightgbm_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, report_metrics = FALSE, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     return(data.frame())
   }
@@ -2098,15 +2104,32 @@ tidy.lightgbm_exp <- function(x, type = "importance", pretty.name = FALSE, binar
       }
       actual <- extract_actual(x)
       if (is.numeric(actual)) {
-        glance(x, pretty.name = pretty.name, ...)
+        glance(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
       } else {
         if (x$classification_type == "binary") {
           predicted <- extract_predicted_binary_labels(x, threshold = binary_classification_threshold)
           predicted_probability <- extract_predicted(x)
-          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name)
+          # Pass report_metrics for Analytics Report Summary ROC AUC / PR AUC (#37256).
+          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name, report_metrics = report_metrics)
         } else {
           predicted <- extract_predicted_multiclass_labels(x)
           ret <- evaluate_multi_(data.frame(predicted = predicted, actual = actual), "predicted", "actual", pretty.name = pretty.name)
+          if (report_metrics) {
+            balanced_accuracy <- multiclass_balanced_accuracy(actual, predicted)
+            auc_by_class <- multiclass_auc_by_class(actual, tryCatch(extract_predicted(x), error = function(e) NULL))
+            macro_roc_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$roc_auc, na.rm = TRUE) else NA_real_
+            macro_pr_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$pr_auc, na.rm = TRUE) else NA_real_
+            extra <- if (pretty.name) {
+              tibble::tibble(`Balanced Accuracy` = balanced_accuracy,
+                             `Macro ROC AUC` = macro_roc_auc,
+                             `Macro PR AUC` = macro_pr_auc)
+            } else {
+              tibble::tibble(balanced_accuracy = balanced_accuracy,
+                             macro_roc_auc = macro_roc_auc,
+                             macro_pr_auc = macro_pr_auc)
+            }
+            ret <- dplyr::bind_cols(ret, extra)
+          }
         }
         # Add note about Inf removal if applicable
         if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -2128,7 +2151,12 @@ tidy.lightgbm_exp <- function(x, type = "importance", pretty.name = FALSE, binar
       per_level <- function(level) {
         evaluate_classification(actual, predicted, level, pretty.name = pretty.name)
       }
-      dplyr::bind_rows(lapply(levels(actual), per_level))
+      ret <- dplyr::bind_rows(lapply(levels(actual), per_level))
+      if (report_metrics && nrow(ret) > 0) {
+        ret <- dplyr::bind_cols(ret, evaluate_by_class_report_metrics(
+          actual, predicted, levels(actual), tryCatch(extract_predicted(x), error = function(e) NULL), pretty.name))
+      }
+      ret
     },
     conf_mat = {
       actual <- extract_actual(x)

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1345,7 +1345,7 @@ glance.lm_exploratory <- function(x, pretty.name = FALSE, ...) { #TODO: add test
 
 #' special version of glance.lm function to use with build_lm.fast.
 #' @export
-glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification_threshold = 0.5, ...) { #TODO: add test
+glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification_threshold = 0.5, report_metrics = FALSE, ...) { #TODO: add test
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)
@@ -1406,6 +1406,32 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
     # Show number of rows for positive case and negative case, especially so that result of SMOTE is visible.
     ret$positives <- sum(x$y == 1, na.rm = TRUE)
     ret$negatives <- sum(x$y != 1, na.rm = TRUE)
+
+    # Opt-in Analytics Report metrics (#37256 / #37156). Same extras as
+    # evaluate_binary_classification(report_metrics=TRUE); default stays FALSE so
+    # existing Logistic Summary tables are unchanged.
+    if (isTRUE(report_metrics)) {
+      actual_for_roc <- as.integer(x$y) == 1
+      pr_auc <- aupr(x$fitted.value, actual_for_roc)
+      predicted_positive <- as.integer(predicted) == 1
+      valid <- !(is.na(actual_for_roc) | is.na(predicted_positive))
+      tn <- sum(!actual_for_roc[valid] & !predicted_positive[valid], na.rm = TRUE)
+      fp <- sum(!actual_for_roc[valid] & predicted_positive[valid], na.rm = TRUE)
+      tp <- sum(actual_for_roc[valid] & predicted_positive[valid], na.rm = TRUE)
+      fn <- sum(actual_for_roc[valid] & !predicted_positive[valid], na.rm = TRUE)
+      specificity <- if ((tn + fp) > 0) tn / (tn + fp) else NA_real_
+      sensitivity <- if ((tp + fn) > 0) tp / (tp + fn) else NA_real_
+      balanced_accuracy <- if (is.na(specificity) || is.na(sensitivity)) NA_real_ else (specificity + sensitivity) / 2
+      if (pretty.name) {
+        ret$`PR AUC` <- pr_auc
+        ret$`Balanced Accuracy` <- balanced_accuracy
+        ret$`Specificity` <- specificity
+      } else {
+        ret$pr_auc <- pr_auc
+        ret$balanced_accuracy <- balanced_accuracy
+        ret$specificity <- specificity
+      }
+    }
   }
 
   # Add Max VIF if VIF is available.
@@ -1424,9 +1450,23 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
       colnames(ret)[colnames(ret) == "logLik"] <- "Log Likelihood"
       colnames(ret)[colnames(ret) == "deviance"] <- "Residual Deviance"
       colnames(ret)[colnames(ret) == "df.residual"] <- "Residual DF"
-      colnames(ret)[colnames(ret) == "auc"] <- "AUC"
-      
-      ret <- ret %>% dplyr::select(AUC, `F1 Score`, `Accuracy Rate`, `Misclass. Rate`, `Precision`, `Recall`, `P Value`, `Rows`, positives, negatives,  `Log Likelihood`, `AIC`, `BIC`, `Residual Deviance`, `Residual DF`, `Null Deviance`, `Null Model DF`, everything())
+      if (isTRUE(report_metrics) && "auc" %in% colnames(ret)) {
+        # Pair with PR AUC like evaluate_binary_classification (#37252 order).
+        colnames(ret)[colnames(ret) == "auc"] <- "ROC AUC"
+        pred_cols <- intersect(
+          c("ROC AUC", "PR AUC", "F1 Score", "Balanced Accuracy", "Accuracy Rate",
+            "Misclass. Rate", "Precision", "Recall", "Specificity"),
+          colnames(ret))
+        stat_cols <- intersect(
+          c("P Value", "Rows", "positives", "negatives", "Log Likelihood", "AIC", "BIC",
+            "Residual Deviance", "Residual DF", "Null Deviance", "Null Model DF"),
+          colnames(ret))
+        other_cols <- setdiff(colnames(ret), c(pred_cols, stat_cols))
+        ret <- ret[, c(pred_cols, stat_cols, other_cols), drop = FALSE]
+      } else {
+        colnames(ret)[colnames(ret) == "auc"] <- "AUC"
+        ret <- ret %>% dplyr::select(AUC, `F1 Score`, `Accuracy Rate`, `Misclass. Rate`, `Precision`, `Recall`, `P Value`, `Rows`, positives, negatives,  `Log Likelihood`, `AIC`, `BIC`, `Residual Deviance`, `Residual DF`, `Null Deviance`, `Null Model DF`, everything())
+      }
 
       if (!is.null(x$orig_levels)) { 
         pos_label <- x$orig_levels[2]

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -1593,7 +1593,7 @@ exp_xgboost <- function(df,
 
 # This is used from Analytics View only when classification type is regression.
 #' @export
-glance.xgboost_exp <- function(x, pretty.name = FALSE, ...) {
+glance.xgboost_exp <- function(x, pretty.name = FALSE, report_metrics = FALSE, ...) {
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)
@@ -1604,7 +1604,7 @@ glance.xgboost_exp <- function(x, pretty.name = FALSE, ...) {
   else {
     stop("glance.xgboost_exp should not be called for classification")
   }
-  ret <- glance.ranger.method(x, pretty.name = pretty.name, ...)
+  ret <- glance.ranger.method(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
   
   # Add note about Inf removal if applicable
   if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -1619,7 +1619,7 @@ glance.xgboost_exp <- function(x, pretty.name = FALSE, ...) {
 }
 
 #' @export
-glance.xgboost_exp.regression <- function(x, pretty.name, ...) {
+glance.xgboost_exp.regression <- function(x, pretty.name, report_metrics = FALSE, ...) {
   predicted <- extract_predicted(x)
   actual <- extract_actual(x)
   root_mean_square_error <- rmse(predicted, actual)
@@ -1632,6 +1632,9 @@ glance.xgboost_exp.regression <- function(x, pretty.name, ...) {
     root_mean_square_error = root_mean_square_error,
     n = n
   )
+  if (isTRUE(report_metrics)) {
+    ret <- ret %>% dplyr::mutate(mean_absolute_error = mae(actual, predicted))
+  }
 
   if(pretty.name){
     map = list(
@@ -1641,13 +1644,16 @@ glance.xgboost_exp.regression <- function(x, pretty.name, ...) {
     )
     ret <- ret %>%
       dplyr::rename(!!!map)
+    if (isTRUE(report_metrics)) {
+      ret <- ret %>% dplyr::rename(`MAE` = mean_absolute_error)
+    }
   }
   ret
 }
 
 #' @export
 #' @param type "importance", "evaluation" or "conf_mat". Feature importance, evaluated scores or confusion matrix of training data.
-tidy.xgboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, ...) {
+tidy.xgboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, report_metrics = FALSE, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     ret <- data.frame()
     return(ret)
@@ -1672,16 +1678,34 @@ tidy.xgboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary
       # get evaluation scores from training data
       actual <- extract_actual(x)
       if(is.numeric(actual)){
-        glance(x, pretty.name = pretty.name, ...)
+        glance(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
       } else {
         if (x$classification_type == "binary") {
           predicted <- extract_predicted_binary_labels(x, threshold = binary_classification_threshold)
           predicted_probability <- extract_predicted(x)
-          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name)
+          # Pass report_metrics for Analytics Report Summary ROC AUC / PR AUC (#37256).
+          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name, report_metrics = report_metrics)
         }
         else {
           predicted <- extract_predicted_multiclass_labels(x)
           ret <- evaluate_multi_(data.frame(predicted=predicted, actual=actual), "predicted", "actual", pretty.name = pretty.name)
+          if (report_metrics) {
+            balanced_accuracy <- multiclass_balanced_accuracy(actual, predicted)
+            # prediction_training for multiclass is a probability matrix with class colnames.
+            auc_by_class <- multiclass_auc_by_class(actual, tryCatch(extract_predicted(x), error = function(e) NULL))
+            macro_roc_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$roc_auc, na.rm = TRUE) else NA_real_
+            macro_pr_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$pr_auc, na.rm = TRUE) else NA_real_
+            extra <- if (pretty.name) {
+              tibble::tibble(`Balanced Accuracy` = balanced_accuracy,
+                             `Macro ROC AUC` = macro_roc_auc,
+                             `Macro PR AUC` = macro_pr_auc)
+            } else {
+              tibble::tibble(balanced_accuracy = balanced_accuracy,
+                             macro_roc_auc = macro_roc_auc,
+                             macro_pr_auc = macro_pr_auc)
+            }
+            ret <- dplyr::bind_cols(ret, extra)
+          }
         }
         # Add note about Inf removal if applicable
         if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -1707,7 +1731,12 @@ tidy.xgboost_exp <- function(x, type = "importance", pretty.name = FALSE, binary
         ret <- evaluate_classification(actual, predicted, level, pretty.name = pretty.name)
         ret
       }
-      dplyr::bind_rows(lapply(levels(actual), per_level))
+      ret <- dplyr::bind_rows(lapply(levels(actual), per_level))
+      if (report_metrics && nrow(ret) > 0) {
+        ret <- dplyr::bind_cols(ret, evaluate_by_class_report_metrics(
+          actual, predicted, levels(actual), tryCatch(extract_predicted(x), error = function(e) NULL), pretty.name))
+      }
+      ret
     },
     conf_mat = {
       # return confusion matrix

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -350,9 +350,9 @@ evaluate_multi_ <- function(df, pred_label_col, actual_val_col, pretty.name = FA
 
 # Generates Analytics View Summary Table for logistic/binomial regression. Handles Test Mode.
 #' @export
-evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_score", pretty.name = FALSE){
+evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_score", pretty.name = FALSE, report_metrics = FALSE){
   actual_val_col <- col_name(substitute(actual_val)) # Get name of column as string.
-  training_ret <- df %>% glance_rowwise(model, binary_classification_threshold = threshold)
+  training_ret <- df %>% glance_rowwise(model, binary_classification_threshold = threshold, report_metrics = report_metrics)
   ret <- training_ret
 
   grouped_col <- colnames(df)[!colnames(df) %in% c("model", ".test_index", "source.data")]
@@ -378,6 +378,31 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
                              dplyr::select(auc = AUC, f_score, accuracy_rate,
                                            misclassification_rate, precision, recall,
                                            n, positives, negatives)
+        # Match training-side report_metrics extras so bind_rows keeps real values
+        # on the test row (#37256; same invariant as rf_evaluation_training_and_test).
+        if (isTRUE(report_metrics)) {
+          actual_raw <- test_pred_ret[[actual_val_col]]
+          actual_for_roc <- binary_label(actual_raw)
+          pred_prob <- test_pred_ret[["predicted_probability"]]
+          threshold_value <- if (is.numeric(threshold)) {
+            threshold
+          } else if (!is.null(eret$threshold)) {
+            eret$threshold[[1]]
+          } else {
+            0.5
+          }
+          predicted_positive <- pred_prob >= threshold_value
+          valid <- !(is.na(actual_for_roc) | is.na(predicted_positive) | is.na(pred_prob))
+          tn <- sum(!actual_for_roc[valid] & !predicted_positive[valid], na.rm = TRUE)
+          fp <- sum(!actual_for_roc[valid] & predicted_positive[valid], na.rm = TRUE)
+          tp <- sum(actual_for_roc[valid] & predicted_positive[valid], na.rm = TRUE)
+          fn <- sum(actual_for_roc[valid] & !predicted_positive[valid], na.rm = TRUE)
+          specificity <- if ((tn + fp) > 0) tn / (tn + fp) else NA_real_
+          sensitivity <- if ((tp + fn) > 0) tp / (tp + fn) else NA_real_
+          test_ret$pr_auc <- aupr(pred_prob, actual_for_roc)
+          test_ret$balanced_accuracy <- if (is.na(specificity) || is.na(sensitivity)) NA_real_ else (specificity + sensitivity) / 2
+          test_ret$specificity <- specificity
+        }
         test_ret$is_test_data <- TRUE
         test_ret
       }, error = function(e){
@@ -396,9 +421,18 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
   }
 
   # sort column order
-  ret <- ret %>% dplyr::select(auc, f_score, accuracy_rate, misclassification_rate, precision,
-                               recall, p.value, positives, negatives, n, logLik, AIC, BIC, # The order of positives, negatives, n is made the same as random forest and decision tree.
-                               deviance, null.deviance, df.null, df.residual, everything())
+  if (isTRUE(report_metrics)) {
+    ret <- ret %>% dplyr::select(dplyr::any_of(c(
+      "auc", "roc_auc", "pr_auc", "f_score", "balanced_accuracy", "accuracy_rate",
+      "misclassification_rate", "precision", "recall", "specificity",
+      "p.value", "positives", "negatives", "n", "logLik", "AIC", "BIC",
+      "deviance", "null.deviance", "df.null", "df.residual")),
+      everything())
+  } else {
+    ret <- ret %>% dplyr::select(auc, f_score, accuracy_rate, misclassification_rate, precision,
+                                 recall, p.value, positives, negatives, n, logLik, AIC, BIC, # The order of positives, negatives, n is made the same as random forest and decision tree.
+                                 deviance, null.deviance, df.null, df.residual, everything())
+  }
 
   # Reorder columns. Bring group_by column first, and then is_test_data column, if it exists.
   if (!is.null(ret$is_test_data)) {
@@ -421,7 +455,14 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
     colnames(ret)[colnames(ret) == "misclassification_rate"] <- "Misclass. Rate"
     colnames(ret)[colnames(ret) == "precision"] <- "Precision"
     colnames(ret)[colnames(ret) == "recall"] <- "Recall"
-    colnames(ret)[colnames(ret) == "auc"] <- "AUC"
+    if (isTRUE(report_metrics)) {
+      colnames(ret)[colnames(ret) == "auc"] <- "ROC AUC"
+      colnames(ret)[colnames(ret) == "pr_auc"] <- "PR AUC"
+      colnames(ret)[colnames(ret) == "balanced_accuracy"] <- "Balanced Accuracy"
+      colnames(ret)[colnames(ret) == "specificity"] <- "Specificity"
+    } else {
+      colnames(ret)[colnames(ret) == "auc"] <- "AUC"
+    }
     colnames(ret)[colnames(ret) == "n"] <- "Rows"
     colnames(ret)[colnames(ret) == "positives"] <- "Rows (TRUE)"
     colnames(ret)[colnames(ret) == "negatives"] <- "Rows (FALSE)"

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2934,7 +2934,7 @@ evaluate_binary_classification <- function(actual, predicted, predicted_probabil
 
 #' @export
 #' @param type "importance", "evaluation" or "conf_mat". Feature importance, evaluated scores or confusion matrix of training data.
-tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, ...) {
+tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, binary_classification_threshold = 0.5, report_metrics = FALSE, ...) {
   if ("error" %in% class(x) && type != "evaluation") {
     ret <- data.frame()
     return(ret)
@@ -2972,16 +2972,34 @@ tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, binary_clas
       # get evaluation scores from training data
       actual <- x$y
       if(is.numeric(actual)){
-        glance(x, pretty.name = pretty.name, ...)
+        glance(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
       } else {
         if (x$classification_type == "binary") {
           predicted <- predict_value_from_prob(NULL, x$prediction_training$predictions, NULL, threshold = binary_classification_threshold)
           predicted_probability <- x$prediction_training$predictions[,1]
-          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name)
+          # Pass report_metrics so Analytics Report Summary gets ROC AUC / PR AUC
+          # (and Balanced Accuracy / Specificity) like tidy.rpart (#37256).
+          ret <- evaluate_binary_classification(actual, predicted, predicted_probability, pretty.name = pretty.name, report_metrics = report_metrics)
         }
         else {
           predicted <- predict_value_from_prob(x$forest$levels, x$prediction_training$predictions, x$y)
           ret <- evaluate_multi_(data.frame(predicted=predicted, actual=actual), "predicted", "actual", pretty.name = pretty.name)
+          if (report_metrics) {
+            balanced_accuracy <- multiclass_balanced_accuracy(actual, predicted)
+            auc_by_class <- multiclass_auc_by_class(actual, x$prediction_training$predictions)
+            macro_roc_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$roc_auc, na.rm = TRUE) else NA_real_
+            macro_pr_auc <- if (nrow(auc_by_class) > 0) mean(auc_by_class$pr_auc, na.rm = TRUE) else NA_real_
+            extra <- if (pretty.name) {
+              tibble::tibble(`Balanced Accuracy` = balanced_accuracy,
+                             `Macro ROC AUC` = macro_roc_auc,
+                             `Macro PR AUC` = macro_pr_auc)
+            } else {
+              tibble::tibble(balanced_accuracy = balanced_accuracy,
+                             macro_roc_auc = macro_roc_auc,
+                             macro_pr_auc = macro_pr_auc)
+            }
+            ret <- dplyr::bind_cols(ret, extra)
+          }
         }
         # Add note about Inf removal if applicable
         if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -3008,7 +3026,12 @@ tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, binary_clas
         ret <- evaluate_classification(actual, predicted, level, pretty.name = pretty.name)
         ret
       }
-      dplyr::bind_rows(lapply(levels(actual), per_level))
+      ret <- dplyr::bind_rows(lapply(levels(actual), per_level))
+      if (report_metrics && nrow(ret) > 0) {
+        ret <- dplyr::bind_cols(ret, evaluate_by_class_report_metrics(
+          actual, predicted, levels(actual), x$prediction_training$predictions, pretty.name))
+      }
+      ret
     },
     conf_mat = {
       # return confusion matrix
@@ -3062,7 +3085,7 @@ tidy.ranger <- function(x, type = "importance", pretty.name = FALSE, binary_clas
 
 # This is used from Analytics View only when classification type is regression.
 #' @export
-glance.ranger <- function(x, pretty.name = FALSE, ...) {
+glance.ranger <- function(x, pretty.name = FALSE, report_metrics = FALSE, ...) {
   if ("error" %in% class(x)) {
     ret <- data.frame(Note = x$message)
     return(ret)
@@ -3071,7 +3094,7 @@ glance.ranger <- function(x, pretty.name = FALSE, ...) {
                                         "Classification" = glance.ranger.classification,
                                         "Probability estimation" = glance.ranger.classification,
                                         "Regression" = glance.ranger.regression)
-  ret <- glance.ranger.method(x, pretty.name = pretty.name, ...)
+  ret <- glance.ranger.method(x, pretty.name = pretty.name, report_metrics = report_metrics, ...)
   
   # Add note about Inf removal if applicable
   if (!is.null(x$inf_removed_rows) && x$inf_removed_rows > 0) {
@@ -3086,7 +3109,7 @@ glance.ranger <- function(x, pretty.name = FALSE, ...) {
 }
 
 #' @export
-glance.ranger.regression <- function(x, pretty.name, ...) {
+glance.ranger.regression <- function(x, pretty.name, report_metrics = FALSE, ...) {
   predicted <- x$prediction_training$predictions
   actual <- x$y
   root_mean_square_error <- rmse(predicted, actual)
@@ -3099,6 +3122,10 @@ glance.ranger.regression <- function(x, pretty.name, ...) {
     root_mean_square_error = root_mean_square_error,
     n = n
   )
+  # Opt-in MAE for Analytics Report parity with glance.rpart (#37256).
+  if (isTRUE(report_metrics)) {
+    ret <- ret %>% dplyr::mutate(mean_absolute_error = mae(actual, predicted))
+  }
 
   if(pretty.name){
     map = list(
@@ -3108,6 +3135,9 @@ glance.ranger.regression <- function(x, pretty.name, ...) {
     )
     ret <- ret %>%
       dplyr::rename(!!!map)
+    if (isTRUE(report_metrics)) {
+      ret <- ret %>% dplyr::rename(`MAE` = mean_absolute_error)
+    }
   }
   ret
 }

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1514,6 +1514,12 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
                     source_data <- df$source.data[[1]]
                     if (!is.null(source_data) && length(test_rows) > 0 && "rpart" %in% class(model_object)) {
                       predict(model_object, newdata = source_data[test_rows, , drop = FALSE], type = "prob")
+                    } else if (!is.null(source_data) && length(test_rows) > 0 &&
+                               inherits(model_object, "exploratory_chaid")) {
+                      chaid_as_probability_matrix(
+                        predict(model_object, newdata = source_data[test_rows, , drop = FALSE], type = "prob"),
+                        model_object$class_levels
+                      )
                     } else {
                       NULL
                     }
@@ -1556,6 +1562,12 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
                 source_data <- df$source.data[[1]]
                 if (!is.null(source_data) && length(test_rows) > 0 && "rpart" %in% class(model_object)) {
                   predict(model_object, newdata = source_data[test_rows, , drop = FALSE], type = "prob")
+                } else if (!is.null(source_data) && length(test_rows) > 0 &&
+                           inherits(model_object, "exploratory_chaid")) {
+                  chaid_as_probability_matrix(
+                    predict(model_object, newdata = source_data[test_rows, , drop = FALSE], type = "prob"),
+                    model_object$class_levels
+                  )
                 } else {
                   NULL
                 }

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -113,6 +113,44 @@ test_that("rf_evaluation_training_and_test produces training and test metrics", 
   expect_true("is_test_data" %in% colnames(summary) || any(grepl("Test", colnames(summary))) || nrow(summary) >= 2)
 })
 
+test_that("exp_chaid report_metrics adds ROC AUC / PR AUC like CART", {
+  expected_binary <- c("ROC AUC", "PR AUC", "Balanced Accuracy", "Specificity")
+  expected_multi <- c("Balanced Accuracy", "Macro ROC AUC", "Macro PR AUC")
+
+  for (test_rate in c(0, 0.3)) {
+    df <- make_binary_df(n = 500, seed = 21)
+    model_df <- suppressWarnings(exp_chaid(df, is_churn, plan, region, tenure,
+                                           test_rate = test_rate, min_split = 20, min_bucket = 5))
+    base <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
+    with_metrics <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE,
+                                                    report_metrics = TRUE)
+    label <- paste0("binary test_rate=", test_rate)
+    expect_true(all(expected_binary %in% colnames(with_metrics)), info = label)
+    expect_false(any(expected_binary %in% colnames(base)), info = label)
+    expect_false("AUC" %in% colnames(with_metrics), info = label)
+    expect_equal(nrow(with_metrics), if (test_rate > 0) 2 else 1, info = label)
+    expect_false(any(is.na(with_metrics[, expected_binary, drop = FALSE])), info = label)
+    expect_equal(
+      intersect(c("ROC AUC", "PR AUC", "F1 Score", "Balanced Accuracy", "Accuracy Rate",
+                  "Misclass. Rate", "Precision", "Recall", "Specificity"),
+                colnames(with_metrics)),
+      c("ROC AUC", "PR AUC", "F1 Score", "Balanced Accuracy", "Accuracy Rate",
+        "Misclass. Rate", "Precision", "Recall", "Specificity"),
+      info = label
+    )
+  }
+
+  df <- make_multi_df(n = 500, seed = 22)
+  model_df <- suppressWarnings(exp_chaid(df, segment, channel, age_group,
+                                         min_split = 20, min_bucket = 5))
+  with_metrics <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE,
+                                                  report_metrics = TRUE)
+  expect_true(all(expected_multi %in% colnames(with_metrics)))
+  by_class <- rf_evaluation_training_and_test(model_df, type = "evaluation_by_class",
+                                              pretty.name = TRUE, report_metrics = TRUE)
+  expect_true(all(c("Balanced Accuracy", "ROC AUC", "PR AUC", "Overall Share") %in% colnames(by_class)))
+})
+
 test_that("confusion matrix tidy returns actual/predicted/count", {
   df <- make_binary_df()
   model_df <- suppressWarnings(exp_chaid(df, is_churn, plan, region,

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -478,8 +478,13 @@ test_that("tree_nodes edge labels collapse contiguous numeric bins (tam #37177)"
     # Every numeric branch collapses its contiguous bin run to ONE range label.
     expect_equal(length(values), 1)
     expect_true(grepl("^(<=|>|\\()", values))
-    # edge_label mirrors cond_value (DTreeGenerator rebuilds from cond_value).
-    expect_equal(edges$edge_label[i], paste0("salary = ", values))
+    # cond_value stays machine-parseable bin labels; edge_label is readable
+    # (CHAID report Condition / tree chart — not "salary = <= x").
+    expect_equal(
+      edges$edge_label[i],
+      chaid_readable_one_condition(paste0("salary in {", values, "}"))
+    )
+    expect_false(grepl(" = <=| = \\(| = >", edges$edge_label[i]))
   }
   # A categorical branch keeps its member enumeration untouched.
   cat_edges <- nodes[!is.na(nodes$parent_id) & nodes$cond_column == "dept", ]

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -488,3 +488,42 @@ test_that("tree_nodes edge labels collapse contiguous numeric bins (tam #37177)"
     expect_true(all(cat_values %in% c("sales", "rnd", "hr")))
   }
 })
+
+test_that("exp_chaid stores partial dependence for rf_partial_dependence()", {
+  skip_if_not_installed("mmpf")
+  df <- make_binary_df(n = 500, seed = 42)
+  model_df <- suppressWarnings(
+    exp_chaid(df, is_churn, plan, region, tenure,
+              min_split = 20, min_bucket = 5, max_pd_vars = 3,
+              pd_with_bin_means = TRUE)
+  )
+  model <- model_df$model[[1]]
+  expect_false(is.null(model$partial_dependence))
+  expect_gt(nrow(model$partial_dependence), 0)
+  expect_true(length(model$imp_vars) >= 1)
+  expect_true(length(model$imp_vars) <= 3)
+  expect_false(is.null(model$partial_binning))
+
+  pd <- model_df %>% rf_partial_dependence()
+  expect_gt(nrow(pd), 0)
+  expect_true(all(c("x_name", "x_value", "y_name", "y_value") %in% names(pd)))
+  expect_true(any(pd$y_name %in% c("Predicted", "Actual")))
+})
+
+test_that("chaid_partial_dependence_vars prefers importance order", {
+  predictors <- c("a", "b", "c", "d")
+  terms_mapping <- c(a = "A", b = "B", c = "C", d = "D")
+  importance <- data.frame(
+    variable = c("C", "A", "D", "B"),
+    importance = c(0.4, 0.3, 0.2, 0.1),
+    stringsAsFactors = FALSE
+  )
+  expect_equal(
+    chaid_partial_dependence_vars(importance, predictors, terms_mapping, 2),
+    c("c", "a")
+  )
+  expect_equal(
+    chaid_partial_dependence_vars(NULL, predictors, terms_mapping, 2),
+    c("a", "b")
+  )
+})

--- a/tests/testthat/test_model_eval.R
+++ b/tests/testthat/test_model_eval.R
@@ -310,6 +310,41 @@ test_that("evaluate binary classification model by training and test", {
   })
 })
 
+test_that("evaluate_binary_training_and_test report_metrics adds ROC/PR/Balanced/Specificity (#37256)", {
+  test_data <- structure(
+    list(
+      `CANCELLED X` = c(0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0),
+      ARR_TIME = c(1:20) * 10,
+      DERAY_TIME = c(1:20),
+      `Carrier Name` = c("Delta Air Lines", "American Eagle", "American Airlines", "Southwest Airlines", "SkyWest Airlines", "Southwest Airlines", "Southwest Airlines", "Delta Air Lines", "Southwest Airlines", "Atlantic Southeast Airlines", "American Airlines", "Southwest Airlines", "US Airways", "US Airways", "Delta Air Lines", "Atlantic Southeast Airlines", "Atlantic Southeast Airlines", "Atlantic Southeast Airlines", "Delta Air Lines", "Delta Air Lines")
+    ),
+    row.names = c(NA, -20L),
+    class = c("tbl_df", "tbl", "data.frame")
+  )
+  ret <- test_data %>% build_lm.fast(`CANCELLED X`,
+                                     `ARR_TIME`,
+                                     `DERAY_TIME`,
+                                     `Carrier Name`,
+                                     family = "binomial",
+                                     model_type = "glm",
+                                     test_rate = 0.5)
+  suppressWarnings({
+    base <- evaluate_binary_training_and_test(ret, "CANCELLED X", pretty.name = TRUE)
+    with_metrics <- evaluate_binary_training_and_test(ret, "CANCELLED X", pretty.name = TRUE, report_metrics = TRUE)
+  })
+  expect_false(any(c("PR AUC", "Balanced Accuracy", "Specificity", "ROC AUC") %in% colnames(base)))
+  expect_true(all(c("ROC AUC", "PR AUC", "Balanced Accuracy", "Specificity") %in% colnames(with_metrics)))
+  expect_false("AUC" %in% colnames(with_metrics))
+  # Statistical model metrics stay present alongside the new prediction metrics.
+  expect_true(all(c("P Value", "AIC", "BIC", "Log Likelihood") %in% colnames(with_metrics)))
+  expect_equal(nrow(with_metrics), 2)
+  expect_false(any(is.na(with_metrics[, c("ROC AUC", "PR AUC", "Balanced Accuracy", "Specificity"), drop = FALSE])))
+  # Default output columns keep the same values.
+  kept <- intersect(colnames(base), colnames(with_metrics))
+  expect_equal(as.data.frame(base)[, kept, drop = FALSE],
+               as.data.frame(with_metrics)[, kept, drop = FALSE])
+})
+
 
 test_that("Group evaluate binary classification model by training and test", {
   group_data <- test_data %>% group_by(klass)

--- a/tests/testthat/test_report_metrics_ml_models.R
+++ b/tests/testthat/test_report_metrics_ml_models.R
@@ -1,0 +1,57 @@
+# how to run this test:
+# devtools::test(filter="report_metrics_ml_models")
+#
+# Training Summary for RF / XGBoost / LightGBM / CatBoost goes through tidy.*
+# (not only rf_evaluation). report_metrics must be forwarded so Analytics Report
+# gets ROC AUC / PR AUC like Decision Tree (#37256).
+
+context("report_metrics for RF / GBDT tidy evaluation (#37256)")
+
+make_binary_df <- function(n = 150, seed = 42) {
+  set.seed(seed)
+  dplyr::tibble(
+    y = rbinom(n, 1, 0.35) == 1,
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  ) %>%
+    dplyr::mutate(x1 = x1 + ifelse(y, 1.2, 0))
+}
+
+expected_binary <- c("ROC AUC", "PR AUC", "Balanced Accuracy", "Specificity")
+
+expect_report_metrics_binary <- function(model_df, label) {
+  base <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE)
+  with_metrics <- rf_evaluation_training_and_test(model_df, pretty.name = TRUE,
+                                                  report_metrics = TRUE)
+  expect_true(all(expected_binary %in% colnames(with_metrics)), info = label)
+  expect_false(any(expected_binary %in% colnames(base)), info = label)
+  expect_false("AUC" %in% colnames(with_metrics), info = label)
+  expect_false(any(is.na(with_metrics[, expected_binary, drop = FALSE])), info = label)
+}
+
+test_that("calc_feature_imp (ranger) report_metrics renames AUC to ROC AUC and adds PR AUC", {
+  df <- make_binary_df()
+  model_df <- df %>% calc_feature_imp(y, x1, x2, test_rate = 0)
+  expect_report_metrics_binary(model_df, "ranger")
+})
+
+test_that("exp_xgboost report_metrics renames AUC to ROC AUC and adds PR AUC", {
+  skip_if_not_installed("xgboost")
+  df <- make_binary_df()
+  model_df <- suppressWarnings(df %>% exp_xgboost(y, x1, x2, test_rate = 0, nrounds = 15))
+  expect_report_metrics_binary(model_df, "xgboost")
+})
+
+test_that("exp_lightgbm report_metrics renames AUC to ROC AUC and adds PR AUC", {
+  skip_if_not_installed("lightgbm")
+  df <- make_binary_df()
+  model_df <- suppressWarnings(df %>% exp_lightgbm(y, x1, x2, test_rate = 0, nrounds = 15))
+  expect_report_metrics_binary(model_df, "lightgbm")
+})
+
+test_that("exp_catboost report_metrics renames AUC to ROC AUC and adds PR AUC", {
+  skip_if_not_installed("catboost")
+  df <- make_binary_df()
+  model_df <- suppressWarnings(df %>% exp_catboost(y, x1, x2, test_rate = 0, iterations = 15))
+  expect_report_metrics_binary(model_df, "catboost")
+})


### PR DESCRIPTION
## Summary
- `exp_chaid` now computes and stores `model$partial_dependence` (and optional `partial_binning`) so `rf_partial_dependence()` / the CHAID logical report **変数の値と予測確率** chart has data.
- Adds `max_pd_vars`, `pd_sample_size`, `pd_grid_resolution`, and `pd_with_bin_means` formals (aligned with `exp_rpart`), plus `tidy(..., type = "partial_dependence")`.
- Rewrites `tree_nodes` `edge_label` via `chaid_readable_one_condition` so characteristic-groups **Condition** (and tree chart edges) read like CART (`給料 <= 2695.8`, `2695.8 < 給料 <= 4228.8`) instead of `給料 = (2695.8, 4228.8]`. `cond_value` stays collapsed bin labels for filters.
- Passes `report_metrics` through `tidy.exploratory_chaid` so the metrics table shows **ROC AUC / PR AUC / Balanced Accuracy / Specificity** (and multiclass Macro / One-vs-Rest AUCs) like CART.
- Bumps package version **16.0.15 → 16.0.16**.
- Also for tam#37256: `evaluate_binary_training_and_test` / `glance.glm_exploratory` gain opt-in `report_metrics=TRUE` (ROC AUC rename + PR AUC / Balanced Accuracy / Specificity) while keeping Logistic statistical columns (AIC/BIC/P-value/deviance).

## Context
The desktop CHAID Analytics Report was wired to `local_importance_binary` / `rf_partial_dependence()`, but CHAID models never built PD at fit time (unlike CART). The chart container rendered with 「表示するデータがありません」.

Separately, terminal-node Condition text used raw interval equality labels (`var = (a, b]` / `var = <= x`), which was much harder to read than CART inequalities.

The metrics table markdown already described ROC AUC / PR AUC and the template passes `report_metrics = TRUE`, but `tidy.exploratory_chaid` dropped the flag so only the legacy `AUC` column appeared.

## Test plan
- [x] `testthat::test_file("tests/testthat/test_build_chaid.R")` (incl. report_metrics / edge-label / PD tests)
- [ ] In desktop app with exploratory 16.0.16 installed: create a **new** CHAID logical analysis and verify 変数の値と予測確率 shows Predicted/Actual curves
- [ ] Same run: Summary terminal-node Condition uses readable inequalities / `in (...)` (not `給料 = (a, b]`)
- [ ] Same run: モデルの評価指標 shows ROC AUC and PR AUC (not plain AUC only)
- [ ] After merge: build/upload exploratory 16.0.16 binaries for Intel / ARM / Windows and bump `requiredRPackagesReduced.json` in tam if shipping together

Made with [Cursor](https://cursor.com)
