### PR TITLE
PCA analysis_conditions updates for #37268

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.16
-Date: 2026-07-25
+Version: 16.0.17
+Date: 2026-07-26
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -338,40 +338,40 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       normalized <- isTRUE(x$normalize_data)
       variables_used <- length(d$variable_sd)
       excluded_names <- d$excluded_variables
-      excluded_display <- if (length(excluded_names) == 0) "-" else paste(excluded_names, collapse = ", ")
+      # #37268: show "None" (JA: なし) when nothing was excluded, not "-".
+      excluded_display <- if (length(excluded_names) == 0) "None" else paste(excluded_names, collapse = ", ")
       excluded_pct <- d$excluded_row_rate * 100
       scale_ratio <- d$scale_ratio
       scale_display <- if (is.na(scale_ratio)) "-" else format(round(scale_ratio, 1), nsmall = 1)
       scale_status <- if (!normalized && is.finite(scale_ratio) && scale_ratio >= cfg$scale_ratio_warning) "scale_warning" else "ok"
+      # #37268: rename Rows Used / Variables Used; drop redundant Rows vs Variables row;
+      # refresh Description copy (and English-canonical strings for the client translator).
       res <- tibble::tibble(
-        Metric = c("Rows Used", "Rows Excluded", "Variables Used", "Excluded Variables",
-                   "Normalization", "SD Ratio (Max/Min)", "Rows vs Variables"),
+        Metric = c("Number of Rows", "Rows Excluded", "Number of Variables", "Excluded Variables",
+                   "Normalization", "SD Ratio (Max/Min)"),
         Value = c(
           as.character(d$analyzed_row_count),
           paste0(d$excluded_row_count, " (", format(round(excluded_pct, 1), nsmall = 1), "%)"),
           as.character(variables_used),
           excluded_display,
           if (normalized) "Yes" else "No",
-          scale_display,
-          paste0(d$analyzed_row_count, " rows / ", variables_used, " variables")
+          scale_display
         ),
         Description = c(
-          "Number of rows used after removing missing values.",
+          "Number of rows used in the analysis.",
           "Number and rate of rows removed because of missing values.",
           "Number of variables used in the analysis.",
-          "Variables dropped before analysis because they had only NA or a single value.",
-          "Whether variables were scaled to unit variance before analysis.",
-          "Ratio of the largest to the smallest variable standard deviation.",
-          "Number of rows compared with the number of variables."
+          "Variables dropped before analysis because they were all missing or had only one unique value.",
+          "Whether variables were standardized before analysis.",
+          "Ratio of the maximum to the minimum standard deviation across all variables."
         ),
         status = c(
-          "ok",
+          if (d$analyzed_row_count <= variables_used) "few_rows" else "ok",
           if (d$excluded_row_rate >= cfg$na_exclusion_warning) "high_na_exclusion" else "ok",
           "ok",
           if (length(excluded_names) == 0) "na" else "ok",
           "ok",
-          scale_status,
-          if (d$analyzed_row_count <= variables_used) "few_rows" else "ok"
+          scale_status
         )
       )
     }

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -347,7 +347,7 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       # #37268: rename Rows Used / Variables Used; drop redundant Rows vs Variables row;
       # refresh Description copy (and English-canonical strings for the client translator).
       res <- tibble::tibble(
-        Metric = c("Number of Rows", "Rows Excluded", "Number of Variables", "Excluded Variables",
+        Metric = c("Row Count", "Rows Excluded", "Number of Variables", "Excluded Variables",
                    "Normalization", "SD Ratio (Max/Min)"),
         Value = c(
           as.character(d$analyzed_row_count),

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -93,7 +93,15 @@ test_that("new report tidy types return expected columns and tokens", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
   res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
   expect_equal(colnames(res), c("Metric", "Value", "Description", "status"))
-  expect_true(all(c("Rows Used","Variables Used","Normalization","SD Ratio (Max/Min)") %in% res$Metric))
+  expect_true(all(c("Number of Rows","Number of Variables","Normalization","SD Ratio (Max/Min)") %in% res$Metric))
+  expect_false("Rows vs Variables" %in% res$Metric)
+  expect_false("Rows Used" %in% res$Metric)
+  expect_false("Variables Used" %in% res$Metric)
+  # #37268: empty excluded-variables cell is "None" (JA: なし), not "-".
+  excluded_row <- res[res$Metric == "Excluded Variables", , drop = FALSE]
+  if (nrow(excluded_row) == 1 && identical(excluded_row$status, "na")) {
+    expect_equal(excluded_row$Value, "None")
+  }
   res <- model_df %>% tidy_rowwise(model, type = "parallel_screeplot")
   expect_equal(colnames(res), c("Component", "Eigenvalue", "Random Data Eigenvalue"))
   res <- model_df %>% tidy_rowwise(model, type = "variances_judged")

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -93,10 +93,11 @@ test_that("new report tidy types return expected columns and tokens", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
   res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
   expect_equal(colnames(res), c("Metric", "Value", "Description", "status"))
-  expect_true(all(c("Number of Rows","Number of Variables","Normalization","SD Ratio (Max/Min)") %in% res$Metric))
+  expect_true(all(c("Row Count","Number of Variables","Normalization","SD Ratio (Max/Min)") %in% res$Metric))
   expect_false("Rows vs Variables" %in% res$Metric)
   expect_false("Rows Used" %in% res$Metric)
   expect_false("Variables Used" %in% res$Metric)
+  expect_false("Number of Rows" %in% res$Metric)
   # #37268: empty excluded-variables cell is "None" (JA: なし), not "-".
   excluded_row <- res[res$Metric == "Excluded Variables", , drop = FALSE]
   if (nrow(excluded_row) == 1 && identical(excluded_row$status, "na")) {


### PR DESCRIPTION
## Description
Paired R changes for [exploratory-io/tam#37268](https://github.com/exploratory-io/tam/issues/37268) (PCA Analytics Report Part 2).

## Implementation Details
- Rename metrics: `Rows Used` → `Row Count`, `Variables Used` → `Number of Variables`
- Drop `Rows vs Variables` row (few_rows status moved onto `Row Count`)
- Empty excluded variables → `None` (JA: なし) instead of `-`
- Refresh Description English strings for the updated copy

## How to Test
```r
mtcars %>% do_prcomp(mpg, cyl, disp, hp) %>% tidy_rowwise(model, type = "analysis_conditions")
```
Expect Metric values: Row Count, Rows Excluded, Number of Variables, Excluded Variables, Normalization, SD Ratio (Max/Min). Excluded Variables Value is `None` when empty.

## Build Impact
R package only — needs install into `~/.exploratory/R/<ver>` for desktop verify.


Made with [Cursor](https://cursor.com)