### PR TITLE
test(oracle): compare resolveOracleClientLocation home with separators neutralized

### DIFF
--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -1282,9 +1282,13 @@ test_that("resolveOracleClientLocation only reports an ORACLE_HOME for the lib s
   file.create(file.path(zipLayout, "libclntsh.dylib.23.1"))
 
   # ROracle only ever looks at $ORACLE_HOME/lib, so home is the parent of the lib directory.
+  # resolveOracleClientLocation derives home with dirname(), which on Windows rewrites every
+  # separator to a forward slash, while tempfile() hands back backslashes -- so compare with the
+  # separators neutralized rather than against the raw homeLayout string. (no-op on Mac/Linux)
+  forwardSlashes <- function(p) gsub("\\\\", "/", p)
   resolved <- exploratory:::resolveOracleClientLocation(homeLayout)
   expect_equal(resolved$libDir, file.path(homeLayout, "lib"))
-  expect_equal(resolved$home, homeLayout)
+  expect_equal(forwardSlashes(resolved$home), forwardSlashes(homeLayout))
 
   # The zip layout cannot be expressed as an ORACLE_HOME, so home stays empty and the
   # caller falls back to loading the library directly.


### PR DESCRIPTION
## Summary

Fixes the single R-package test failure in the [2026-07-29 Windows daily run](https://exploratory-devbuild.s3.us-east-1.amazonaws.com/test_results/test_all_result-win-20260729-071938.md):

```
test_system.R:1287:3 — resolveOracleClientLocation only reports an ORACLE_HOME for the lib subdirectory layout
Expected 'resolved$home' to equal 'homeLayout'. Differences: 1/1 mismatches
x[1]: "C:/Users/EXPLOR~1/AppData/Local/Temp/RtmpU1ENxW/file18b41bfa68e1/client64"
y[1]: "C:\\Users\\EXPLOR~1\\AppData\\Local\\Temp\\RtmpU1ENxW\\file18b41bfa68e1/client64"
```

**This is a test bug, not a production bug** — the two strings name the same directory and differ only in separator style.

## Root cause

Windows-only path-separator mismatch, introduced with the Oracle (OCI) work in #1567:

- `tempfile()` on Windows returns **backslashes** (`C:\Users\...\file18b4...`).
- `file.path()` appends with a **forward slash**, so the test's `homeLayout` is a **mixed-separator** string: `C:\Users\...\file18b4.../client64`.
- `resolveOracleClientLocation()` derives `home` via `dirname(libDir)`, and **`dirname()` on Windows rewrites every separator to a forward slash** — so it returns `C:/Users/.../client64`.

The two can therefore never be `identical()` on Windows. Mac/Linux never see it because `tempfile()` already returns forward slashes there, so `dirname()` changes nothing.

Verified live on the Windows daily-test box (`exp-test1`) against the installed package:

```
resolved$home : C:/Users/exploratory/AppData/Local/Temp/Rtmp809iaV/file1368464e319/client64
homeLayout    : C:\Users\exploratory\AppData\Local\Temp\Rtmp809iaV\file1368464e319/client64
PRE-FIX  identical: FALSE
POST-FIX identical: TRUE
libDir assertion  : TRUE
```

Production is unaffected: `home` only ever feeds `Sys.setenv(ORACLE_HOME=)` on non-Windows (the Windows branch of `applyOracleClientEnv` prepends `libDir` to `PATH` and never reads `home`), and forward slashes are valid on Windows regardless.

## Fix

Compare `resolved$home` with the separators neutralized instead of against the raw `homeLayout` string — a no-op on Mac/Linux. The assertion still pins that `home` is the parent of the `lib` directory; the zip-layout `home == ""` case and the `libDir` assertion are untouched, so the test keeps its original meaning.

Same class as tam's existing `r-file-path-separator` lesson (assert against the production transformation, not a hardcoded separator style), recurring here on the R side.

**No `DESCRIPTION` version bump** — tests only, no shipped R code change, so no rebuilt per-platform binaries are required.

## Test plan

- [x] Verified live on `exp-test1` (Windows, R 4.6.1, `exploratory` 16.0.24) that the assertion is `FALSE` pre-fix and `TRUE` post-fix against the real `resolveOracleClientLocation`.
- [x] Full `tests/testthat/test_system.R` still passes on Mac ARM (no new failures; only the pre-existing unrelated skip/warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
