### PR TITLE
feat(factanal): parallel analysis method (Factor Model / Diagonal SMC) (#37332)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.24
-Date: 2026-07-28
+Version: 16.0.25
+Date: 2026-07-29
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -299,7 +299,7 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
     return(NULL) # no usable null distribution; the caller reports the parallel analysis as unavailable
   }
   random_eigen_mat <- do.call(cbind, random_eigen_list)
-  random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
+  random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob, na.rm = TRUE)
   recommended_n <- compute_parallel_recommended_n(actual_eigen, random_threshold)
 
   list(
@@ -308,11 +308,13 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
     requested_n_iter = n_iter,
     successful_n_iter = length(random_eigen_list),
     failed_n_iter = n_iter - length(random_eigen_list),
+    quantile_prob = quantile_prob,
     recommended_n = recommended_n,
     table = tibble::tibble(
       factor_number = seq_along(actual_eigen),
       actual_eigenvalue = actual_eigen,
-      random_eigenvalue_threshold = random_threshold
+      random_eigenvalue_threshold = random_threshold,
+      retained = seq_along(actual_eigen) <= recommended_n
     )
   )
 }

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -136,6 +136,78 @@ judge_loading <- function(loadings, cfg = factanal_report_config()) {
        primary_factor = primary_factor, secondary_factors = "", direction = direction)
 }
 
+# The factor-analysis eigenvalues used by parallel analysis (issue tam#37332). Both actual-data and
+# random-data eigenvalues in compute_parallel_analysis() are routed through this so the two sides
+# are always compared on the same basis.
+#
+# method = "factor_model":
+#   Estimate communalities from a one-factor model using the selected factor extraction method,
+#   following the factor-analysis approach used by psych::fa.parallel(). nfactors = 1 below is used
+#   ONLY to estimate communalities for these eigenvalues -- it has nothing to do with how many
+#   factors exp_factanal() itself ultimately extracts.
+#
+# method = "smc":
+#   Replace the diagonal of the correlation matrix with squared multiple correlations (SMC) and
+#   compute eigenvalues of the reduced matrix.
+#
+# method = "pca":
+#   Plain eigenvalues of the correlation matrix, diagonal untouched (the classic PCA-style parallel
+#   analysis). NOT exposed on the exp_factanal() "Parallel Analysis Method" property (issue
+#   tam#37332 only offers factor_model/smc there) -- this value exists so do_prcomp(), which shares
+#   this helper via compute_parallel_analysis(), keeps its own pre-existing PCA parallel analysis
+#   (issue #37019/#37294) unchanged. PCA eigenvalues must equal x$sdev^2 exactly when normalized, an
+#   invariant only the untouched-diagonal eigenvalues satisfy.
+compute_parallel_factor_eigenvalues <- function(cor_matrix, method = c("factor_model", "smc", "pca"),
+                                                 fm = "minres", n_obs = NULL) {
+  method <- match.arg(method)
+  cor_matrix <- as.matrix(cor_matrix)
+  if (nrow(cor_matrix) != ncol(cor_matrix)) {
+    stop("cor_matrix must be a square matrix")
+  }
+  if (any(!is.finite(cor_matrix))) {
+    stop("cor_matrix contains non-finite values")
+  }
+
+  if (identical(method, "pca")) {
+    return(eigen(cor_matrix, symmetric = TRUE, only.values = TRUE)$values)
+  }
+
+  if (identical(method, "smc")) {
+    reduced_cor <- cor_matrix
+    smc_values <- psych::smc(cor_matrix)
+    if (length(smc_values) != ncol(cor_matrix) || any(!is.finite(smc_values))) {
+      stop("SMC communalities could not be computed")
+    }
+    diag(reduced_cor) <- smc_values
+    return(eigen(reduced_cor, symmetric = TRUE, only.values = TRUE)$values)
+  }
+
+  # Factor-model method.
+  fa_args <- list(r = cor_matrix, nfactors = 1, fm = fm, rotate = "none", warnings = FALSE)
+  if (!is.null(n_obs)) {
+    fa_args$n.obs <- n_obs
+  }
+  factor_fit <- do.call(psych::fa, fa_args)
+  factor_eigenvalues <- factor_fit$values
+  if (is.null(factor_eigenvalues) || length(factor_eigenvalues) != ncol(cor_matrix) ||
+      any(!is.finite(factor_eigenvalues))) {
+    stop("Factor-model eigenvalues could not be computed")
+  }
+  as.numeric(factor_eigenvalues)
+}
+
+# The number of LEADING factors whose actual eigenvalue exceeds the random-data threshold, stopping
+# at the first factor that does not -- not a simple count of how many factors exceed it anywhere in
+# the sequence (issue tam#37332). e.g. TRUE, TRUE, FALSE, TRUE -> 2, not 3.
+compute_parallel_recommended_n <- function(actual_eigen, random_threshold) {
+  retained <- actual_eigen > random_threshold
+  first_not_retained <- which(!retained)[1]
+  if (is.na(first_not_retained)) {
+    return(length(retained))
+  }
+  first_not_retained - 1L
+}
+
 # Horn's parallel analysis: compares actual correlation-matrix eigenvalues against the
 # quantile of eigenvalues from random normal data of the same shape. (issue #37018 spec 3.4)
 #' @param cor_type Correlation type the whole analysis uses. For anything other than "pearson" both the
@@ -143,8 +215,16 @@ judge_loading <- function(loadings, cfg = factanal_report_config()) {
 #'        analysis never silently falls back to Pearson. (issue #26623)
 #' @param cor_matrix Correlation matrix already built for the analysis. Reused for the actual eigenvalues
 #'        so the scree/parallel chart matches the matrix `fa()` was fitted on.
+#' @param method How communalities are estimated for the parallel-analysis eigenvalues: "factor_model"
+#'        (one-factor model using `fm`), "smc" (diagonal replaced by squared multiple correlations),
+#'        or "pca" (plain eigenvalues, diagonal untouched -- do_prcomp's own PCA-style parallel
+#'        analysis; not exposed on exp_factanal()'s property). The SAME method is applied to the
+#'        actual data and to every random-data iteration. (issue tam#37332)
+#' @param fm Factor extraction method used by `method = "factor_model"`. Ignored otherwise.
 compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
-                                      cor_type = "pearson", cor_matrix = NULL) {
+                                      cor_type = "pearson", cor_matrix = NULL,
+                                      method = c("factor_model", "smc", "pca"), fm = "minres") {
+  method <- match.arg(method)
   if (length(n_iter) != 1L || is.na(n_iter) || n_iter < 1 || n_iter != as.integer(n_iter)) {
     stop("n_iter must be a positive integer")
   }
@@ -155,57 +235,30 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
   x <- as.data.frame(x)
   n <- nrow(x)
   p <- ncol(x)
-  if (!identical(cor_type, "pearson")) {
-    # Polychoric/tetrachoric/mixed: the null distribution is built by shuffling each column
-    # independently, which keeps every variable's category marginals but destroys the association,
-    # and the SAME correlation method is applied to it. Drawing normal deviates instead would
-    # compare a polychoric eigenvalue against a Pearson one.
-    actual_eigen <- if (!is.null(cor_matrix)) {
-      eigen(cor_matrix, symmetric = TRUE, only.values = TRUE)$values
-    } else {
-      eigen(build_factor_correlation(x, cor_type)$correlation, symmetric = TRUE, only.values = TRUE)$values
-    }
-    had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-    old_seed <- if (had_seed) get(".Random.seed", envir = .GlobalEnv) else NULL
-    set.seed(1234)
-    on.exit({
-      if (had_seed) {
-        assign(".Random.seed", old_seed, envir = .GlobalEnv)
-      } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
-        rm(".Random.seed", envir = .GlobalEnv)
-      }
-    }, add = TRUE)
-    random_eigen_list <- lapply(seq_len(n_iter), function(i) {
-      shuffled <- as.data.frame(lapply(x, function(col) col[sample.int(n)]))
-      res <- build_factor_correlation(shuffled, cor_type)
-      # build_factor_correlation degrades to Pearson when the estimation fails. Comparing a
-      # polychoric eigenvalue against a Pearson threshold is exactly the mix-up this whole change
-      # exists to prevent, so drop the iteration instead.
-      if (isTRUE(res$failed)) return(NULL)
-      eigen(res$correlation, symmetric = TRUE, only.values = TRUE)$values
-    })
-    random_eigen_list <- random_eigen_list[!vapply(random_eigen_list, is.null, logical(1))]
-    if (length(random_eigen_list) == 0) {
-      return(NULL) # no usable null distribution; the caller reports the parallel analysis as unavailable
-    }
-    random_eigen_mat <- do.call(cbind, random_eigen_list)
-    random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
-    return(list(
-      recommended_n = sum(actual_eigen > random_threshold),
-      table = tibble::tibble(
-        factor_number = seq_along(actual_eigen),
-        actual_eigenvalue = actual_eigen,
-        random_eigenvalue_threshold = random_threshold
-      )
-    ))
-  }
-  # Reuse the analysis's own matrix when it was handed one, so the scree/parallel chart and the
-  # fit can never be based on two separately-computed Pearson matrices. (issue #26623)
-  actual_eigen <- if (!is.null(cor_matrix)) {
-    eigen(cor_matrix, symmetric = TRUE, only.values = TRUE)$values
+
+  # Build or reuse the actual correlation matrix. Reusing the analysis's own matrix when it was
+  # handed one means the scree/parallel chart and the fit can never be based on two separately
+  # computed matrices. (issue #26623)
+  actual_cor <- if (!is.null(cor_matrix)) {
+    cor_matrix
+  } else if (identical(cor_type, "pearson")) {
+    stats::cor(x, use = "pairwise.complete.obs")
   } else {
-    eigen(cor(x, use = "pairwise.complete.obs"), symmetric = TRUE, only.values = TRUE)$values
+    actual_cor_result <- build_factor_correlation(x, cor_type)
+    if (isTRUE(actual_cor_result$failed)) {
+      return(NULL)
+    }
+    actual_cor_result$correlation
   }
+
+  actual_eigen <- tryCatch(
+    compute_parallel_factor_eigenvalues(actual_cor, method = method, fm = fm, n_obs = n),
+    error = function(e) NULL
+  )
+  if (is.null(actual_eigen)) {
+    return(NULL)
+  }
+
   # Snapshot the RNG so this null-distribution draw does not perturb the outer deterministic
   # stream that later groups' sampling relies on. Restore afterward.
   had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
@@ -218,13 +271,44 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
       rm(".Random.seed", envir = .GlobalEnv)
     }
   }, add = TRUE)
-  random_eigen_mat <- replicate(n_iter, {
-    rd <- matrix(stats::rnorm(n * p), nrow = n, ncol = p)
-    eigen(cor(rd), symmetric = TRUE, only.values = TRUE)$values
+
+  random_eigen_list <- lapply(seq_len(n_iter), function(i) {
+    random_cor <- if (identical(cor_type, "pearson")) {
+      rd <- matrix(stats::rnorm(n * p), nrow = n, ncol = p)
+      stats::cor(rd)
+    } else {
+      # Shuffling each column independently keeps every variable's category marginals but
+      # destroys the association, and the SAME correlation method is applied to it -- drawing
+      # normal deviates instead would compare a polychoric eigenvalue against a Pearson one.
+      shuffled <- as.data.frame(lapply(x, function(col) col[sample.int(n)]))
+      res <- build_factor_correlation(shuffled, cor_type)
+      # build_factor_correlation degrades to Pearson when the estimation fails. Comparing a
+      # polychoric eigenvalue against a Pearson threshold is exactly the mix-up this whole change
+      # exists to prevent, so drop the iteration instead.
+      if (isTRUE(res$failed)) return(NULL)
+      res$correlation
+    }
+    if (is.null(random_cor)) return(NULL)
+    tryCatch(
+      compute_parallel_factor_eigenvalues(random_cor, method = method, fm = fm, n_obs = n),
+      error = function(e) NULL
+    )
   })
+  random_eigen_list <- random_eigen_list[!vapply(random_eigen_list, is.null, logical(1))]
+  if (length(random_eigen_list) == 0) {
+    return(NULL) # no usable null distribution; the caller reports the parallel analysis as unavailable
+  }
+  random_eigen_mat <- do.call(cbind, random_eigen_list)
   random_threshold <- apply(random_eigen_mat, 1, stats::quantile, probs = quantile_prob)
+  recommended_n <- compute_parallel_recommended_n(actual_eigen, random_threshold)
+
   list(
-    recommended_n = sum(actual_eigen > random_threshold),
+    method = method,
+    factor_extraction_method = fm,
+    requested_n_iter = n_iter,
+    successful_n_iter = length(random_eigen_list),
+    failed_n_iter = n_iter - length(random_eigen_list),
+    recommended_n = recommended_n,
     table = tibble::tibble(
       factor_number = seq_along(actual_eigen),
       actual_eigenvalue = actual_eigen,
@@ -242,8 +326,14 @@ compute_parallel_analysis <- function(x, n_iter = 100, quantile_prob = 0.95,
 #' @param parallel_n_iter Iterations of the parallel analysis null distribution (default 100 for
 #'        every correlation type). Polychoric-family correlations re-estimate the correlation on
 #'        each iteration, so this is the dominant cost of a polychoric run.
+#' @param parallel_method How communalities are estimated for the parallel-analysis eigenvalues:
+#'        "factor_model" (default; a one-factor model using `fm`) or "smc" (diagonal replaced by
+#'        squared multiple correlations). Applied identically to the actual data and the random-data
+#'        null distribution. (issue tam#37332)
 exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regression", rotate = "none", max_nrow = NULL, seed = 1,
-                         cor_type = "auto", parallel_n_iter = NULL) {
+                         cor_type = "auto", parallel_n_iter = NULL,
+                         parallel_method = c("factor_model", "smc")) {
+  parallel_method <- match.arg(parallel_method)
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
   if (length(selected_cols) < nfactors) {
@@ -423,8 +513,13 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     fit$bartlett <- tryCatch(psych::cortest.bartlett(cor_mat, n = nrow(encoded_df)), error = function(e) NULL)
     n_iter <- if (!is.null(parallel_n_iter)) parallel_n_iter else 100
     fit$parallel <- tryCatch(compute_parallel_analysis(encoded_df, n_iter = n_iter,
-                                                       cor_type = resolved$type, cor_matrix = cor_mat),
+                                                       cor_type = resolved$type, cor_matrix = cor_mat,
+                                                       method = parallel_method, fm = fm),
                              error = function(e) NULL)
+    # Kept even when fit$parallel itself is NULL (e.g. n_iter too small to yield a usable null
+    # distribution), so the report can still show which setting was selected. (issue tam#37332)
+    fit$parallel_method <- parallel_method
+    fit$parallel_factor_extraction_method <- fm
     # Keyed off the REQUESTED family, so a failed polychoric estimation still shows the table with
     # its "Estimation failed" row rather than hiding the only signal the user has.
     fit$cor_diagnostics <- if (identical(requested_family, "pearson")) NULL else {
@@ -723,11 +818,14 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # NOTE: "Target Variables" / "Data Rows" instead of the shorter "Variables" / "Rows":
       # the client's shared translation map already binds those two keys to different wordings
       # for other tables, and a direct-map key can only have one translation. (issue #26623)
-      Item = c("Correlation", "Factor Extraction Method", "Rotation", "Target Variables", "Data Rows"),
+      Item = c("Correlation", "Factor Extraction Method", "Rotation", "Parallel Analysis Method", "Target Variables", "Data Rows"),
       Value = c(
         factanal_correlation_label(cor_type),
         factanal_extraction_method_label(x$fm),
         factanal_rotation_label(rotation),
+        # issue tam#37332: reported even when parallel analysis itself failed (x$parallel NULL),
+        # since x$parallel_method is set independently of whether the computation succeeded.
+        factanal_parallel_method_label(x$parallel_method),
         if (length(x$n_variables) == 1L && !is.na(x$n_variables)) as.character(x$n_variables) else "N/A",
         if (length(x$n_rows_used) == 1L && !is.na(x$n_rows_used)) as.character(x$n_rows_used) else "N/A"
       ),
@@ -763,26 +861,45 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     }
   }
   else if (type == "factor_count") {
+    # Kaiser criterion always reads the plain correlation-matrix eigenvalues (issue tam#37332
+    # section 10): it is a separate, well-known rule of thumb that this change does not touch.
     eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     kaiser_n <- sum(eig > 1)
     par <- x$parallel
     parallel_rec <- if (is.null(par)) "Not available" else as.character(par$recommended_n)
+    # The description names which eigenvalue the Parallel Analysis row actually compared, so it
+    # stays honest once the method is selectable (issue tam#37332).
+    parallel_description <- if (is.null(par)) {
+      "Parallel analysis could not be computed."
+    } else if (identical(par$method, "smc")) {
+      "Number of factors whose SMC-based factor eigenvalue exceeds the random-data threshold."
+    } else {
+      "Number of factors whose factor-model eigenvalue exceeds the random-data threshold."
+    }
     res <- tibble::tibble(
       Method = c("Kaiser Criterion", "Parallel Analysis", "Scree Plot"),
       `Recommended Number of Factors` = c(as.character(kaiser_n), parallel_rec, "Check the chart"),
       Description = c(
         "Number of factors with an eigenvalue greater than 1.",
-        "Number of factors whose eigenvalue exceeds the random-data eigenvalue.",
+        parallel_description,
         "Look for the point where the eigenvalue drop levels off (the elbow)."
       )
     )
   }
   else if (type == "parallel_screeplot") {
-    eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     par <- x$parallel
-    threshold <- if (is.null(par)) rep(NA_real_, length(eig)) else par$table$random_eigenvalue_threshold
-    length(threshold) <- length(eig) # pad/truncate to align with eigenvalue count
-    res <- tibble::tibble(Factor = 1:length(eig), Eigenvalue = eig, `Random Data Eigenvalue` = threshold)
+    # The actual-data curve MUST be the same kind of eigenvalue the parallel analysis itself used
+    # (factor-model or SMC) -- not the plain correlation-matrix eigenvalues -- or the chart compares
+    # two different quantities against each other. (issue tam#37332 section 9)
+    if (is.null(par)) {
+      n_vars <- ncol(x$correlation)
+      eig <- rep(NA_real_, n_vars)
+      threshold <- rep(NA_real_, n_vars)
+    } else {
+      eig <- par$table$actual_eigenvalue
+      threshold <- par$table$random_eigenvalue_threshold
+    }
+    res <- tibble::tibble(Factor = seq_along(eig), Eigenvalue = eig, `Random Data Eigenvalue` = threshold)
   }
   else if (type == "score_coefficients") {
     # Factor score coefficients (因子得点係数 / SPSS's Factor Score Coefficient Matrix) -- the weights

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -566,6 +566,17 @@ factanal_extraction_method_label <- function(fm) {
          as.character(fm))
 }
 
+# NULL (a model saved before issue tam#37332) is treated as the "factor_model" default -- the
+# analysis actually ran with that behavior even though the field did not exist yet. Any other
+# unrecognized value is a genuine anomaly, so it is reported as "Not Available" rather than guessed.
+factanal_parallel_method_label <- function(method) {
+  method <- if (is.null(method) || length(method) != 1L || is.na(method)) "factor_model" else as.character(method)
+  switch(method,
+         factor_model = "Factor Model",
+         smc = "Diagonal SMC",
+         "Not Available")
+}
+
 
 # Language-neutral tokens for the selector's warnings, so the client can render localized text
 # instead of the English sentences the selector composes for logs. (issue #26623)

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -338,7 +338,12 @@ do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_singl
       }
 
       fit$parallel <- tryCatch(
-        compute_parallel_analysis(encoded_df, cor_type = resolved$type, cor_matrix = fit$correlation),
+        # method = "pca": keep PCA's own parallel analysis on plain (untouched-diagonal) correlation
+        # eigenvalues -- compute_parallel_analysis() now defaults to Factor Analysis's
+        # "factor_model" method (issue tam#37332), which do_prcomp must NOT silently pick up, since
+        # "Eigenvalue = x$sdev^2" below is only guaranteed to match the PCA-style eigenvalues.
+        compute_parallel_analysis(encoded_df, cor_type = resolved$type, cor_matrix = fit$correlation,
+                                  method = "pca"),
         error = function(e) NULL)
       fit$kaiser_components <- tryCatch(
         # A correlation matrix is standardized by construction, so under a categorical correlation

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -338,10 +338,12 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   set.seed(1)
   pa <- compute_parallel_analysis(mtcars[, c("mpg","cyl","disp","hp","drat","wt","qsec")], n_iter = 20)
   expect_true(is.numeric(pa$recommended_n))
-  expect_equal(colnames(pa$table), c("factor_number", "actual_eigenvalue", "random_eigenvalue_threshold"))
+  expect_equal(colnames(pa$table), c("factor_number", "actual_eigenvalue", "random_eigenvalue_threshold", "retained"))
   # method defaults to "factor_model" (issue tam#37332).
   expect_equal(pa$method, "factor_model")
   expect_equal(pa$factor_extraction_method, "minres")
+  expect_equal(pa$quantile_prob, 0.95)
+  expect_equal(pa$table$retained, seq_len(nrow(pa$table)) <= pa$recommended_n)
   set.seed(99)
   before <- .Random.seed
   compute_parallel_analysis(mtcars[, 1:3], n_iter = 2)

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -339,6 +339,9 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   pa <- compute_parallel_analysis(mtcars[, c("mpg","cyl","disp","hp","drat","wt","qsec")], n_iter = 20)
   expect_true(is.numeric(pa$recommended_n))
   expect_equal(colnames(pa$table), c("factor_number", "actual_eigenvalue", "random_eigenvalue_threshold"))
+  # method defaults to "factor_model" (issue tam#37332).
+  expect_equal(pa$method, "factor_model")
+  expect_equal(pa$factor_extraction_method, "minres")
   set.seed(99)
   before <- .Random.seed
   compute_parallel_analysis(mtcars[, 1:3], n_iter = 2)
@@ -347,4 +350,93 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   before <- .Random.seed
   expect_error(compute_parallel_analysis(mtcars[, 1:3], n_iter = 0), "positive integer")
   expect_equal(.Random.seed, before)
+})
+
+test_that("parallel analysis method: factor_model vs smc (issue #37332)", {
+  df <- mtcars[, c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec")]
+
+  # compute_parallel_factor_eigenvalues: both methods return one eigenvalue per variable, and the
+  # two methods must disagree on a real correlation matrix (smc is a strictly reduced-diagonal
+  # matrix vs a one-factor communality estimate -- they are not expected to coincide).
+  cor_mat <- stats::cor(df)
+  eig_factor_model <- compute_parallel_factor_eigenvalues(cor_mat, method = "factor_model", fm = "minres", n_obs = nrow(df))
+  eig_smc <- compute_parallel_factor_eigenvalues(cor_mat, method = "smc")
+  expect_equal(length(eig_factor_model), ncol(df))
+  expect_equal(length(eig_smc), ncol(df))
+  expect_false(isTRUE(all.equal(eig_factor_model, eig_smc)))
+  # method must be one of the two allowed values.
+  expect_error(compute_parallel_factor_eigenvalues(cor_mat, method = "bogus"))
+  # A non-square matrix is rejected before any estimation is attempted.
+  expect_error(compute_parallel_factor_eigenvalues(cor_mat[, 1:3], method = "smc"), "square matrix")
+  expect_error(compute_parallel_factor_eigenvalues(matrix(c(1, NA, NA, 1), 2, 2), method = "smc"), "non-finite")
+
+  # compute_parallel_recommended_n: counts only the LEADING run of TRUE, not a simple sum.
+  expect_equal(compute_parallel_recommended_n(c(2, 2, 0.5, 2), c(1, 1, 1, 1)), 2)
+  expect_equal(compute_parallel_recommended_n(c(2, 2, 2, 2), c(1, 1, 1, 1)), 4)
+  expect_equal(compute_parallel_recommended_n(c(0.5, 2, 2, 2), c(1, 1, 1, 1)), 0)
+
+  # compute_parallel_analysis dispatches on method and applies it to BOTH the actual data and the
+  # random-data null distribution -- confirmed by the two methods producing different results on
+  # the same data/seed.
+  set.seed(7)
+  pa_factor_model <- compute_parallel_analysis(df, n_iter = 15, method = "factor_model", fm = "minres")
+  set.seed(7)
+  pa_smc <- compute_parallel_analysis(df, n_iter = 15, method = "smc")
+  expect_equal(pa_factor_model$method, "factor_model")
+  expect_equal(pa_smc$method, "smc")
+  expect_false(isTRUE(all.equal(pa_factor_model$table$actual_eigenvalue, pa_smc$table$actual_eigenvalue)))
+  expect_false(isTRUE(all.equal(pa_factor_model$table$random_eigenvalue_threshold, pa_smc$table$random_eigenvalue_threshold)))
+
+  # exp_factanal(): parallel_method defaults to factor_model, is forwarded to compute_parallel_analysis,
+  # is stored on the fit even when parallel itself is unavailable, and match.arg rejects bogus values.
+  model_df <- exp_factanal(df, mpg, cyl, disp, hp, drat, wt, qsec, nfactors = 2, fm = "minres", parallel_n_iter = 10)
+  fit <- model_df$model[[1]]
+  expect_equal(fit$parallel_method, "factor_model")
+  expect_equal(fit$parallel_factor_extraction_method, "minres")
+  expect_equal(fit$parallel$method, "factor_model")
+
+  smc_model_df <- exp_factanal(df, mpg, cyl, disp, hp, drat, wt, qsec, nfactors = 2, fm = "minres",
+                               parallel_n_iter = 10, parallel_method = "smc")
+  smc_fit <- smc_model_df$model[[1]]
+  expect_equal(smc_fit$parallel_method, "smc")
+  expect_equal(smc_fit$parallel$method, "smc")
+
+  expect_error(exp_factanal(df, mpg, cyl, disp, hp, drat, wt, qsec, nfactors = 2, parallel_method = "bogus"))
+
+  # parallel_screeplot: the actual-data curve must be the SAME eigenvalues the parallel analysis
+  # itself used (method-aware), not a fresh plain correlation-matrix eigen() -- so it must equal
+  # fit$parallel$table$actual_eigenvalue and must NOT equal the plain screeplot's eigenvalues, since
+  # factor-model/SMC eigenvalues differ from PCA-style correlation-matrix eigenvalues.
+  screeplot_res <- model_df %>% tidy_rowwise(model, type = "screeplot")
+  parallel_screeplot_res <- model_df %>% tidy_rowwise(model, type = "parallel_screeplot")
+  expect_equal(parallel_screeplot_res$Eigenvalue, fit$parallel$table$actual_eigenvalue)
+  expect_false(isTRUE(all.equal(parallel_screeplot_res$Eigenvalue, screeplot_res$eigenvalue)))
+  # The normal (non-parallel) scree plot is untouched by the method selection (issue #37332 section 10).
+  expect_equal(screeplot_res$eigenvalue, eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values)
+
+  # factor_count description names the method actually used.
+  fc_factor_model <- model_df %>% tidy_rowwise(model, type = "factor_count")
+  expect_equal(fc_factor_model$Description[[2]], "Number of factors whose factor-model eigenvalue exceeds the random-data threshold.")
+  fc_smc <- smc_model_df %>% tidy_rowwise(model, type = "factor_count")
+  expect_equal(fc_smc$Description[[2]], "Number of factors whose SMC-based factor eigenvalue exceeds the random-data threshold.")
+
+  # analysis_method table carries the new row.
+  am_factor_model <- model_df %>% tidy_rowwise(model, type = "analysis_method")
+  expect_equal(am_factor_model$Item[[4]], "Parallel Analysis Method")
+  expect_equal(am_factor_model$Value[[4]], "Factor Model")
+  am_smc <- smc_model_df %>% tidy_rowwise(model, type = "analysis_method")
+  expect_equal(am_smc$Value[[4]], "Diagonal SMC")
+
+  # factanal_parallel_method_label: NULL degrades to the factor_model default; unknown -> Not Available.
+  expect_equal(factanal_parallel_method_label(NULL), "Factor Model")
+  expect_equal(factanal_parallel_method_label("factor_model"), "Factor Model")
+  expect_equal(factanal_parallel_method_label("smc"), "Diagonal SMC")
+  expect_equal(factanal_parallel_method_label("something_else"), "Not Available")
+
+  # A model saved before issue #37332 has no parallel_method field at all; the report must still
+  # show a sensible default rather than erroring or showing NA/blank.
+  legacy_fit <- fit
+  legacy_fit$parallel_method <- NULL
+  legacy_am <- tidy(legacy_fit, type = "analysis_method")
+  expect_equal(legacy_am$Value[[4]], "Factor Model")
 })

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -148,10 +148,16 @@ test_that("every downstream computation uses the polychoric matrix, not Pearson 
   expect_false(isTRUE(all.equal(poly$kmo, pearson$kmo)))
   expect_false(isTRUE(all.equal(poly$bartlett$chisq, pearson$bartlett$chisq)))
 
-  # The parallel analysis compares against the SAME matrix fa() was fitted on.
+  # The parallel analysis compares against the SAME matrix fa() was fitted on -- but via the
+  # selected parallel-analysis method (default "factor_model"), not a plain eigen() of that matrix
+  # (issue tam#37332): a plain correlation-matrix eigen would be PCA-style, not factor-analysis-style.
   expect_equal(poly$parallel$table$actual_eigenvalue,
-               eigen(poly$correlation, symmetric = TRUE, only.values = TRUE)$values)
-  # The scree plot / Kaiser criterion read the same matrix as well.
+               compute_parallel_factor_eigenvalues(poly$correlation, method = "factor_model",
+                                                   fm = poly$fm, n_obs = poly$n_rows_used))
+  expect_false(isTRUE(all.equal(poly$parallel$table$actual_eigenvalue,
+                                eigen(poly$correlation, symmetric = TRUE, only.values = TRUE)$values)))
+  # The scree plot / Kaiser criterion still read the plain matrix eigenvalues (issue #37332 section
+  # 10: the normal scree plot is intentionally unaffected by the parallel-analysis method).
   expect_equal(tidy(poly, type = "screeplot")$eigenvalue,
                eigen(poly$correlation, only.values = TRUE)$values)
 
@@ -168,12 +174,14 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
                        parallel_n_iter = 5)$model[[1]]
 
   method_tbl <- tidy(poly, type = "analysis_method")
-  expect_equal(method_tbl$Item, c("Correlation", "Factor Extraction Method", "Rotation", "Target Variables", "Data Rows"))
+  expect_equal(method_tbl$Item, c("Correlation", "Factor Extraction Method", "Rotation", "Parallel Analysis Method", "Target Variables", "Data Rows"))
   expect_equal(method_tbl$Value[[1]], "Polychoric Correlation")
   expect_equal(method_tbl$Value[[2]], "Minimum Residual")
   expect_equal(method_tbl$Value[[3]], "Varimax (Orthogonal)")
-  expect_equal(method_tbl$Value[[4]], "6")
-  expect_equal(method_tbl$Value[[5]], as.character(nrow(df)))
+  # exp_factanal() was not passed parallel_method, so the default (issue tam#37332) applies.
+  expect_equal(method_tbl$Value[[4]], "Factor Model")
+  expect_equal(method_tbl$Value[[5]], "6")
+  expect_equal(method_tbl$Value[[6]], as.character(nrow(df)))
   # Hidden columns the client binds the report explanation from.
   expect_equal(unique(method_tbl$correlation_type), "polychoric")
   expect_true(all(method_tbl$correlation_is_auto == "TRUE"))
@@ -348,12 +356,14 @@ test_that("verification pass 2 findings (issue #26623)", {
   expect_true("sparse_categories" %in% tokens)
   expect_equal(factanal_selection_warning_tokens(select_factor_correlation_type(mtcars[, 1:4])), character())
 
-  # The parallel analysis reuses the analysis's own matrix rather than recomputing a second one.
+  # The parallel analysis reuses the analysis's own matrix rather than recomputing a second one --
+  # verified by checking that the SAME matrix (not one recomputed from x) drives the method-aware
+  # eigenvalues (issue tam#37332: no longer a plain eigen() of the matrix).
+  cor_subset <- cor(mtcars[, c("mpg", "hp", "drat", "wt")])
   parallel_result <- compute_parallel_analysis(mtcars[, c("mpg", "hp", "drat", "wt")], n_iter = 3,
-                                               cor_type = "pearson",
-                                               cor_matrix = cor(mtcars[, c("mpg", "hp", "drat", "wt")]))
+                                               cor_type = "pearson", cor_matrix = cor_subset)
   expect_equal(parallel_result$table$actual_eigenvalue,
-               eigen(cor(mtcars[, c("mpg", "hp", "drat", "wt")]), only.values = TRUE)$values)
+               compute_parallel_factor_eigenvalues(cor_subset, method = "factor_model", fm = "minres", n_obs = 32))
 })
 
 test_that("positive definiteness reports the matrix BEFORE psych's smoothing (issue #26623)", {
@@ -468,8 +478,12 @@ test_that("the parallel analysis null distribution never mixes in Pearson eigenv
   on.exit(restore(), add = TRUE)
   result <- compute_parallel_analysis(df, n_iter = 4, cor_type = "polychoric",
                                       cor_matrix = diag(ncol(df)))
-  # Only the successful iterations (identity matrices) contribute, so every threshold is 1.
-  expect_true(all(abs(result$table$random_eigenvalue_threshold - 1) < 1e-8))
+  # Only the successful iterations (identity matrices) contribute -- an identity correlation
+  # matrix has zero factor-model / SMC eigenvalues (no shared variance among variables), unlike a
+  # plain eigen() of it (which would trivially be 1 for every dimension). (issue tam#37332)
+  expected <- compute_parallel_factor_eigenvalues(diag(ncol(df)), method = "factor_model",
+                                                   fm = "minres", n_obs = nrow(df))
+  expect_true(all(abs(result$table$random_eigenvalue_threshold - expected) < 1e-8))
 })
 
 test_that("verification pass 4 findings (issue #26623)", {


### PR DESCRIPTION
## Summary
- `compute_parallel_analysis()` now estimates parallel-analysis eigenvalues via a selectable `method`: `"factor_model"` (new default — one-factor-model communalities using the selected extraction method) or `"smc"` (diagonal replaced by squared multiple correlations), instead of always using plain correlation-matrix eigenvalues (PCA-style). New helper `compute_parallel_factor_eigenvalues()`.
- `exp_factanal()` gains `parallel_method` (default `"factor_model"`), forwarded together with `fm`. `fit$parallel_method` / `fit$parallel_factor_extraction_method` are kept even when the parallel computation itself fails.
- Recommended factor count now stops at the first non-retained factor (`compute_parallel_recommended_n`) instead of summing every factor whose eigenvalue exceeds the threshold anywhere in the sequence.
- `parallel_screeplot` reads the parallel analysis's own `actual_eigenvalue` instead of recomputing a plain `eigen()` of the correlation matrix. The plain (non-parallel) scree plot and Kaiser criterion are intentionally untouched.
- `analysis_method` table gains a "Parallel Analysis Method" row; `factor_count`'s Parallel Analysis row description now names which eigenvalue kind was actually compared.
- `do_prcomp()` explicitly passes `method = "pca"` (a third, UI-unexposed value) to `compute_parallel_analysis()` so its own pre-existing PCA-style parallel analysis is unaffected by Factor Analysis's new default — required so `variances_judged`'s `Eigenvalue == x$sdev^2` invariant isn't silently broken.

## Test plan
- [x] `tests/testthat/test_factanal.R` — 6/6 `test_that` blocks pass, incl. new "parallel analysis method: factor_model vs smc" coverage
- [x] `tests/testthat/test_factanal_correlation.R` — 20/20 pass; 3 pre-existing tests updated (they asserted the old plain-eigen behavior as correct)
- [x] `tests/testthat/test_prcomp.R` — 31/31 pass, unchanged (confirms the `method = "pca"` fix)
- [x] Live end-to-end: executed the literal generated-R call shape (matching tam's `CommandGeneratorBase.js` output) against the modified source via `pkgload::load_all()`, both `factor_model` and `smc`, confirmed distinct eigenvalues/recommended_n/report text
- [ ] Paired tam PR: exploratory-io/tam#37332 UI + wiring
- [ ] Cross-platform binary build/upload to download2 + `requiredRPackagesReduced.json` version bump (follow-up, not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)