### PR TITLE
fix(factanal,prcomp): stop auto-promoting numeric rating-scale columns to ordinal (tam#37344)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.26
-Date: 2026-07-29
+Version: 16.0.27
+Date: 2026-07-30
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -58,30 +58,6 @@ get_factor_category_levels <- function(x, supplied_levels = NULL) {
 }
 
 # -----------------------------------------------------------------------------
-# Is a numeric column really a rating scale (1-5 survey answer) rather than a
-# continuous measurement?
-#
-# The spec's literal rule calls every numeric column with 3+ distinct values
-# "numeric", which would mean a 1-to-5 survey item imported as an integer -- the
-# exact data the polychoric request is about -- never reaches the ordinal branch.
-# So numeric columns are treated as ordinal only when they look like a rating
-# scale: consecutive integers, 3 to `max_categories` of them, starting at 0 or 1.
-# A measurement like cyl (4, 6, 8) or a count is not consecutive-from-0/1 and
-# stays numeric, so existing all-numeric analyses keep using Pearson.
-# -----------------------------------------------------------------------------
-is_rating_scale_numeric <- function(observed, max_categories = 7) {
-  observed <- observed[is.finite(observed)]
-  if (length(observed) == 0) return(FALSE)
-  if (any(observed != floor(observed))) return(FALSE)
-  values <- sort(unique(observed))
-  n_values <- length(values)
-  if (n_values < 3 || n_values > max_categories) return(FALSE)
-  if (!(min(values) %in% c(0, 1))) return(FALSE)
-  # Consecutive integers only: 1,2,3,4,5 yes; 1,2,5 no.
-  identical(as.numeric(max(values) - min(values) + 1), as.numeric(n_values))
-}
-
-# -----------------------------------------------------------------------------
 # Detect the type of one variable.
 # -----------------------------------------------------------------------------
 inspect_factor_variable <- function(variable_name, x, declared_type = "auto", supplied_levels = NULL) {
@@ -114,9 +90,13 @@ inspect_factor_variable <- function(variable_name, x, declared_type = "auto", su
   } else if (is.factor(x)) {
     detected_type <- if (nlevels(x) == 2) "binary" else "nominal"
   } else if (is.numeric(x)) {
-    detected_type <- if (n_observed_categories == 2) "binary"
-      else if (is_rating_scale_numeric(observed)) "ordinal"
-      else "numeric"
+    # A numeric column is NEVER auto-promoted to ordinal, even when it looks like a rating scale
+    # (e.g. consecutive 1-5 integers) -- issue #37344 reversed that heuristic (formerly
+    # is_rating_scale_numeric, issue #26623) because it read as a type-mismatch bug: the report
+    # would call a column "categorical" when the user had declared it numeric. Use an ordered
+    # factor, or a manual Correlation Type override, to explicitly opt a numeric-looking scale
+    # into ordinal/Polychoric treatment.
+    detected_type <- if (n_observed_categories == 2) "binary" else "numeric"
   } else if (is.character(x)) {
     detected_type <- if (n_observed_categories == 2) "binary" else "nominal"
   } else {

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -9,6 +9,14 @@ context("test factor analysis correlation type, exp_factanal cor_type")
 
 # Builds ordinal survey-like data: q1-q3 load on one latent factor, q4-q6 on another.
 # `skew=TRUE` concentrates the responses so the 5-category rule picks Polychoric.
+#
+# Returns plain integer columns on purpose -- some callers (build_factor_correlation,
+# compute_parallel_analysis's stubbed correlation builder, etc.) call low-level functions
+# DIRECTLY with this data and expect a numeric matrix, bypassing exp_factanal()'s own
+# type-detection/encoding step entirely. Callers that need exp_factanal()'s AUTO correlation-type
+# selection to actually reach Polychoric must opt in explicitly via as_ordinal_fixture() below
+# (issue #37344 removed the numeric-rating-scale heuristic that used to do this from a plain
+# integer column's shape).
 factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
   set.seed(seed)
   lat1 <- stats::rnorm(n)
@@ -24,6 +32,14 @@ factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
   }
   data.frame(q1 = make_col(lat1), q2 = make_col(lat1), q3 = make_col(lat1),
              q4 = make_col(lat2), q5 = make_col(lat2), q6 = make_col(lat2))
+}
+
+# Declares every column of `df` as an EXPLICIT ordered category (ordered factor), so
+# exp_factanal()'s AUTO correlation-type selection reaches Polychoric for data that only LOOKS
+# like a rating scale (issue #37344: a numeric column never auto-promotes on shape alone).
+as_ordinal_fixture <- function(df) {
+  df[] <- lapply(df, function(col) factor(col, ordered = TRUE))
+  df
 }
 
 # Swaps build_factor_correlation for a stub and returns a restore function.
@@ -66,10 +82,13 @@ test_that("correlation type auto-selection rules (issue #26623)", {
   n <- 300
   set.seed(11)
   lat <- stats::rnorm(n)
+  # Ordered factor, not plain integer: an EXPLICIT ordinal type is required to reach
+  # auto-Polychoric (issue #37344 removed the numeric-rating-scale heuristic).
   ordinal_col <- function(k) {
     z <- 0.7 * lat + sqrt(1 - 0.7^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = k + 1)),
-                   include.lowest = TRUE, labels = FALSE))
+    codes <- as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = k + 1)),
+                            include.lowest = TRUE, labels = FALSE))
+    factor(codes, ordered = TRUE)
   }
   method_of <- function(df) select_factor_correlation_type(df)$selected_method
 
@@ -85,8 +104,8 @@ test_that("correlation type auto-selection rules (issue #26623)", {
                                     b = factor(ordinal_col(4), ordered = TRUE),
                                     c = factor(ordinal_col(4), ordered = TRUE))), "polychoric")
   # 5 categories: skewed/concentrated -> Polychoric, balanced -> Pearson.
-  expect_equal(method_of(factanal_ordinal_fixture(skew = TRUE)), "polychoric")
-  expect_equal(method_of(factanal_ordinal_fixture(skew = FALSE)), "pearson")
+  expect_equal(method_of(as_ordinal_fixture(factanal_ordinal_fixture(skew = TRUE))), "polychoric")
+  expect_equal(method_of(as_ordinal_fixture(factanal_ordinal_fixture(skew = FALSE))), "pearson")
   # 6 or more ordered categories -> Pearson by default.
   expect_equal(method_of(data.frame(a = ordinal_col(7), b = ordinal_col(7), c = ordinal_col(7))), "pearson")
   # Numeric + ordinal mix -> Mixed correlation.
@@ -102,16 +121,29 @@ test_that("correlation type auto-selection rules (issue #26623)", {
   expect_true(grepl("Invalid variables", invalid$reason))
 })
 
-test_that("numeric rating-scale detection does not reclassify ordinary measurements (issue #26623)", {
-  # A 1-5 (or 0-4) consecutive integer scale is treated as ordinal...
-  expect_true(is_rating_scale_numeric(c(1, 2, 3, 4, 5)))
-  expect_true(is_rating_scale_numeric(c(0, 1, 2, 3)))
-  # ...but a measurement with gaps, non-integers, too many levels, or not starting at 0/1 is not.
-  expect_false(is_rating_scale_numeric(c(4, 6, 8)))          # mtcars$cyl
-  expect_false(is_rating_scale_numeric(c(1.5, 2.5, 3.5)))
-  expect_false(is_rating_scale_numeric(1:8))
-  expect_false(is_rating_scale_numeric(c(3, 4, 5)))
-  # So an all-numeric data frame like mtcars keeps using Pearson.
+test_that("numeric measurements are never auto-promoted to ordinal, even when they look like a rating scale (issue #37344)", {
+  # A 1-5 (or 0-4) consecutive integer scale used to be auto-treated as ordinal (issue #26623);
+  # that heuristic read as a type-mismatch bug to users who declared the column numeric, so it was
+  # reversed: only an EXPLICIT category declaration (an ordered factor, or a manual Correlation
+  # Type override) reaches Polychoric now. A plain numeric column always detects as "numeric".
+  expect_equal(inspect_factor_variable("q", c(1, 2, 3, 4, 5))$detected_type, "numeric")
+  expect_equal(inspect_factor_variable("q", c(0, 1, 2, 3))$detected_type, "numeric")
+  expect_equal(inspect_factor_variable("q", c(4, 6, 8))$detected_type, "numeric")   # mtcars$cyl
+
+  # So an all-numeric data frame that LOOKS like a 1-4 rating scale still uses Pearson...
+  # (4 categories, not 5, so the outcome doesn't depend on the 5-category skew rule.)
+  rating_like <- data.frame(a = rep(1:4, 25), b = rep(1:4, 25), c = rep(1:4, 25))
+  expect_equal(select_factor_correlation_type(rating_like)$selected_method, "pearson")
+  # ...unless the same data is explicitly declared ordinal via an ordered factor,
+  expect_equal(select_factor_correlation_type(
+    data.frame(a = factor(rating_like$a, ordered = TRUE), b = factor(rating_like$b, ordered = TRUE),
+              c = factor(rating_like$c, ordered = TRUE)))$selected_method, "polychoric")
+  # ...or a manual Correlation Type override.
+  manual <- resolve_factanal_correlation_type("polychoric", select_factor_correlation_type(rating_like))
+  expect_equal(manual$type, "polychoric")
+  expect_false(manual$auto)
+
+  # An all-numeric data frame like mtcars keeps using Pearson too.
   expect_equal(select_factor_correlation_type(mtcars[, c("cyl", "mpg", "hp", "drat")])$selected_method, "pearson")
 })
 
@@ -134,7 +166,7 @@ test_that("exp_factanal Pearson results are unchanged by the correlation-type su
 })
 
 test_that("every downstream computation uses the polychoric matrix, not Pearson (issue #26623)", {
-  df <- factanal_ordinal_fixture()
+  df <- as_ordinal_fixture(factanal_ordinal_fixture())
   poly <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
                        parallel_n_iter = 5)$model[[1]]
   pearson <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
@@ -169,7 +201,7 @@ test_that("every downstream computation uses the polychoric matrix, not Pearson 
 })
 
 test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
-  df <- factanal_ordinal_fixture()
+  df <- as_ordinal_fixture(factanal_ordinal_fixture())
   poly <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, fm = "minres", rotate = "varimax",
                        parallel_n_iter = 5)$model[[1]]
 
@@ -219,9 +251,12 @@ test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
   n <- 250
   lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
   binary_col <- function(latent) as.integer(0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n) > 0.3)
+  # Ordered factor, not plain integer: an EXPLICIT ordinal type is required to reach
+  # auto-Polychoric (issue #37344 removed the numeric-rating-scale heuristic).
   ordinal_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    codes <- as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    factor(codes, ordered = TRUE)
   }
   binary_df <- data.frame(b1 = binary_col(lat1), b2 = binary_col(lat1), b3 = binary_col(lat1),
                           b4 = binary_col(lat2), b5 = binary_col(lat2), b6 = binary_col(lat2))
@@ -314,9 +349,12 @@ test_that("mixed-correlation diagnostics only describe the categorical variables
   set.seed(21)
   n <- 300
   lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
+  # Ordered factor, not plain integer: an EXPLICIT ordinal type is required to reach
+  # auto-Polychoric (issue #37344 removed the numeric-rating-scale heuristic).
   ordinal_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    codes <- as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    factor(codes, ordered = TRUE)
   }
   mixed_df <- data.frame(x1 = lat1 + stats::rnorm(n, 0, .5), x2 = lat1 + stats::rnorm(n, 0, .5),
                          q1 = ordinal_col(lat2), q2 = ordinal_col(lat2), q3 = ordinal_col(lat2))
@@ -332,7 +370,7 @@ test_that("mixed-correlation diagnostics only describe the categorical variables
 })
 
 test_that("verification pass 2 findings (issue #26623)", {
-  df <- factanal_ordinal_fixture()
+  df <- as_ordinal_fixture(factanal_ordinal_fixture())
   fit <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "varimax",
                       parallel_n_iter = 3)$model[[1]]
   method_tbl <- tidy(fit, type = "analysis_method")
@@ -426,8 +464,11 @@ test_that("verification pass 3 findings (issue #26623)", {
   expect_true(any(grepl("Correlations estimated from categories", failed_diagnostics$Description)))
 
   # Counts are singular when there is exactly one hit. Balanced columns, then one rare category
-  # injected into a single variable.
-  balanced <- data.frame(q1 = rep(1:4, 50), q2 = rep(1:4, 50), q3 = rep(1:4, 50))
+  # injected into a single variable. Ordered factor, not plain integer: an EXPLICIT ordinal type
+  # is required to reach the categorical/sparse-detection code path (issue #37344).
+  balanced <- data.frame(q1 = factor(rep(1:4, 50), levels = 1:4, ordered = TRUE),
+                         q2 = factor(rep(1:4, 50), levels = 1:4, ordered = TRUE),
+                         q3 = factor(rep(1:4, 50), levels = 1:4, ordered = TRUE))
   balanced$q1[balanced$q1 == 4] <- 3
   balanced$q1[1] <- 4   # a single response in the top category (1 of 200 = below the 5% cutoff)
   balanced_selection <- select_factor_correlation_type(balanced)
@@ -600,6 +641,11 @@ test_that("Repeat By groups all use the same correlation (issue #26623)", {
   set.seed(31)
   n <- 200
   latent_a <- stats::rnorm(n)
+  # Plain integer, not ordered factor: correlation type is resolved ONCE from the POOLED data
+  # across both groups (group_a's ordinal-shaped values rbind'd with group_b's continuous
+  # values under the same column name) -- an ordered factor here would make rbind coerce the
+  # mismatched types to NA. Whether the pooled selection lands on Pearson or Polychoric is not
+  # what this test checks; it only asserts every group ends up using the SAME one.
   ordinal_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
     as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -450,7 +450,9 @@ test_that("do_prcomp cor_type='auto' picks polychoric for ordinal data and Pears
   set.seed(37294)
   n <- 300
   latent_a <- rnorm(n); latent_b <- rnorm(n)
-  to_four <- function(z) as.integer(cut(z, breaks = c(-Inf, -0.6, 0, 0.6, Inf), labels = FALSE))
+  # Ordered factor, not plain integer: an EXPLICIT ordinal type is required to reach
+  # auto-Polychoric (issue #37344 removed the numeric-rating-scale heuristic).
+  to_four <- function(z) factor(as.integer(cut(z, breaks = c(-Inf, -0.6, 0, 0.6, Inf), labels = FALSE)), ordered = TRUE)
   ordinal <- data.frame(a = to_four(latent_a + rnorm(n, 0, 0.5)), b = to_four(latent_a + rnorm(n, 0, 0.5)),
                         c = to_four(latent_b + rnorm(n, 0, 0.5)), e = to_four(latent_b + rnorm(n, 0, 0.5)))
   ordinal_fit <- (ordinal %>% do_prcomp(a, b, c, e))$model[[1]]


### PR DESCRIPTION
## Summary

Related to https://github.com/exploratory-io/tam/issues/37344.

Factor Analysis (`exp_factanal`, #26623) and PCA (`do_prcomp`, #37294) share a correlation-type auto-selection module. It used to reclassify a numeric column as **ordinal** when it looked like a 1-5 rating scale (consecutive integers, 3-7 of them, starting at 0 or 1), auto-selecting Polychoric correlation for it (`is_rating_scale_numeric`, approved as an intentional spec deviation in `tam`'s `docs/plans/specs/26623_compliance.md`, 2026-07-22).

That heuristic read as a type-mismatch bug to users: the analysis report would describe a column the user had declared **numeric** as "categorical". tam issue #37344 reported exactly this.

**Behavior change:** a numeric column now always detects as `"numeric"` under Auto correlation-type selection — it is never silently promoted to ordinal by its shape alone. Explicit ordinal treatment still works two ways, both unaffected by this change:
- Declare the column as an **ordered factor** (`is.ordered(x)` detection is untouched).
- Manually select **Polychoric** as the Correlation Type property (manual override always bypasses auto-detection).

`is_rating_scale_numeric()` is removed entirely (it had exactly one caller). A separate, unrelated heuristic in `factanal_polychoric_available()` — which only decides whether to *suggest* Polychoric as an available manual option in the report, and never auto-applies it — is intentionally left alone; it doesn't silently change results, so it isn't in scope for this fix.

## Test plan

- `test_factanal_correlation.R`: replaced the direct `is_rating_scale_numeric()` unit tests with `numeric measurements are never auto-promoted to ordinal, even when they look like a rating scale (issue #37344)`, asserting `inspect_factor_variable()`/`select_factor_correlation_type()` resolve Pearson for rating-scale-shaped numeric data, and Polychoric only via explicit ordered factor or manual override.
- Fixtures across `test_factanal_correlation.R` and `test_prcomp.R` that relied on the removed heuristic to reach an auto-Polychoric fit now declare their ordinal columns explicitly (ordered factor) via a new `as_ordinal_fixture()` helper, applied only where a test's assertions genuinely depend on auto-detection reaching Polychoric.
- Fixtures consumed only by low-level functions that expect a numeric matrix directly (`build_factor_correlation()`, `compute_parallel_analysis()`'s test stub) are left as plain integer, matching what those functions actually need — converting them broke `stats::cor()` on factor input and an `rbind()` type-mismatch in the Repeat By fixture; reverted after tracing each failure to its root cause.
- Full suite, run against local source via `pkgload::load_all()`:
  - `test_factanal_correlation.R`: 166 passed, 0 failed, 0 errors
  - `test_factanal.R`: 440 passed, 0 failed, 0 errors
  - `test_prcomp.R`: 202 passed, 0 failed, 0 errors
- Verified the pre-existing "ultra-Heywood case" warning noise in `test_factanal.R` (155 warnings) is unrelated to this change — reproduced identically against a clean worktree pinned at this branch's true merge-base (`85160df5`) with none of this PR's changes applied.

## Follow-up (tam side)

- `tam`'s `exp_factanal.js`/`exp_factanal_ja.js` auto-Polychoric report wording (which explicitly named "numeric rating scales such as 1-5" as an automatic case) needs revising, since that's no longer an automatic outcome for a plain numeric column.
- `tam`'s `docs/plans/specs/26623_compliance.md` "Intentional deviations" entry for this heuristic needs a reversal addendum.
- `tam`'s `tools/requiredRPackagesReduced.json` needs bumping to this package version once binaries are built and uploaded.