### PR TITLE
WIP: PCA: add principal component score scale (SPSS-compatible unit variance) (tam#27224)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.24
+Version: 16.0.25
 Date: 2026-07-28
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -120,13 +120,57 @@ prcomp_signed_loadings <- function(x) {
   cor(cleaned_df, x$x)
 }
 
+#' Principal component scores in the scale the user asked for. (issue #27224)
+#'
+#' `prcomp()` returns scores whose spread reflects each component's own variance (sdev), while
+#' SPSS (and `psych::principal()`) reports scores standardized to standard deviation 1. Both
+#' describe the SAME solution -- the components, loadings and explained variance are identical and
+#' only the scale of the score numbers differs -- so this is an output-scale choice, not a
+#' different analysis.
+#'
+#' MUST be called AFTER sign stabilization, so the chosen scale is applied to the signs the report
+#' actually shows.
+#'
+#' @param fit a prcomp-shaped fit (needs `$x` and `$sdev`)
+#' @param score_scale "preserve_variance" (prcomp's own scores) or "unit_variance" (SD = 1, SPSS-compatible)
+#' @return the score matrix, same dim/dimnames as `fit$x`
+get_prcomp_scores <- function(fit, score_scale = c("preserve_variance", "unit_variance")) {
+  score_scale <- match.arg(score_scale)
+  if (identical(score_scale, "preserve_variance")) {
+    return(fit$x)
+  }
+  sdev <- fit$sdev[seq_len(ncol(fit$x))]
+  # Dividing by a ~0 sdev turns rounding noise into a huge score, so refuse rather than emit
+  # garbage. A degenerate component means a variable is (nearly) a linear combination of the
+  # others, or there are fewer rows than variables. EXP-ANA-36 carries no params.
+  if (any(!is.finite(sdev) | sdev <= sqrt(.Machine$double.eps))) {
+    stop("EXP-ANA-36 :: [] :: Some principal components have zero or near-zero standard deviation and cannot be standardized.")
+  }
+  sweep(fit$x, MARGIN = 2, STATS = sdev, FUN = "/")
+}
+
+#' User-facing score matrix of a stored fit, with back-compat fallback. (issue #27224)
+#'
+#' `$scores` only exists on fits produced after #27224. Models saved before it (and k-means fits,
+#' which never carry report data) fall back to `$x`, i.e. the previous behavior exactly.
+get_stored_prcomp_scores <- function(x) {
+  if (!is.null(x$scores)) x$scores else x$x
+}
+
+#' The score scale a stored fit was built with, with back-compat fallback. (issue #27224)
+get_stored_prcomp_score_scale <- function(x) {
+  if (!is.null(x$score_scale)) x$score_scale else "preserve_variance"
+}
+
 #' do PCA
 #' allow_single_column - Do not throw error and go ahead with PCA even if only one column is left after preprocessing. For K-means.
 #' retained_components - Number of principal components the report treats as retained. NULL = auto (use parallel analysis recommendation). Clamped to [1, number of components].
 #' with_report_data - Whether to compute and attach the redesigned PCA report data (parallel analysis, Kaiser, retained/diagnostics) AND apply sign stabilization. Pure-PCA only; exp_kmeans passes FALSE so k-means fits are neither given report data nor sign-flipped. (issue #37019)
 #' cor_type - Correlation the analysis runs on: "auto" (decide from the variable types and the shape of their distributions), "pearson", "polychoric", "tetrachoric" or "mixed". Anything other than Pearson eigen-decomposes that correlation matrix instead of calling prcomp() on the raw data, and the observation scores become APPROXIMATE (see prcomp_build_categorical_fit). Pure-PCA only -- honored when with_report_data is TRUE, so exp_kmeans is unaffected. (issue #37294)
+#' score_scale - Scale of the principal component scores that are OUTPUT (data columns, biplot, observation map): "preserve_variance" (default; prcomp's own scores, whose spread reflects each component's variance) or "unit_variance" (each component's scores standardized to SD 1, matching SPSS / psych::principal). Display scale only -- loadings, coefficients, contributions, explained variance and every judgment are computed from the canonical prcomp scores and are IDENTICAL either way. Pure-PCA only: exp_kmeans passes with_report_data = FALSE and is always kept at "preserve_variance" so clustering input never changes. (issue #27224)
 #' @export
-do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_single_column = FALSE, seed = 1, na.rm = TRUE, retained_components = NULL, with_report_data = TRUE, cor_type = "auto") {
+do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_single_column = FALSE, seed = 1, na.rm = TRUE, retained_components = NULL, with_report_data = TRUE, cor_type = "auto", score_scale = c("preserve_variance", "unit_variance")) {
+  score_scale <- match.arg(score_scale)
   all_cols <- colnames(df)
   # this evaluates select arguments like starts_with
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
@@ -389,6 +433,17 @@ do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_singl
       }, error = function(e) NULL)
     }
 
+    # User-facing score matrix (issue #27224). fit$x stays the canonical prcomp score matrix that
+    # every loading / contribution / representation computation reads; fit$scores is what the
+    # OUTPUT (data columns, biplot, observation map) shows. Built here -- outside the
+    # with_report_data block, but AFTER the sign stabilization inside it -- so the scale is applied
+    # to the signs the report shows and so a fit built with with_report_data = FALSE still gets a
+    # $scores field. k-means is pinned to preserve_variance: rescaling its PCA scores would change
+    # the clustering input, and its dialog exposes no such option.
+    effective_score_scale <- if (with_report_data) score_scale else "preserve_variance"
+    fit$score_scale <- effective_score_scale
+    fit$scores <- get_prcomp_scores(fit, score_scale = effective_score_scale)
+
     class(fit) <- c("prcomp_exploratory", class(fit))
     fit
   }
@@ -424,8 +479,11 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     # prepare loadings matrix
     loadings_matrix <- x$rotation[,1:2] # keep only PC1 and PC2 for biplot
 
-    # prepare scores matrix
-    scores_matrix <- x$x[,1:2] # keep only PC1 and PC2 for biplot
+    # prepare scores matrix. Observation coordinates use the USER-FACING scores (issue #27224), so
+    # a "unit variance" (SPSS-compatible) analysis plots the same numbers the Data tab shows. The
+    # loading vectors are rescaled to the observations below (scale_ratio), so the biplot stays
+    # readable either way -- only the axis range differs.
+    scores_matrix <- get_stored_prcomp_scores(x)[, 1:2, drop = FALSE] # keep only PC1 and PC2 for biplot
 
     if (is.null(n_sample)) { # set default of 5000 for biplot case.
       n_sample = 5000
@@ -529,15 +587,23 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       scale_status <- if (!normalized && is.finite(scale_ratio) && scale_ratio >= cfg$scale_ratio_warning) "scale_warning" else "ok"
       # #37268: rename Rows Used / Variables Used; drop redundant Rows vs Variables row;
       # refresh Description copy (and English-canonical strings for the client translator).
+      # Score Scale (issue #27224). English-canonical value labels; the client translates.
+      # Old saved models have no $score_scale -- they were built with prcomp's own scores.
+      score_scale_display <- if (identical(get_stored_prcomp_score_scale(x), "unit_variance")) {
+        "Unit Variance"
+      } else {
+        "Preserve Component Variance"
+      }
       res <- tibble::tibble(
         Metric = c("Row Count", "Rows Excluded", "Number of Variables", "Excluded Variables",
-                   "Normalization", "SD Ratio (Max/Min)"),
+                   "Normalization", "Score Scale", "SD Ratio (Max/Min)"),
         Value = c(
           as.character(d$analyzed_row_count),
           paste0(d$excluded_row_count, " (", format(round(excluded_pct, 1), nsmall = 1), "%)"),
           as.character(variables_used),
           excluded_display,
           if (normalized) "Yes" else "No",
+          score_scale_display,
           scale_display
         ),
         Description = c(
@@ -546,6 +612,7 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
           "Number of variables used in the analysis.",
           "Variables dropped before analysis because they were all missing or had only one unique value.",
           "Whether variables were standardized before analysis.",
+          "How principal-component scores are scaled.",
           "Ratio of the maximum to the minimum standard deviation across all variables."
         ),
         status = c(
@@ -553,6 +620,7 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
           if (d$excluded_row_rate >= cfg$na_exclusion_warning) "high_na_exclusion" else "ok",
           "ok",
           if (length(excluded_names) == 0) "na" else "ok",
+          "ok",
           "ok",
           scale_status
         )
@@ -825,11 +893,28 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     # on non-dominant variables. rotation is already sign-stabilized (A2) -- do NOT re-flip. Empty
     # typed tibble for k-means / old saved models.
     if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
-      res <- tibble::tibble(Variable = character(0), Component = character(0), Coefficient = numeric(0))
+      res <- tibble::tibble(Variable = character(0), Component = character(0),
+                            Coefficient = numeric(0), `Score Coefficient` = numeric(0))
     }
     else {
+      # `Score Coefficient` = the weights that actually produce the OUTPUT scores (issue #27224).
+      # With "preserve variance" that IS the rotation, so the two columns coincide; with
+      # "unit variance" (SPSS-compatible) the score is rotation / sdev -- SPSS's "Component Score
+      # Coefficient Matrix". The client only shows this column in the unit-variance case, where the
+      # two differ. sdev is guaranteed non-degenerate here: get_prcomp_scores() refuses to build
+      # unit-variance scores otherwise, so a stored "unit_variance" fit cannot divide by ~0.
+      score_scale <- get_stored_prcomp_score_scale(x)
+      score_coefficients <- if (identical(score_scale, "unit_variance")) {
+        sweep(x$rotation, MARGIN = 2, STATS = x$sdev[seq_len(ncol(x$rotation))], FUN = "/")
+      } else {
+        x$rotation
+      }
       res <- tibble::as_tibble(x$rotation, rownames = "Variable") %>%
-        tidyr::gather(Component, Coefficient, dplyr::starts_with("PC"), convert = TRUE) %>%
+        tidyr::gather(Component, Coefficient, dplyr::starts_with("PC"), convert = TRUE)
+      score_res <- tibble::as_tibble(score_coefficients, rownames = "Variable") %>%
+        tidyr::gather(Component, `Score Coefficient`, dplyr::starts_with("PC"), convert = TRUE)
+      res <- res %>%
+        dplyr::left_join(score_res, by = c("Variable", "Component")) %>%
         dplyr::mutate(Component = forcats::fct_inorder(Component)) # PC2 before PC10 on chart
     }
   }
@@ -926,8 +1011,12 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       # res <- res %>% dplyr::mutate(cluster=factor(x$kmeans$cluster)) # this caused error when input had column x.
       res$cluster <- factor(x$kmeans$cluster)
     }
-    res <- res %>% dplyr::bind_cols(as.data.frame(x$x))
-    column_names <- attr(x$rotation, "dimname")[[1]] 
+    # PC score columns appended to the data use the USER-FACING scores (issue #27224):
+    # prcomp's own scores by default, or SD-1 standardized scores when the analysis was run with
+    # score_scale = "unit_variance". Falls back to x$x for models saved before #27224 and for
+    # k-means fits (which never set $scores through a UI option).
+    res <- res %>% dplyr::bind_cols(as.data.frame(get_stored_prcomp_scores(x)))
+    column_names <- attr(x$rotation, "dimname")[[1]]
     if (normalize_data) {
       res <- res %>% dplyr::mutate(dplyr::across(dplyr::all_of(column_names), exploratory::normalize))
     }

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -139,14 +139,15 @@ get_prcomp_scores <- function(fit, score_scale = c("preserve_variance", "unit_va
   if (identical(score_scale, "preserve_variance")) {
     return(fit$x)
   }
-  sdev <- fit$sdev[seq_len(ncol(fit$x))]
   # Dividing by a ~0 sdev turns rounding noise into a huge score, so refuse rather than emit
   # garbage. A degenerate component means a variable is (nearly) a linear combination of the
-  # others, or there are fewer rows than variables. EXP-ANA-36 carries no params.
-  if (any(!is.finite(sdev) | sdev <= sqrt(.Machine$double.eps))) {
+  # others, or there are fewer rows than variables. Guard the WHOLE sdev vector -- not just the
+  # columns being swept -- so a degenerate trailing component is reported even in the (currently
+  # impossible) case where sdev is longer than the score matrix. EXP-ANA-36 carries no params.
+  if (any(!is.finite(fit$sdev) | fit$sdev <= sqrt(.Machine$double.eps))) {
     stop("EXP-ANA-36 :: [] :: Some principal components have zero or near-zero standard deviation and cannot be standardized.")
   }
-  sweep(fit$x, MARGIN = 2, STATS = sdev, FUN = "/")
+  sweep(fit$x, MARGIN = 2, STATS = fit$sdev[seq_len(ncol(fit$x))], FUN = "/")
 }
 
 #' User-facing score matrix of a stored fit, with back-compat fallback. (issue #27224)

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -649,6 +649,7 @@ test_that("polychoric fits honor the score scale too (#27224)", {
   expect_equal(fit$score_scale, "unit_variance")
   expect_equal(unname(sweep(fit$scores, 2, fit$sdev, "*")), unname(fit$x), tolerance = 1e-10)
   # Approximate scores: dividing by the eigenvalue-derived sdev lands close to, but not exactly at,
-  # SD 1 -- documented behavior, so assert the loose bound rather than an exact 1.
-  expect_true(all(abs(apply(fit$scores, 2, sd) - 1) < 0.35))
+  # SD 1 -- documented behavior (the report says so), so assert a bound rather than an exact 1.
+  # Measured on this fixture: 0.976 .. 1.124, i.e. a max deviation of 0.124.
+  expect_true(all(abs(apply(fit$scores, 2, sd) - 1) < 0.2))
 })

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -338,14 +338,16 @@ test_that("all 8 report tidy types return 0-row typed tibbles for an old saved m
 test_that("coefficients tidy type returns rotation weights (long, signed)", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
   res <- model_df %>% tidy_rowwise(model, type = "coefficients")
-  expect_equal(colnames(res), c("Variable", "Component", "Coefficient"))
+  expect_equal(colnames(res), c("Variable", "Component", "Coefficient", "Score Coefficient"))
   expect_true(any(res$Coefficient < 0))            # signed eigenvector weights
   expect_true(nrow(res) == 6 * length(unique(res$Component)))  # vars x components
+  # Default scale preserves component variance, so the score coefficient IS the rotation. (#27224)
+  expect_equal(res$`Score Coefficient`, res$Coefficient, tolerance = 1e-12)
   # kmeans fit -> empty
   km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
   r2 <- km %>% tidy_rowwise(model, type = "coefficients")
   expect_equal(nrow(r2), 0)
-  expect_equal(colnames(r2), c("Variable", "Component", "Coefficient"))
+  expect_equal(colnames(r2), c("Variable", "Component", "Coefficient", "Score Coefficient"))
 })
 
 # ---------------------------------------------------------------------------
@@ -501,4 +503,152 @@ test_that("exp_kmeans is unaffected by the PCA correlation-type support", {
   expect_null(fit$correlation_type)
   expect_null(fit$is_categorical_correlation)
   expect_null(fit$signed_loadings)
+})
+
+# ---------------------------------------------------------------------------
+# Principal component score scale (issue #27224)
+# ---------------------------------------------------------------------------
+
+test_that("do_prcomp defaults to preserve_variance and attaches the canonical scores", {
+  fit <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt))$model[[1]]
+  expect_equal(fit$score_scale, "preserve_variance")
+  expect_equal(unname(fit$scores), unname(fit$x), tolerance = 1e-12)
+  # The default score SDs are the component SDs, not 1 -- that is the whole point of the option.
+  expect_equal(unname(apply(fit$scores, 2, sd)), unname(fit$sdev), tolerance = 1e-8)
+})
+
+test_that("unit_variance standardizes every component to SD 1 without changing the solution", {
+  ref <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt))$model[[1]]
+  fit <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, score_scale = "unit_variance"))$model[[1]]
+  expect_equal(fit$score_scale, "unit_variance")
+  expect_equal(unname(apply(fit$scores, 2, sd)), rep(1, length(fit$sdev)), tolerance = 1e-8)
+  # Only the scale of the OUTPUT scores changes: eigenvalues, coefficients and the canonical
+  # score matrix are identical to the default run.
+  expect_equal(fit$sdev, ref$sdev, tolerance = 1e-12)
+  expect_equal(fit$rotation, ref$rotation, tolerance = 1e-12)
+  expect_equal(fit$x, ref$x, tolerance = 1e-12)
+  # scores * sdev == x, i.e. the scaling is exactly the documented sweep.
+  expect_equal(unname(sweep(fit$scores, 2, fit$sdev, "*")), unname(fit$x), tolerance = 1e-10)
+})
+
+test_that("unit_variance scores are built AFTER sign stabilization (#27224)", {
+  fit <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, score_scale = "unit_variance"))$model[[1]]
+  # Sign stabilization flips fit$x; scaling it afterwards keeps the same sign, so every score
+  # column must correlate POSITIVELY with the canonical (already flipped) score column.
+  correlations <- vapply(seq_len(ncol(fit$scores)), function(i) cor(fit$scores[, i], fit$x[, i]), numeric(1))
+  expect_true(all(correlations > 0))
+  # And the report's sign contract still holds: the strongest-loading variable loads positively.
+  loadings <- cor(mtcars[, c("mpg", "cyl", "disp", "hp", "drat", "wt")], fit$x)
+  strongest <- vapply(seq_len(ncol(loadings)), function(i) loadings[which.max(abs(loadings[, i])), i], numeric(1))
+  expect_true(all(strongest >= 0))
+})
+
+test_that("data / biplot tidy types output the selected score scale (#27224)", {
+  preserve <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
+  unitvar  <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, score_scale = "unit_variance")
+  d_preserve <- preserve %>% tidy_rowwise(model, type = "data")
+  d_unitvar  <- unitvar  %>% tidy_rowwise(model, type = "data")
+  expect_equal(sd(d_preserve$PC1), preserve$model[[1]]$sdev[1], tolerance = 1e-8)
+  expect_equal(sd(d_unitvar$PC1), 1, tolerance = 1e-8)
+  # Same solution, different score scale: the two PC1 columns are perfectly correlated.
+  expect_equal(cor(d_preserve$PC1, d_unitvar$PC1), 1, tolerance = 1e-10)
+
+  # Biplot observation rows carry the same scale (loading rows are appended after the scores).
+  b_preserve <- preserve %>% tidy_rowwise(model, type = "biplot")
+  b_unitvar  <- unitvar  %>% tidy_rowwise(model, type = "biplot")
+  obs_preserve <- b_preserve$PC1[is.na(b_preserve$measure_name)]
+  obs_unitvar  <- b_unitvar$PC1[is.na(b_unitvar$measure_name)]
+  expect_equal(sd(obs_preserve), preserve$model[[1]]$sdev[1], tolerance = 1e-8)
+  expect_equal(sd(obs_unitvar), 1, tolerance = 1e-8)
+})
+
+test_that("score-independent report outputs are identical under both score scales (#27224)", {
+  preserve <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
+  unitvar  <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, score_scale = "unit_variance")
+  for (ty in c("variances", "variances_judged", "loadings", "loadings_signed", "loadings_signed_wide",
+               "contributions", "component_profiles", "variable_map", "representation",
+               "screeplot", "parallel_screeplot")) {
+    expect_equal(preserve %>% tidy_rowwise(model, type = ty),
+                 unitvar %>% tidy_rowwise(model, type = ty), info = ty)
+  }
+})
+
+test_that("old saved models without $scores fall back to the canonical scores (#27224)", {
+  model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp)
+  reference <- model_df %>% tidy_rowwise(model, type = "data")
+  model_df$model[[1]]$scores <- NULL      # model saved before #27224
+  model_df$model[[1]]$score_scale <- NULL
+  legacy <- model_df %>% tidy_rowwise(model, type = "data")
+  expect_equal(legacy, reference)
+  # The conditions table and the coefficients table degrade to the pre-#27224 meaning too.
+  conditions <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(conditions$Value[conditions$Metric == "Score Scale"], "Preserve Component Variance")
+  coefficients <- model_df %>% tidy_rowwise(model, type = "coefficients")
+  expect_equal(coefficients$`Score Coefficient`, coefficients$Coefficient, tolerance = 1e-12)
+})
+
+test_that("exp_kmeans is pinned to preserve_variance (#27224)", {
+  km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
+  fit <- km$model[[1]]
+  expect_equal(fit$score_scale, "preserve_variance")
+  expect_equal(unname(fit$scores), unname(fit$x), tolerance = 1e-12)
+})
+
+test_that("unit_variance refuses to standardize a degenerate component (EXP-ANA-36, #27224)", {
+  set.seed(27224)
+  n <- 100
+  df <- data.frame(a = rnorm(n), b = rnorm(n))
+  df$c <- df$a + df$b # exactly collinear -> the last component has ~0 standard deviation
+  # The default scale still works; only unit variance is impossible.
+  expect_silent(df %>% do_prcomp(a, b, c))
+  expect_error(df %>% do_prcomp(a, b, c, score_scale = "unit_variance"), "EXP-ANA-36")
+})
+
+test_that("do_prcomp rejects an unknown score_scale value (#27224)", {
+  expect_error(mtcars %>% do_prcomp(mpg, cyl, disp, score_scale = "spss"))
+})
+
+test_that("analysis_conditions carries the Score Scale row (#27224)", {
+  preserve <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp)) %>% tidy_rowwise(model, type = "analysis_conditions")
+  expect_true("Score Scale" %in% preserve$Metric)
+  expect_equal(preserve$Value[preserve$Metric == "Score Scale"], "Preserve Component Variance")
+  expect_equal(preserve$Description[preserve$Metric == "Score Scale"],
+               "How principal-component scores are scaled.")
+  expect_equal(preserve$status[preserve$Metric == "Score Scale"], "ok")
+  # Sits between Normalization and SD Ratio, per the spec's Metric ordering.
+  expect_equal(which(preserve$Metric == "Score Scale"), which(preserve$Metric == "Normalization") + 1L)
+  expect_equal(which(preserve$Metric == "SD Ratio (Max/Min)"), which(preserve$Metric == "Score Scale") + 1L)
+
+  unitvar <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, score_scale = "unit_variance")) %>%
+    tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(unitvar$Value[unitvar$Metric == "Score Scale"], "Unit Variance")
+})
+
+test_that("coefficients carry rotation / sdev as the score coefficient under unit_variance (#27224)", {
+  model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, score_scale = "unit_variance")
+  fit <- model_df$model[[1]]
+  res <- model_df %>% tidy_rowwise(model, type = "coefficients")
+  expect_equal(colnames(res), c("Variable", "Component", "Coefficient", "Score Coefficient"))
+  # Component coefficient stays the (sign-stabilized) rotation; score coefficient is rotation/sdev.
+  expected <- sweep(fit$rotation, 2, fit$sdev, "/")
+  got <- res %>%
+    dplyr::mutate(Component = as.character(Component)) %>%
+    dplyr::arrange(match(Variable, rownames(expected)), match(Component, colnames(expected)))
+  expect_equal(got$Coefficient, as.vector(t(fit$rotation)), tolerance = 1e-10)
+  expect_equal(got$`Score Coefficient`, as.vector(t(expected)), tolerance = 1e-10)
+  # Verifying the meaning: applying the score coefficients to the standardized data reproduces
+  # the SD-1 scores the Data tab shows -- this is SPSS's Component Score Coefficient Matrix.
+  standardized <- scale(as.matrix(mtcars[, rownames(expected)]))
+  expect_equal(unname(standardized %*% expected), unname(fit$scores), tolerance = 1e-8)
+})
+
+test_that("polychoric fits honor the score scale too (#27224)", {
+  df <- make_ordinal_survey()
+  fit <- (df %>% do_prcomp(q1, q2, q3, q4, q5, q6,
+                           cor_type = "polychoric", score_scale = "unit_variance"))$model[[1]]
+  expect_equal(fit$score_scale, "unit_variance")
+  expect_equal(unname(sweep(fit$scores, 2, fit$sdev, "*")), unname(fit$x), tolerance = 1e-10)
+  # Approximate scores: dividing by the eigenvalue-derived sdev lands close to, but not exactly at,
+  # SD 1 -- documented behavior, so assert the loose bound rather than an exact 1.
+  expect_true(all(abs(apply(fit$scores, 2, sd) - 1) < 0.35))
 })


### PR DESCRIPTION
## Description

R side of https://github.com/exploratory-io/tam/issues/27224 — PCA scores did not match SPSS.

As the issue's own investigation established, this was never a wrong result: `stats::prcomp()` returns scores whose spread is each component's own standard deviation, while SPSS and `psych::principal()` report scores standardized to SD 1. Same components, same loadings, same explained variance — only the **scale** of the score numbers differs, by a different factor per component.

So `do_prcomp()` gains an OUTPUT-scale option rather than a different analysis:

```r
do_prcomp(df, ..., score_scale = c("preserve_variance", "unit_variance"))
```

- `preserve_variance` (default) — `prcomp()`'s own scores; the historical behavior, bit-for-bit.
- `unit_variance` — each component's scores standardized to SD 1 (SPSS-compatible).

Verified against `psych::principal(rotate = "none")` on mtcars: the unit-variance scores match to **2.7e-15**, SD exactly 1.

Paired desktop change: exploratory-io/tam branch `fix/issue-27224`.

## Implementation

- `get_prcomp_scores(fit, score_scale)` — the sweep, refusing (`EXP-ANA-36`) when any component's SD is zero / near zero, so a collinear variable produces a clear error instead of huge garbage scores.
- `fit$scores` / `fit$score_scale` are built **after** sign stabilization and **outside** the `with_report_data` block, so the scale applies to the signs the report shows and a k-means fit still gets the field.
- `fit$x` stays the canonical prcomp score matrix. Every loading / contribution / representation / pattern computation still reads it, so those outputs are identical under both scales.
- `tidy()`:
  - `data` / `gathered_data` and `biplot` read the user-facing scores, via `get_stored_prcomp_scores()` which falls back to `fit$x` for models saved before this change;
  - `analysis_conditions` gains a **Score Scale** row (`"Unit Variance"` / `"Preserve Component Variance"`);
  - `coefficients` gains a **Score Coefficient** column (`rotation / sdev` under unit variance — SPSS's Component Score Coefficient Matrix).
- `exp_kmeans` is pinned to `preserve_variance` (`effective_score_scale`): its PCA is display-only and its dialog exposes no such option.
- Version 16.0.26 → **16.0.27**.

## Testing

`devtools::test(filter = "prcomp")` green, including new cases for:

- unit variance gives SD 1 while `sdev` / `rotation` / `fit$x` are unchanged, and `scores * sdev == x`;
- scores are built after sign stabilization (every score column correlates positively with the canonical one; the strongest-loading variable still loads positively);
- 11 score-independent tidy types are identical under both scales;
- the `data` and `biplot` outputs carry the selected scale;
- old saved models without `$scores` behave exactly as before (data tab, conditions row, coefficients column);
- `exp_kmeans` is pinned to `preserve_variance`;
- a degenerate component is refused with `EXP-ANA-36`, while the default scale still runs;
- the score coefficients reproduce the SD-1 scores: `scale(data) %*% score_coefficients == fit$scores`;
- a polychoric fit honors the scale (approximate scores, so SD lands near 1 — measured 0.976..1.124, and the desktop report discloses this).

`test_kmeans_1.R` / `test_kmeans_2.R` also green.

## Release note

The desktop client emits `score_scale` **unconditionally**, so per-platform 16.0.27 binaries must be built and uploaded to download2 `contrib/4.6` before the paired tam PR ships — otherwise every PCA run (including saved ones) fails with `unused argument (score_scale)`. Same shape as the existing `cor_type` precedent.
