### PR TITLE
test(oracle): assert applyOracleClientEnv's actual outcome instead of skipping

### DIFF
--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -1297,14 +1297,18 @@ test_that("resolveOracleClientLocation only reports an ORACLE_HOME for the lib s
   expect_equal(resolvedZip$home, "")
 })
 
-test_that("applyOracleClientEnv reports FALSE when no Oracle client can be found", {
-  # An unusable explicit directory falls through to the well known locations, so this can
-  # only assert the not-found path on a machine that has no Oracle client installed.
-  skip_if(exploratory:::resolveOracleClientLocation("")$libDir != "",
-          "an Oracle client is installed on this machine")
+test_that("applyOracleClientEnv reports whether an Oracle client can be found", {
+  # An unusable explicit directory falls through to the well known locations, so the
+  # outcome here depends on whether this machine has a client installed at all -- assert
+  # whichever outcome that implies instead of skipping when one happens to be present.
   emptyDir <- tempfile()
   dir.create(emptyDir)
-  expect_false(exploratory:::applyOracleClientEnv(emptyDir))
+  clientInstalled <- exploratory:::resolveOracleClientLocation("")$libDir != ""
+  if (clientInstalled) {
+    expect_true(exploratory:::applyOracleClientEnv(emptyDir))
+  } else {
+    expect_false(exploratory:::applyOracleClientEnv(emptyDir))
+  }
 })
 
 test_that("oracleOCINlsLang always forces the AL32UTF8 character set", {


### PR DESCRIPTION
## Summary
- The unnamed skip in the exp-test1 daily report (tam#37393-ish, surfaced by [datablog#3219](https://github.com/exploratory-io/tam/pull/37392)'s skip-reporting fix) turned out to be `applyOracleClientEnv reports FALSE when no Oracle client can be found` in `test_system.R`, guarded by `skip_if(resolveOracleClientLocation("")$libDir != "", ...)`.
- exp-test1 has Oracle Instant Client installed at `C:\instantclient_23_7` (needed by the other Oracle datasource tests), so the skip was correct behavior, not a missing-install bug.
- `skip_if` only lets the test validate one side of `applyOracleClientEnv`'s behavior (client absent). Since `resolveOracleClientLocation` falls through an unusable explicit dir to the well-known locations, the test can just as validly assert the "client present" outcome instead of skipping.

## Changes
- `tests/testthat/test_system.R`: replaced the `skip_if` guard with an `if`/`else` that asserts `expect_true` when a client is discoverable and `expect_false` when none is — the test now runs (and passes) on every machine instead of skipping on ones with a client installed.

## Test plan
- [x] Ran `test_system.R` on exp-test1 (which has the Oracle client installed) before and after: before — `skip: 1`; after — `success: 1, error: 0, skip: 0`.
- [x] Full file still 87/87 tests, 0 errors, 0 skips on exp-test1 after the change.