### PR TITLE
fix(factanal): tolerate a sampled rating-scale missing its low end (#37344)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.27
-Date: 2026-07-29
+Version: 16.0.28
+Date: 2026-07-30
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -65,9 +65,23 @@ get_factor_category_levels <- function(x, supplied_levels = NULL) {
 # "numeric", which would mean a 1-to-5 survey item imported as an integer -- the
 # exact data the polychoric request is about -- never reaches the ordinal branch.
 # So numeric columns are treated as ordinal only when they look like a rating
-# scale: consecutive integers, 3 to `max_categories` of them, starting at 0 or 1.
-# A measurement like cyl (4, 6, 8) or a count is not consecutive-from-0/1 and
-# stays numeric, so existing all-numeric analyses keep using Pearson.
+# scale: consecutive integers, 3 to `max_categories` of them, starting close to
+# 0 or 1.
+#
+# "Starts close to" (0, 1, or 2), not "starts exactly at 0 or 1" (issue #37344):
+# a skewed-positive item (e.g. satisfaction) routinely draws zero responses at
+# its lowest category in a given sample even though the scale itself runs from
+# 1. Requiring the SAMPLE's observed minimum to be exactly 0/1 misreads that
+# sampling gap as evidence the column isn't a rating scale at all, silently
+# falling back to "numeric" -- which can flip an entire multi-item selection
+# from Polychoric to Mixed (or Pearson) because one sibling item happened not
+# to draw a floor response. Tolerating a one-category gap at the low end keeps
+# genuine measurements like cyl (4, 6, 8) or a count starting well above 2 out
+# (those fail the consecutive-integers check below, or fall outside this
+# tolerance), while accepting the sampling-gap case.
+#
+# A measurement like cyl (4, 6, 8) or a count is not consecutive-from-a-low-
+# floor and stays numeric, so existing all-numeric analyses keep using Pearson.
 # -----------------------------------------------------------------------------
 is_rating_scale_numeric <- function(observed, max_categories = 7) {
   observed <- observed[is.finite(observed)]
@@ -76,7 +90,7 @@ is_rating_scale_numeric <- function(observed, max_categories = 7) {
   values <- sort(unique(observed))
   n_values <- length(values)
   if (n_values < 3 || n_values > max_categories) return(FALSE)
-  if (!(min(values) %in% c(0, 1))) return(FALSE)
+  if (!(min(values) %in% c(0, 1, 2))) return(FALSE)
   # Consecutive integers only: 1,2,3,4,5 yes; 1,2,5 no.
   identical(as.numeric(max(values) - min(values) + 1), as.numeric(n_values))
 }

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -115,6 +115,33 @@ test_that("numeric rating-scale detection does not reclassify ordinary measureme
   expect_equal(select_factor_correlation_type(mtcars[, c("cyl", "mpg", "hp", "drat")])$selected_method, "pearson")
 })
 
+test_that("numeric rating-scale detection tolerates a sample that never observed the scale's low end (issue #37344)", {
+  # A skewed-positive 1-5 satisfaction item routinely gets zero "1" responses in a given
+  # sample even though the scale itself runs 1-5. The observed minimum (2) must not make
+  # this read as an ordinary numeric measurement.
+  expect_true(is_rating_scale_numeric(c(2, 3, 4, 5)))
+  expect_true(is_rating_scale_numeric(c(2, 3, 4)))
+  # A minimum this far from a plausible 0/1 floor still reads as an ordinary measurement,
+  # not a rating scale that simply missed its low end -- unchanged from the #26623 behavior.
+  expect_false(is_rating_scale_numeric(c(3, 4, 5)))
+  expect_false(is_rating_scale_numeric(c(4, 5, 6, 7)))
+
+  # Three sibling 1-5 satisfaction items where ONE never sampled a "1" response must all
+  # still classify as ordinal (not mixed): a per-column sampling gap must not change the
+  # correlation method chosen for the whole analysis.
+  set.seed(37344)
+  n <- 500
+  df <- data.frame(
+    a = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 1), 5),
+    b = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 2), 5), # this sample never observes "1"
+    c = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 1), 5)
+  )
+  expect_equal(min(df$b), 2)
+  selection <- select_factor_correlation_type(df)
+  expect_equal(unname(selection$variable_summary$detected_type), c("ordinal", "ordinal", "ordinal"))
+  expect_true(selection$selected_method %in% c("polychoric", "pearson"))
+})
+
 test_that("exp_factanal Pearson results are unchanged by the correlation-type support (issue #26623)", {
   set.seed(3)
   n <- 200


### PR DESCRIPTION
## Description

Related to https://github.com/exploratory-io/tam/issues/37344.

`is_rating_scale_numeric()` (the #26623 heuristic that lets a numeric column read as an ordinal rating scale for Factor Analysis's auto correlation-type selection) required the analyzed **sample's** observed minimum to be exactly 0 or 1. A skewed-positive item (e.g. satisfaction, 1-5) routinely draws zero responses at its lowest category in a given sample even though the scale itself runs from 1 — so that one column silently fell back to `"numeric"` while sibling items (which happened to draw a floor response) stayed `"ordinal"`, flipping the whole selection from Polychoric to **Mixed**.

Reproduced with three correlated 1-5 satisfaction columns where one never samples a "1": before this fix, `detected_type` is `c("ordinal", "ordinal", "numeric")` and `selected_method` is `"mixed"`; after the fix all three read `"ordinal"` and the existing distribution-based 5-category decision (Polychoric vs Pearson) runs as intended.

## Implementation Details

- Widen `is_rating_scale_numeric()`'s accepted observed minimum from `{0, 1}` to `{0, 1, 2}` — tolerates a one-category sampling gap at the low end.
- Genuine measurements (`cyl`, a count starting well above 2) are unaffected — they already fail the consecutive-integers or category-count checks, unchanged.
- No change to the 5-category distribution-based Polychoric/Pearson decision, the ≤4-category deterministic Polychoric rule, or anything for declared/ordered-factor columns.

## How to Test

```r
source("R/factanal_correlation.R")
is_rating_scale_numeric(c(2, 3, 4, 5))   # TRUE  (was FALSE)
is_rating_scale_numeric(c(3, 4, 5))      # FALSE (unchanged -- too far from a plausible floor)
```

New regression test in `tests/testthat/test_factanal_correlation.R`: "numeric rating-scale detection tolerates a sample that never observed the scale's low end (issue #37344)".

## Build Impact

Pure R source change (`R/factanal_correlation.R`), no compiled code. Version bump / per-platform binary build+upload intentionally **not done yet** — holding for confirmation before shipping.