### PR TITLE
fix(pca): show TRUE/FALSE for Normalization in the Analysis Method table too (tam#27224)

### DIFF
--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -652,7 +652,9 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       Item = c("Correlation", "Normalization", "Target Variables", "Data Rows"),
       Value = c(
         factanal_correlation_label(cor_type),
-        if (normalized) "Yes" else "No",
+        # Raw boolean string, not "Yes"/"No" (issue #27224 follow-up) -- matches the
+        # analysis_conditions table's Normalization row and this file's own hidden columns below.
+        if (normalized) "TRUE" else "FALSE",
         if (length(n_variables) == 1L && !is.na(n_variables)) as.character(n_variables) else "N/A",
         if (length(n_rows_used) == 1L && !is.na(n_rows_used)) as.character(n_rows_used) else "N/A"
       ),


### PR DESCRIPTION
Follow-up to #1577 (already merged). Same tweak as that PR, applied to the OTHER table with a Normalization row (`analysis_method` / 分析方法, not `analysis_conditions` / 分析に使われたデータ).

The client's `extractAnalysisMethod()` only reads this table's hidden columns, never the visible Normalization Value, so no tam-side change is needed alongside this one.