### PR TITLE
fix(factanal,prcomp): decide variable type from the column type, not value shape (tam#37344)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.28
+Version: 16.0.29
 Date: 2026-07-30
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/factanal_correlation.R
+++ b/R/factanal_correlation.R
@@ -58,45 +58,30 @@ get_factor_category_levels <- function(x, supplied_levels = NULL) {
 }
 
 # -----------------------------------------------------------------------------
-# Is a numeric column really a rating scale (1-5 survey answer) rather than a
-# continuous measurement?
-#
-# The spec's literal rule calls every numeric column with 3+ distinct values
-# "numeric", which would mean a 1-to-5 survey item imported as an integer -- the
-# exact data the polychoric request is about -- never reaches the ordinal branch.
-# So numeric columns are treated as ordinal only when they look like a rating
-# scale: consecutive integers, 3 to `max_categories` of them, starting close to
-# 0 or 1.
-#
-# "Starts close to" (0, 1, or 2), not "starts exactly at 0 or 1" (issue #37344):
-# a skewed-positive item (e.g. satisfaction) routinely draws zero responses at
-# its lowest category in a given sample even though the scale itself runs from
-# 1. Requiring the SAMPLE's observed minimum to be exactly 0/1 misreads that
-# sampling gap as evidence the column isn't a rating scale at all, silently
-# falling back to "numeric" -- which can flip an entire multi-item selection
-# from Polychoric to Mixed (or Pearson) because one sibling item happened not
-# to draw a floor response. Tolerating a one-category gap at the low end keeps
-# genuine measurements like cyl (4, 6, 8) or a count starting well above 2 out
-# (those fail the consecutive-integers check below, or fall outside this
-# tolerance), while accepting the sampling-gap case.
-#
-# A measurement like cyl (4, 6, 8) or a count is not consecutive-from-a-low-
-# floor and stays numeric, so existing all-numeric analyses keep using Pearson.
-# -----------------------------------------------------------------------------
-is_rating_scale_numeric <- function(observed, max_categories = 7) {
-  observed <- observed[is.finite(observed)]
-  if (length(observed) == 0) return(FALSE)
-  if (any(observed != floor(observed))) return(FALSE)
-  values <- sort(unique(observed))
-  n_values <- length(values)
-  if (n_values < 3 || n_values > max_categories) return(FALSE)
-  if (!(min(values) %in% c(0, 1, 2))) return(FALSE)
-  # Consecutive integers only: 1,2,3,4,5 yes; 1,2,5 no.
-  identical(as.numeric(max(values) - min(values) + 1), as.numeric(n_values))
-}
-
-# -----------------------------------------------------------------------------
 # Detect the type of one variable.
+#
+# Detection is driven by the column's DATA TYPE, never by the shape of the
+# values a numeric column happens to hold (issue #37344). An earlier revision
+# guessed that a numeric column "looked like" a 1-5 rating scale (consecutive
+# small integers) and promoted it to ordinal, so that survey items imported as
+# integers reached the polychoric branch. That guess was retired because it is
+# not knowable from the values alone:
+#   - it silently described a column the user declared numeric as categorical
+#     in the report, which reads as a type mismatch;
+#   - it was sample-dependent -- a skewed item that drew no response at its
+#     lowest category changed type, flipping the correlation chosen for the
+#     WHOLE analysis (Polychoric -> Mixed) because of sampling luck alone;
+#   - widening the shape rule to cover that only moved the boundary, since a
+#     genuine small-integer measurement (a count, a 1-7 code) is indistinguish-
+#     able from a rating scale by its values.
+#
+# A numeric column is therefore always "numeric" (Pearson), with one exception
+# that predates the heuristic and is the original request of issue #26623: a
+# numeric column holding exactly two distinct values is a 0/1 dummy, i.e.
+# binary, and belongs on the tetrachoric branch.
+#
+# To have ordinal (polychoric) treatment, a column must SAY it is ordered --
+# an ordered factor, supplied category levels, or an explicit declared type.
 # -----------------------------------------------------------------------------
 inspect_factor_variable <- function(variable_name, x, declared_type = "auto", supplied_levels = NULL) {
   declared_type <- normalize_factor_variable_type(declared_type)
@@ -128,9 +113,10 @@ inspect_factor_variable <- function(variable_name, x, declared_type = "auto", su
   } else if (is.factor(x)) {
     detected_type <- if (nlevels(x) == 2) "binary" else "nominal"
   } else if (is.numeric(x)) {
-    detected_type <- if (n_observed_categories == 2) "binary"
-      else if (is_rating_scale_numeric(observed)) "ordinal"
-      else "numeric"
+    # Type-based (issue #37344): a numeric column stays numeric no matter what its
+    # values look like. The only exception is a two-value 0/1 dummy, which is binary
+    # (tetrachoric) -- the original ask of issue #26623.
+    detected_type <- if (n_observed_categories == 2) "binary" else "numeric"
   } else if (is.character(x)) {
     detected_type <- if (n_observed_categories == 2) "binary" else "nominal"
   } else {

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -7,6 +7,19 @@ context("test factor analysis correlation type, exp_factanal cor_type")
 # Polychoric correlation support (issue #26623)
 # =============================================================================
 
+# Ordered-factor helpers. Detection is TYPE based (issue #37344): a numeric column is
+# always numeric, whatever its values look like, so a fixture that wants ordinal
+# treatment has to SAY it is ordered rather than rely on small consecutive integers.
+# Levels are fixed 1..k so a category nobody happened to answer is still a defined
+# category (which is also what real ordered survey data carries).
+ordered_k <- function(codes, k) factor(as.integer(codes), levels = seq_len(k), ordered = TRUE)
+ordered_five <- function(codes) ordered_k(codes, 5)
+
+# Ordered-factor columns carry their order as levels, so plain numeric maths (stats::cor,
+# scale) cannot be run on them directly. Stubs that stand in for build_factor_correlation
+# need the same numeric encoding the real builder applies internally.
+as_numeric_codes <- function(d) as.data.frame(lapply(as.data.frame(d), as.numeric))
+
 # Builds ordinal survey-like data: q1-q3 load on one latent factor, q4-q6 on another.
 # `skew=TRUE` concentrates the responses so the 5-category rule picks Polychoric.
 factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
@@ -16,10 +29,10 @@ factanal_ordinal_fixture <- function(n = 300, skew = TRUE, seed = 42) {
   make_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
     if (skew) {
-      as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+      ordered_five(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
     } else {
-      as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = 6)),
-                     include.lowest = TRUE, labels = FALSE))
+      ordered_five(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = 6)),
+                       include.lowest = TRUE, labels = FALSE))
     }
   }
   data.frame(q1 = make_col(lat1), q2 = make_col(lat1), q3 = make_col(lat1),
@@ -68,8 +81,8 @@ test_that("correlation type auto-selection rules (issue #26623)", {
   lat <- stats::rnorm(n)
   ordinal_col <- function(k) {
     z <- 0.7 * lat + sqrt(1 - 0.7^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = k + 1)),
-                   include.lowest = TRUE, labels = FALSE))
+    ordered_k(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = k + 1)),
+                  include.lowest = TRUE, labels = FALSE), k)
   }
   method_of <- function(df) select_factor_correlation_type(df)$selected_method
 
@@ -102,44 +115,46 @@ test_that("correlation type auto-selection rules (issue #26623)", {
   expect_true(grepl("Invalid variables", invalid$reason))
 })
 
-test_that("numeric rating-scale detection does not reclassify ordinary measurements (issue #26623)", {
-  # A 1-5 (or 0-4) consecutive integer scale is treated as ordinal...
-  expect_true(is_rating_scale_numeric(c(1, 2, 3, 4, 5)))
-  expect_true(is_rating_scale_numeric(c(0, 1, 2, 3)))
-  # ...but a measurement with gaps, non-integers, too many levels, or not starting at 0/1 is not.
-  expect_false(is_rating_scale_numeric(c(4, 6, 8)))          # mtcars$cyl
-  expect_false(is_rating_scale_numeric(c(1.5, 2.5, 3.5)))
-  expect_false(is_rating_scale_numeric(1:8))
-  expect_false(is_rating_scale_numeric(c(3, 4, 5)))
-  # So an all-numeric data frame like mtcars keeps using Pearson.
+test_that("a numeric column is detected from its TYPE, never from the shape of its values (issue #37344)", {
+  detect <- function(x) inspect_factor_variable("v", x)$detected_type
+
+  # Values that "look like" a 1-5 rating scale do NOT make a numeric column ordinal.
+  # This is the whole point of #37344: the report must not describe a column the user
+  # declared numeric as a category, and the type must not depend on which values the
+  # sample happened to draw.
+  expect_equal(detect(c(1, 2, 3, 4, 5)), "numeric")
+  expect_equal(detect(c(0, 1, 2, 3)), "numeric")
+  expect_equal(detect(c(2, 3, 4, 5)), "numeric")   # a sample that never drew the scale's "1"
+  # Ordinary measurements are unchanged.
+  expect_equal(detect(c(4, 6, 8)), "numeric")      # mtcars$cyl
+  expect_equal(detect(c(1.5, 2.5, 3.5)), "numeric")
+  expect_equal(detect(1:8), "numeric")
+
+  # A numeric 0/1 dummy stays BINARY -- the original request of #26623 (tetrachoric).
+  expect_equal(detect(c(0, 1)), "binary")
+  expect_equal(detect(c(1, 2)), "binary")
+
+  # Saying the column is ordered is what earns ordinal treatment.
+  expect_equal(detect(factor(c(1, 2, 3, 4, 5), levels = 1:5, ordered = TRUE)), "ordinal")
+  expect_equal(inspect_factor_variable("v", c(1, 2, 3, 4, 5), declared_type = "ordinal")$detected_type, "ordinal")
+  expect_equal(inspect_factor_variable("v", c(1, 2, 3, 4, 5), supplied_levels = 1:5)$detected_type, "ordinal")
+
+  # The heuristic is gone, not merely bypassed.
+  expect_false(exists("is_rating_scale_numeric", envir = asNamespace("exploratory"), inherits = FALSE))
+
+  # An all-numeric data frame still uses Pearson...
   expect_equal(select_factor_correlation_type(mtcars[, c("cyl", "mpg", "hp", "drat")])$selected_method, "pearson")
-})
-
-test_that("numeric rating-scale detection tolerates a sample that never observed the scale's low end (issue #37344)", {
-  # A skewed-positive 1-5 satisfaction item routinely gets zero "1" responses in a given
-  # sample even though the scale itself runs 1-5. The observed minimum (2) must not make
-  # this read as an ordinary numeric measurement.
-  expect_true(is_rating_scale_numeric(c(2, 3, 4, 5)))
-  expect_true(is_rating_scale_numeric(c(2, 3, 4)))
-  # A minimum this far from a plausible 0/1 floor still reads as an ordinary measurement,
-  # not a rating scale that simply missed its low end -- unchanged from the #26623 behavior.
-  expect_false(is_rating_scale_numeric(c(3, 4, 5)))
-  expect_false(is_rating_scale_numeric(c(4, 5, 6, 7)))
-
-  # Three sibling 1-5 satisfaction items where ONE never sampled a "1" response must all
-  # still classify as ordinal (not mixed): a per-column sampling gap must not change the
-  # correlation method chosen for the whole analysis.
+  # ...and so does a set of integer 1-5 survey items, because they are typed numeric.
   set.seed(37344)
-  n <- 500
-  df <- data.frame(
-    a = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 1), 5),
-    b = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 2), 5), # this sample never observes "1"
-    c = pmin(pmax(round(stats::rnorm(n, mean = 3.6)), 1), 5)
-  )
-  expect_equal(min(df$b), 2)
+  n <- 300
+  likert <- function(floor_at) pmin(pmax(round(stats::rnorm(n, mean = 3.6)), floor_at), 5)
+  df <- data.frame(a = likert(1), b = likert(2), c = likert(1))
   selection <- select_factor_correlation_type(df)
-  expect_equal(unname(selection$variable_summary$detected_type), c("ordinal", "ordinal", "ordinal"))
-  expect_true(selection$selected_method %in% c("polychoric", "pearson"))
+  expect_equal(unname(selection$variable_summary$detected_type), c("numeric", "numeric", "numeric"))
+  expect_equal(selection$selected_method, "pearson")
+  # Crucially it is not "mixed": one column drawing no "1" no longer changes the method
+  # chosen for the whole analysis, which was the reported #37344 symptom.
+  expect_false(selection$selected_method == "mixed")
 })
 
 test_that("exp_factanal Pearson results are unchanged by the correlation-type support (issue #26623)", {
@@ -248,7 +263,7 @@ test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
   binary_col <- function(latent) as.integer(0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n) > 0.3)
   ordinal_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    ordered_five(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
   }
   binary_df <- data.frame(b1 = binary_col(lat1), b2 = binary_col(lat1), b3 = binary_col(lat1),
                           b4 = binary_col(lat2), b5 = binary_col(lat2), b6 = binary_col(lat2))
@@ -273,7 +288,11 @@ test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
 })
 
 test_that("build_factor_correlation returns one matrix for the whole analysis (issue #26623)", {
-  df <- factanal_ordinal_fixture(n = 200)
+  # build_factor_correlation works on the numeric-encoded frame: exp_factanal runs
+  # encode_factanal_data first, which turns ordered categories into their 1..k codes.
+  # (Before #37344 the fixture was already bare integers, so this step was invisible.)
+  df_raw <- factanal_ordinal_fixture(n = 200)
+  df <- encode_factanal_data(df_raw, select_factor_correlation_type(df_raw))
   pearson <- build_factor_correlation(df, "pearson")
   expect_equal(pearson$type, "pearson")
   expect_equal(pearson$correlation, stats::cor(df, use = "pairwise.complete.obs"))
@@ -343,7 +362,7 @@ test_that("mixed-correlation diagnostics only describe the categorical variables
   lat1 <- stats::rnorm(n); lat2 <- stats::rnorm(n)
   ordinal_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    ordered_five(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
   }
   mixed_df <- data.frame(x1 = lat1 + stats::rnorm(n, 0, .5), x2 = lat1 + stats::rnorm(n, 0, .5),
                          q1 = ordinal_col(lat2), q2 = ordinal_col(lat2), q3 = ordinal_col(lat2))
@@ -454,9 +473,11 @@ test_that("verification pass 3 findings (issue #26623)", {
 
   # Counts are singular when there is exactly one hit. Balanced columns, then one rare category
   # injected into a single variable.
-  balanced <- data.frame(q1 = rep(1:4, 50), q2 = rep(1:4, 50), q3 = rep(1:4, 50))
-  balanced$q1[balanced$q1 == 4] <- 3
-  balanced$q1[1] <- 4   # a single response in the top category (1 of 200 = below the 5% cutoff)
+  balanced_codes <- data.frame(q1 = rep(1:4, 50), q2 = rep(1:4, 50), q3 = rep(1:4, 50))
+  balanced_codes$q1[balanced_codes$q1 == 4] <- 3
+  balanced_codes$q1[1] <- 4   # a single response in the top category (1 of 200 = below the 5% cutoff)
+  # Ordered factors, so these are categorical variables at all (#37344: bare integers are numeric).
+  balanced <- as.data.frame(lapply(balanced_codes, ordered_k, k = 4))
   balanced_selection <- select_factor_correlation_type(balanced)
   single <- compute_polychoric_diagnostics(balanced,
                                            list(correlation = diag(3), thresholds = NULL,
@@ -500,7 +521,7 @@ test_that("the parallel analysis null distribution never mixes in Pearson eigenv
   fake_build <- function(data, correlation_type, ...) {
     calls <<- calls + 1
     if (calls %% 2 == 0) {
-      list(correlation = stats::cor(data), thresholds = NULL, type = "pearson",
+      list(correlation = stats::cor(as_numeric_codes(data)), thresholds = NULL, type = "pearson",
            smoothed = FALSE, warnings = "failed", failed = TRUE)
     } else {
       list(correlation = diag(ncol(data)), thresholds = NULL, type = correlation_type,
@@ -592,7 +613,7 @@ test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
     if (identical(correlation_type, "pearson")) {
       return(original_build(data, correlation_type, use = use, correct = correct))
     }
-    list(correlation = stats::cor(data, use = use), thresholds = NULL, type = "pearson",
+    list(correlation = stats::cor(as_numeric_codes(data), use = use), thresholds = NULL, type = "pearson",
          smoothed = FALSE, warnings = "simulated polychoric failure", failed = TRUE)
   }
   restore <- stub_build_factor_correlation(failing_build)
@@ -621,22 +642,35 @@ test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
 })
 
 test_that("Repeat By groups all use the same correlation (issue #26623)", {
-  # Group A is ordinal (would pick Polychoric on its own), group B is continuous (Pearson). One
-  # report describes one correlation, and loadings must be comparable across facets, so the choice
-  # is made once from the whole data.
+  # Group A is skewed (would pick Polychoric on its own), group B is balanced (Pearson on its
+  # own). One report describes one correlation, and loadings must be comparable across facets,
+  # so the choice is made once from the whole data.
+  #
+  # Both groups are ordered factors of the SAME 5 levels: a column has one type, so the two
+  # groups can only differ in DISTRIBUTION, not in type. (Before #37344 this fixture rbind()ed
+  # an integer group onto a continuous group; ordered factors cannot be stacked onto doubles --
+  # rbind would coerce every value to NA.)
   set.seed(31)
   n <- 200
-  latent_a <- stats::rnorm(n)
-  ordinal_col <- function(latent) {
+  skewed_col <- function(latent) {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    ordered_five(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
   }
-  group_a <- data.frame(g = "A", q1 = ordinal_col(latent_a), q2 = ordinal_col(latent_a),
-                        q3 = ordinal_col(latent_a), stringsAsFactors = FALSE)
+  balanced_col <- function(latent) {
+    z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
+    ordered_five(cut(z, breaks = stats::quantile(z, probs = seq(0, 1, length.out = 6)),
+                     include.lowest = TRUE, labels = FALSE))
+  }
+  latent_a <- stats::rnorm(n)
+  group_a <- data.frame(g = "A", q1 = skewed_col(latent_a), q2 = skewed_col(latent_a),
+                        q3 = skewed_col(latent_a), stringsAsFactors = FALSE)
   latent_b <- stats::rnorm(n)
-  group_b <- data.frame(g = "B",
-                        q1 = latent_b + stats::rnorm(n), q2 = latent_b + stats::rnorm(n),
-                        q3 = latent_b + stats::rnorm(n), stringsAsFactors = FALSE)
+  group_b <- data.frame(g = "B", q1 = balanced_col(latent_b), q2 = balanced_col(latent_b),
+                        q3 = balanced_col(latent_b), stringsAsFactors = FALSE)
+  # Sanity: on their own the two groups really would disagree, which is what makes the
+  # single-choice assertion below meaningful.
+  expect_false(identical(select_factor_correlation_type(group_a[, c("q1","q2","q3")])$selected_method,
+                         select_factor_correlation_type(group_b[, c("q1","q2","q3")])$selected_method))
   grouped <- dplyr::group_by(rbind(group_a, group_b), g)
 
   model_df <- exp_factanal(grouped, q1, q2, q3, nfactors = 1, rotate = "none", parallel_n_iter = 3)
@@ -656,7 +690,7 @@ test_that("an unsupported facet is skipped, not fatal, under Repeat By (issue #2
   latent <- stats::rnorm(n)
   ordinal_col <- function() {
     z <- 0.75 * latent + sqrt(1 - 0.75^2) * stats::rnorm(n)
-    as.integer(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
+    ordered_five(cut(z, breaks = c(-Inf, stats::quantile(z, c(.55, .75, .88, .96)), Inf), labels = FALSE))
   }
   good <- data.frame(g = "good", q1 = sample(c("yes", "no"), n, TRUE),
                      q2 = ordinal_col(), q3 = ordinal_col(), stringsAsFactors = FALSE)

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -360,7 +360,10 @@ make_ordinal_survey <- function(n = 300, seed = 37294) {
   set.seed(seed)
   latent_a <- rnorm(n)
   latent_b <- rnorm(n)
-  to_five <- function(z) as.integer(cut(z, breaks = c(-Inf, -1, -0.3, 0.3, 1, Inf), labels = FALSE))
+  # Ordered factor, not bare integers: detection is TYPE based (issue #37344), so a
+  # numeric column is numeric no matter how rating-scale-shaped its values are.
+  to_five <- function(z) factor(as.integer(cut(z, breaks = c(-Inf, -1, -0.3, 0.3, 1, Inf), labels = FALSE)),
+                                levels = 1:5, ordered = TRUE)
   data.frame(
     q1 = to_five(latent_a + rnorm(n, 0, 0.6)), q2 = to_five(latent_a + rnorm(n, 0, 0.6)),
     q3 = to_five(latent_a + rnorm(n, 0, 0.6)), q4 = to_five(latent_b + rnorm(n, 0, 0.6)),
@@ -385,7 +388,7 @@ test_that("do_prcomp polychoric scores are scale(data) %*% eigenvectors (issue #
   fit <- (df %>% do_prcomp(q1, q2, q3, q4, q5, q6, cor_type = "polychoric"))$model[[1]]
   # The approximation the issue specifies. Sign stabilization sweeps rotation and x together,
   # so the identity survives it.
-  expected <- scale(as.matrix(df)) %*% fit$rotation
+  expected <- scale(as.matrix(as.data.frame(lapply(df, as.numeric)))) %*% fit$rotation
   expect_equal(unname(expected), unname(fit$x), tolerance = 1e-10)
 })
 
@@ -409,7 +412,7 @@ test_that("do_prcomp polychoric loadings come from the polychoric solution, not 
   expect_equal(unname(loadings),
                unname(fit$rotation %*% diag(fit$sdev, nrow = length(fit$sdev))), tolerance = 1e-10)
   # And it is NOT the Pearson cross-correlation the pre-#37294 branches recomputed.
-  pearson_loadings <- cor(as.matrix(df), fit$x)
+  pearson_loadings <- cor(as.matrix(as.data.frame(lapply(df, as.numeric))), fit$x)
   expect_false(isTRUE(all.equal(unname(loadings), unname(pearson_loadings), tolerance = 1e-6)))
 })
 
@@ -452,7 +455,9 @@ test_that("do_prcomp cor_type='auto' picks polychoric for ordinal data and Pears
   set.seed(37294)
   n <- 300
   latent_a <- rnorm(n); latent_b <- rnorm(n)
-  to_four <- function(z) as.integer(cut(z, breaks = c(-Inf, -0.6, 0, 0.6, Inf), labels = FALSE))
+  # Ordered factor, not bare integers -- see #37344 note above.
+  to_four <- function(z) factor(as.integer(cut(z, breaks = c(-Inf, -0.6, 0, 0.6, Inf), labels = FALSE)),
+                                levels = 1:4, ordered = TRUE)
   ordinal <- data.frame(a = to_four(latent_a + rnorm(n, 0, 0.5)), b = to_four(latent_a + rnorm(n, 0, 0.5)),
                         c = to_four(latent_b + rnorm(n, 0, 0.5)), e = to_four(latent_b + rnorm(n, 0, 0.5)))
   ordinal_fit <- (ordinal %>% do_prcomp(a, b, c, e))$model[[1]]


### PR DESCRIPTION
## Summary

Retires the `is_rating_scale_numeric()` heuristic. Variable-type detection in `select_factor_correlation_type()` (used by **Factor Analysis** and **PCA**) is now driven purely by the column's data type.

- numeric → **numeric** (Pearson), whatever the values look like
- numeric with exactly 2 distinct values → **binary** (tetrachoric) — unchanged, this is the original ask of tam#26623
- ordinal (polychoric) requires the column to *say* it is ordered: ordered factor, supplied category levels, or an explicit declared type

## Why

The heuristic promoted a numeric column to ordinal when its values were consecutive small integers, so integer-coded survey items reached the polychoric branch. It could not be made correct:

1. **It mislabels the user's data.** The report described a column declared numeric (`#`) as a category — the reported symptom in tam#37344.
2. **It was sample-dependent.** A skewed 1-5 item that drew no response at its lowest category flipped from `ordinal` to `numeric`, changing the correlation for the *whole* analysis (Polychoric → Mixed). Verified on the reporter's real data: `上司との関係` had values `2,3,4,5` and alone forced `mixed` across 8 otherwise-identical items.
3. **Widening the rule only moves the boundary.** A genuine small-integer measurement (a count, a 1-7 code) is indistinguishable from a rating scale by its values alone. This supersedes #1576, which widened the accepted minimum and did not address the underlying ambiguity.

This also makes Factor Analysis / PCA **consistent with Cronbach's Alpha**, whose `reliability_classify_item()` has always been type-based with the same two-value exception.

## Test changes

Fixtures that want ordinal treatment now build ordered factors rather than bare integers. Two knock-on adjustments, both because ordered factors are not numbers:

- `build_factor_correlation` is now exercised through `encode_factanal_data` first — the order `exp_factanal` itself uses. The old fixture was already integers, so this step was invisible.
- The Repeat By fixture compares a **skewed** vs a **balanced** ordered-factor group instead of ordinal vs continuous: a column has one type, and `rbind` cannot stack an ordered factor onto doubles (every value becomes `NA`). The test's intent — the groups disagree on their own, so the single whole-data choice is meaningful — is asserted explicitly.

## Validation

`test_factanal_correlation.R` 20, `test_factanal.R` 8, `test_prcomp.R` 43, `test_reliability.R` 13 — **84 tests, 0 failures**.

Verified against the reporter's actual project data: the 8 numeric 1-5 columns now detect as `numeric` and select `pearson`, so the report no longer describes them as categories.

Version bumped to **16.0.29**.

Relates to tam#37344.