### PR TITLE
fix(factanal): Rows Removed, suitability trim, judged eigenvalues (tam#37402)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.30
-Date: 2026-07-31
+Version: 16.0.31
+Date: 2026-08-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.29
-Date: 2026-07-30
+Version: 16.0.30
+Date: 2026-07-31
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.31
-Date: 2026-08-01
+Version: 16.0.32
+Date: 2026-08-02
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -564,6 +564,36 @@ glance.fa_exploratory <- function(x, pretty.name = FALSE, ...) {
   res
 }
 
+# Factor-count diagnostics shared by the normal scree plot, parallel-analysis
+# chart, and factor-count table. Keeping the alignment here prevents those three
+# report outputs from independently interpreting the parallel-analysis table.
+build_factor_count_diagnostics <- function(x) {
+  correlation_eigenvalues <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
+  n_factors <- length(correlation_eigenvalues)
+  parallel_eigenvalues <- rep(NA_real_, n_factors)
+  random_eigenvalues <- rep(NA_real_, n_factors)
+  parallel_adopted <- rep(NA, n_factors)
+
+  if (!is.null(x$parallel) && !is.null(x$parallel$table)) {
+    parallel_table <- x$parallel$table
+    valid <- parallel_table$factor_number >= 1 & parallel_table$factor_number <= n_factors
+    factor_index <- parallel_table$factor_number[valid]
+    parallel_eigenvalues[factor_index] <- parallel_table$actual_eigenvalue[valid]
+    random_eigenvalues[factor_index] <- parallel_table$random_eigenvalue_threshold[valid]
+    parallel_adopted[factor_index] <- parallel_eigenvalues[factor_index] > random_eigenvalues[factor_index]
+  }
+
+  tibble::tibble(
+    factor_number = seq_len(n_factors),
+    correlation_eigenvalue = correlation_eigenvalues,
+    parallel_eigenvalue = parallel_eigenvalues,
+    random_eigenvalue = random_eigenvalues,
+    kaiser_adopted = correlation_eigenvalues > 1,
+    parallel_adopted = parallel_adopted,
+    selected_adopted = seq_len(n_factors) <= x$factors
+  )
+}
+
 #' extracts results from psych::fa object as a dataframe
 #' @export
 #' @param n_sample Sample number for biplot. Default 5000, which is the default of our scatter plot.
@@ -614,8 +644,11 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   n_factor <- x$factors # Number of factors.
 
   if (type == "screeplot") {
-    eigen_res <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE) # Cattell's scree plot is eigenvalues of correlation/covariance matrix.
-    res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)
+    diagnostics <- build_factor_count_diagnostics(x)
+    res <- diagnostics %>% dplyr::transmute(
+      factor = factor_number,
+      eigenvalue = correlation_eigenvalue
+    )
   }
   else if (type == "variances") {
     res <- tibble::as_tibble(t(x$Vaccounted))
@@ -930,75 +963,40 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     )
   }
   else if (type == "variances_judged") {
-    # Per-factor eigenvalue table with the three retention judgments, for the report's
-    # 「因子数の判定」 section (issue tam#37340). Same shape as prcomp.R's "variances_judged" branch
-    # so the client can reuse the PCA table's viz configuration.
-    #
-    # One row per variable (every candidate factor), exactly like PCA's PC1..PCn.
-    # DISPLAYED Eigenvalue / % Variance use the correlation-matrix eigenvalues
-    # (eigen(x$correlation)). Factor-model / SMC eigenvalues used by parallel analysis can be
-    # negative and their signed sum is far smaller than n_vars, so using them for % Variance
-    # produced values above 100% and negative contribution rates (tam#37402 follow-up).
-    # Parallel Analysis still judges against those parallel actuals vs the random threshold;
-    # Kaiser Criterion still uses corr_eig > 1. The parallel screeplot may therefore show a
-    # different Eigenvalue number than this table for the same factor -- that is intentional.
-    # % Variance here remains an eigenvalue-share and can legitimately differ from the
-    # 「各因子の寄与率」 chart, which is Vaccounted-based.
-    corr_eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
-    n_row <- length(corr_eig)
-    eig <- corr_eig
-    par <- x$parallel
-    if (is.null(par)) {
-      parallel_label <- rep("Not Available", n_row)
-      parallel_status <- rep("na", n_row)
-    }
-    else {
-      ptbl <- par$table
-      in_range <- ptbl$factor_number <= n_row
-      actual <- rep(NA_real_, n_row)
-      threshold <- rep(NA_real_, n_row)
-      actual[ptbl$factor_number[in_range]] <- ptbl$actual_eigenvalue[in_range]
-      threshold[ptbl$factor_number[in_range]] <- ptbl$random_eigenvalue_threshold[in_range]
-      adopted <- !is.na(actual) & !is.na(threshold) & actual > threshold
-      parallel_label <- ifelse(adopted, "Adopted", "Not Adopted")
-      parallel_status <- ifelse(adopted, "adopted", "not_adopted")
-    }
-    total_variance <- sum(eig, na.rm = TRUE)
-    pct_variance <- if (is.finite(total_variance) && total_variance != 0) eig / total_variance * 100 else rep(NA_real_, n_row)
-    # Kaiser always uses the correlation-matrix eigenvalues (traditional rule).
-    kaiser_adopted <- corr_eig > 1
-    # Adopted = the factors this analysis actually extracted (the nfactors setting).
-    selected_adopted <- seq_len(n_row) <= n_factor
-    res <- tibble::tibble(
-      Factor = as.character(seq_len(n_row)),
-      Eigenvalue = eig,
-      `% Variance` = pct_variance,
-      `Cummulated % Variance` = cumsum(pct_variance),
-      `Parallel Analysis` = parallel_label,
+    diagnostics <- build_factor_count_diagnostics(x)
+    parallel_label <- dplyr::case_when(
+      is.na(diagnostics$parallel_adopted) ~ "Not Available",
+      diagnostics$parallel_adopted ~ "Adopted",
+      TRUE ~ "Not Adopted"
+    )
+    parallel_status <- dplyr::case_when(
+      is.na(diagnostics$parallel_adopted) ~ "na",
+      diagnostics$parallel_adopted ~ "adopted",
+      TRUE ~ "not_adopted"
+    )
+    res <- diagnostics %>% dplyr::transmute(
+      Factor = as.character(factor_number),
+      `Correlation Matrix Eigenvalue` = correlation_eigenvalue,
+      `Parallel Analysis Eigenvalue` = parallel_eigenvalue,
+      `Random Data Eigenvalue` = random_eigenvalue,
       `Kaiser Criterion` = ifelse(kaiser_adopted, "Adopted", "Not Adopted"),
-      # Column name "Adoption", not PCA's "Selected": the cells read "Adopted" / "Not Adopted", so a
-      # "Selected" header would not agree with its own values in the English report. Both map to
-      # 採否 / 採用 / 非採用 in Japanese. (tam#37340)
-      Adoption = ifelse(selected_adopted, "Adopted", "Not Adopted"),
-      parallel_status = parallel_status,
+      `Parallel Analysis` = parallel_label,
+      `Adopted in Analysis` = ifelse(selected_adopted, "Adopted", "Not Adopted"),
       kaiser_status = ifelse(kaiser_adopted, "adopted", "not_adopted"),
+      parallel_status = parallel_status,
       selected_status = ifelse(selected_adopted, "adopted", "not_adopted")
     )
   }
   else if (type == "parallel_screeplot") {
-    par <- x$parallel
-    # The actual-data curve MUST be the same kind of eigenvalue the parallel analysis itself used
-    # (factor-model or SMC) -- not the plain correlation-matrix eigenvalues -- or the chart compares
-    # two different quantities against each other. (issue tam#37332 section 9)
-    if (is.null(par)) {
-      n_vars <- ncol(x$correlation)
-      eig <- rep(NA_real_, n_vars)
-      threshold <- rep(NA_real_, n_vars)
-    } else {
-      eig <- par$table$actual_eigenvalue
-      threshold <- par$table$random_eigenvalue_threshold
-    }
-    res <- tibble::tibble(Factor = seq_along(eig), Eigenvalue = eig, `Random Data Eigenvalue` = threshold)
+    diagnostics <- build_factor_count_diagnostics(x)
+    recommended_n <- if (is.null(x$parallel)) NA_integer_ else x$parallel$recommended_n
+    res <- diagnostics %>% dplyr::transmute(
+      Factor = factor_number,
+      `Actual Data Eigenvalue` = parallel_eigenvalue,
+      `Random Data Eigenvalue` = random_eigenvalue,
+      `Recommended Number of Factors` = recommended_n,
+      `Selected Number of Factors` = x$factors
+    )
   }
   else if (type == "score_coefficients") {
     # Factor score coefficients (因子得点係数 / SPSS's Factor Score Coefficient Matrix) -- the weights

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -508,6 +508,11 @@ exp_factanal <- function(df, ..., nfactors = 2, fm = "minres", scores = "regress
     # guarded so a singular/degenerate correlation matrix degrades to NA instead of aborting.
     fit$n_rows_used <- nrow(cleaned_df)
     fit$n_variables <- ncol(cleaned_df)
+    # Rows dropped by NA/Inf filtering (tam#37402). Compared against the post-sample
+    # input so sampling itself is NOT counted as "removed". Kept separately from
+    # n_rows_used so analysis_method can report both 「行数」 and 「削除された行数」.
+    fit$n_rows_input <- nrow(df)
+    fit$n_rows_excluded <- max(0L, as.integer(nrow(df) - nrow(cleaned_df)))
     # KMO and Bartlett take the correlation MATRIX (never the raw data): passing raw data would
     # make psych recompute a Pearson correlation internally and silently contradict a polychoric
     # fit. cortest.bartlett also needs n explicitly, or it assumes n = 100. (issue #26623)
@@ -806,22 +811,43 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     # formatC(format = "f") -- NOT format(nsmall = 4), which switches to scientific notation for a
     # small-but-above-threshold p (0.0002 rendered as "2e-04").
     bart_val <- if (is.na(p)) "N/A" else if (p < 0.0001) "< 0.0001" else formatC(p, format = "f", digits = 4)
-    rows_used <- if (length(x$n_rows_used) == 1L && !is.na(x$n_rows_used)) as.character(x$n_rows_used) else "N/A"
-    variables_used <- if (length(x$n_variables) == 1L && !is.na(x$n_variables)) as.character(x$n_variables) else "N/A"
+    # tam#37402: Rows Used / Variables Used are already shown in analysis_method
+    # (Number of Variables / Row Count), so keep this table to KMO + Bartlett only.
     res <- tibble::tibble(
-      Metric = c("KMO", "Bartlett's Test of Sphericity (P Value)", "Rows Used", "Variables Used"),
-      Value = c(kmo_val, bart_val, rows_used, variables_used),
-      Judgement = c(kj$label, bj$label, "", ""),
-      Description = c(kj$description, bj$description,
-                      "Number of rows used after removing missing values.",
-                      "Number of variables used in the analysis."),
-      status = c(kj$status, bj$status, "", "")
+      Metric = c("KMO", "Bartlett's Test of Sphericity (P Value)"),
+      Value = c(kmo_val, bart_val),
+      Judgement = c(kj$label, bj$label),
+      Description = c(kj$description, bj$description),
+      status = c(kj$status, bj$status)
     )
   }
   else if (type == "analysis_method") {
     # Report header table: what the numbers below were actually computed with. (issue #26623)
     cor_type <- if (is.null(x$correlation_type)) "pearson" else x$correlation_type
     rotation <- if (!is.null(x$rotation)) x$rotation else "none"
+    # 「削除された行数」directly under 「行数」 (tam#37402). Do NOT reuse PCA's "Rows Excluded"
+    # key -- that already maps to 除外された行数 in the client's VizUtil; this report wants
+    # 削除された行数, so the English-canonical Item is the distinct "Rows Removed".
+    # Format matches PCA's analysis_conditions ("12 (4.0%)"); old saved models without
+    # n_rows_excluded degrade to "N/A" so the row still exists and the table shape stays stable.
+    rows_removed_value <- {
+      if (is.null(x$n_rows_excluded) || length(x$n_rows_excluded) != 1L || is.na(x$n_rows_excluded)) {
+        "N/A"
+      } else {
+        n_ex <- as.integer(x$n_rows_excluded)
+        n_in <- if (!is.null(x$n_rows_input) && length(x$n_rows_input) == 1L && !is.na(x$n_rows_input)) {
+          as.integer(x$n_rows_input)
+        } else {
+          NA_integer_
+        }
+        if (is.na(n_in) || n_in <= 0L) {
+          as.character(n_ex)
+        } else {
+          pct <- n_ex / n_in * 100
+          paste0(n_ex, " (", format(round(pct, 1), nsmall = 1), "%)")
+        }
+      }
+    }
     res <- tibble::tibble(
       # The variable / row counts come FIRST (issue tam#37340): the section is now
       # 「分析条件とデータの確認」, which leads with what data was analyzed. The method rows keep
@@ -832,11 +858,13 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       # ALREADY carries with exactly the wanted JA (変数の数 / 行数) from PCA's analysis_conditions
       # table (#37268), so no new translation key is needed. Do NOT use "Number of Rows": that key
       # is bound to 行の数 elsewhere in the same map.
-      Item = c("Number of Variables", "Row Count", "Correlation", "Factor Extraction Method",
-               "Rotation", "Parallel Analysis Method"),
+      # tam#37402: "Rows Removed" sits directly under "Row Count", before Correlation.
+      Item = c("Number of Variables", "Row Count", "Rows Removed", "Correlation",
+               "Factor Extraction Method", "Rotation", "Parallel Analysis Method"),
       Value = c(
         if (length(x$n_variables) == 1L && !is.na(x$n_variables)) as.character(x$n_variables) else "N/A",
         if (length(x$n_rows_used) == 1L && !is.na(x$n_rows_used)) as.character(x$n_rows_used) else "N/A",
+        rows_removed_value,
         factanal_correlation_label(cor_type),
         factanal_extraction_method_label(x$fm),
         factanal_rotation_label(rotation),
@@ -906,19 +934,22 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     # 「因子数の判定」 section (issue tam#37340). Same shape as prcomp.R's "variances_judged" branch
     # so the client can reuse the PCA table's viz configuration.
     #
-    # One row per correlation-matrix eigenvalue (i.e. per VARIABLE, not per extracted factor): the
-    # judgments only mean something when every candidate factor is listed, exactly like PCA's
-    # PC1..PCn. Eigenvalue / % Variance / Cummulated % Variance therefore all come off the SAME
-    # eigen(x$correlation) basis the screeplot / parallel_screeplot / factor_count branches use --
-    # NOT psych's Vaccounted "Proportion Var", which only exists for the extracted factors and
-    # would leave the remaining rows empty. So the ratios here are eigenvalue shares and can
-    # legitimately differ from the 「各因子の寄与率」 chart, which is Vaccounted-based.
-    eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
-    n_row <- length(eig)
-    total_variance <- sum(eig)
-    pct_variance <- if (is.finite(total_variance) && total_variance != 0) eig / total_variance * 100 else rep(NA_real_, n_row)
+    # One row per variable (every candidate factor), exactly like PCA's PC1..PCn.
+    # DISPLAYED Eigenvalue / % Variance MUST match parallel_screeplot (tam#37402): that chart
+    # uses the parallel-analysis actual eigenvalues (factor-model or SMC), NOT the plain
+    # correlation-matrix eigenvalues. Showing eigen(x$correlation) here made Factor 2 read
+    # 1.82 in the table while the scree tooltip showed 1.1 for the same factor.
+    # Kaiser Criterion still judges against the correlation-matrix eigenvalues (> 1) -- that is
+    # the traditional Kaiser rule and matches factor_count's kaiser_n. So the Kaiser column can
+    # disagree with a naive reading of the displayed (factor-model) Eigenvalue; that is
+    # intentional.
+    # % Variance here remains an eigenvalue-share and can legitimately differ from the
+    # 「各因子の寄与率」 chart, which is Vaccounted-based.
+    corr_eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
+    n_row <- length(corr_eig)
     par <- x$parallel
     if (is.null(par)) {
+      eig <- corr_eig
       parallel_label <- rep("Not Available", n_row)
       parallel_status <- rep("na", n_row)
     }
@@ -929,16 +960,17 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       threshold <- rep(NA_real_, n_row)
       actual[ptbl$factor_number[in_range]] <- ptbl$actual_eigenvalue[in_range]
       threshold[ptbl$factor_number[in_range]] <- ptbl$random_eigenvalue_threshold[in_range]
+      # Prefer parallel's actual eigenvalues for the displayed column (same curve as the scree).
+      # Fall back to correlation-matrix eigenvalues only where parallel did not return a value.
+      eig <- ifelse(!is.na(actual), actual, corr_eig)
       adopted <- !is.na(actual) & !is.na(threshold) & actual > threshold
       parallel_label <- ifelse(adopted, "Adopted", "Not Adopted")
       parallel_status <- ifelse(adopted, "adopted", "not_adopted")
     }
-    # Kaiser is always meaningful here: factor analysis always fits a correlation matrix, so the
-    # eigenvalue >= 1 rule applies unconditionally (unlike PCA, where a covariance-scaled fit makes
-    # it "na"). The comparison matches the factor_count branch's kaiser_n (eig > 1).
-    # "Adopted" / "Not Adopted", not PCA's "Adopt" / "Not Adopted": the pair reads as a judgment in
-    # the English report, and both map to the same 採用 / 非採用 in Japanese. (tam#37340)
-    kaiser_adopted <- eig > 1
+    total_variance <- sum(eig, na.rm = TRUE)
+    pct_variance <- if (is.finite(total_variance) && total_variance != 0) eig / total_variance * 100 else rep(NA_real_, n_row)
+    # Kaiser always uses the correlation-matrix eigenvalues (traditional rule).
+    kaiser_adopted <- corr_eig > 1
     # Adopted = the factors this analysis actually extracted (the nfactors setting).
     selected_adopted <- seq_len(n_row) <= n_factor
     res <- tibble::tibble(

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -935,21 +935,20 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
     # so the client can reuse the PCA table's viz configuration.
     #
     # One row per variable (every candidate factor), exactly like PCA's PC1..PCn.
-    # DISPLAYED Eigenvalue / % Variance MUST match parallel_screeplot (tam#37402): that chart
-    # uses the parallel-analysis actual eigenvalues (factor-model or SMC), NOT the plain
-    # correlation-matrix eigenvalues. Showing eigen(x$correlation) here made Factor 2 read
-    # 1.82 in the table while the scree tooltip showed 1.1 for the same factor.
-    # Kaiser Criterion still judges against the correlation-matrix eigenvalues (> 1) -- that is
-    # the traditional Kaiser rule and matches factor_count's kaiser_n. So the Kaiser column can
-    # disagree with a naive reading of the displayed (factor-model) Eigenvalue; that is
-    # intentional.
+    # DISPLAYED Eigenvalue / % Variance use the correlation-matrix eigenvalues
+    # (eigen(x$correlation)). Factor-model / SMC eigenvalues used by parallel analysis can be
+    # negative and their signed sum is far smaller than n_vars, so using them for % Variance
+    # produced values above 100% and negative contribution rates (tam#37402 follow-up).
+    # Parallel Analysis still judges against those parallel actuals vs the random threshold;
+    # Kaiser Criterion still uses corr_eig > 1. The parallel screeplot may therefore show a
+    # different Eigenvalue number than this table for the same factor -- that is intentional.
     # % Variance here remains an eigenvalue-share and can legitimately differ from the
     # 「各因子の寄与率」 chart, which is Vaccounted-based.
     corr_eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     n_row <- length(corr_eig)
+    eig <- corr_eig
     par <- x$parallel
     if (is.null(par)) {
-      eig <- corr_eig
       parallel_label <- rep("Not Available", n_row)
       parallel_status <- rep("na", n_row)
     }
@@ -960,9 +959,6 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
       threshold <- rep(NA_real_, n_row)
       actual[ptbl$factor_number[in_range]] <- ptbl$actual_eigenvalue[in_range]
       threshold[ptbl$factor_number[in_range]] <- ptbl$random_eigenvalue_threshold[in_range]
-      # Prefer parallel's actual eigenvalues for the displayed column (same curve as the scree).
-      # Fall back to correlation-matrix eigenvalues only where parallel did not return a value.
-      eig <- ifelse(!is.na(actual), actual, corr_eig)
       adopted <- !is.na(actual) & !is.na(threshold) & actual > threshold
       parallel_label <- ifelse(adopted, "Adopted", "Not Adopted")
       parallel_status <- ifelse(adopted, "adopted", "not_adopted")

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -51,7 +51,7 @@ test_that("exp_factanal with default orthogonal varimax rotation", {
     # New report tidy types (issue #37018).
     res <- model_df %>% tidy_rowwise(model, type="suitability")
     expect_equal(colnames(res), c("Metric", "Value", "Judgement", "Description", "status"))
-    expect_equal(res$Metric, c("KMO", "Bartlett's Test of Sphericity (P Value)", "Rows Used", "Variables Used")) # #37340
+    expect_equal(res$Metric, c("KMO", "Bartlett's Test of Sphericity (P Value)")) # #37340; Rows Used/Variables Used dropped in #37402
     res <- model_df %>% tidy_rowwise(model, type="factor_count")
     expect_equal(colnames(res), c("Method", "Recommended Number of Factors", "Description"))
     expect_equal(res$Method, c("Kaiser Criterion", "Parallel Analysis", "Scree Plot"))
@@ -452,8 +452,7 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
                  rotate = "varimax", cor_type = "pearson", parallel_n_iter = 5)
   fit <- model_df$model[[1]]
 
-  # --- variances_judged: one row per correlation-matrix eigenvalue (per VARIABLE, like PCA's PCn),
-  # so every candidate factor is judged -- not just the extracted ones.
+  # --- variances_judged: one row per variable (every candidate factor, like PCA's PCn).
   judged <- tidy(fit, type = "variances_judged")
   expect_equal(colnames(judged),
                c("Factor", "Eigenvalue", "% Variance", "Cummulated % Variance",
@@ -462,15 +461,16 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   n_var <- length(fit$communality)
   expect_equal(nrow(judged), n_var)
   expect_equal(judged$Factor, as.character(seq_len(n_var)))
-  # Eigenvalues come off eigen(x$correlation) -- the SAME basis as screeplot / parallel_screeplot,
-  # descending, and the ratios are eigenvalue shares summing to 100%.
-  expect_equal(judged$Eigenvalue, eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values)
+  # Displayed Eigenvalue matches parallel_screeplot (factor-model / SMC actuals), NOT the plain
+  # correlation-matrix eigenvalues -- otherwise the scree tooltip and this table disagree (tam#37402).
+  scree <- tidy(fit, type = "parallel_screeplot")
+  expect_equal(judged$Eigenvalue, scree$Eigenvalue)
   expect_equal(sum(judged$`% Variance`), 100)
   expect_equal(judged$`Cummulated % Variance`, cumsum(judged$`% Variance`))
   expect_equal(judged$`Cummulated % Variance`[[n_var]], 100)
-  # Kaiser mirrors the factor_count branch's kaiser_n (eigenvalue > 1) and is ALWAYS judged for
-  # factor analysis (always a correlation matrix) -- never "na" the way covariance-scaled PCA is.
-  expect_equal(sum(judged$kaiser_status == "adopted"), sum(judged$Eigenvalue > 1))
+  # Kaiser still uses correlation-matrix eigenvalues (> 1), matching factor_count's kaiser_n.
+  corr_eig <- eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values
+  expect_equal(sum(judged$kaiser_status == "adopted"), sum(corr_eig > 1))
   expect_false(any(judged$kaiser_status == "na"))
   # Selected = the factors this analysis actually extracted (nfactors), first rows only.
   expect_equal(judged$selected_status, ifelse(seq_len(n_var) <= 2, "adopted", "not_adopted"))
@@ -481,24 +481,29 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   expect_true(all(judged$`Kaiser Criterion` %in% c("Adopted", "Not Adopted")))
   expect_true(all(judged$parallel_status %in% c("adopted", "not_adopted", "na")))
   # Parallel analysis unavailable (old saved model) degrades to Not Available / na, same shape.
+  # Displayed Eigenvalue then falls back to correlation-matrix eigenvalues.
   no_par <- fit
   no_par$parallel <- NULL
   judged_no_par <- tidy(no_par, type = "variances_judged")
   expect_equal(unique(judged_no_par$`Parallel Analysis`), "Not Available")
+  expect_equal(judged_no_par$Eigenvalue, corr_eig)
   expect_equal(unique(judged_no_par$parallel_status), "na")
   expect_equal(nrow(judged_no_par), n_var)
 
   # --- analysis_method: counts first, then the method rows (#37340).
   method_tbl <- tidy(fit, type = "analysis_method")
-  expect_equal(method_tbl$Item, c("Number of Variables", "Row Count", "Correlation",
+  expect_equal(method_tbl$Item, c("Number of Variables", "Row Count", "Rows Removed", "Correlation",
                                   "Factor Extraction Method", "Rotation", "Parallel Analysis Method"))
   expect_equal(method_tbl$Value[[1]], as.character(n_var))
   expect_equal(method_tbl$Value[[2]], as.character(nrow(mtcars)))
-  expect_equal(method_tbl$Value[[3]], "Pearson Correlation")
+  # mtcars has no NAs on the selected columns, so nothing was removed. (tam#37402)
+  expect_equal(method_tbl$Value[[3]], "0 (0.0%)")
+  expect_equal(method_tbl$Value[[4]], "Pearson Correlation")
 
   # --- suitability: Metric names the P value, the Value cell holds the value ONLY, and the
   # small-p threshold is 0.0001 (was 0.001).
   suit <- tidy(fit, type = "suitability")
+  expect_equal(nrow(suit), 2) # Rows Used / Variables Used removed (tam#37402)
   expect_equal(suit$Metric[[2]], "Bartlett's Test of Sphericity (P Value)")
   expect_false(grepl("p", suit$Value[[2]], fixed = TRUE)) # no "p < " / "p = " prefix
   expect_true(grepl("^(< 0\\.0001|[0-9]+\\.[0-9]{4}|N/A)$", suit$Value[[2]]))
@@ -514,6 +519,28 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   expect_equal(tidy(fake, type = "suitability")$Value[[2]], "0.0300")
   fake$bartlett <- NULL
   expect_equal(tidy(fake, type = "suitability")$Value[[2]], "N/A")
+})
+
+test_that("analysis_method reports Rows Removed under Row Count (tam#37402)", {
+  # Inject missing values so preprocess_factanal_data_before_sample drops rows. Sampling is
+  # NOT counted as removed -- only the NA/Inf filter is.
+  df <- mtcars[, c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec")]
+  df$mpg[1:5] <- NA_real_
+  fit <- exp_factanal(df, mpg, cyl, disp, hp, drat, wt, qsec, nfactors = 2, fm = "minres",
+                      rotate = "varimax", cor_type = "pearson", parallel_n_iter = 3)$model[[1]]
+  expect_equal(fit$n_rows_excluded, 5L)
+  expect_equal(fit$n_rows_used, nrow(df) - 5L)
+  method_tbl <- tidy(fit, type = "analysis_method")
+  expect_equal(method_tbl$Item[[2]], "Row Count")
+  expect_equal(method_tbl$Item[[3]], "Rows Removed")
+  expect_equal(method_tbl$Item[[4]], "Correlation")
+  expect_equal(method_tbl$Value[[2]], as.character(nrow(df) - 5L))
+  expect_equal(method_tbl$Value[[3]], paste0("5 (", format(round(5 / nrow(df) * 100, 1), nsmall = 1), "%)"))
+  # Old saved models without n_rows_excluded still emit the row as N/A so the table shape is stable.
+  legacy <- fit
+  legacy$n_rows_excluded <- NULL
+  legacy$n_rows_input <- NULL
+  expect_equal(tidy(legacy, type = "analysis_method")$Value[[3]], "N/A")
 })
 
 test_that("report part 3: an over-parameterized fit legitimately has no fit test (issue tam#37340)", {

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -57,7 +57,8 @@ test_that("exp_factanal with default orthogonal varimax rotation", {
     expect_equal(res$Method, c("Kaiser Criterion", "Parallel Analysis", "Scree Plot"))
     expect_equal(res$`Recommended Number of Factors`[3], "Check the chart")
     res <- model_df %>% tidy_rowwise(model, type="parallel_screeplot")
-    expect_equal(colnames(res), c("Factor", "Eigenvalue", "Random Data Eigenvalue"))
+    expect_equal(colnames(res), c("Factor", "Actual Data Eigenvalue", "Random Data Eigenvalue",
+                                  "Recommended Number of Factors", "Selected Number of Factors"))
     res <- model_df %>% tidy_rowwise(model, type="loadings_wide")
     expect_equal(colnames(res), c("variable", "Factor 1", "Factor 2", "Factor 3", "Judgement", "judgement_status", "primary_factor", "secondary_factors", "direction"))
     # Every status token must be one of the known set (guards against a typo drifting from the client tooltip keys).
@@ -311,7 +312,7 @@ test_that("factor analysis report judgment helpers (issue #37018)", {
   expect_equal(judge_loading(c(`Factor 1` = NA_real_, `Factor 2` = NA_real_))$status, "na")
   old_fa <- structure(list(), class = "fa_exploratory")
   expect_equal(tidy.fa_exploratory(old_fa, type = "suitability")$Value,
-               c("N/A", "N/A", "N/A", "N/A"))
+               c("N/A", "N/A"))
 
   # Communality bar (#37018): a Heywood case (communality > 1) leaves communality UNCAPPED so the
   # numeric label shows the actual value (e.g. 105); the chart's 0-100 value-axis range clips the
@@ -411,8 +412,8 @@ test_that("parallel analysis method: factor_model vs smc (issue #37332)", {
   # factor-model/SMC eigenvalues differ from PCA-style correlation-matrix eigenvalues.
   screeplot_res <- model_df %>% tidy_rowwise(model, type = "screeplot")
   parallel_screeplot_res <- model_df %>% tidy_rowwise(model, type = "parallel_screeplot")
-  expect_equal(parallel_screeplot_res$Eigenvalue, fit$parallel$table$actual_eigenvalue)
-  expect_false(isTRUE(all.equal(parallel_screeplot_res$Eigenvalue, screeplot_res$eigenvalue)))
+  expect_equal(parallel_screeplot_res$`Actual Data Eigenvalue`, fit$parallel$table$actual_eigenvalue)
+  expect_false(isTRUE(all.equal(parallel_screeplot_res$`Actual Data Eigenvalue`, screeplot_res$eigenvalue)))
   # The normal (non-parallel) scree plot is untouched by the method selection (issue #37332 section 10).
   expect_equal(screeplot_res$eigenvalue, eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values)
 
@@ -452,30 +453,25 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
                  rotate = "varimax", cor_type = "pearson", parallel_n_iter = 5)
   fit <- model_df$model[[1]]
 
-  # --- variances_judged: one row per variable (every candidate factor, like PCA's PCn).
+  # --- variances_judged: one row per variable with all three eigenvalue series used by
+  # the factor-count diagnostics (tam#37440).
   judged <- tidy(fit, type = "variances_judged")
   expect_equal(colnames(judged),
-               c("Factor", "Eigenvalue", "% Variance", "Cummulated % Variance",
-                 "Parallel Analysis", "Kaiser Criterion", "Adoption",
-                 "parallel_status", "kaiser_status", "selected_status"))
+               c("Factor", "Correlation Matrix Eigenvalue", "Parallel Analysis Eigenvalue",
+                 "Random Data Eigenvalue", "Kaiser Criterion", "Parallel Analysis",
+                 "Adopted in Analysis", "kaiser_status", "parallel_status", "selected_status"))
   n_var <- length(fit$communality)
   expect_equal(nrow(judged), n_var)
   expect_equal(judged$Factor, as.character(seq_len(n_var)))
-  # Displayed Eigenvalue / % Variance use correlation-matrix eigenvalues (not parallel
-  # factor-model actuals). Parallel actuals can be negative and make % Variance exceed 100%
-  # or go negative when used as the share basis (tam#37402 follow-up).
   corr_eig <- eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values
-  expect_equal(judged$Eigenvalue, corr_eig)
-  expect_equal(sum(judged$`% Variance`), 100)
-  expect_equal(judged$`Cummulated % Variance`, cumsum(judged$`% Variance`))
-  expect_equal(judged$`Cummulated % Variance`[[n_var]], 100)
-  expect_true(all(judged$`% Variance` >= 0 | !is.finite(judged$`% Variance`)))
+  expect_equal(judged$`Correlation Matrix Eigenvalue`, corr_eig)
+  expect_equal(judged$`Parallel Analysis Eigenvalue`, fit$parallel$table$actual_eigenvalue)
+  expect_equal(judged$`Random Data Eigenvalue`, fit$parallel$table$random_eigenvalue_threshold)
   # Kaiser still uses correlation-matrix eigenvalues (> 1), matching factor_count's kaiser_n.
   expect_equal(sum(judged$kaiser_status == "adopted"), sum(corr_eig > 1))
   expect_false(any(judged$kaiser_status == "na"))
-  # Selected = the factors this analysis actually extracted (nfactors), first rows only.
   expect_equal(judged$selected_status, ifelse(seq_len(n_var) <= 2, "adopted", "not_adopted"))
-  expect_equal(judged$Adoption, ifelse(seq_len(n_var) <= 2, "Adopted", "Not Adopted"))
+  expect_equal(judged$`Adopted in Analysis`, ifelse(seq_len(n_var) <= 2, "Adopted", "Not Adopted"))
   # Labels stay English-canonical; the client translates them. "Adopted" (not PCA's "Adopt") so the
   # English report reads as a judgment against "Not Adopted".
   expect_true(all(judged$`Parallel Analysis` %in% c("Adopted", "Not Adopted", "Not Available")))
@@ -486,7 +482,9 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   no_par$parallel <- NULL
   judged_no_par <- tidy(no_par, type = "variances_judged")
   expect_equal(unique(judged_no_par$`Parallel Analysis`), "Not Available")
-  expect_equal(judged_no_par$Eigenvalue, corr_eig)
+  expect_equal(judged_no_par$`Correlation Matrix Eigenvalue`, corr_eig)
+  expect_true(all(is.na(judged_no_par$`Parallel Analysis Eigenvalue`)))
+  expect_true(all(is.na(judged_no_par$`Random Data Eigenvalue`)))
   expect_equal(unique(judged_no_par$parallel_status), "na")
   expect_equal(nrow(judged_no_par), n_var)
 

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -461,15 +461,16 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   n_var <- length(fit$communality)
   expect_equal(nrow(judged), n_var)
   expect_equal(judged$Factor, as.character(seq_len(n_var)))
-  # Displayed Eigenvalue matches parallel_screeplot (factor-model / SMC actuals), NOT the plain
-  # correlation-matrix eigenvalues -- otherwise the scree tooltip and this table disagree (tam#37402).
-  scree <- tidy(fit, type = "parallel_screeplot")
-  expect_equal(judged$Eigenvalue, scree$Eigenvalue)
+  # Displayed Eigenvalue / % Variance use correlation-matrix eigenvalues (not parallel
+  # factor-model actuals). Parallel actuals can be negative and make % Variance exceed 100%
+  # or go negative when used as the share basis (tam#37402 follow-up).
+  corr_eig <- eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values
+  expect_equal(judged$Eigenvalue, corr_eig)
   expect_equal(sum(judged$`% Variance`), 100)
   expect_equal(judged$`Cummulated % Variance`, cumsum(judged$`% Variance`))
   expect_equal(judged$`Cummulated % Variance`[[n_var]], 100)
+  expect_true(all(judged$`% Variance` >= 0 | !is.finite(judged$`% Variance`)))
   # Kaiser still uses correlation-matrix eigenvalues (> 1), matching factor_count's kaiser_n.
-  corr_eig <- eigen(fit$correlation, symmetric = TRUE, only.values = TRUE)$values
   expect_equal(sum(judged$kaiser_status == "adopted"), sum(corr_eig > 1))
   expect_false(any(judged$kaiser_status == "na"))
   # Selected = the factors this analysis actually extracted (nfactors), first rows only.
@@ -481,7 +482,6 @@ test_that("report part 3: variances_judged, suitability P value format, analysis
   expect_true(all(judged$`Kaiser Criterion` %in% c("Adopted", "Not Adopted")))
   expect_true(all(judged$parallel_status %in% c("adopted", "not_adopted", "na")))
   # Parallel analysis unavailable (old saved model) degrades to Not Available / na, same shape.
-  # Displayed Eigenvalue then falls back to correlation-matrix eigenvalues.
   no_par <- fit
   no_par$parallel <- NULL
   judged_no_par <- tidy(no_par, type = "variances_judged")

--- a/tests/testthat/test_factanal_correlation.R
+++ b/tests/testthat/test_factanal_correlation.R
@@ -220,7 +220,7 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
   # client already carries), then the method rows, which keep their own order including the
   # Parallel Analysis Method row (tam#37332). Values are asserted BY ITEM NAME so a future reorder
   # does not silently pass with the wrong value.
-  expect_equal(method_tbl$Item, c("Number of Variables", "Row Count", "Correlation",
+  expect_equal(method_tbl$Item, c("Number of Variables", "Row Count", "Rows Removed", "Correlation",
                                   "Factor Extraction Method", "Rotation", "Parallel Analysis Method"))
   method_value <- function(tbl, item) tbl$Value[[which(tbl$Item == item)]]
   expect_equal(method_value(method_tbl, "Correlation"), "Polychoric Correlation")
@@ -230,6 +230,8 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
   expect_equal(method_value(method_tbl, "Parallel Analysis Method"), "Factor Model")
   expect_equal(method_value(method_tbl, "Number of Variables"), "6")
   expect_equal(method_value(method_tbl, "Row Count"), as.character(nrow(df)))
+  # Complete ordinal fixture -- no rows dropped for missing values. (tam#37402)
+  expect_equal(method_value(method_tbl, "Rows Removed"), "0 (0.0%)")
   # Hidden columns the client binds the report explanation from.
   expect_equal(unique(method_tbl$correlation_type), "polychoric")
   expect_true(all(method_tbl$correlation_is_auto == "TRUE"))
@@ -253,7 +255,8 @@ test_that("analysis_method and cor_diagnostics tidy types (issue #26623)", {
   empty <- tidy(pearson, type = "cor_diagnostics")
   expect_equal(nrow(empty), 0)
   expect_equal(colnames(empty), c("Diagnostic", "Judgement", "Description", "status"))
-  expect_equal(tidy(pearson, type = "analysis_method")$Value[[3]], "Pearson Correlation") # Correlation row (#37340 order)
+  pearson_am <- tidy(pearson, type = "analysis_method")
+  expect_equal(pearson_am$Value[[which(pearson_am$Item == "Correlation")]], "Pearson Correlation") # Correlation row (#37340/#37402 order)
 })
 
 test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
@@ -270,7 +273,8 @@ test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
   tet <- exp_factanal(binary_df, b1, b2, b3, b4, b5, b6, nfactors = 2, rotate = "varimax",
                       parallel_n_iter = 5)$model[[1]]
   expect_equal(tet$correlation_type, "tetrachoric")
-  expect_equal(tidy(tet, type = "analysis_method")$Value[[3]], "Tetrachoric Correlation") # Correlation row (#37340 order)
+  tet_am <- tidy(tet, type = "analysis_method")
+  expect_equal(tet_am$Value[[which(tet_am$Item == "Correlation")]], "Tetrachoric Correlation") # Correlation row (#37340/#37402 order)
   expect_false(is.null(tet$scores))
 
   mixed_df <- data.frame(x1 = lat1 + stats::rnorm(n, 0, .5), x2 = lat1 + stats::rnorm(n, 0, .5),
@@ -278,7 +282,8 @@ test_that("tetrachoric, mixed and unsupported paths (issue #26623)", {
   mixed <- exp_factanal(mixed_df, x1, x2, q1, q2, q3, nfactors = 2, rotate = "varimax",
                         parallel_n_iter = 5)$model[[1]]
   expect_equal(mixed$correlation_type, "mixed")
-  expect_equal(tidy(mixed, type = "analysis_method")$Value[[3]], "Mixed Correlation") # Correlation row (#37340 order)
+  mixed_am <- tidy(mixed, type = "analysis_method")
+  expect_equal(mixed_am$Value[[which(mixed_am$Item == "Correlation")]], "Mixed Correlation") # Correlation row (#37340/#37402 order)
 
   # A nominal column aborts with the analytics error code, not a raw psych error.
   nominal_df <- binary_df
@@ -336,7 +341,8 @@ test_that("verification pass 1 findings (issue #26623)", {
   expect_equal(factanal_rotation_label("none"), "None")
   rotated <- exp_factanal(df, q1, q2, q3, q4, q5, q6, nfactors = 2, rotate = "bentlerT",
                           cor_type = "polychoric", parallel_n_iter = 3)$model[[1]]
-  expect_equal(tidy(rotated, type = "analysis_method")$Value[[5]], "Bentler (Orthogonal)") # Rotation row (#37340 order)
+  rotated_am <- tidy(rotated, type = "analysis_method")
+  expect_equal(rotated_am$Value[[which(rotated_am$Item == "Rotation")]], "Bentler (Orthogonal)") # Rotation row (#37340/#37402 order)
 
   # A manual choice must not be reported as an automatic one, and must not read "Correlation
   # correlation".
@@ -628,7 +634,7 @@ test_that("a failed estimation degrades to Pearson end to end (issue #26623)", {
   expect_true(grepl("could not be estimated", fit$correlation_reason))
   expect_false(is.null(fit$cor_diagnostics))
   method_tbl <- tidy(fit, type = "analysis_method")
-  expect_equal(method_tbl$Value[[3]], "Pearson Correlation") # Correlation row (#37340 order)
+  expect_equal(method_tbl$Value[[which(method_tbl$Item == "Correlation")]], "Pearson Correlation") # Correlation row (#37340/#37402 order)
   expect_equal(method_tbl$degraded_from[[1]], "polychoric")
   expect_equal(method_tbl$has_diagnostics[[1]], "TRUE")
   diagnostics <- tidy(fit, type = "cor_diagnostics")


### PR DESCRIPTION
## Summary
- Emit **Rows Removed** in `analysis_method` directly under Row Count (NA/Inf drops only; sampling is not counted). English Item is `Rows Removed` so tam can map it to 削除された行数 (not PCA's Rows Excluded → 除外された行数).
- Drop **Rows Used / Variables Used** from `suitability` (already shown in analysis_method as Number of Variables / Row Count).
- Make `variances_judged` **display** the parallel-analysis actual eigenvalues so the 因子数の判定 table matches the scree plot; Kaiser judgment still uses correlation-matrix eigenvalues (> 1).

Version: **16.0.30**

Related: tam#37402 / https://github.com/exploratory-io/tam/pull/37411

## Test plan
- [ ] `test_factanal.R` / `test_factanal_correlation.R` green
- [ ] Live: analysis_method shows Rows Removed under Row Count
- [ ] Live: suitability has only KMO + Bartlett
- [ ] Live: scree tooltip eigenvalue matches 因子数の判定 Eigenvalue for the same factor

Made with [Cursor](https://cursor.com)