### PR TITLE
WIP: Thread a guess_max parameter through Excel import so type detection scans the whole file

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -3713,14 +3713,14 @@ download_data_file <- function(url, type){
 
 #'API that searches and imports multiple same structure Excel Sheets in the Excel Book and merge them to a single data frame
 #'@export
-searchAndReadExcelFileMultiSheets <- function(file, forPreview = FALSE, pattern = "", col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
+searchAndReadExcelFileMultiSheets <- function(file, forPreview = FALSE, pattern = "", col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, guess_max = min(1000, n_max), use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
   # search condition is case insensitive. (ref: https://www.regular-expressions.info/modifiers.html, https://stackoverflow.com/questions/5671719/case-insensitive-search-of-a-list-in-r)
   sheets <- readxl::excel_sheets(file)
   sheets <- sheets[stringr::str_detect(sheets, pattern)]
   if (length(sheets) == 0) {
     stop(paste0('EXP-DATASRC-20 :: ', jsonlite::toJSON(file), ' :: There is no sheet in the file that matches with the specified condition.'))
   }
-  exploratory::read_excel_file_multi_sheets(file = file, forPreview = forPreview, sheets = sheets, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max,
+  exploratory::read_excel_file_multi_sheets(file = file, forPreview = forPreview, sheets = sheets, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, guess_max = guess_max,
                                 use_readxl = use_readxl, detectDates = detectDates, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names,
                                 tzone = tzone, convertDataTypeToChar = convertDataTypeToChar)
 
@@ -3744,7 +3744,7 @@ glob_to_regex <- function(pattern) {
 
 #'API that searches and imports multiple same structure Excel files and merge them to a single data frame
 #'@export
-searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
+searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, guess_max = min(1000, n_max), use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
   # search condition is case insensitive. (ref: https://www.regular-expressions.info/modifiers.html, https://stackoverflow.com/questions/5671719/case-insensitive-search-of-a-list-in-r)
   if (!dir.exists(folder)) {
     stop(paste0('EXP-DATASRC-2 :: ', jsonlite::toJSON(folder), ' :: The folder does not exist.')) # TODO: escape folder name.
@@ -3771,7 +3771,7 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
   if (length(files) == 0) {
     stop(paste0('EXP-DATASRC-3 :: ', jsonlite::toJSON(folder), ' :: There is no file in the folder that matches with the specified condition.')) # TODO: escape folder name.
   }
-  exploratory::read_excel_files(files = as.character(files), forPreview = forPreview, sheet = sheet, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max,
+  exploratory::read_excel_files(files = as.character(files), forPreview = forPreview, sheet = sheet, col_names = col_names, col_types = col_types, na = na, skip = skip, trim_ws = trim_ws, n_max = n_max, guess_max = guess_max,
                                 use_readxl = use_readxl, detectDates = detectDates, skipEmptyRows = skipEmptyRows, skipEmptyCols = skipEmptyCols, check.names = check.names,
                                 tzone = tzone, convertDataTypeToChar = convertDataTypeToChar)
 
@@ -3782,7 +3782,7 @@ searchAndReadExcelFiles <- function(folder, forPreview = FALSE, pattern = "", sh
 #'From the Exploratory Desktop, this argument is set as c("Sheet1", "Sheet2", "Sheet3") style.
 #'NOTE: readxl package can handle either sheet name or sheet index for the "sheet" argument and the sheet index starts from 1.
 #'@export
-read_excel_file_multi_sheets <- function(file, forPrevew = FALSE, sheets = c(1), col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
+read_excel_file_multi_sheets <- function(file, forPrevew = FALSE, sheets = c(1), col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, guess_max = min(1000, n_max), use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
   # set name to the files so that it can be used for the "id" column created by purrr::map_dfr.
   sheets <- setNames(as.list(sheets), sheets)
   df <- purrr::map_dfr(sheets, .f = ~exploratory::read_excel_file(
@@ -3794,6 +3794,7 @@ read_excel_file_multi_sheets <- function(file, forPrevew = FALSE, sheets = c(1),
                        skip = skip,
                        trim_ws = trim_ws,
                        n_max = n_max,
+                       guess_max = guess_max,
                        use_readxl = use_readxl,
                        detectDates = detectDates,
                        skipEmptyRows = skipEmptyRows,
@@ -3816,7 +3817,7 @@ read_excel_file_multi_sheets <- function(file, forPrevew = FALSE, sheets = c(1),
 
 #'API that imports multiple same structure Excel files and merge it to a single data frame
 #'@export
-read_excel_files <- function(files, forPreview = FALSE, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
+read_excel_files <- function(files, forPreview = FALSE, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, guess_max = min(1000, n_max), use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = TRUE, ...) {
     # for preview mode, just use the first file.
     if (forPreview & length(files) > 0) {
       files <- files[1]
@@ -3830,6 +3831,7 @@ read_excel_files <- function(files, forPreview = FALSE, sheet = 1, col_names = T
            skip = skip,
            trim_ws = trim_ws,
            n_max = n_max,
+           guess_max = guess_max,
            use_readxl = use_readxl,
            detectDates = detecDates,
            skipEmptyRows = skipEmptyRows,
@@ -3851,7 +3853,7 @@ read_excel_files <- function(files, forPreview = FALSE, sheet = 1, col_names = T
 #'Wrapper for openxlsx::read.xlsx (in case of .xlsx file) and readxl::read_excel (in case of old .xls file)
 #'Use openxlsx::read.xlsx since it's memory footprint is less than that of readxl::read_excel and this creates benefit for users with less memory like Windows 32 bit users.
 #'@export
-read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = FALSE, ...){
+read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL, na = "", skip = 0, trim_ws = TRUE, n_max = Inf, guess_max = min(1000, n_max), use_readxl = NULL, detectDates = FALSE, skipEmptyRows = FALSE, skipEmptyCols = FALSE, check.names = FALSE, tzone = NULL, convertDataTypeToChar = FALSE, ...){
   loadNamespace("openxlsx")
   loadNamespace('readxl')
   loadNamespace('stringr')
@@ -3908,18 +3910,18 @@ read_excel_file <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
           stringr::str_detect(path, "^ftp://")) {
         # need to download first since readxl::read_excel cannot work with URL.
         tmp <- download_data_file(path, "excel")
-        df <- readxl::read_excel(tmp, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max)
+        df <- readxl::read_excel(tmp, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max)
       } else {
         # On Windows, if the path has multibyte chars, work around error from readxl::read_excel by copying the file to temp directory.
         if (Sys.info()[["sysname"]] == "Windows" && grepl("[^ -~]", path)) {
           new_path <- tempfile(fileext = stringr::str_c(".", tools::file_ext(path)))
           fs::file_copy(path, new_path) # Using file_copy since file.copy fails with some paths with multibyte chars. #26852
-          df <- readxl::read_excel(new_path, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max)
+          df <- readxl::read_excel(new_path, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max)
           file.remove(new_path)
         }
         else {
           # If it's local file without multibyte path, simply call readxl::read_excel
-          df <- readxl::read_excel(path, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max)
+          df <- readxl::read_excel(path, sheet = sheet, col_names = col_names, col_types = col_types, na = na, trim_ws = trim_ws, skip = skip, n_max = n_max, guess_max = guess_max)
         }
       }
       if(col_names == FALSE) {

--- a/tests/testthat/test_system.R
+++ b/tests/testthat/test_system.R
@@ -696,6 +696,49 @@ test_that("read_excel_files", {
   expect_equal(colnames(df), c("id", "放送...1", "放送...2", "個人...3", "個人...4"))
 })
 
+# tam issue #37277 - "Data Source: Excel: Determine column data types like CSV."
+# Regression coverage for the new guess_max parameter threaded through
+# read_excel_file(): readxl's own default (min(1000, n_max) == 1000 rows for a
+# real, non-preview import where n_max defaults to Inf) samples ONLY the first
+# guess_max rows sequentially from the top of the sheet, unlike CSV import. So a
+# column whose first 1000+ rows are blank is misdetected (typically as logical),
+# and any real value appearing later in the file is silently discarded/coerced to
+# NA on read. Passing a guess_max large enough to cover the whole sheet (which
+# tam's RTranslator.toImportExcelScriptParameters now does for every real
+# import/update/refresh) must fix this without needing any col_types override.
+test_that("read_excel_file: guess_max controls whether a column with many leading blank rows is typed correctly", {
+  skip_if_not_installed("openxlsx")
+
+  t_file <- tempfile(fileext = ".xlsx")
+  n_blank <- 1010 # just over readxl's default guess_max of 1000, keeps the test fast
+  id_col <- as.character(seq_len(n_blank + 3))
+  # A column that looks blank/NA for far more than 1000 rows, then contains
+  # genuine date-like text further down the sheet (e.g. imported/typed as text
+  # by the source system, matching the reported customer-ID/date scenario).
+  mystery_col <- c(rep(NA_character_, n_blank), "2024-01-01", "2024-01-02", "2024-01-03")
+  df_in <- data.frame(id = id_col, mystery_col = mystery_col, stringsAsFactors = FALSE)
+  openxlsx::write.xlsx(df_in, t_file)
+  on.exit(unlink(t_file), add = TRUE)
+
+  # With readxl's default guess_max (1000, driven off the default n_max = Inf),
+  # the long leading run of NAs makes the column guess as logical, and the real
+  # values that appear after row 1000 are dropped to NA.
+  df_default_guess <- exploratory::read_excel_file(t_file)
+  expect_true(is.logical(df_default_guess$mystery_col))
+  expect_true(all(is.na(df_default_guess$mystery_col)))
+
+  # With a guess_max that covers the whole sheet (what tam now generates for a
+  # real, non-preview import), the trailing real values are seen during type
+  # guessing and the column comes back as character with its data intact --
+  # matching CSV import's whole-file type detection.
+  df_full_guess <- exploratory::read_excel_file(t_file, guess_max = n_blank + 3)
+  expect_true(is.character(df_full_guess$mystery_col))
+  expect_equal(
+    df_full_guess$mystery_col[(n_blank + 1):(n_blank + 3)],
+    c("2024-01-01", "2024-01-02", "2024-01-03")
+  )
+})
+
 test_that("test setConnectionPoolMode", {
   # Save the original pool_connection value to restore later
   original_pool_connection <- exploratory::getConnectionPoolMode()


### PR DESCRIPTION
## Companion PR for Desktop — "Data Source: Excel: Determine column data types like CSV."

This is the R-side half of the fix. The tam-side PR (JS) is: [exploratory-io/tam#37451](https://github.com/exploratory-io/tam/pull/37451)

### Root cause

`read_excel_file()` (and the multi-file / multi-sheet / search-mode wrappers built on top of it — `read_excel_files()`, `read_excel_file_multi_sheets()`, `searchAndReadExcelFiles()`, `searchAndReadExcelFileMultiSheets()`) call `readxl::read_excel(...)` without ever passing a `guess_max` argument. That means readxl always falls back to its own default, `min(1000, n_max)` — which is **1000 rows** for a real (non-preview) import, since `n_max` defaults to `Inf` there.

Unlike CSV import (`read_delim_file`, which already exposes `guess_max`), an Excel column whose first ~1000 rows are blank/NA (or otherwise unrepresentative — e.g. an ID column that's purely numeric for thousands of rows before turning alphanumeric) gets misdetected using only that early slice — typically as `Logical` — and any real values that appear later in the sheet are silently coerced to `NA` on read. That's the exact symptom in the issue.

### Fix

Add `guess_max = min(1000, n_max)` as an explicit, **backward-compatible default** parameter (identical to the value readxl would have computed implicitly before, so every existing caller — including the S3/Azure/GCS/Google Drive Excel readers, which are not touched here — keeps its current behavior unless it's given a larger value). Forward it into every `readxl::read_excel(...)` call site inside `read_excel_file()`, and thread it through the wrapper functions that call `read_excel_file()`/`read_excel_files()`.

The companion tam PR passes an explicit `guess_max` large enough to cover the whole sheet (`1048576`, the `.xlsx` max row count) for real (non-preview) imports only — preview/dialog-apply keeps the small, fast default.

### Tests

Added a self-contained `testthat` test in `tests/testthat/test_system.R` (`read_excel_file: guess_max controls whether a column with many leading blank rows is typed correctly`) that:
1. Builds a synthetic `.xlsx` via `openxlsx::write.xlsx` with 1010 leading blank rows in a column, followed by real date-like text — no network access needed.
2. Asserts the column comes back as `logical`/all-`NA` with readxl's default `guess_max`.
3. Asserts the column comes back as `character` with the real values intact when `guess_max` is explicitly set to cover the whole sheet.

**I do not have R / an Rserve connection available in this sandbox and could not execute this test.** Please run it (and ideally reproduce the original issue with a real customer-shaped file) before merging. Per this repo's `r-codegen-fix-live-execution-required` convention, this needs live verification.

### Known follow-ups / things I could not do here

- **This has zero effect until a new package version is built, bumped in tam's `tools/requiredRPackagesReduced.json`, regenerated via `tools/build_required_r_packages.sh`, and the per-platform binaries are built + published to `download2.exploratory.io`.** I have no build/publish infrastructure in this sandbox (see this repo's `r-upgrade`-style release process) — a human needs to do this before the fix is live anywhere.
- Did **not** bump `DESCRIPTION`'s `Version` — didn't want to imply a real release without an actual build.
- Did **not** thread `guess_max` through the S3/Azure/GCS/Google Drive Excel readers (`R/aws_s3.R`, `R/azure.R`, `R/google_cloud_storage.R`, `R/google_drive.R`) — they all call `read_excel_file(...)` with named args and no `guess_max`, so they keep the current 1000-row behavior. Flagging as a follow-up scope decision, not an oversight — the reported issue is about local Excel file import.
- Noticed a pre-existing, unrelated typo in `read_excel_files()`: `detectDates = detecDates` (missing "t") passes an undefined R symbol. Left untouched to keep this PR scoped to #37277 — worth a separate look.

Co-Authored-By: Claude Sonnet 5 &lt;noreply@anthropic.com&gt;
