### PR TITLE
Add rpart multiclass probability report data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.35
-Date: 2026-08-02
+Version: 16.0.36
+Date: 2026-08-04
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2788,6 +2788,67 @@ multiclass_auc_by_class <- function(actual, probability_matrix) {
   dplyr::bind_rows(rows)
 }
 
+# Return one-vs-rest probability rows for a multi-category rpart model. The
+# regular prediction() contract exposes only the winning probability, so the
+# report needs this model-aware data surface for category curves/density.
+dtree_report_multiclass_probabilities <- function(df) {
+  if (!is.data.frame(df) || !"model" %in% colnames(df)) return(data.frame())
+
+  model <- df$model[[1]]
+  if (is.null(model) || !inherits(model, "rpart") || !identical(model$classification_type, "multi")) {
+    return(data.frame())
+  }
+
+  source_data <- if ("source.data" %in% colnames(df)) df$source.data[[1]] else NULL
+  if (is.null(source_data) || !is.data.frame(source_data)) return(data.frame())
+
+  test_index <- if (".test_index" %in% colnames(df)) as.integer(df$.test_index[[1]]) else integer(0)
+  train_data <- if (length(test_index) > 0) source_data[-test_index, , drop = FALSE] else source_data
+  test_data <- if (length(test_index) > 0) source_data[test_index, , drop = FALSE] else source_data[0, , drop = FALSE]
+
+  target_col <- model$orig_target_col
+  if (is.null(target_col) || !target_col %in% colnames(source_data)) return(data.frame())
+
+  levels_target <- attr(model, "ylevels")
+  if (is.null(levels_target)) levels_target <- model$ylevels
+  if (is.null(levels_target)) levels_target <- levels(as.factor(source_data[[target_col]]))
+
+  make_rows <- function(data, is_test) {
+    if (nrow(data) == 0) return(data.frame())
+
+    probabilities <- tryCatch(
+      stats::predict(model, newdata = data, type = "prob"),
+      error = function(e) NULL
+    )
+    if (is.null(probabilities)) return(data.frame())
+
+    probabilities <- as.data.frame(probabilities, check.names = FALSE)
+    categories <- intersect(levels_target, colnames(probabilities))
+    if (length(categories) == 0) categories <- colnames(probabilities)
+
+    dplyr::bind_rows(lapply(categories, function(category) {
+      actual <- as.character(data[[target_col]])
+      is_positive <- actual == category
+      data.frame(
+        Category = category,
+        `Predicted Probability` = probabilities[[category]],
+        `Actual Positive` = is_positive,
+        `Actual Group` = factor(
+          ifelse(is_positive, "This Category", "Other Categories"),
+          levels = c("This Category", "Other Categories")
+        ),
+        `Actual Category` = actual,
+        is_test_data = is_test,
+        baseline_precision = mean(is_positive, na.rm = TRUE),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+      )
+    }))
+  }
+
+  dplyr::bind_rows(make_rows(train_data, FALSE), make_rows(test_data, TRUE))
+}
+
 # Extra per-category columns appended to the "Summary by Class" table for the
 # Decision Tree report (#37156): balanced accuracy, One-vs-Rest ROC AUC / PR AUC,
 # and the category's share of the evaluated rows (which is also the PR curve's

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1126,8 +1126,12 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
     y_value <- attributes(x)$ylevels[x$y]
     predicted_label_col <- avoid_conflict(colnames(data), "predicted_label")
     predicted_probability_col <- avoid_conflict(colnames(data), "predicted_probability")
+    predictions <- NULL
+    unknown_category_row_numbers <- NULL
+    na_row_numbers <- NULL
     switch(data_type,
       training = {
+        na_row_numbers <- x$na.action
         # If SMOTE was applied, use stored predictions on original training data
         if (!is.null(x$smote_applied) && x$smote_applied && !is.null(x$predicted_class_original)) {
           predicted_value_nona <- x$predicted_class_original
@@ -1153,30 +1157,54 @@ augment.rpart.classification <- function(x, data = NULL, newdata = NULL, data_ty
               predicted_probability_nona <- probs[, positive_class_col]
             }
           } else {
-            predicted_probability_nona <- apply(x$predicted_prob_original, 1, max)
+            predictions <- x$predicted_prob_original
+            predicted_probability_nona <- apply(predictions, 1, max)
           }
           predicted_value <- restore_na(predicted_value_nona, x$na.action)
           predicted_probability <- restore_na(predicted_probability_nona, x$na.action)
         } else {
           predicted_value_nona <- x$predicted_class
           predicted_value <- restore_na(predicted_value_nona, x$na.action)
-          # binary case and multiclass case are both handled inside this func.
-          predicted_probability_nona <- get_predicted_probability_rpart(x)
+          if (x$classification_type == "multi") {
+            predictions <- predict(x)
+            predicted_probability_nona <- apply(predictions, 1, max)
+          } else {
+            predicted_probability_nona <- get_predicted_probability_rpart(x)
+          }
           predicted_probability <- restore_na(predicted_probability_nona, x$na.action)
         }
       },
       test = {
         predicted_value_nona <- x$predicted_class_test
-        predicted_value_nona <- restore_na(predicted_value_nona, x$unknown_category_rows_index_test)
-        predicted_value <- restore_na(predicted_value_nona, x$na_row_numbers_test)
-        # binary case and multiclass case are both handled inside this func.
-        predicted_probability_nona <- get_predicted_probability_rpart(x, data_type = "test")
-        predicted_probability_nona <- restore_na(predicted_probability_nona, x$unknown_category_rows_index_test)
-        predicted_probability <- restore_na(predicted_probability_nona, x$na_row_numbers_test)
+        unknown_category_row_numbers <- x$unknown_category_rows_index_test
+        na_row_numbers <- x$na_row_numbers_test
+        predicted_value_nona <- restore_na(predicted_value_nona, unknown_category_row_numbers)
+        predicted_value <- restore_na(predicted_value_nona, na_row_numbers)
+        if (x$classification_type == "multi") {
+          predictions <- x$prediction_test
+          predicted_probability_nona <- apply(predictions, 1, max)
+        } else {
+          predicted_probability_nona <- get_predicted_probability_rpart(x, data_type = "test")
+        }
+        predicted_probability_nona <- restore_na(predicted_probability_nona, unknown_category_row_numbers)
+        predicted_probability <- restore_na(predicted_probability_nona, na_row_numbers)
       })
 
-    data[[predicted_label_col]] <- predicted_value
-    data[[predicted_probability_col]] <- predicted_probability
+    if (x$classification_type == "multi") {
+      data <- ranger.set_multi_predicted_values(
+        data,
+        predictions,
+        predicted_value,
+        predicted_probability,
+        na_row_numbers,
+        unknown_category_row_numbers,
+        pred_prob_col = predicted_probability_col,
+        pred_value_col = predicted_label_col
+      )
+    } else {
+      data[[predicted_label_col]] <- predicted_value
+      data[[predicted_probability_col]] <- predicted_probability
+    }
     data
 
   } else {

--- a/tests/testthat/test_dtree_report_multiclass_probabilities.R
+++ b/tests/testthat/test_dtree_report_multiclass_probabilities.R
@@ -28,6 +28,19 @@ test_that("dtree_report_multiclass_probabilities returns train and test one-vs-r
   expect_equal(sum(!ret$is_test_data), (n - length(test_index)) * 3)
   expect_equal(levels(ret$`Actual Group`), c("This Category", "Other Categories"))
 
-  category_a <- ret[ret$Category == "A" & !ret$is_test_data, , drop = FALSE]
-  expect_equal(category_a$baseline_precision, rep(mean(category_a$`Actual Positive`), nrow(category_a)))
+  for (category in c("A", "B", "C")) {
+    for (is_test in c(FALSE, TRUE)) {
+      rows <- ret[ret$Category == category & ret$is_test_data == is_test, , drop = FALSE]
+      expected_positive <- rows$`Actual Category` == category
+      expected_group <- ifelse(expected_positive, "This Category", "Other Categories")
+
+      expect_equal(rows$`Actual Positive`, expected_positive, info = paste(category, is_test))
+      expect_equal(as.character(rows$`Actual Group`), expected_group, info = paste(category, is_test))
+      expect_equal(
+        rows$baseline_precision,
+        rep(mean(expected_positive, na.rm = TRUE), nrow(rows)),
+        info = paste(category, is_test)
+      )
+    }
+  }
 })

--- a/tests/testthat/test_dtree_report_multiclass_probabilities.R
+++ b/tests/testthat/test_dtree_report_multiclass_probabilities.R
@@ -1,0 +1,33 @@
+context("test decision tree multiclass probability report")
+
+test_that("dtree_report_multiclass_probabilities returns train and test one-vs-rest rows", {
+  set.seed(1)
+  n <- 90
+  source_data <- data.frame(
+    target = factor(rep(c("A", "B", "C"), each = n / 3), levels = c("A", "B", "C")),
+    predictor = c(rnorm(n / 3, -2), rnorm(n / 3, 0), rnorm(n / 3, 2))
+  )
+  model <- rpart::rpart(target ~ predictor, data = source_data, minsplit = 2, cp = 0)
+  model$classification_type <- "multi"
+  model$orig_target_col <- "target"
+
+  test_index <- seq(3, n, by = 4)
+  model_df <- data.frame(
+    model = I(list(model)),
+    .test_index = I(list(test_index)),
+    source.data = I(list(source_data))
+  )
+
+  ret <- exploratory:::dtree_report_multiclass_probabilities(model_df)
+
+  expect_equal(nrow(ret), n * 3)
+  expect_equal(sort(unique(ret$Category)), c("A", "B", "C"))
+  expect_true(all(ret$`Predicted Probability` >= 0 & ret$`Predicted Probability` <= 1))
+  expect_true(all(c("Actual Positive", "Actual Group", "Actual Category", "is_test_data", "baseline_precision") %in% colnames(ret)))
+  expect_equal(sum(ret$is_test_data), length(test_index) * 3)
+  expect_equal(sum(!ret$is_test_data), (n - length(test_index)) * 3)
+  expect_equal(levels(ret$`Actual Group`), c("This Category", "Other Categories"))
+
+  category_a <- ret[ret$Category == "A" & !ret$is_test_data, , drop = FALSE]
+  expect_equal(category_a$baseline_precision, rep(mean(category_a$`Actual Positive`), nrow(category_a)))
+})

--- a/tests/testthat/test_rpart.R
+++ b/tests/testthat/test_rpart.R
@@ -48,6 +48,48 @@ test_that("exp_rpart multiclass classification", {
   expect_true(is.data.frame(res))
 })
 
+test_that("exp_rpart multiclass prediction includes per-class probabilities", {
+  set.seed(1)
+  model_df <- iris %>%
+    exp_rpart(Species, Sepal.Length, Sepal.Width, test_rate = 0.2)
+
+  probability_columns <- paste0("predicted_probability_", levels(iris$Species))
+  training <- prediction(model_df, data = "training")
+  test <- prediction(model_df, data = "test")
+  combined <- prediction(model_df, data = "training_and_test")
+
+  for (result in list(training, test, combined)) {
+    expect_true(all(probability_columns %in% colnames(result)))
+    probabilities <- as.matrix(result[, probability_columns, drop = FALSE])
+    expect_equal(result$predicted_probability, apply(probabilities, 1, max), tolerance = 1e-12)
+    predicted_class <- as.character(result$predicted_label)
+    max_probability <- apply(probabilities, 1, max)
+    expect_true(all(mapply(function(label, row, maximum) {
+      label %in% levels(iris$Species)[which(row == maximum)]
+    }, predicted_class, split(probabilities, row(probabilities)), max_probability)))
+  }
+
+  expect_equal(nrow(combined), nrow(training) + nrow(test))
+
+  pretty <- prediction(model_df, data = "training_and_test", pretty.name = TRUE)
+  expect_true(all(paste0("Predicted Probability for ", levels(iris$Species)) %in% colnames(pretty)))
+
+  unknown_category_data <- tibble::tibble(
+    target = factor(c("A", "B", "C", "A", "B", "C", "A", "B", "C", "A"),
+                    levels = c("A", "B", "C")),
+    category = factor(c(rep("known", 8), rep("unseen", 2)),
+                      levels = c("known", "unseen")),
+    value = seq_len(10)
+  )
+  unknown_category_model <- unknown_category_data %>%
+    exp_rpart(target, category, value, test_rate = 0.2, test_split_type = "ordered")
+  unknown_category_test <- prediction(unknown_category_model, data = "test")
+  expect_equal(nrow(unknown_category_test), 3)
+  expect_equal(sum(is.na(unknown_category_test$predicted_probability)), 2)
+  unknown_probability_columns <- paste0("predicted_probability_", levels(unknown_category_data$target))
+  expect_true(all(unknown_probability_columns %in% colnames(unknown_category_test)))
+})
+
 test_that("exp_rpart regression", {
   model_df <- flight %>% exp_rpart(`DEP DELAY`, `delay ed`, `ARR DELAY`, test_rate = 0.3)
   train_ret <- prediction(model_df)


### PR DESCRIPTION
## Description

Adds the R-side data helper and prediction output required by Tam issue #37501. This PR is paired with [Tam PR #37507](https://github.com/exploratory-io/tam/pull/37507).

## What Changed

- Added `dtree_report_multiclass_probabilities()` for one-vs-rest multiclass rpart report rows.
- Exposed per-category prediction probabilities from rpart training, test, and combined prediction paths.
- Preserved `Predicted Label` and `Predicted Probability` semantics.
- Preserved NA and unknown-category row alignment.
- Added focused tests for category probability columns, maximum-probability invariants, and unknown-category rows.
- Bumped the package version from 16.0.35 to 16.0.36 so Tam can install this implementation.

## How to Test

```sh
R_LIBS_USER=/Users/hidekoji/.exploratory/R/4.6_ARM Rscript -e 'library(dplyr); pkgload::load_all("."); testthat::test_file("tests/testthat/test_rpart.R", reporter="summary"); testthat::test_file("tests/testthat/test_dtree_report_multiclass_probabilities.R", reporter="summary")'
```

The focused R tests pass locally with existing non-fatal warnings. Full CI remains the release gate.

## Build Impact

- No new R package dependencies.
- `DESCRIPTION` is version 16.0.36 dated 2026-08-04.
- Tam manifests pin the corresponding `exploratory_16.0.36` package for Intel macOS, ARM macOS, and Windows.

## Exit Criteria

- [x] Per-category multiclass rpart probabilities are returned.
- [x] Existing predicted label/probability behavior is preserved.
- [x] Training/test/combined and NA/unknown-category paths are covered.
- [ ] Dependency-complete CI and package binary publication remain pending.
