### PR TITLE
Expose Likelihood Ratio Chi-Square / DF / McFadden R2 for binomial glance (tam#37504)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.35
-Date: 2026-08-02
+Version: 16.0.37
+Date: 2026-08-04
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_lm.R
+++ b/R/build_lm.R
@@ -1358,7 +1358,13 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
   attr(f0,".Environment")<-environment() # Since we removed .Environment attribute for size reduction, add it back so that the following process works.
   lazyeval::f_rhs(f0) <- 1 # create null model formula.
   x0 <- glm(f0, x$model, family = x$family) # build null model. Use x$model rather than x$data since x$model seems to be the data after glm handled missingness.
-  pvalue <- with(anova(x0,x),pchisq(Deviance,Df,lower.tail=FALSE)[2]) 
+  # Keep the intermediate LR-test Chi-Square/DF around (#37504) -- they were already being
+  # computed here just to feed pchisq(), then discarded. binomial/quasibinomial + report_metrics
+  # exposes them as their own columns below (Prediction Quality section split, tam#37504).
+  lr_anova <- anova(x0,x)
+  lr_chisq <- lr_anova$Deviance[2]
+  lr_df <- lr_anova$Df[2]
+  pvalue <- pchisq(lr_chisq, lr_df, lower.tail=FALSE)
   if(pretty.name) {
     ret <- ret %>% dplyr::mutate(`P Value`=!!pvalue, `Rows`=!!length(x$y))
   }
@@ -1422,14 +1428,28 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
       specificity <- if ((tn + fp) > 0) tn / (tn + fp) else NA_real_
       sensitivity <- if ((tp + fn) > 0) tp / (tp + fn) else NA_real_
       balanced_accuracy <- if (is.na(specificity) || is.na(sensitivity)) NA_real_ else (specificity + sensitivity) / 2
+      # McFadden's Pseudo R-Squared: 1 - LL(model)/LL(null), equivalently 1 - deviance/null.deviance
+      # since deviance = -2*logLik. Goodness-of-fit metric for the Prediction Quality /
+      # Goodness of Fit split (tam#37504).
+      mcfadden_r2 <- if (is.finite(x$null.deviance) && x$null.deviance != 0) {
+        1 - (x$deviance / x$null.deviance)
+      } else {
+        NA_real_
+      }
       if (pretty.name) {
         ret$`PR AUC` <- pr_auc
         ret$`Balanced Accuracy` <- balanced_accuracy
         ret$`Specificity` <- specificity
+        ret$`Likelihood Ratio Chi-Square` <- lr_chisq
+        ret$`DF` <- lr_df
+        ret$`McFadden R Squared` <- mcfadden_r2
       } else {
         ret$pr_auc <- pr_auc
         ret$balanced_accuracy <- balanced_accuracy
         ret$specificity <- specificity
+        ret$lr_chisq <- lr_chisq
+        ret$lr_df <- lr_df
+        ret$mcfadden_r2 <- mcfadden_r2
       }
     }
   }
@@ -1458,7 +1478,8 @@ glance.glm_exploratory <- function(x, pretty.name = FALSE, binary_classification
             "Misclass. Rate", "Precision", "Recall", "Specificity"),
           colnames(ret))
         stat_cols <- intersect(
-          c("P Value", "Rows", "positives", "negatives", "Log Likelihood", "AIC", "BIC",
+          c("Likelihood Ratio Chi-Square", "DF", "P Value", "McFadden R Squared", "Rows",
+            "positives", "negatives", "Log Likelihood", "AIC", "BIC",
             "Residual Deviance", "Residual DF", "Null Deviance", "Null Model DF"),
           colnames(ret))
         other_cols <- setdiff(colnames(ret), c(pred_cols, stat_cols))

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -425,8 +425,8 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
     ret <- ret %>% dplyr::select(dplyr::any_of(c(
       "auc", "roc_auc", "pr_auc", "f_score", "balanced_accuracy", "accuracy_rate",
       "misclassification_rate", "precision", "recall", "specificity",
-      "p.value", "positives", "negatives", "n", "logLik", "AIC", "BIC",
-      "deviance", "null.deviance", "df.null", "df.residual")),
+      "lr_chisq", "lr_df", "p.value", "mcfadden_r2", "positives", "negatives", "n",
+      "logLik", "AIC", "BIC", "deviance", "null.deviance", "df.null", "df.residual")),
       everything())
   } else {
     ret <- ret %>% dplyr::select(auc, f_score, accuracy_rate, misclassification_rate, precision,
@@ -466,7 +466,10 @@ evaluate_binary_training_and_test <- function(df, actual_val, threshold = "f_sco
     colnames(ret)[colnames(ret) == "n"] <- "Rows"
     colnames(ret)[colnames(ret) == "positives"] <- "Rows (TRUE)"
     colnames(ret)[colnames(ret) == "negatives"] <- "Rows (FALSE)"
+    colnames(ret)[colnames(ret) == "lr_chisq"] <- "Likelihood Ratio Chi-Square"
+    colnames(ret)[colnames(ret) == "lr_df"] <- "DF"
     colnames(ret)[colnames(ret) == "p.value"] <- "P Value"
+    colnames(ret)[colnames(ret) == "mcfadden_r2"] <- "McFadden R Squared"
     colnames(ret)[colnames(ret) == "logLik"] <- "Log Likelihood"
     colnames(ret)[colnames(ret) == "deviance"] <- "Residual Deviance"
     colnames(ret)[colnames(ret) == "null.deviance"] <- "Null Deviance"


### PR DESCRIPTION
## Summary

Paired R-side change for tam#37504 / tam PR exploratory-io/tam#37512 — splitting the Logistic Regression analytics report's combined 予測精度 table into a Prediction Accuracy table and a Goodness of Fit table.

Exposes three model-level columns from `glance.glm_exploratory` that weren't available before:

- **`Likelihood Ratio Chi-Square`** / **`DF`** — these were *already being computed* inside the function's existing model-significance P-value calculation (`anova(null_model, full_model)`) and then thrown away. This change keeps the intermediate `anova()` result and exposes `$Deviance[2]` / `$Df[2]` as their own columns instead of recomputing anything.
- **`McFadden R Squared`** — `1 - deviance / null.deviance`.

`evaluate_binary_training_and_test()` is updated in lockstep for column ordering and `pretty.name` renaming, so the new columns appear in a sensible position for the report table.

## Scope / gating

All three are gated behind **binomial/quasibinomial family AND `report_metrics = TRUE`** — the same opt-in gate as the PR AUC / Balanced Accuracy / Specificity additions from #37256. The only caller passing `report_metrics = TRUE` is tam's `logistic.json`; `binomial.json` and every non-binomial family are unaffected.

## Verification (live execution, not string assertions)

- `pchisq(Likelihood Ratio Chi-Square, DF, lower.tail = FALSE)` reproduces the existing `P Value` column exactly.
- `DF == Null Model DF - Residual DF`.
- `McFadden R Squared == 1 - Residual Deviance / Null Deviance`.
- `report_metrics = FALSE` (both `pretty.name` on and off) produces a **byte-identical column set** to before — checked with `identical(colnames(ret), expect_cols)` against the exact vectors already asserted in `tests/testthat/test_model_eval.R`.
- `family = gaussian()` with `report_metrics = TRUE` gains no new columns.

## ⚠️ This PR may not be needed — please read before merging

tam PR exploratory-io/tam#37513 implements the same report change **entirely in the tam-side preprocessor**, deriving the identical three values with plain `dplyr::mutate()` arithmetic on columns `evaluate_binary_training_and_test()` *already* returns:

```
Likelihood Ratio Chi-Square = `Null Deviance` - `Residual Deviance`
DF                          = `Null Model DF` - `Residual DF`
McFadden R Squared          = 1 - `Residual Deviance` / `Null Deviance`
```

Those are algebraically identical to what this PR computes in R — in fact the first two identities are exactly what this PR's own live verification asserts (see above), which is itself proof the tam-side derivation is sound.

The tam-only approach avoids this PR's entire release chain: a version bump in `tools/requiredRPackagesReduced.json`, regenerating the 4 installer manifests, rebuilding and uploading per-platform binaries to download2, plus a scheduler/server deploy. That chain is not theoretical — during local render verification the desktop app **restored the manifest-pinned 16.0.35 over the locally installed 16.0.37**, so the report silently rendered without the new columns (`any_of()` dropped them without erroring).

So: merge this only if we want these metrics available from `glance.glm_exploratory` for other/future consumers. If tam#37513's approach is taken, this PR should be closed and the `DESCRIPTION` version bump reverted.
