### PR TITLE
fix(roc): collapse tied predicted probabilities in do_roc_ (tam#37510)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.37
+Version: 16.0.38
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/model_eval.R
+++ b/R/model_eval.R
@@ -38,23 +38,37 @@ do_roc_ <- function(df, pred_prob_col, actual_val_col, grid = NULL, with_auc = F
 
     # and get actual values
     val <- arranged[[actual_val_col]]
+    prob <- arranged[[pred_prob_col]]
 
+    n <- length(val)
     act_sum <- sum(val)
+
+    # Collapse tied predicted probabilities into a single ROC vertex.
+    # A model that assigns the same probability to many rows (e.g. a decision tree,
+    # where every row that falls in the same leaf shares one probability) cannot
+    # distinguish those rows, so their order within the tied block is arbitrary and
+    # must not affect the curve. Keep only the LAST cumulative point of each run of
+    # identical probabilities, which turns the arbitrary staircase inside a tied block
+    # into the single straight chord it should be.
+    # When every probability is distinct (e.g. a logistic regression score), last_index
+    # is simply every index and the output is identical to keeping one point per row.
+    last_index <- if (n == 0) integer(0) else c(which(diff(prob) != 0), n)
+    m <- length(last_index)
 
     fpr <- if (all(val)){
       # should be all zero but put 1 to draw a curve
-      c(rep(0, length(val)), 1)
+      c(rep(0, m), 1)
     } else {
       # cumulative rate of false case
-      c(0, cumsum(!val) / (length(val) - act_sum))
+      c(0, (cumsum(!val) / (n - act_sum))[last_index])
     }
 
     tpr <- if (all(!val)) {
       # should be all zero but put 1 to draw a curve
-      c(rep(0, length(val)), 1)
+      c(rep(0, m), 1)
     } else {
       # cumulative rate of true case
-      c(0, cumsum(val) / act_sum)
+      c(0, (cumsum(val) / act_sum)[last_index])
     }
 
     ret <- data.frame(

--- a/tests/testthat/test_model_eval.R
+++ b/tests/testthat/test_model_eval.R
@@ -71,6 +71,166 @@ test_that("test do_roc with 2 numeric values", {
   expect_equal(colnames(ret), c("true_positive_rate", "false_positive_rate"))
 })
 
+# Verbatim copy of the pre-fix do_roc_ point calculation (one ROC point per data row,
+# no tie handling). Used to pin the guarantee that the tie-collapsing fix does not change
+# the output at all when every predicted probability is distinct, which is the case for
+# every continuous-score model (logistic regression, xgboost, lightgbm, ...).
+roc_points_before_tie_fix <- function(df, pred_prob_col, actual_val_col) {
+  df <- df[!is.na(df[[pred_prob_col]]) & !is.na(df[[actual_val_col]]), ]
+  df[[actual_val_col]] <- exploratory:::binary_label(df[[actual_val_col]])
+  arranged <- df[order(-df[[pred_prob_col]]), ]
+  val <- arranged[[actual_val_col]]
+  act_sum <- sum(val)
+  fpr <- if (all(val)) {
+    c(rep(0, length(val)), 1)
+  } else {
+    c(0, cumsum(!val) / (length(val) - act_sum))
+  }
+  tpr <- if (all(!val)) {
+    c(rep(0, length(val)), 1)
+  } else {
+    c(0, cumsum(val) / act_sum)
+  }
+  list(tpr = tpr, fpr = fpr)
+}
+
+test_that("test do_roc collapses tied predicted probabilities into one point each", {
+  # A decision tree assigns one probability per leaf, so many rows share the exact same
+  # predicted probability. Those rows are indistinguishable to the model, so the curve
+  # must have one vertex per distinct probability, not one per row.
+  leaf_prob <- c(0.05, 0.20, 0.45, 0.70, 0.90)
+  leaf_positives <- c(2, 8, 18, 28, 36) # out of 40 rows in each leaf
+  prob <- rep(leaf_prob, each = 40)
+  actual <- unlist(lapply(leaf_positives, function(x) rep(c(1, 0), c(x, 40 - x))))
+  test_data <- data.frame(prob = prob, actual = actual)
+
+  ret <- do_roc_(test_data, "prob", "actual")
+  # (0,0) origin plus one vertex per distinct probability.
+  expect_equal(nrow(ret), length(leaf_prob) + 1)
+  expect_equal(length(ret[["true_positive_rate"]]), length(ret[["false_positive_rate"]]))
+  # The curve must still start at (0,0) and end at (1,1).
+  expect_equal(ret[["true_positive_rate"]][[1]], 0)
+  expect_equal(ret[["false_positive_rate"]][[1]], 0)
+  expect_equal(ret[["true_positive_rate"]][[nrow(ret)]], 1)
+  expect_equal(ret[["false_positive_rate"]][[nrow(ret)]], 1)
+  # Monotone non-decreasing on both axes.
+  expect_true(all(diff(ret[["true_positive_rate"]]) >= 0))
+  expect_true(all(diff(ret[["false_positive_rate"]]) >= 0))
+})
+
+test_that("test do_roc is independent of the input row order when probabilities are tied", {
+  set.seed(20260805)
+  n <- 600
+  prob <- rep(c(0.1, 0.3, 0.55, 0.8), length.out = n)
+  actual <- rbinom(n, 1, prob)
+  test_data <- data.frame(prob = prob, actual = actual)
+
+  ret <- do_roc_(test_data, "prob", "actual", with_auc = TRUE)
+
+  # Shuffling the rows changes nothing the model can see, so the curve must not move.
+  for (i in 1:5) {
+    shuffled <- test_data[sample(nrow(test_data)), ]
+    shuffled_ret <- do_roc_(shuffled, "prob", "actual", with_auc = TRUE)
+    expect_equal(nrow(shuffled_ret), nrow(ret))
+    expect_true(all.equal(shuffled_ret[["true_positive_rate"]], ret[["true_positive_rate"]]))
+    expect_true(all.equal(shuffled_ret[["false_positive_rate"]], ret[["false_positive_rate"]]))
+    # AUC was already tie-aware and row-order-independent before the fix. Keep it that way.
+    expect_true(all.equal(shuffled_ret[["auc"]], ret[["auc"]]))
+  }
+})
+
+test_that("test do_roc output is unchanged when there are no tied probabilities", {
+  # Every continuous-score model (logistic regression, xgboost, lightgbm, ...) produces
+  # distinct probabilities, and for those the tie-collapsing fix must be a no-op.
+  set.seed(20260805)
+  for (i in 1:20) {
+    n <- sample(5:200, 1)
+    prob <- runif(n) # continuous, so no ties
+    actual <- rbinom(n, 1, prob)
+    if (length(unique(actual)) < 2) {
+      next # degenerate cases are covered by their own test
+    }
+    test_data <- data.frame(prob = prob, actual = actual)
+
+    expected <- roc_points_before_tie_fix(test_data, "prob", "actual")
+    ret <- do_roc_(test_data, "prob", "actual")
+
+    expect_identical(ret[["true_positive_rate"]], expected$tpr)
+    expect_identical(ret[["false_positive_rate"]], expected$fpr)
+  }
+})
+
+test_that("test do_roc degenerate cases", {
+  degenerate_cases <- list(
+    all_positive = data.frame(prob = c(0.9, 0.5, 0.1), actual = c(1, 1, 1)),
+    all_negative = data.frame(prob = c(0.9, 0.5, 0.1), actual = c(0, 0, 0)),
+    all_positive_tied = data.frame(prob = c(0.5, 0.5, 0.5), actual = c(1, 1, 1)),
+    all_negative_tied = data.frame(prob = c(0.5, 0.5, 0.5), actual = c(0, 0, 0)),
+    single_positive_row = data.frame(prob = 0.7, actual = 1),
+    single_negative_row = data.frame(prob = 0.7, actual = 0),
+    every_probability_tied = data.frame(prob = rep(0.4, 10), actual = rep(c(1, 0), 5))
+  )
+
+  for (case_name in names(degenerate_cases)) {
+    ret <- do_roc_(degenerate_cases[[case_name]], "prob", "actual")
+    # fpr and tpr must always have the same length, or the data.frame() call would error.
+    expect_equal(length(ret[["true_positive_rate"]]), length(ret[["false_positive_rate"]]),
+                 info = case_name)
+    expect_true(all(!is.na(ret[["true_positive_rate"]])), info = case_name)
+    expect_true(all(!is.na(ret[["false_positive_rate"]])), info = case_name)
+  }
+
+  # A group that becomes empty after NA filtering must not error either.
+  empty_group_data <- data.frame(
+    group = c("a", "a", "b", "b"),
+    prob = c(0.9, 0.1, NA, NA),
+    actual = c(1, 0, 1, 0)
+  )
+  ret <- empty_group_data %>% dplyr::group_by(group) %>% do_roc_("prob", "actual")
+  expect_equal(length(ret[["true_positive_rate"]]), length(ret[["false_positive_rate"]]))
+  expect_true(all(!is.na(ret[["true_positive_rate"]])))
+})
+
+test_that("test do_roc with grouped input and tied probabilities", {
+  set.seed(20260805)
+  n <- 400
+  test_data <- data.frame(
+    group = rep(c("x", "y"), each = n / 2),
+    prob = rep(c(0.2, 0.5, 0.8), length.out = n),
+    actual = rbinom(n, 1, 0.4)
+  )
+
+  ret <- test_data %>% dplyr::group_by(group) %>% do_roc_("prob", "actual", with_auc = TRUE)
+  expect_equal(colnames(ret), c("group", "true_positive_rate", "false_positive_rate", "auc"))
+  # 3 distinct probabilities per group, plus the (0,0) origin, in each of 2 groups.
+  expect_equal(nrow(ret), 2 * (3 + 1))
+  expect_equal(sort(unique(ret[["group"]])), c("x", "y"))
+
+  # Each group's curve must match the curve of that group computed on its own.
+  for (group_name in c("x", "y")) {
+    one_group <- test_data[test_data$group == group_name, ]
+    expected <- do_roc_(one_group, "prob", "actual", with_auc = TRUE)
+    actual_ret <- ret[ret$group == group_name, ]
+    expect_true(all.equal(actual_ret[["true_positive_rate"]], expected[["true_positive_rate"]]))
+    expect_true(all.equal(actual_ret[["false_positive_rate"]], expected[["false_positive_rate"]]))
+    expect_true(all.equal(actual_ret[["auc"]], expected[["auc"]]))
+  }
+})
+
+test_that("test do_roc auc is unchanged by the tie handling fix", {
+  set.seed(20260805)
+  n <- 500
+  prob <- rep(c(0.15, 0.35, 0.55, 0.75, 0.95), length.out = n)
+  actual <- rbinom(n, 1, prob)
+  test_data <- data.frame(prob = prob, actual = actual)
+
+  ret <- do_roc_(test_data, "prob", "actual", with_auc = TRUE)
+  # auroc() is already tie-aware, so the reported AUC must equal it exactly.
+  expected_auc <- exploratory:::auroc(test_data$prob, exploratory:::binary_label(test_data$actual))
+  expect_equal(ret[["auc"]][[1]], expected_auc)
+  expect_equal(length(unique(ret[["auc"]])), 1)
+})
+
 test_that("test evaluate_binary with 2 numeric values", {
   test_data <- structure(
     list(


### PR DESCRIPTION
## The bug

`do_roc_()` in `R/model_eval.R` built one ROC point per **data row** and never aggregated ties:

```r
arranged <- df[order(-df[[pred_prob_col]]), ]
val <- arranged[[actual_val_col]]
act_sum <- sum(val)
fpr <- c(0, cumsum(!val) / (length(val) - act_sum))
tpr <- c(0, cumsum(val) / act_sum)
```

`order()` breaks ties by original row order, which is arbitrary with respect to the actual class. Walking row-by-row through a block of identical probabilities therefore drew a random staircase instead of the single straight chord that block should be.

This has been the behavior since the function was written 9 years ago.

## Why tree models expose it and continuous-score models don't

A decision tree (CART / CHAID) assigns **one probability per leaf**, so hundreds or thousands of rows share an exactly identical predicted probability. Those rows are indistinguishable to the model, so their internal order carries no information — but the old code let that arbitrary order dictate the curve's shape.

A continuous-score model (logistic regression, xgboost, lightgbm, …) produces a distinct probability for essentially every row, so there are no tied blocks and the row-by-row walk happens to be correct.

Measured empirically on a 1470-row CART with 6 leaves (6 distinct probabilities):

| | |
|---|---|
| Correct number of curve vertices | **7** |
| Points `do_roc_` actually returned | **1471** |
| Change in `tpr` at the same `fpr` from shuffling **only** the row order | up to **0.087** |

So the rendered curve's shape was an artifact of row order.

**What was NOT wrong:** the curve stayed monotone (no decreasing `tpr`), and `auroc()` is already tie-aware, so the reported AUC value was correct and row-order-independent throughout. Only the curve **geometry** was wrong.

## The fix

Keep only the **last** cumulative point of each run of identical probabilities — the same idiom already proven in tam's `dtree_report_threshold_sweep()`:

```r
last_index <- if (n == 0) integer(0) else c(which(diff(prob) != 0), n)
m <- length(last_index)

fpr <- if (all(val)) c(rep(0, m), 1) else c(0, (cumsum(!val) / (n - act_sum))[last_index])
tpr <- if (all(!val)) c(rep(0, m), 1) else c(0, (cumsum(val)  / act_sum)[last_index])
```

The two degenerate branches now use `m` (the number of distinct probabilities) instead of `length(val)`, so `fpr` and `tpr` keep equal length in every case — including 0 rows (a group left empty after NA filtering) and 1 row. Unequal lengths there would error in the `data.frame(tpr, fpr)` call right below.

The `grid` reduction block, `with_auc` / `auroc()`, column naming, and the `group_modify` wrapper are untouched.

## Guarantee: no behavior change when there are no ties

`do_roc_` is shared by 8 analytics templates (logistic, binomial, rpart, chaid, calc_feature_imp, xgboost, lightgbm, catboost). For a continuous-score model every probability is distinct, `last_index` becomes every index, and the output is **byte-identical to today's**.

This is pinned by a dedicated test rather than argued: `roc_points_before_tie_fix()` is a verbatim copy of the pre-fix point calculation, and the test asserts `expect_identical()` on both `tpr` and `fpr` against the new function across 20 random no-tie datasets. (Verified separately over 200 random datasets offline: 0 mismatches.)

That test is the guarantee that logistic regression and the other continuous-score models are untouched.

## Tests

Added to `tests/testthat/test_model_eval.R`:

1. **Tie collapse** — 5 leaf probabilities × 40 rows each returns exactly 6 points (k+1), starts at (0,0), ends at (1,1), monotone on both axes.
2. **Row-order independence** — the core regression test. Same data, 5 different shuffles, `all.equal` on `tpr`, `fpr`, and `auc`.
3. **No-tie output unchanged** — the guarantee described above.
4. **Degenerate cases** — all-positive, all-negative, all-positive-tied, all-negative-tied, single positive row, single negative row, every probability tied, and a group left empty by NA filtering. Asserts no error, no NA, and `length(tpr) == length(fpr)` in every case.
5. **Grouped input** — `group_by()` still returns correct per-group curves; each group's curve is compared against that group computed on its own.
6. **AUC unchanged** — the reported AUC equals tie-aware `auroc()` exactly.

**Verified the new tests fail on the old code:** `git stash`-ed only the `R/model_eval.R` change and re-ran the file — the three tie-related tests produced **12 assertion failures** (121 pass / 12 fail). The "unchanged behavior" tests (no-tie identity, degenerate cases, AUC) pass on both the old and new code, as they must.

### Test results (after the fix)

| File | Pass | Fail | Error | Skip |
|---|---|---|---|---|
| `test_model_eval.R` | 133 | 0 | 0 | 0 |
| `test_r_parser.R` | 56 | 0 | 0 | 0 |
| `test_build_catboost.R` | 47 | 0 | 0 | 0 |
| `test_build_glm.R` | 45 | 0 | 0 | 0 |
| `test_rpart.R` | 23 | 0 | 0 | 0 |
| `test_build_chaid.R` | 155 | 0 | 0 | 0 |

(`test_model_eval.R`, `test_r_parser.R`, `test_build_catboost.R` are the only test files in the repo that reference `do_roc` / `roc`; the rest were run as downstream consumers of the affected analytics.)

## Version

`DESCRIPTION` bumped **16.0.37 → 16.0.38**.

## Follow-up for the desktop side

- tam PR #37529 will pin **16.0.38**.
- Per-platform binaries need rebuilding (Mac Intel / Mac ARM / Windows / Linux) and the four generated installer manifests regenerated via `tools/build_required_r_packages.sh` on the tam side.
- Because this changes ROC **curve geometry** for tree models (fewer, correctly-placed vertices), the scheduler / server R deployment should also pick up 16.0.38 so published and scheduled tree-model reports match the desktop.

## Out of scope (noted, not fixed)

`R/build_catboost.R:1547` calls `do_roc_(data.frame(actual = ..., predicted_probability = ...), "actual", "predicted_probability")`, which passes `actual` as `pred_prob_col` and `predicted_probability` as `actual_val_col` — the two arguments look swapped relative to the `do_roc_(df, pred_prob_col, actual_val_col)` signature. Unrelated to tie handling and left untouched here.
