### PR TITLE
fix(xgboost): predict.xgb.Booster returns a matrix for multi:softprob, not a flat vector (tam#37510)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.37
+Version: 16.0.38
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_xgboost.R
+++ b/R/build_xgboost.R
@@ -812,8 +812,22 @@ predict_xgboost <- function(model, df) {
   obj <- model$params$objective
 
   if (obj == "multi:softprob") {
-    # predicted is a vector containing probabilities for each class
-    probs <- matrix(predicted, nrow = length(model$y_levels)) %>% t()
+    # tam#37510 follow-up: predict.xgb.Booster's return shape for multi:softprob
+    # changed across xgboost R package versions. Older versions returned a
+    # flat, row-major vector (row1_class1, row1_class2, ..., row2_class1, ...)
+    # that this code reshaped into a matrix via matrix(nrow=num_class) %>% t().
+    # xgboost >= ~2.1 (confirmed live on 3.2.1.1) instead returns the
+    # nrow(mat_data) x num_class probability matrix DIRECTLY -- reshaping that
+    # again with matrix(nrow=num_class) silently re-flattens it column-major
+    # and regroups UNRELATED values from different original rows/columns into
+    # each "row", corrupting every probability (row sums that must equal 1.0
+    # instead ranged 0.007-2.67 on real data). Detect which convention the
+    # installed package actually used instead of assuming either one.
+    probs <- if (is.matrix(predicted) && ncol(predicted) == length(model$y_levels)) {
+      predicted
+    } else {
+      matrix(predicted, nrow = length(model$y_levels)) %>% t()
+    }
     # probs <- fill_mat_NA(as.numeric(rownames(mat_data)), probs, nrow(df)) # code from xgboost step.
     probs <- fill_mat_NA(1:nrow(df), probs, nrow(df)) # Not sure if this is necessary. TODO: check.
     colnames(probs) <- model$y_levels

--- a/tests/testthat/test_build_xgboost.R
+++ b/tests/testthat/test_build_xgboost.R
@@ -400,6 +400,40 @@ test_that("test build_xgboost with multi softprob", {
   expect_true(length(unique(prediction_ret$predicted_label)) > 1)
 })
 
+# tam#37510 follow-up: predict.xgb.Booster's return shape for multi:softprob
+# changed across xgboost R package versions -- older versions returned a
+# flat, row-major vector that predict_xgboost() reshaped via
+# matrix(nrow=num_class) %>% t(), but xgboost >= ~2.1 (installed: 3.2.1.1)
+# returns the nrow x num_class probability matrix DIRECTLY. Reshaping an
+# ALREADY-correct matrix with matrix(nrow=num_class) re-flattens it column-
+# major and regroups unrelated values from different original rows/columns
+# together -- every probability comes out wrong, but each individual value is
+# still a plausible-looking number > 0, so the existing "all(prob > 0)"
+# assertion above cannot catch it. The one property that must ALWAYS hold for
+# genuine softmax/softprob output -- each row's per-class probabilities sum
+# to 1 -- is exactly what a scrambled reshape breaks; verified directly on
+# real (non-test-fixture) data that this drifted to summing anywhere from
+# 0.007 to 2.67 pre-fix.
+test_that("test build_xgboost with multi softprob -- per-row class probabilities sum to 1 (tam#37510 follow-up)", {
+  set.seed(1)
+  n <- 60
+  test_data <- data.frame(
+    x1 = rnorm(n),
+    x2 = rnorm(n),
+    category = factor(sample(c("A", "B", "C"), n, replace = TRUE))
+  )
+  model_df <- test_data %>% exp_xgboost(category, x1, x2, test_rate = 0, nrounds = 5)
+  model <- model_df$model[[1]]
+
+  predict_xgboost <- get("predict_xgboost", envir = asNamespace("exploratory"))
+  predicted <- predict_xgboost(model, model$df)
+  expect_true(is.matrix(predicted))
+  expect_equal(ncol(predicted), length(model$y_levels))
+  expect_equal(colnames(predicted), as.character(model$y_levels))
+  row_sums <- rowSums(predicted)
+  expect_true(all(abs(row_sums[!is.na(row_sums)] - 1) < 1e-6))
+})
+
 test_that("test build_xgboost with linear booster", {
   test_data <- structure(
     list(


### PR DESCRIPTION
## Problem

`predict_xgboost()` in `R/build_xgboost.R` reshaped `predict()`'s `multi:softprob` output via `matrix(predicted, nrow=num_class) %>% t()`, assuming the **old** xgboost R package convention: a flat, row-major vector (`row1_class1, row1_class2, ..., row2_class1, ...`).

The installed xgboost R package (**3.2.1.1**) instead returns the `nrow(mat_data) x num_class` probability matrix **directly** — each row already sums to 1.0, confirmed live. Reshaping an already-correct matrix via `matrix(nrow=num_class)` silently re-flattens it column-major and regroups unrelated values from different original rows/columns together. Every probability comes out wrong, but each individual value still looks plausible (`>0`, `<1`), so nothing errors.

Discovered while investigating why an XGBoost multiclass model's ROC curve rendered as a near-diagonal (random-classifier) line in exploratory-io/tam#37510's exit-criteria verification, even though the same target/predictors/dataset showed a properly bowed curve for Random Forest. Live-verified on real (non-fixture) data:
- Per-row probability sums drifted from the required 1.0 to anywhere between 0.007 and 2.67.
- Correlation between predicted probability and actual class dropped to ~-0.02 to 0.003 — indistinguishable from random.

## Fix

Detect which convention the installed package actually used instead of assuming either one:

```r
probs <- if (is.matrix(predicted) && ncol(predicted) == length(model$y_levels)) {
  predicted  # xgboost >= ~2.1 already returns the correctly-shaped matrix
} else {
  matrix(predicted, nrow = length(model$y_levels)) %>% t()  # legacy flat-vector convention
}
```

`multi:softmax` and binary/regression `predict()` outputs are unaffected (still plain vectors either way — live-verified).

## Note on already-fit models

An xgboost model **fit before this fix** has its per-row probabilities permanently baked into `model$prediction_training` at fit time (used by the `training`/`test` `augment()` paths for Analytics View reports). This fix only affects **future** fits — an existing saved model needs to be **re-run** once this version is installed for its report charts to self-heal. A fresh `newdata=` prediction (not relying on the cached value) is correct immediately.

## Tests

Added a regression test asserting the one property that must ALWAYS hold for genuine softmax/softprob output — each row's per-class probabilities sum to 1 — since the existing `all(prob > 0)` assertion in the sibling test was too weak to have caught this (a scrambled reshape still produces individually-positive-looking values).

Verified via negative control: fails with exactly this assertion when the fix is reverted, passes when restored. All pre-existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)