### PR TITLE
fix(lightgbm): predict.lgb.Booster returns a matrix for multiclass, not a flat vector (tam#37510)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.37
+Version: 16.0.40
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_lightgbm.R
+++ b/R/build_lightgbm.R
@@ -1096,7 +1096,25 @@ predict_lightgbm <- function(model, df, predraw = FALSE) {
   }
 
   if (!is.null(obj) && obj == "multiclass") {
-    probs <- matrix(pred, ncol = length(model$y_levels), byrow = TRUE)
+    # tam#37510 follow-up: predict.lgb.Booster's return shape for a multiclass
+    # objective changed across lightgbm R package versions, the same drift
+    # already found and fixed in xgboost (exploratory_func#1589). Older
+    # versions returned a flat, row-major vector that this code reshaped via
+    # matrix(ncol=num_class, byrow=TRUE). The installed lightgbm R package
+    # (4.6.0, confirmed live) instead returns the nrow x num_class probability
+    # matrix DIRECTLY (each row already sums to 1.0). Reshaping an already-
+    # correct matrix with matrix(byrow=TRUE) silently re-flattens it and
+    # regroups unrelated values from different original rows/columns together
+    # -- every probability came out wrong (row sums ranged 0.22-2.53 on real
+    # data, correlation with actual class dropped to ~0.04-0.09) but each
+    # individual value still looked plausible, so nothing errored. Detect
+    # which convention the installed package actually used instead of
+    # assuming either one.
+    probs <- if (is.matrix(pred) && ncol(pred) == length(model$y_levels)) {
+      pred
+    } else {
+      matrix(pred, ncol = length(model$y_levels), byrow = TRUE)
+    }
     probs <- fill_mat_NA(1:nrow(df), probs, nrow(df))
     colnames(probs) <- model$y_levels
     return(probs)

--- a/tests/testthat/test_build_lightgbm.R
+++ b/tests/testthat/test_build_lightgbm.R
@@ -186,6 +186,36 @@ test_that("test lightgbm_multi with numeric target", {
   expect_true(all(prediction_ret$predicted_label %in% c(5, 10, 15)))
 })
 
+# tam#37510 follow-up: predict_lightgbm() reshaped predict()'s multiclass
+# output via matrix(pred, ncol=num_class, byrow=TRUE), assuming the OLD
+# lightgbm R package convention of a flat, row-major vector. The installed
+# lightgbm R package (4.6.0) instead returns the nrow x num_class probability
+# matrix DIRECTLY (confirmed live: each row already sums to 1.0). Reshaping
+# an ALREADY-correct matrix via matrix(byrow=TRUE) silently re-flattens and
+# regroups unrelated values together -- every probability comes out wrong,
+# but each individual value still looks like a plausible probability, so
+# nothing errors. Assert the one property that must ALWAYS hold for genuine
+# multiclass probability output: each row's per-class probabilities sum to 1.
+test_that("test lightgbm_multi -- per-row class probabilities sum to 1 (tam#37510 follow-up)", {
+  set.seed(1)
+  n <- 60
+  test_data <- data.frame(
+    x1 = rnorm(n),
+    x2 = rnorm(n),
+    category = factor(sample(c("A", "B", "C"), n, replace = TRUE))
+  )
+  model_df <- suppressWarnings(test_data %>% exp_lightgbm(category, x1, x2, test_rate = 0, nrounds = 5))
+  model <- model_df$model[[1]]
+
+  predict_lightgbm <- get("predict_lightgbm", envir = asNamespace("exploratory"))
+  predicted <- predict_lightgbm(model, model$df)
+  expect_true(is.matrix(predicted))
+  expect_equal(ncol(predicted), length(model$y_levels))
+  expect_equal(colnames(predicted), as.character(model$y_levels))
+  row_sums <- rowSums(predicted)
+  expect_true(all(abs(row_sums[!is.na(row_sums)] - 1) < 1e-6))
+})
+
 test_that("test lightgbm_multi with not clean names and NA", {
   test_data <- data.frame(
     label = rep(seq(3) * 5, 100),


### PR DESCRIPTION
## Problem

Same bug class as exploratory-io/exploratory_func#1589 (XGBoost), found this time in LightGBM.

`predict_lightgbm()` in `R/build_lightgbm.R` reshaped `predict()`'s multiclass output via `matrix(pred, ncol=num_class, byrow=TRUE)`, assuming the **old** lightgbm R package convention: a flat, row-major vector.

The installed lightgbm R package (**4.6.0**) instead returns the `nrow(mat_data) x num_class` probability matrix **directly** — each row already sums to 1.0, confirmed live. Reshaping an already-correct matrix via `matrix(byrow=TRUE)` silently re-flattens and regroups unrelated values from different original rows/columns together. Every probability comes out wrong, but each individual value still looks plausible (`>0`, `<1`), so nothing errors.

Found because a user reported LightGBM's multiclass ROC curve was still near-diagonal (random-looking), and the PR curve flat at each category's baseline, even after re-running with the tam#37510 fixes (including the #1589 XGBoost fix) already applied. Live-verified on real (non-fixture) multiclass model data:
- Per-row probability sums drifted from the required 1.0 to anywhere between 0.22 and 2.53.
- Correlation between predicted probability and actual class dropped to ~0.04-0.09 — indistinguishable from random, even though the model's own training error was near zero (the model itself was fine; only the extracted probabilities were scrambled).

## Fix

Detect which convention the installed package actually used instead of assuming either one — mirrors #1589's fix exactly:

```r
probs <- if (is.matrix(pred) && ncol(pred) == length(model$y_levels)) {
  pred  # lightgbm >= 4.x already returns the correctly-shaped matrix
} else {
  matrix(pred, ncol = length(model$y_levels), byrow = TRUE)  # legacy flat-vector convention
}
```

Binary and regression `predict()` outputs are unaffected (single-column vectors either way, unchanged code path).

## Tests

Added a regression test asserting the one property that must ALWAYS hold for genuine multiclass probability output — each row's per-class probabilities sum to 1.

Verified via negative control: fails with exactly this assertion when the fix is reverted, passes when restored. All pre-existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)