### PR TITLE
chore: bump version to 16.0.41

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.40
+Version: 16.0.41
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func


### PR DESCRIPTION
Bumps bundled package version after #1581 (Excel guess_max fix) merge.

Live-verified on Mac build box: `test_system.R` guess_max regression test passes (0 failures) via `devtools::load_all`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>