### PR TITLE
fix(catboost): use predicted probabilities for ROC

### DIFF
--- a/R/build_catboost.R
+++ b/R/build_catboost.R
@@ -1544,7 +1544,7 @@ tidy.catboost_exp <- function(x, type = "importance", pretty.name = FALSE, binar
       }
       actual <- extract_actual(x)
       predicted_probability <- extract_predicted(x)
-      do_roc_(data.frame(actual = actual, predicted_probability = predicted_probability), "actual", "predicted_probability")
+      do_roc_(data.frame(actual = actual, predicted_probability = predicted_probability), "predicted_probability", "actual")
     },
     summary_table = {
       tidy.catboost_exp(x, type = "evaluation", pretty.name = pretty.name, binary_classification_threshold = binary_classification_threshold, ...)

--- a/tests/testthat/test_build_catboost.R
+++ b/tests/testthat/test_build_catboost.R
@@ -282,6 +282,30 @@ test_that("direct catboost_binary supports classification evaluation and augment
   expect_true("predicted_probability" %in% colnames(augmented))
 })
 
+test_that("catboost binary ROC uses predicted probabilities as ROC scores", {
+  actual <- factor(c("yes", "no", "yes", "no", "no", "yes"))
+  predicted_probability <- c(0.95, 0.82, 0.71, 0.36, 0.19, 0.04)
+  model <- structure(
+    list(
+      df = data.frame(y = actual, x = seq_along(actual)),
+      terms = stats::terms(y ~ x),
+      prediction_training = predicted_probability,
+      classification_type = "binary"
+    ),
+    class = c("catboost_binary", "catboost_exp")
+  )
+
+  ret <- tidy(model, type = "roc")
+  expected <- do_roc_(
+    data.frame(actual = actual, predicted_probability = predicted_probability),
+    "predicted_probability",
+    "actual"
+  )
+
+  expect_equal(ret, expected)
+  expect_equal(nrow(ret), length(predicted_probability) + 1)
+})
+
 test_that("direct catboost_multi returns empty ROC data instead of failing", {
   testthat::skip_if_not_installed("catboost")
 


### PR DESCRIPTION
## Summary

Fix CatBoost ROC generation to pass the predicted-probability column as the ROC score and the target column as the actual label.

The arguments were reversed, which made ROC sorting and tied-score collapsing operate on the binary target rather than model probabilities.

## Validation

- `testthat::test_local(filter = "(build_catboost|model_eval)")`
- Added a lightweight binary CatBoost ROC regression test that runs without the `catboost` package.
- Existing tests that require `catboost` remain skipped when the package is unavailable.