### PR TITLE
fix: validate K-Modes Repeat-By and sampling metadata

### DIFF
--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -607,11 +607,10 @@ exp_kmodes <- function(df, ...,
                        map_category_top_n = 30) {
   selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
   grouped_cols <- grouped_by(df)
-  selected_cols <- setdiff(selected_cols, grouped_cols)
-
   if (any(selected_cols %in% grouped_cols)) {
     stop("Repeat-By column cannot be used as a variable column.")
   }
+  selected_cols <- setdiff(selected_cols, grouped_cols)
   if (length(selected_cols) < 2) {
     stop("K-Modes requires at least 2 variables. Select more variables.")
   }
@@ -632,10 +631,11 @@ exp_kmodes <- function(df, ...,
       set.seed(seed)
     }
     df <- df %>% dplyr::ungroup()
+    sampled_nrow <- NULL
     if (!is.null(max_nrow) && nrow(df) > max_nrow) {
+      sampled_nrow <- max_nrow
       df <- df %>% sample_rows(max_nrow)
     }
-    sampled_nrow <- if (!is.null(max_nrow)) max_nrow else NULL
 
     df_original <- df %>% dplyr::mutate(.kmodes_row_id = dplyr::row_number())
     prepared_all <- kmodes_prepare_data(df_original, selected_cols,

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -45,6 +45,40 @@ test_that("exp_kmodes is deterministic for a given seed", {
   expect_identical(first$model[[1]]$cluster, second$model[[1]]$cluster)
 })
 
+test_that("exp_kmodes rejects a Repeat-By column selected as a variable", {
+  df <- tibble::tibble(
+    repeat_by = rep(c("A", "B"), 20),
+    a = rep(c("x", "y"), 20),
+    b = rep(c("u", "v"), 20)
+  ) %>% dplyr::group_by(repeat_by)
+
+  expect_error(
+    exp_kmodes(df, repeat_by, a, b, centers = 2, elbow_method_mode = "none"),
+    "Repeat-By column cannot be used"
+  )
+})
+
+test_that("sampled_nrow is set only when max_nrow actually samples", {
+  df <- tibble::tibble(
+    a = rep(c("x", "y"), 20),
+    b = rep(c("u", "v"), 20)
+  )
+
+  not_sampled <- exp_kmodes(
+    df, a, b, centers = 2, max_nrow = 100,
+    elbow_method_mode = "none", map_sample_size = 2
+  )$model[[1]]
+  expect_null(not_sampled$sampled_nrow)
+  expect_equal(nrow(not_sampled$df_original), nrow(df))
+
+  sampled <- exp_kmodes(
+    df, a, b, centers = 2, max_nrow = 10,
+    elbow_method_mode = "none", map_sample_size = 2
+  )$model[[1]]
+  expect_equal(sampled$sampled_nrow, 10)
+  expect_equal(nrow(sampled$df_original), 10)
+})
+
 test_that("ordered factors are clustered as unordered categories", {
   # An ordered factor must contribute match/mismatch only. If the order leaked
   # into the distance, "low" would be closer to "mid" than to "high"; here every


### PR DESCRIPTION
## Summary

- Validate Repeat-By columns before removing grouped columns so invalid selections fail clearly.
- Report `sampled_nrow` only when `max_nrow` actually limits the input.
- Add regression tests for both cases.

## Validation

- `R CMD INSTALL --no-multiarch --no-byte-compile`
- Focused regression checks passed.
- `git diff --check` passed.

The MCA dependency is already present in Tam's reduced and platform manifests, with FactoMineR 2.15 binaries available on download2.