### PR TITLE
fix: use pairing keys for paired tests (exploratory 16.0.43)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.42
+Version: 16.0.43
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/test_wrapper.R
+++ b/R/test_wrapper.R
@@ -955,6 +955,48 @@ exp_ttest_aggregated <- function(df, category, n, category_mean, category_sd, te
   do_on_each_group(df, ttest_each, name = "model", with_unnest = FALSE)
 }
 
+#' Align the two category vectors for a paired test.
+#'
+#' When a pairing key is supplied, observations are matched by key instead of
+#' by their current row order. The first category's order is retained so the
+#' existing direction/base-level behavior is unchanged.
+paired_test_vectors <- function(df, var1_col, var2_col, pairing_key_col = NULL, test_name) {
+  category_levels <- levels(df[[var2_col]])
+  before_index <- df[[var2_col]] == category_levels[1]
+  after_index <- df[[var2_col]] == category_levels[2]
+  var1_before <- df[[var1_col]][before_index]
+  var1_after <- df[[var1_col]][after_index]
+
+  if (is.null(pairing_key_col)) {
+    if (length(var1_before) != length(var1_after)) {
+      stop(paste0("Paired ", test_name, " requires equal number of observations in both groups"))
+    }
+    return(list(before = var1_before, after = var1_after))
+  }
+
+  if (!pairing_key_col %in% colnames(df)) {
+    stop(paste0("Pairing key column `", pairing_key_col, "` was not found"))
+  }
+
+  pairing_values <- df[[pairing_key_col]]
+  if (anyNA(pairing_values)) {
+    stop(paste0("Paired ", test_name, " requires non-missing pairing keys"))
+  }
+
+  key_before <- pairing_values[before_index]
+  key_after <- pairing_values[after_index]
+  if (anyDuplicated(key_before) || anyDuplicated(key_after)) {
+    stop(paste0("Paired ", test_name, " requires each pairing key to occur once in each group"))
+  }
+
+  after_match <- match(key_before, key_after)
+  if (length(var1_before) != length(var1_after) || anyNA(after_match)) {
+    stop(paste0("Paired ", test_name, " requires each pairing key to occur in both groups"))
+  }
+
+  list(before = var1_before, after = var1_after[after_match])
+}
+
 #' t-test wrapper for Analytics View
 #' @export
 #' @param conf.level - Level of confidence for confidence interval. Passed to t.test as part of ...
@@ -963,10 +1005,11 @@ exp_ttest_aggregated <- function(df, category, n, category_mean, category_sd, te
 #' @param d - Cohen's d to detect in power analysis.
 #' @param common_sd - Used for calculation of Cohen's d.
 #' @param diff_to_detect - Used for calculation of Cohen's d.
+#' @param pairing_key - Optional column used to align paired observations.
 exp_ttest <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05,
                       sig.level = 0.05, d = NULL, common_sd = NULL, diff_to_detect = NULL, power = NULL, beta = NULL,
                       outlier_filter_type = NULL, outlier_filter_threshold = NULL, paired = FALSE,
-                      ...) {
+                      ..., pairing_key = NULL) {
   if (!is.null(power) && !is.null(beta) && (power + beta != 1.0)) {
     stop("Specify only one of Power or Type 2 Error, or they must add up to 1.0.")
   }
@@ -975,6 +1018,7 @@ exp_ttest <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05,
   }
   var1_col <- col_name(substitute(var1))
   var2_col <- col_name(substitute(var2))
+  pairing_key_col <- col_name(substitute(pairing_key))
   grouped_cols <- grouped_by(df)
 
   # Apply func2 to var2.
@@ -1101,15 +1145,15 @@ exp_ttest <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05,
           stop("The explanatory variable needs to have 2 unique values.")
         }
 
-        # Split the target value column (var1_col) into two vectores 
-        # by the category of the explanatory variable (var2_col).
-        var1_before <- df_test[[var1_col]][df_test[[var2_col]] == levels(df_test[[var2_col]])[1]]
-        var1_after <- df_test[[var1_col]][df_test[[var2_col]] == levels(df_test[[var2_col]])[2]]
-
-        # Check that the number of observations in both groups are the same.
-        if (length(var1_before) != length(var1_after)) {
-          stop("Paired t-test requires equal number of observations in both groups")
-        }
+        paired_vectors <- paired_test_vectors(
+          df_test,
+          var1_col,
+          var2_col,
+          pairing_key_col,
+          "t-test"
+        )
+        var1_before <- paired_vectors$before
+        var1_after <- paired_vectors$after
 
         # Call t.test with the two vectors.
         model <- t.test(var1_before, var1_after, paired = TRUE, ...)
@@ -1401,9 +1445,11 @@ wilcox_norm_dist_sd <- function(alternative, paired, statistic, n1, n2, tie_coun
 #' @export
 #' @param conf.int - Whether to calculate estimate and confidence interval. Default FALSE. Passed to wilcox.test as part of ...
 #' @param conf.level - Level of confidence for confidence interval. Passed to wilcox.test as part of ...
-exp_wilcox <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05, paired = FALSE, ...) {
+#' @param pairing_key - Optional column used to align paired observations.
+exp_wilcox <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05, paired = FALSE, ..., pairing_key = NULL) {
   var1_col <- col_name(substitute(var1))
   var2_col <- col_name(substitute(var2))
+  pairing_key_col <- col_name(substitute(pairing_key))
   grouped_cols <- grouped_by(df)
 
   if (!is.null(func2)) {
@@ -1473,15 +1519,15 @@ exp_wilcox <- function(df, var1, var2, func2 = NULL, test_sig_level = 0.05, pair
       }
       base.level <- levels(df_test[[var2_col]])[2]
       if (paired) {
-        # Split the target value column (var1_col) into two vectors
-        # by the category of the explanatory variable (var2_col).
-        var1_before <- df_test[[var1_col]][df_test[[var2_col]] == levels(df_test[[var2_col]])[1]]
-        var1_after <- df_test[[var1_col]][df_test[[var2_col]] == levels(df_test[[var2_col]])[2]]
-
-        # Check that the number of observations in both groups are the same.
-        if (length(var1_before) != length(var1_after)) {
-          stop("Paired Wilcoxon test requires equal number of observations in both groups")
-        }
+        paired_vectors <- paired_test_vectors(
+          df_test,
+          var1_col,
+          var2_col,
+          pairing_key_col,
+          "Wilcoxon test"
+        )
+        var1_before <- paired_vectors$before
+        var1_after <- paired_vectors$after
 
         # Call wilcox.test with the two vectors.
         model <- wilcox.test(var1_before, var1_after, paired = TRUE, ...)

--- a/tests/testthat/test_test_wrapper_2.R
+++ b/tests/testthat/test_test_wrapper_2.R
@@ -128,6 +128,52 @@ test_that("test exp_wilcox paired results match direct wilcox.test", {
   expect_equal(ret$`W Value`[[1]] + direct_result$statistic[[1]], n * (n + 1) / 2)
 })
 
+test_that("exp_wilcox aligns shuffled rows by pairing key", {
+  set.seed(123)
+  n <- 10
+  subject_ids <- paste0("P", sprintf("%02d", 1:n))
+  before <- round(rnorm(n, mean = 50, sd = 5), 1)
+  after <- round(rnorm(n, mean = 45, sd = 5), 1)
+  shuffled_after <- c(3, 1, 10, 5, 8, 2, 9, 4, 7, 6)
+
+  data_shuffled <- tibble::tibble(
+    subject_id = c(subject_ids, subject_ids[shuffled_after]),
+    period = factor(rep(c("before", "after"), each = n), levels = c("before", "after")),
+    value = c(before, after[shuffled_after])
+  )
+  data_ordered <- tibble::tibble(
+    subject_id = rep(subject_ids, 2),
+    period = factor(rep(c("before", "after"), each = n), levels = c("before", "after")),
+    value = c(before, after)
+  )
+
+  keyed_model <- exp_wilcox(
+    data_shuffled,
+    value,
+    period,
+    paired = TRUE,
+    pairing_key = subject_id
+  ) %>% tidy_rowwise(model, type = "model")
+  ordered_model <- exp_wilcox(data_ordered, value, period, paired = TRUE) %>%
+    tidy_rowwise(model, type = "model")
+
+  expect_equal(keyed_model$`W Value`, ordered_model$`W Value`)
+  expect_equal(keyed_model$`P Value`, ordered_model$`P Value`)
+})
+
+test_that("exp_wilcox validates pairing keys", {
+  duplicate_keys <- tibble::tibble(
+    subject_id = c("A", "A", "B", "B"),
+    period = c("before", "before", "after", "after"),
+    value = c(1, 2, 3, 4)
+  )
+
+  expect_error(
+    exp_wilcox(duplicate_keys, value, period, paired = TRUE, pairing_key = subject_id),
+    "requires each pairing key to occur once in each group"
+  )
+})
+
 test_that("test exp_wilcox paired with conf.int results match direct wilcox.test", {
   set.seed(42)
   n <- 30

--- a/tests/testthat/test_ttest_paired.R
+++ b/tests/testthat/test_ttest_paired.R
@@ -134,6 +134,52 @@ test_that("test paired ttest", {
                "The explanatory variable needs to have 2 unique values.")
 })
 
+test_that("paired ttest aligns shuffled rows by pairing key", {
+  data_shuffled <- tibble::tibble(
+    subject_id = c("A", "B", "C", "D", "C", "A", "D", "B"),
+    period = c(rep("before", 4), rep("after", 4)),
+    value = c(1, 100, 3, 200, 30, 10, 20, 2)
+  )
+  data_ordered <- data_shuffled %>%
+    dplyr::arrange(period, subject_id)
+
+  keyed_model <- exp_ttest(
+    data_shuffled,
+    value,
+    period,
+    paired = TRUE,
+    pairing_key = subject_id
+  )$model[[1]]
+  ordered_model <- exp_ttest(data_ordered, value, period, paired = TRUE)$model[[1]]
+
+  expect_equal(keyed_model$p.value, ordered_model$p.value)
+  expect_equal(keyed_model$statistic, ordered_model$statistic)
+  expect_equal(keyed_model$estimate, ordered_model$estimate)
+  expect_equal(keyed_model$conf.int, ordered_model$conf.int)
+})
+
+test_that("paired ttest validates pairing keys", {
+  duplicate_keys <- tibble::tibble(
+    subject_id = c("A", "A", "B", "B"),
+    period = c("before", "before", "after", "after"),
+    value = c(1, 2, 3, 4)
+  )
+  missing_key <- tibble::tibble(
+    subject_id = c("A", NA, "A", "B"),
+    period = c("before", "before", "after", "after"),
+    value = c(1, 2, 3, 4)
+  )
+
+  expect_error(
+    exp_ttest(duplicate_keys, value, period, paired = TRUE, pairing_key = subject_id),
+    "requires each pairing key to occur once in each group"
+  )
+  expect_error(
+    exp_ttest(missing_key, value, period, paired = TRUE, pairing_key = subject_id),
+    "requires non-missing pairing keys"
+  )
+})
+
 test_that("test paired ttest with grouped data", {
   # Base data for the paired sample t-test.
   wide.data <- data.frame(
@@ -162,9 +208,15 @@ test_that("test paired ttest with grouped data", {
   # Run the exploratory t-test.
   model_df <- long.data %>% group_by(Category) %>% exp_ttest(Value, Group, paired = TRUE)
 
+  keyed_model_df <- long.data %>%
+    group_by(Category) %>%
+    exp_ttest(Value, Group, paired = TRUE, pairing_key = Subject)
+
   # Compare the base model and the exploratory model. 
   expect_equal(base.model.cat1$p.value, model_df$model[[1]]$p.value)
   expect_equal(base.model.cat1$estimate, model_df$model[[1]]$estimate)
+  expect_equal(model_df$model[[1]]$p.value, keyed_model_df$model[[1]]$p.value)
+  expect_equal(model_df$model[[1]]$estimate, keyed_model_df$model[[1]]$estimate)
 
   # Test different combinations of arguments with grouped data
   # Test case 1: Change significance level


### PR DESCRIPTION
## Summary

- Align paired t-test and paired Wilcoxon observations by the configured pairing key.
- Preserve the existing row-order behavior when no pairing key is provided.
- Validate missing, duplicate, and unmatched pairing keys.
- Bump the exploratory package version from 16.0.42 to 16.0.43.

## Binaries

- Mac Intel: https://download2.exploratory.io/bin/macosx/contrib/4.6/exploratory_16.0.43.tgz
- Mac ARM: https://download2.exploratory.io/bin/macosx/big-sur-arm64/contrib/4.6/exploratory_16.0.43.tgz
- Windows: https://download2.exploratory.io/bin/windows/contrib/4.6/exploratory_16.0.43.zip

All three download2 URLs return HTTP 200 and match the verified artifact MD5.

## Tests

- `test_ttest_paired.R`: 67 passing
- `test_test_wrapper_2.R`: 45 passing

Companion implementation for exploratory-io/tam#37604.