### PR TITLE
feat: standardize analytics report summary section (tam#37638)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.44
+Version: 16.0.45
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.45
+Version: 16.0.46
 Date: 2026-08-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -881,6 +881,15 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
         }
       }
     }
+    # tam#37638: FA is the role model for this issue, and this table's row set is already
+    # correct -- the 変数名（数値型）/変数名（順序付きカテゴリ型）/因子数 rows are injected
+    # CLIENT-SIDE by FactanalReportBindUtil.injectSummaryRowsIntoAnalysisMethod (tam#37402 /
+    # tam#37620 / tam#37633), not emitted by R. An earlier version of this change duplicated that
+    # work here in R; reverted -- adding them from both sides would either double-inject rows
+    # (whenever this R Item label doesn't exactly match the client's INJECTED_ITEMS set, e.g. the
+    # mixed-correlation case) or silently rely on the client's idempotent strip-and-reinject to
+    # paper over it. Only tam#37638's own additions belong here: 項目 header rename (tam-side
+    # tableColumnHeaderTemplate) and the Rows Removed format below.
     res <- tibble::tibble(
       # The variable / row counts come FIRST (issue tam#37340): the section is now
       # 「分析条件とデータの確認」, which leads with what data was analyzed. The method rows keep

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -574,8 +574,14 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     # the client translates. Empty typed tibble for k-means / old saved models (no report data).
     cfg <- prcomp_report_config()
     if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
+      # Same column shape as the populated branch below (tam#37638), so a consumer that reads the
+      # hidden method columns never sees a table that is missing them entirely.
       res <- tibble::tibble(Metric = character(0), Value = character(0),
-                            Description = character(0), status = character(0))
+                            Description = character(0), status = character(0),
+                            correlation_type = character(0), correlation_is_auto = character(0),
+                            degraded_from = character(0), polychoric_available = character(0),
+                            warning_tokens = character(0), has_diagnostics = character(0),
+                            reason = character(0))
     }
     else {
       d <- x$input_diagnostics
@@ -600,39 +606,69 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       } else {
         "Preserve Component Variance"
       }
+      # tam#37638: this is now the report's ONE 「分析条件とデータの確認」 table -- the separate
+      # 「分析方法」 table was folded in, so Correlation and Variable Names live here too and the
+      # row order follows the spec (variables -> rows -> method). The old "Rows Excluded" key is
+      # now "Rows Removed" to match the wanted 削除された行数 (the Factor Analysis role-model
+      # table already uses that key); the client keeps a fallback for saved analytics.
+      variable_names_display <- {
+        nms <- names(d$variable_sd)
+        if (is.null(nms) || length(nms) == 0) "N/A" else paste(nms, collapse = ", ")
+      }
+      cor_type_for_table <- if (is.null(x$correlation_type)) "pearson" else x$correlation_type
       res <- tibble::tibble(
-        Metric = c("Row Count", "Rows Excluded", "Number of Variables", "Excluded Variables",
-                   "Normalization", "Score Scale", "SD Ratio (Max/Min)"),
+        Metric = c("Number of Variables", "Variable Names", "Excluded Variables",
+                   "Row Count", "Rows Removed", "Normalization",
+                   "SD Ratio (Max/Min)", "Correlation", "Score Scale"),
         Value = c(
+          as.character(variables_used),
+          variable_names_display,
+          excluded_display,
           as.character(d$analyzed_row_count),
           paste0(d$excluded_row_count, " (", format(round(excluded_pct, 1), nsmall = 1), "%)"),
-          as.character(variables_used),
-          excluded_display,
           # English-canonical boolean string, not "Yes"/"No" (issue #27224 follow-up): matches
           # the plain TRUE/FALSE convention this file's own analysis_method hidden columns
           # already use, and reads unambiguously as a raw boolean value in the report table.
           if (normalized) "TRUE" else "FALSE",
-          score_scale_display,
-          scale_display
+          scale_display,
+          factanal_correlation_label(cor_type_for_table),
+          score_scale_display
         ),
         Description = c(
+          "Number of variables used in the analysis.",
+          "Names of the variables used in the analysis.",
+          "Variables dropped before analysis because they were all missing or had only one unique value.",
           "Number of rows used in the analysis.",
           "Number and rate of rows removed because of missing values.",
-          "Number of variables used in the analysis.",
-          "Variables dropped before analysis because they were all missing or had only one unique value.",
           "Whether variables were standardized before analysis.",
-          "How principal-component scores are scaled.",
-          "Ratio of the maximum to the minimum standard deviation across all variables."
+          "Ratio of the maximum to the minimum standard deviation across all variables.",
+          "Which correlation the principal components were computed from.",
+          "How principal-component scores are scaled."
         ),
         status = c(
+          "ok",
+          "ok",
+          if (length(excluded_names) == 0) "na" else "ok",
           if (d$analyzed_row_count <= variables_used) "few_rows" else "ok",
           if (d$excluded_row_rate >= cfg$na_exclusion_warning) "high_na_exclusion" else "ok",
           "ok",
-          if (length(excluded_names) == 0) "na" else "ok",
+          scale_status,
           "ok",
-          "ok",
-          scale_status
+          "ok"
         )
+      )
+      # Hidden columns, identical in meaning to the ones analysis_method emits. They ride along
+      # here so ONE viz can feed both the rendered table and the report's explanation text now
+      # that the two tables were merged (tam#37638). Booleans are explicit "TRUE"/"FALSE"
+      # STRINGS -- see the analysis_method block below for why.
+      res <- res %>% dplyr::mutate(
+        correlation_type = cor_type_for_table,
+        correlation_is_auto = if (isTRUE(x$correlation_is_auto)) "TRUE" else "FALSE",
+        degraded_from = if (is.null(x$correlation_degraded_from)) "" else x$correlation_degraded_from,
+        polychoric_available = if (isTRUE(x$correlation_polychoric_available)) "TRUE" else "FALSE",
+        warning_tokens = paste(factanal_selection_warning_tokens(x$correlation_selection), collapse = ","),
+        has_diagnostics = if (!is.null(x$cor_diagnostics) && nrow(x$cor_diagnostics) > 0) "TRUE" else "FALSE",
+        reason = if (is.null(x$correlation_reason)) "" else x$correlation_reason
       )
     }
   }

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -675,16 +675,35 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
              round(confidence_interval$upper[[1]], 3))
     } else NA_character_
 
+    # tam#37638. The report renders this ONE table as TWO sections -- 分析条件とデータの確認
+    # (the data/method rows) and 信頼性の指標 (the coefficient rows) -- by filtering on Metric,
+    # so the rows are grouped in the order each section wants them.
+    #   * "Complete Responses" / "Responses with Missing" became "Row Count" / "Rows Removed":
+    #     keys the client's translation map ALREADY carries as 行数 / 削除された行数 from the
+    #     Factor Analysis and PCA tables, which is exactly the wanted wording.
+    #   * "Variable Names", "Correlation" and "Reliability Metric" are new. Correlation's reason
+    #     used to live in the separate correlation_method table, which the report drops.
     summary_table <- tibble::tibble(
-      Metric = c(coefficient_name, "Standardized Alpha", "95% CI", "Number of Variables",
-                 "Complete Responses", "Responses with Missing", "Total Missing Cells",
-                 "Average Inter-item Correlation", "Flagged Item"),
+      Metric = c(coefficient_name, "Standardized Alpha", "95% CI",
+                 "Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+                 "Correlation", "Reliability Metric",
+                 "Total Missing Cells", "Average Inter-item Correlation", "Flagged Item"),
       Value = c(as.character(round(display_alpha, 3)),
                 as.character(round(standardized_alpha, 3)),
                 ci_text,
                 as.character(ncol(cleaned_df)),
+                paste(colnames(cleaned_df), collapse = ", "),
                 as.character(complete_n),
-                as.character(rows_with_missing_n),
+                # "N (P%)", matching the Factor Analysis / PCA 削除された行数 rows this report is
+                # being standardized against (tam#37638). total_n is the pre-filter row count.
+                if (is.null(total_n) || length(total_n) != 1L || is.na(total_n) || total_n <= 0) {
+                  as.character(rows_with_missing_n)
+                } else {
+                  paste0(rows_with_missing_n, " (",
+                         format(round(rows_with_missing_n / total_n * 100, 1), nsmall = 1), "%)")
+                },
+                reliability_correlation_label(selected_method),
+                coefficient_name,
                 as.character(total_missing_n),
                 as.character(round(average_r, 3)),
                 flagged_item),
@@ -692,9 +711,15 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
         reliability_classify_alpha(display_alpha),
         "Standardized consistency",
         if (nrow(confidence_interval) > 0) "Feldt/Duhachek interval" else NA_character_,
-        paste0(ncol(cleaned_df), " items used"),
+        # tam#37638: a FIXED sentence, not the old composed "N items used". This cell is rendered
+        # in the 説明 column of 分析条件とデータの確認 and the client translates report cells by
+        # EXACT string match, so a runtime-composed string can never be localized.
+        "Number of variables used in the analysis",
+        "Variables used in the analysis",
         "Rows with no missing values",
         "Rows with 1+ missing value",
+        reliability_correlation_reason(correlation_method, item_types),
+        reliability_metric_reason(selected_method),
         "Missing cells across all items",
         dplyr::case_when(
           average_r >= 0.50 ~ "High relatedness",
@@ -753,6 +778,50 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
 }
 
 # ------------------------------------------------------------
+# Correlation / coefficient labels and their selection reasons (tam#37638).
+# Extracted so the 分析条件とデータの確認 table and the legacy correlation_method table cannot
+# drift apart. Every returned sentence is a FIXED English string, never composed at runtime: the
+# client translates report table cells by exact string match, so a runtime-composed sentence would
+# render untranslated in Japanese.
+# ------------------------------------------------------------
+
+reliability_correlation_label <- function(selected_method) {
+  switch(selected_method,
+    pearson = "Pearson Correlation",
+    polychoric = "Polychoric Correlation",
+    mixed = "Mixed Correlation",
+    selected_method)
+}
+
+reliability_correlation_reason <- function(requested_method, item_types) {
+  requested <- if (is.null(requested_method)) "auto" else requested_method
+  if (requested != "auto") {
+    return(switch(requested,
+      pearson = "Pearson was specified in the settings.",
+      polychoric = "Polychoric was specified in the settings.",
+      mixed = "Mixed Correlation was specified in the settings.",
+      "Specified in the settings."))
+  }
+  unique_types <- unique(unname(item_types))
+  if (all(unique_types == "continuous")) {
+    "All variables are Numeric."
+  } else if (all(unique_types %in% c("ordinal", "dichotomous"))) {
+    "All variables are Factor or Logical."
+  } else {
+    "Numeric and Factor/Logical variables are mixed."
+  }
+}
+
+# Why THIS reliability coefficient: it follows directly from the correlation that was selected.
+reliability_metric_reason <- function(selected_method) {
+  switch(selected_method,
+    pearson = "Cronbach's Alpha was selected because the correlation is Pearson.",
+    polychoric = "Ordinal Alpha was selected because the correlation is Polychoric.",
+    mixed = "Mixed-Correlation Alpha was selected because the correlation is Mixed.",
+    "Selected based on the correlation used.")
+}
+
+# ------------------------------------------------------------
 # glance / tidy
 # ------------------------------------------------------------
 
@@ -807,28 +876,10 @@ tidy.cronbach_alpha_exploratory <- function(x, type = "summary", pretty.name = F
   } else if (type == "correlation_method") {
     # The "which correlation was used and why" table. English labels only -- the
     # Analytics report localizes them through the usual translation path.
-    method_label <- switch(x$selected_method,
-      pearson = "Pearson Correlation",
-      polychoric = "Polychoric Correlation",
-      mixed = "Mixed Correlation",
-      x$selected_method)
-    requested <- if (is.null(x$requested_method)) "auto" else x$requested_method
-    reason <- if (requested != "auto") {
-      switch(requested,
-        pearson = "Pearson was specified in the settings.",
-        polychoric = "Polychoric was specified in the settings.",
-        mixed = "Mixed Correlation was specified in the settings.",
-        "Specified in the settings.")
-    } else {
-      unique_types <- unique(unname(x$item_types))
-      if (all(unique_types == "continuous")) {
-        "All variables are Numeric."
-      } else if (all(unique_types %in% c("ordinal", "dichotomous"))) {
-        "All variables are Factor or Logical."
-      } else {
-        "Numeric and Factor/Logical variables are mixed."
-      }
-    }
+    # tam#37638: the label / reason logic is shared with the summary table's Correlation row, so
+    # the two can never disagree about which correlation was used or why.
+    method_label <- reliability_correlation_label(x$selected_method)
+    reason <- reliability_correlation_reason(x$requested_method, x$item_types)
     res <- tibble::tibble(
       `Item` = c("Correlation Type", "Primary Metric", "Selection Reason"),
       `Value` = c(method_label, x$coefficient_name, reason))

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -235,7 +235,10 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
     else {
       # Return cor_exploratory model, which is a set of correlation data frame and the original data.
       # We use the original data for scatter matrix on Analytics View.
-      ret <- list(cor = ret, data = df)
+      # analysis_conditions feeds the report's 分析条件とデータの確認 table (tam#37638). Computed
+      # here because `mat` (the SELECTED columns, before any pair filtering) is only in scope now.
+      ret <- list(cor = ret, data = df,
+                  analysis_conditions = cor_analysis_conditions(mat, method, use))
       class(ret) <- c("cor_exploratory", class(ret))
       ret
     }
@@ -251,6 +254,90 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
   }
 }
 
+
+# Correlation report: the 分析条件とデータの確認 table (tam#37638).
+#
+# Built at fit time, while the selected columns are still in hand, and stored on the
+# cor_exploratory model -- tidy() only reads it back. Every sentence is a FIXED English string
+# (never composed at runtime) because the client translates report table cells by exact string
+# match; a composed sentence would render untranslated in Japanese. The strings deliberately
+# match the ones reliability.R already emits, so both reports share one set of translations.
+cor_correlation_label <- function(resolved_method) {
+  switch(resolved_method,
+    pearson = "Pearson Correlation",
+    polychoric = "Polychoric Correlation",
+    mixed = "Mixed Correlation",
+    spearman = "Spearman Correlation",
+    kendall = "Kendall Correlation",
+    resolved_method)
+}
+
+cor_correlation_reason <- function(mat, requested_method) {
+  if (!identical(requested_method, "auto")) {
+    return(switch(requested_method,
+      pearson = "Pearson was specified in the settings.",
+      polychoric = "Polychoric was specified in the settings.",
+      mixed = "Mixed Correlation was specified in the settings.",
+      "Specified in the settings."))
+  }
+  is_ordinal <- vapply(mat, function(x) is.factor(x) || is.logical(x), logical(1))
+  is_continuous <- vapply(mat, is.numeric, logical(1))
+  if (all(is_continuous)) {
+    "All variables are Numeric."
+  } else if (all(is_ordinal)) {
+    "All variables are Factor or Logical."
+  } else {
+    "Numeric and Factor/Logical variables are mixed."
+  }
+}
+
+cor_analysis_conditions <- function(mat, requested_method, use) {
+  variable_names <- colnames(mat)
+  # A variable that is entirely missing, or that never varies, cannot produce a correlation with
+  # anything -- the same predicate PCA uses to decide what it drops before analysis.
+  is_unusable <- vapply(mat, function(x) {
+    values <- x[!is.na(x)]
+    length(values) == 0 || length(unique(values)) < 2
+  }, logical(1))
+  excluded_names <- variable_names[is_unusable]
+  total_rows <- nrow(mat)
+  # With the default pairwise.complete.obs a row still contributes to every pair it has both
+  # values for, so only an ALL-missing row is truly unused. Under complete.obs any missing value
+  # drops the whole row. Report whichever the analysis actually did.
+  rows_used <- if (identical(use, "complete.obs")) {
+    sum(stats::complete.cases(mat))
+  } else {
+    sum(rowSums(!is.na(mat)) > 0)
+  }
+  rows_removed <- max(0L, as.integer(total_rows - rows_used))
+  removed_pct <- if (total_rows > 0) rows_removed / total_rows * 100 else 0
+  tibble::tibble(
+    Metric = c("Number of Variables", "Variable Names", "Excluded Variables",
+               "Row Count", "Rows Removed", "Correlation"),
+    Value = c(
+      as.character(length(variable_names)),
+      if (length(variable_names) == 0) "N/A" else paste(variable_names, collapse = ", "),
+      if (length(excluded_names) == 0) "None" else paste(excluded_names, collapse = ", "),
+      as.character(rows_used),
+      paste0(rows_removed, " (", format(round(removed_pct, 1), nsmall = 1), "%)"),
+      cor_correlation_label(resolve_correlation_method(mat, requested_method))
+    ),
+    Description = c(
+      "Number of variables used in the analysis.",
+      "Names of the variables used in the analysis.",
+      "Variables dropped before analysis because they were all missing or had only one unique value.",
+      "Number of rows used in the analysis.",
+      "Number and rate of rows removed because of missing values.",
+      "Which correlation the coefficients were computed with."
+    ),
+    # Hidden columns: the report reads them to decide whether to explain the automatic choice.
+    # Explicit "TRUE"/"FALSE" STRINGS, not R logicals -- a logical can reach the client as "1"/"0"
+    # depending on the pivot pipeline, and the client's isTrue() only accepts "TRUE"/"true"/true.
+    correlation_type = resolve_correlation_method(mat, requested_method),
+    correlation_is_auto = if (identical(requested_method, "auto")) "TRUE" else "FALSE",
+    reason = cor_correlation_reason(mat, requested_method)
+  )
+}
 
 resolve_correlation_method <- function(mat, method) {
   if (!identical(method, "auto")) {
@@ -391,6 +478,18 @@ do_cor_internal <- function(mat, use, method, diag, output_cols, na.rm) {
 tidy.cor_exploratory <- function(x, type = "cor", ...) { #TODO: add test
   if (type == "cor") {
     x$cor
+  }
+  else if (type == "analysis_conditions") {
+    # tam#37638. An analytics saved before this existed has no $analysis_conditions -- return the
+    # empty tibble with the same column shape so the report's table renders empty instead of
+    # erroring, and the client's extractor falls back to its own defaults.
+    if (is.null(x$analysis_conditions)) {
+      tibble::tibble(Metric = character(0), Value = character(0), Description = character(0),
+                     correlation_type = character(0), correlation_is_auto = character(0),
+                     reason = character(0))
+    } else {
+      x$analysis_conditions
+    }
   }
   else {
     x$data

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -301,13 +301,18 @@ cor_analysis_conditions <- function(mat, requested_method, use) {
   }, logical(1))
   excluded_names <- variable_names[is_unusable]
   total_rows <- nrow(mat)
-  # With the default pairwise.complete.obs a row still contributes to every pair it has both
-  # values for, so only an ALL-missing row is truly unused. Under complete.obs any missing value
-  # drops the whole row. Report whichever the analysis actually did.
-  rows_used <- if (identical(use, "complete.obs")) {
+  resolved_method <- resolve_correlation_method(mat, requested_method)
+  # Pairwise correlations use a row only when at least two selected variables are observed; a row
+  # with one value cannot contribute to any off-diagonal pair. Polychoric and mixed correlations
+  # map every use mode other than complete.obs to pairwise.complete.obs in do_cor_internal().
+  uses_pairwise <- identical(use, "pairwise.complete.obs") ||
+    (resolved_method %in% c("polychoric", "mixed") && !identical(use, "complete.obs"))
+  rows_used <- if (uses_pairwise) {
+    sum(rowSums(!is.na(mat)) >= 2L)
+  } else if (use %in% c("complete.obs", "na.or.complete")) {
     sum(stats::complete.cases(mat))
   } else {
-    sum(rowSums(!is.na(mat)) > 0)
+    total_rows
   }
   rows_removed <- max(0L, as.integer(total_rows - rows_used))
   removed_pct <- if (total_rows > 0) rows_removed / total_rows * 100 else 0
@@ -320,7 +325,7 @@ cor_analysis_conditions <- function(mat, requested_method, use) {
       if (length(excluded_names) == 0) "None" else paste(excluded_names, collapse = ", "),
       as.character(rows_used),
       paste0(rows_removed, " (", format(round(removed_pct, 1), nsmall = 1), "%)"),
-      cor_correlation_label(resolve_correlation_method(mat, requested_method))
+      cor_correlation_label(resolved_method)
     ),
     Description = c(
       "Number of variables used in the analysis.",
@@ -333,7 +338,7 @@ cor_analysis_conditions <- function(mat, requested_method, use) {
     # Hidden columns: the report reads them to decide whether to explain the automatic choice.
     # Explicit "TRUE"/"FALSE" STRINGS, not R logicals -- a logical can reach the client as "1"/"0"
     # depending on the pivot pipeline, and the client's isTrue() only accepts "TRUE"/"true"/true.
-    correlation_type = resolve_correlation_method(mat, requested_method),
+    correlation_type = resolved_method,
     correlation_is_auto = if (identical(requested_method, "auto")) "TRUE" else "FALSE",
     reason = cor_correlation_reason(mat, requested_method)
   )

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -92,8 +92,23 @@ test_that("do_prcomp attaches report data, sign stabilization, retained resoluti
 test_that("new report tidy types return expected columns and tokens", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt)
   res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
-  expect_equal(colnames(res), c("Metric", "Value", "Description", "status"))
+  # tam#37638: the separate analysis_method table was folded in here, so the hidden method
+  # columns ride along and the report can bind its explanation text from this one viz.
+  expect_equal(colnames(res), c("Metric", "Value", "Description", "status",
+                              "correlation_type", "correlation_is_auto", "degraded_from",
+                              "polychoric_available", "warning_tokens", "has_diagnostics",
+                              "reason"))
   expect_true(all(c("Row Count","Number of Variables","Normalization","SD Ratio (Max/Min)") %in% res$Metric))
+  # tam#37638: the exact row set and ORDER the report's 分析条件とデータの確認 table renders.
+  expect_equal(res$Metric,
+               c("Number of Variables", "Variable Names", "Excluded Variables", "Row Count",
+                 "Rows Removed", "Normalization", "SD Ratio (Max/Min)", "Correlation",
+                 "Score Scale"))
+  # Renamed from "Rows Excluded" so the report can say 削除された行数, like Factor Analysis.
+  expect_false("Rows Excluded" %in% res$Metric)
+  expect_equal(res$Value[[which(res$Metric == "Variable Names")]], "mpg, cyl, disp, hp, drat, wt")
+  expect_equal(res$Value[[which(res$Metric == "Correlation")]], "Pearson Correlation")
+  expect_equal(res$correlation_type[[1]], "pearson")
   expect_false("Rows vs Variables" %in% res$Metric)
   expect_false("Rows Used" %in% res$Metric)
   expect_false("Variables Used" %in% res$Metric)
@@ -119,7 +134,12 @@ test_that("new report tidy types return expected columns and tokens", {
 test_that("new report tidy types return empty typed tibbles for kmeans fits", {
   km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
   ac <- km %>% tidy_rowwise(model, type = "analysis_conditions")
-  expect_equal(colnames(ac), c("Metric", "Value", "Description", "status"))
+  # tam#37638: same column shape as the populated branch, so a consumer reading the hidden
+  # method columns never sees a table that lacks them entirely.
+  expect_equal(colnames(ac), c("Metric", "Value", "Description", "status",
+                              "correlation_type", "correlation_is_auto", "degraded_from",
+                              "polychoric_available", "warning_tokens", "has_diagnostics",
+                              "reason"))
   expect_equal(nrow(ac), 0)
   ps <- km %>% tidy_rowwise(model, type = "parallel_screeplot")
   expect_equal(colnames(ps), c("Component", "Eigenvalue", "Random Data Eigenvalue"))
@@ -227,7 +247,9 @@ PRCOMP_STRESS_NAME <- "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
 
 # The eight report tidy types + their required columns (empty case = 0 rows, same cols).
 PRCOMP_REPORT_TYPE_COLS <- list(
-  analysis_conditions = c("Metric", "Value", "Description", "status"),
+  analysis_conditions = c("Metric", "Value", "Description", "status",
+                          "correlation_type", "correlation_is_auto", "degraded_from",
+                          "polychoric_available", "warning_tokens", "has_diagnostics", "reason"),
   parallel_screeplot  = c("Component", "Eigenvalue", "Random Data Eigenvalue"),
   variances_judged    = c("Component", "Eigenvalue", "% Variance", "Cummulated % Variance",
                           "Parallel Analysis", "Kaiser Criterion", "Selected",
@@ -620,9 +642,11 @@ test_that("analysis_conditions carries the Score Scale row (#27224)", {
   expect_equal(preserve$Description[preserve$Metric == "Score Scale"],
                "How principal-component scores are scaled.")
   expect_equal(preserve$status[preserve$Metric == "Score Scale"], "ok")
-  # Sits between Normalization and SD Ratio, per the spec's Metric ordering.
-  expect_equal(which(preserve$Metric == "Score Scale"), which(preserve$Metric == "Normalization") + 1L)
-  expect_equal(which(preserve$Metric == "SD Ratio (Max/Min)"), which(preserve$Metric == "Score Scale") + 1L)
+  # tam#37638 reordered this table to the standardized 分析条件とデータの確認 layout: the method
+  # rows (Correlation, Score Scale) now come AFTER the data rows, so Score Scale is last.
+  expect_equal(which(preserve$Metric == "SD Ratio (Max/Min)"), which(preserve$Metric == "Normalization") + 1L)
+  expect_equal(which(preserve$Metric == "Score Scale"), which(preserve$Metric == "Correlation") + 1L)
+  expect_equal(which(preserve$Metric == "Score Scale"), length(preserve$Metric))
 
   unitvar <- (mtcars %>% do_prcomp(mpg, cyl, disp, hp, score_scale = "unit_variance")) %>%
     tidy_rowwise(model, type = "analysis_conditions")

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -291,3 +291,50 @@ test_that("exp_cronbach_alpha works with group_by (per group model)", {
   res <- model_df %>% glance_rowwise(model, pretty.name = TRUE)
   expect_equal(nrow(res), 2)
 })
+
+test_that("summary table carries the analysis-condition rows and their reasons (issue tam#37638)", {
+  set.seed(11)
+  n <- 120
+  latent <- rnorm(n)
+  df <- data.frame(
+    q1 = round(latent + rnorm(n, 0, 0.6)),
+    q2 = round(latent + rnorm(n, 0, 0.6)),
+    q3 = round(latent + rnorm(n, 0, 0.7)),
+    q4 = round(latent + rnorm(n, 0, 0.8))
+  )
+  df$q2[1:12] <- NA
+  model_df <- df %>% exp_cronbach_alpha(q1, q2, q3, q4)
+  s <- model_df %>% tidy_rowwise(model, type = "summary")
+
+  # The report splits THIS one output into two tables by filtering Metric, so both groups have
+  # to be present and contiguous in the order each table wants to render them.
+  expect_true(all(c("Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+                    "Correlation", "Reliability Metric") %in% s$Metric))
+  cond <- s$Metric[s$Metric %in% c("Number of Variables", "Variable Names", "Row Count",
+                                   "Rows Removed", "Correlation", "Reliability Metric")]
+  expect_equal(cond, c("Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+                       "Correlation", "Reliability Metric"))
+  # Renamed so the client's existing 行数 / 削除された行数 keys apply (they used to be
+  # 回答数 / 欠損を含む回答数).
+  expect_false("Complete Responses" %in% s$Metric)
+  expect_false("Responses with Missing" %in% s$Metric)
+
+  val <- function(metric) s$Value[[which(s$Metric == metric)]]
+  interp <- function(metric) s$Interpretation[[which(s$Metric == metric)]]
+  expect_equal(val("Variable Names"), "q1, q2, q3, q4")
+  expect_equal(val("Correlation"), "Pearson Correlation")
+  expect_equal(val("Reliability Metric"), "Cronbach's Alpha")
+  # 「削除された行数」 is "N (P%)", matching the Factor Analysis / PCA tables.
+  expect_match(val("Rows Removed"), "^[0-9]+ \\([0-9.]+%\\)$")
+
+  # The selection REASONS moved here from the standalone correlation_method table, which the
+  # report no longer renders. Both are fixed English strings so the client can translate them.
+  expect_equal(interp("Correlation"), "All variables are Numeric.")
+  expect_equal(interp("Reliability Metric"),
+               "Cronbach's Alpha was selected because the correlation is Pearson.")
+
+  # The legacy tidy type still agrees with the summary rows -- they share one helper now.
+  cm <- model_df %>% tidy_rowwise(model, type = "correlation_method")
+  expect_equal(cm$Value[[which(cm$Item == "Correlation Type")]], val("Correlation"))
+  expect_equal(cm$Value[[which(cm$Item == "Selection Reason")]], interp("Correlation"))
+})

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -774,3 +774,22 @@ test_that("do_cor model carries the report's analysis_conditions (issue tam#3763
   expect_equal(colnames(legacy_cond),
                c("Metric", "Value", "Description", "correlation_type", "correlation_is_auto", "reason"))
 })
+
+test_that("do_cor analysis_conditions counts rows according to use", {
+  df <- data.frame(
+    a = c(1, 4, NA, 7),
+    b = c(2, NA, 5, 8),
+    c = c(3, NA, 6, 9)
+  )
+
+  pairwise <- df %>% do_cor(a, b, c, use = "pairwise.complete.obs", return_type = "model") %>%
+    (function(x) tidy(x$model[[1]], type = "analysis_conditions"))
+  # The second row has only one observed variable and contributes to no pairwise correlation.
+  expect_equal(pairwise$Value[[4]], "3")
+  expect_equal(pairwise$Value[[5]], "1 (25.0%)")
+
+  na_or_complete <- df %>% do_cor(a, b, c, use = "na.or.complete", return_type = "model") %>%
+    (function(x) tidy(x$model[[1]], type = "analysis_conditions"))
+  expect_equal(na_or_complete$Value[[4]], "2")
+  expect_equal(na_or_complete$Value[[5]], "2 (50.0%)")
+})

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -726,3 +726,51 @@ test_that("do_cmdscale all 0 distances error", {
     do_cmdscale(data, var1, var2, val)
   }, "All distances are 0. Multidimensional scaling cannot be calculated.")
 })
+
+test_that("do_cor model carries the report's analysis_conditions (issue tam#37638)", {
+  set.seed(13)
+  df <- data.frame(a = rnorm(40), b = rnorm(40), c = rnorm(40))
+  df$b[1:4] <- NA
+  df$flat <- 1
+
+  model_df <- df %>% do_cor(a, b, c, flat, method = "auto", return_type = "model")
+  cond <- model_df$model[[1]] %>% tidy(type = "analysis_conditions")
+
+  expect_equal(cond$Metric,
+               c("Number of Variables", "Variable Names", "Excluded Variables",
+                 "Row Count", "Rows Removed", "Correlation"))
+  expect_equal(cond$Value[[1]], "4")
+  expect_equal(cond$Value[[2]], "a, b, c, flat")
+  # A constant column cannot correlate with anything, so it is reported as excluded -- the same
+  # predicate PCA uses for what it drops before analysis.
+  expect_equal(cond$Value[[3]], "flat")
+  expect_equal(cond$Value[[6]], "Pearson Correlation")
+  # Hidden columns the report binds its explanation text from. Explicit "TRUE"/"FALSE" strings.
+  expect_equal(cond$correlation_type[[1]], "pearson")
+  expect_equal(cond$correlation_is_auto[[1]], "TRUE")
+  expect_equal(cond$reason[[1]], "All variables are Numeric.")
+
+  # With pairwise.complete.obs (the default) only an all-missing row is unused, so no row is
+  # removed here; complete.obs drops any row with a missing value.
+  expect_equal(cond$Value[[4]], "40")
+  expect_match(cond$Value[[5]], "^0 \\(0.0%\\)$")
+  complete_cond <- df %>% do_cor(a, b, c, use = "complete.obs", return_type = "model") %>%
+    (function(x) tidy(x$model[[1]], type = "analysis_conditions"))
+  expect_equal(complete_cond$Value[[4]], "36")
+  expect_match(complete_cond$Value[[5]], "^4 \\(10.0%\\)$")
+
+  # An explicit method is not "auto", and the reason says so instead of inventing a rationale.
+  spearman <- df %>% do_cor(a, b, c, method = "spearman", return_type = "model")
+  sc <- spearman$model[[1]] %>% tidy(type = "analysis_conditions")
+  expect_equal(sc$correlation_is_auto[[1]], "FALSE")
+  expect_equal(sc$Value[[6]], "Spearman Correlation")
+
+  # A model saved before this existed has no $analysis_conditions: return the empty table with
+  # the same shape rather than erroring, so the report renders empty and the client falls back.
+  legacy <- model_df$model[[1]]
+  legacy$analysis_conditions <- NULL
+  legacy_cond <- tidy(legacy, type = "analysis_conditions")
+  expect_equal(nrow(legacy_cond), 0)
+  expect_equal(colnames(legacy_cond),
+               c("Metric", "Value", "Description", "correlation_type", "correlation_is_auto", "reason"))
+})


### PR DESCRIPTION
## Summary

Paired R-side change for [tam#37638](https://github.com/exploratory-io/tam/issues/37638) / tam PR fix/analytics-spec-loop-16385e, which standardizes the "analysis conditions and data" summary section across Factor Analysis / PCA / Cronbach's Alpha / Correlation report types, using Factor Analysis as the role model.

## Changes

- **factanal.R** — no behavioral change. Its `analysis_method` table already has the correct row set (変数名（数値型）/因子数) via tam's client-side `FactanalReportBindUtil` injector (tam#37402/#37620/#37633). An earlier draft of this PR duplicated that work in R and was reverted after discovering the pre-existing mechanism during a `origin/master` merge on the tam side — only an explanatory comment remains.
- **prcomp.R** — `tidy(type="analysis_conditions")` folds the old separate `analysis_method` table into ONE 9-row table in spec order (Number of Variables, Variable Names, Excluded Variables, Row Count, Rows Removed, Normalization, SD Ratio, Correlation, Score Scale), carrying the hidden correlation-method columns so one viz feeds both the rendered table and the report's explanation text. The empty-tibble branch (k-means / old saved models) gets the same column shape.
- **reliability.R** — `tidy(type="summary")` gains Variable Names / Correlation / Reliability Metric rows, each carrying its SELECTION REASON in `Interpretation` (shared label+reason helpers with the legacy `correlation_method` tidy type). Renamed Complete Responses / Responses with Missing → Row Count / Rows Removed to match Factor Analysis / PCA wording. Replaced a runtime-composed `"N items used"` description — which could never be translated, since the client translates report cells by exact string match — with a fixed sentence.
- **stats_wrapper.R** — `do_cor()` gains an `analysis_conditions` tidy type entirely; the Correlation report had no summary table before this. Computed at fit time from the selected columns (variable/row counts, excluded-variable detection, resolved correlation label+reason), stored on the `cor_exploratory` model; an empty same-shape tibble for models saved before it existed.

Every new report string is a FIXED English sentence, never composed at runtime, because the client translates report table cells by exact string match.

Version bumped to 16.0.45 in the paired tam PR.

## Testing

Live `testthat` execution, not string assertions on generated code: 1,912 assertions across `test_factanal.R` / `test_factanal_correlation.R` / `test_prcomp.R` / `test_reliability.R` / `test_stats_wrapper.R`, all passing.

Also verified end-to-end (not just unit-level) that `factanal.R`'s real `analysis_method` output, fed through the real client-side `FactanalReportBindUtil.injectSummaryRowsIntoAnalysisMethod`, produces the correct 9-row table with no duplication.

## Related

- tam PR: fix/analytics-spec-loop-16385e (requires this PR merged + `exploratory` bumped to 16.0.45 + per-platform binaries rebuilt/uploaded to download2 before release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)