### PR TITLE
feat(multiple_answers): add count_na option to exp_multiple_answers_to_longer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.44
-Date: 2026-08-05
+Version: 16.0.45
+Date: 2026-08-11
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/util.R
+++ b/R/util.R
@@ -3845,6 +3845,10 @@ pivot_wider <- function(data, names_from, values_from = NULL, ...) {
 #'   blank cell) instead of emitting an empty-string row. Default TRUE.
 #' @param dedupe_within_row Collapse a choice repeated within the same
 #'   original cell (e.g. "A,A,B") down to one row. Default TRUE.
+#' @param count_na Include a genuinely-missing (NA) target-cell value as its
+#'   own answer row instead of dropping it. Independent of `exclude_empty`,
+#'   which only drops explicit empty-string ("") choices once this is FALSE.
+#'   Default FALSE.
 #' @param add_row_id Add a column identifying which original row each output
 #'   row came from. Default TRUE.
 #' @param row_id_col Name of the row-id column when `add_row_id` is TRUE.
@@ -3874,6 +3878,7 @@ exp_multiple_answers_to_longer <- function(df, ...,
                                             trim_ws = TRUE,
                                             exclude_empty = TRUE,
                                             dedupe_within_row = TRUE,
+                                            count_na = FALSE,
                                             add_row_id = TRUE,
                                             row_id_col = "Original Row ID",
                                             keep_other_columns = TRUE) {
@@ -3930,8 +3935,13 @@ exp_multiple_answers_to_longer <- function(df, ...,
     if (trim_ws) {
       piece$value <- trimws(piece$value)
     }
+    if (!count_na) {
+      piece <- piece[!is.na(piece$value), , drop = FALSE]
+    }
     if (exclude_empty) {
-      piece <- piece[!is.na(piece$value) & piece$value != "", , drop = FALSE]
+      # NA retention is count_na's job (handled above); this only drops
+      # explicit empty-string choices, never re-drops a kept NA.
+      piece <- piece[is.na(piece$value) | piece$value != "", , drop = FALSE]
     }
     if (dedupe_within_row) {
       piece <- piece[!duplicated(piece[c(row_id_col_internal, "value")]), , drop = FALSE]

--- a/R/util.R
+++ b/R/util.R
@@ -3845,10 +3845,10 @@ pivot_wider <- function(data, names_from, values_from = NULL, ...) {
 #'   blank cell) instead of emitting an empty-string row. Default TRUE.
 #' @param dedupe_within_row Collapse a choice repeated within the same
 #'   original cell (e.g. "A,A,B") down to one row. Default TRUE.
-#' @param count_na Include a genuinely-missing (NA) target-cell value as its
-#'   own answer row instead of dropping it. Independent of `exclude_empty`,
+#' @param exclude_na Drop a genuinely-missing (NA) target-cell value instead
+#'   of emitting it as its own answer row. Independent of `exclude_empty`,
 #'   which only drops explicit empty-string ("") choices once this is FALSE.
-#'   Default FALSE.
+#'   Default TRUE.
 #' @param add_row_id Add a column identifying which original row each output
 #'   row came from. Default TRUE.
 #' @param row_id_col Name of the row-id column when `add_row_id` is TRUE.
@@ -3878,7 +3878,7 @@ exp_multiple_answers_to_longer <- function(df, ...,
                                             trim_ws = TRUE,
                                             exclude_empty = TRUE,
                                             dedupe_within_row = TRUE,
-                                            count_na = FALSE,
+                                            exclude_na = TRUE,
                                             add_row_id = TRUE,
                                             row_id_col = "Original Row ID",
                                             keep_other_columns = TRUE) {
@@ -3935,11 +3935,11 @@ exp_multiple_answers_to_longer <- function(df, ...,
     if (trim_ws) {
       piece$value <- trimws(piece$value)
     }
-    if (!count_na) {
+    if (exclude_na) {
       piece <- piece[!is.na(piece$value), , drop = FALSE]
     }
     if (exclude_empty) {
-      # NA retention is count_na's job (handled above); this only drops
+      # NA retention is exclude_na's job (handled above); this only drops
       # explicit empty-string choices, never re-drops a kept NA.
       piece <- piece[is.na(piece$value) | piece$value != "", , drop = FALSE]
     }

--- a/tests/testthat/test_multiple_answers_to_longer.R
+++ b/tests/testthat/test_multiple_answers_to_longer.R
@@ -66,30 +66,30 @@ test_that("exclude_empty = FALSE keeps blank answers", {
   expect_true("" %in% result$Answer)
 })
 
-test_that("count_na = FALSE (default) drops a genuinely-missing cell", {
+test_that("exclude_na = TRUE (default) drops a genuinely-missing cell", {
   df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada"), stringsAsFactors = FALSE)
   result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")
   expect_equal(nrow(result), 1)
   expect_equal(result$Answer, "Yamada")
 })
 
-test_that("count_na = TRUE keeps a genuinely-missing cell as its own answer row", {
+test_that("exclude_na = FALSE keeps a genuinely-missing cell as its own answer row", {
   df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada"), stringsAsFactors = FALSE)
-  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", count_na = TRUE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", exclude_na = FALSE)
   expect_equal(nrow(result), 2)
   expect_true(any(is.na(result$Answer)))
   expect_true("Yamada" %in% result$Answer)
 })
 
-test_that("count_na = TRUE + exclude_empty = TRUE keeps NA but still drops empty strings", {
+test_that("exclude_na = FALSE + exclude_empty = TRUE keeps NA but still drops empty strings", {
   df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada,,Edion"), stringsAsFactors = FALSE)
-  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", count_na = TRUE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", exclude_na = FALSE)
   expect_equal(sum(is.na(result$Answer)), 1)
   expect_false("" %in% result$Answer)
   expect_equal(sort(result$Answer[!is.na(result$Answer)]), c("Edion", "Yamada"))
 })
 
-test_that("count_na = FALSE + exclude_empty = FALSE drops NA but keeps empty strings", {
+test_that("exclude_na = TRUE (default) + exclude_empty = FALSE drops NA but keeps empty strings", {
   df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada,,Edion"), stringsAsFactors = FALSE)
   result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", exclude_empty = FALSE)
   expect_equal(nrow(result), 3)
@@ -97,14 +97,14 @@ test_that("count_na = FALSE + exclude_empty = FALSE drops NA but keeps empty str
   expect_equal(sort(result$Answer), c("", "Edion", "Yamada"))
 })
 
-test_that("count_na = TRUE keeps NA rows independently per target column", {
+test_that("exclude_na = FALSE keeps NA rows independently per target column", {
   df <- data.frame(
     id = c(1),
     store = c(NA_character_),
     category = c(NA_character_),
     stringsAsFactors = FALSE
   )
-  result <- df %>% exp_multiple_answers_to_longer(store, category, sep = ",", count_na = TRUE)
+  result <- df %>% exp_multiple_answers_to_longer(store, category, sep = ",", exclude_na = FALSE)
   expect_equal(nrow(result), 2)
   expect_true(all(is.na(result$Answer)))
   expect_equal(sort(result$Question), c("category", "store"))

--- a/tests/testthat/test_multiple_answers_to_longer.R
+++ b/tests/testthat/test_multiple_answers_to_longer.R
@@ -66,6 +66,50 @@ test_that("exclude_empty = FALSE keeps blank answers", {
   expect_true("" %in% result$Answer)
 })
 
+test_that("count_na = FALSE (default) drops a genuinely-missing cell", {
+  df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada"), stringsAsFactors = FALSE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")
+  expect_equal(nrow(result), 1)
+  expect_equal(result$Answer, "Yamada")
+})
+
+test_that("count_na = TRUE keeps a genuinely-missing cell as its own answer row", {
+  df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada"), stringsAsFactors = FALSE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", count_na = TRUE)
+  expect_equal(nrow(result), 2)
+  expect_true(any(is.na(result$Answer)))
+  expect_true("Yamada" %in% result$Answer)
+})
+
+test_that("count_na = TRUE + exclude_empty = TRUE keeps NA but still drops empty strings", {
+  df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada,,Edion"), stringsAsFactors = FALSE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", count_na = TRUE)
+  expect_equal(sum(is.na(result$Answer)), 1)
+  expect_false("" %in% result$Answer)
+  expect_equal(sort(result$Answer[!is.na(result$Answer)]), c("Edion", "Yamada"))
+})
+
+test_that("count_na = FALSE + exclude_empty = FALSE drops NA but keeps empty strings", {
+  df <- data.frame(id = c(1, 2), store = c(NA_character_, "Yamada,,Edion"), stringsAsFactors = FALSE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",", exclude_empty = FALSE)
+  expect_equal(nrow(result), 3)
+  expect_false(any(is.na(result$Answer)))
+  expect_equal(sort(result$Answer), c("", "Edion", "Yamada"))
+})
+
+test_that("count_na = TRUE keeps NA rows independently per target column", {
+  df <- data.frame(
+    id = c(1),
+    store = c(NA_character_),
+    category = c(NA_character_),
+    stringsAsFactors = FALSE
+  )
+  result <- df %>% exp_multiple_answers_to_longer(store, category, sep = ",", count_na = TRUE)
+  expect_equal(nrow(result), 2)
+  expect_true(all(is.na(result$Answer)))
+  expect_equal(sort(result$Question), c("category", "store"))
+})
+
 test_that("dedupe_within_row = TRUE (default) collapses a repeated answer in one cell to one row", {
   df <- data.frame(id = c(1), store = c("Yamada,Yamada,Edion"), stringsAsFactors = FALSE)
   result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")


### PR DESCRIPTION
## Summary
- Adds a new `exclude_na = TRUE` parameter to `exp_multiple_answers_to_longer()` that controls whether a genuinely-missing (`NA`) target-cell value is dropped, or emitted as its own answer row.
- Decouples NA handling from `exclude_empty`, which previously removed both `NA` and empty-string (`""`) choices in a single condition -- `exclude_empty` now only drops explicit empty strings; NA retention is entirely controlled by the new `exclude_na` flag.
- Bumps package version to 16.0.45.

Companion tam PR wires a new "Exclude NA" checkbox in the "Separate Multiple-Response Values into Rows" dialog through to this parameter (design doc: `docs/plans/design/37591_additional_fix_design.md` in tam).

**Note:** this parameter was originally named `count_na` (default `FALSE`, meaning "keep NA off by default"). It was renamed to `exclude_na` (default `TRUE`, inverted sense) to stay consistent with the existing `exclude_empty` parameter's naming and default-checked convention. The actual default runtime behavior (NA excluded unless the user opts in) is unchanged -- only the parameter name and boolean sense flipped. See commit `e8ff1d0d` for the rename.

## Behavior

| `exclude_na` | `exclude_empty` | NA row in output? |
|---|---|---|
| TRUE (default) | TRUE (default) | No -- same as today |
| TRUE (default) | FALSE | No (today: was kept -- see note below) |
| FALSE | TRUE | Yes |
| FALSE | FALSE | Yes |

Note: a saved step with `exclude_empty = FALSE` today keeps both NA and empty-string rows. After this change (with `exclude_na` at its new default of TRUE), that step will drop NA rows on re-run while still keeping empty-string rows. This is an intentional decoupling, confirmed acceptable with the issue owner since the feature has not shipped in a release yet.

## Test plan
- [x] 5 `testthat` cases in `tests/testthat/test_multiple_answers_to_longer.R` covering: default (NA dropped), `exclude_na = FALSE` (NA kept), `exclude_na = FALSE` + `exclude_empty = TRUE` (NA kept, empty string still dropped), `exclude_na = TRUE` (default) + `exclude_empty = FALSE` (NA dropped, empty string kept), and NA handled independently across multiple target columns.
- [x] Confirmed via TDD: all 5 tests fail against the pre-change source, then pass after the implementation.
- [x] All pre-existing tests in the same file still pass unmodified (none previously exercised `NA`).
- [x] Verified via `devtools::load_all()` + `testthat::test_file()` against the R 4.6 ARM library used by the desktop app -- all green after the rename too.
