### PR TITLE
feat(kmodes): add analysis_conditions tidy type (tam#37682)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.45
-Date: 2026-08-05
+Version: 16.0.46
+Date: 2026-08-12
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -767,6 +767,28 @@ kmodes_summary_table <- function(x, with_excluded_rows = FALSE) {
   summary_df
 }
 
+#' "Analysis Conditions and Data" table of a K-Modes model (issue #37682, the K-Modes
+#' follow-up to the FA/PCA/Cronbach/Correlation summary-section standardization done in
+#' tam#37638). One row per condition, Metric/Value, matching that role model's shape --
+#' every value is already a plain string (a count or a comma-joined name list), so no
+#' further per-column number formatting is needed on the viz side.
+#' @param x A kmodes_exploratory model.
+#' @return A tibble with `Metric` and `Value` columns.
+kmodes_analysis_conditions_table <- function(x) {
+  variable_names_display <- paste(x$selected_cols, collapse = ", ")
+  tibble::tibble(
+    Metric = c("Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+               "Number of Clusters"),
+    Value = c(
+      as.character(x$n_variables),
+      variable_names_display,
+      as.character(x$n_used),
+      as.character(x$excluded_nrow),
+      as.character(x$centers)
+    )
+  )
+}
+
 #' Row-level output of a K-Modes model.
 #' @param x A kmodes_exploratory model.
 #' @return The original rows with the cluster assignment and diagnostics attached.
@@ -792,6 +814,9 @@ kmodes_data_table <- function(x) {
 tidy.kmodes_exploratory <- function(x, type = "summary", with_excluded_rows = FALSE, ...) {
   if (type == "summary") {
     return(kmodes_summary_table(x, with_excluded_rows = with_excluded_rows))
+  }
+  if (type == "analysis_conditions") {
+    return(kmodes_analysis_conditions_table(x))
   }
   if (type == "modes") {
     return(x$modes)

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -148,6 +148,23 @@ test_that("tidy summary carries the size, matching rate, silhouette and one Mode
   expect_equal(with_excluded$size[[4]], 3)
 })
 
+test_that("analysis_conditions reports variable count, names, row count, rows removed and cluster count (issue #37682)", {
+  df <- kmodes_test_df()
+  model_df <- exp_kmodes(df, `利用目的`, `契約タイプ`, `導入経路`, centers = 3, seed = 1,
+                         elbow_method_mode = "none")
+  res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(colnames(res), c("Metric", "Value"))
+  expect_equal(res$Metric, c("Number of Variables", "Variable Names", "Row Count",
+                            "Rows Removed", "Number of Clusters"))
+  expect_equal(res$Value[[1]], "3")
+  expect_true(grepl("利用目的", res$Value[[2]], fixed = TRUE))
+  expect_true(grepl("契約タイプ", res$Value[[2]], fixed = TRUE))
+  expect_true(grepl("導入経路", res$Value[[2]], fixed = TRUE))
+  expect_equal(res$Value[[3]], as.character(nrow(df) - 3))
+  expect_equal(res$Value[[4]], "3")
+  expect_equal(res$Value[[5]], "3")
+})
+
 test_that("the matching rate is the complement of the dissimilarity rate", {
   df <- kmodes_test_df()
   model_df <- exp_kmodes(df, `利用目的`, `契約タイプ`, `導入経路`, centers = 3, seed = 1,


### PR DESCRIPTION
## Summary
Adds `type == "analysis_conditions"` to `tidy.kmodes_exploratory`, returning the
「分析条件とデータの確認」 Metric/Value table (Number of Variables / Variable Names /
Row Count / Rows Removed / Number of Clusters).

This is the K-Modes follow-up to the FA/PCA/Cronbach's Alpha/Correlation summary-section
standardization done in tam#37638, which explicitly deferred K-Means/K-Modes as a
follow-up issue with no written spec at the time. tam#37682 is that follow-up.

All values come from fields `exp_kmodes` already computes on the model
(`n_variables`, `selected_cols`, `n_used`, `excluded_nrow`, `centers`) -- no new
model-fitting computation was needed.

## Testing
- New `testthat` case in `tests/testthat/test_kmodes.R`, using the existing
  multibyte-name fixture (`利用目的`/`契約タイプ`/`導入経路`).
- Full `test_kmodes.R` suite: 104 passed, 0 failed (live-executed against the
  bundled `exploratory` package's dependencies, `.libPaths()` pointed at
  `~/.exploratory/R/4.6_ARM`).

## Paired tam PR
See exploratory-io/tam#37682 for the JSON/markdown side (new `analysis_conditions`
viz block, new intro sentence, new H2 heading). That PR needs this one merged +
an `exploratory` package version bump (installer manifest regen + per-platform
binary build/upload) before the new table renders real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)