### PR TITLE
feat(kmeans): populate analysis_conditions tidy type for K-Means fits

### DIFF
--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -205,6 +205,9 @@ exp_kmeans <- function(df, ...,
   excluded_nrow <- nrow_before_filter - nrow(filtered_df)
   selected_cols <- attr(filtered_df, 'predictors') # predictors are updated (removed) in preprocess_factanal_data_before_sample. Sync with it.
   df <- filtered_df
+  # Rows actually analyzed (post NA-filter, post sampling), for the report's
+  # 分析条件とデータの確認 table (tam#37681, x$n_rows_used below).
+  n_rows_used <- nrow(df)
 
   # Always compute the normal (elbow_method_mode = FALSE) results
   kmeans_model_df <- df %>% build_kmeans.cols(!!!rlang::syms(selected_cols),
@@ -301,6 +304,11 @@ exp_kmeans <- function(df, ...,
       }
       x$sampled_nrow <- sampled_nrow
       x$excluded_nrow <- excluded_nrow
+      # 分析条件とデータの確認 table inputs (tam#37681): row count actually used and the
+      # final (post-drop) variable list, read by tidy.prcomp_exploratory's
+      # analysis_conditions branch in prcomp.R.
+      x$n_rows_used <- n_rows_used
+      x$selected_cols <- selected_cols
       if (!is.null(elbow_result)) {
         x$elbow_result <- elbow_result
       }

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -200,14 +200,11 @@ exp_kmeans <- function(df, ...,
   # As the name suggests, this preprocessing function was originally designed to be done
   # before sampling, but we found that for this k-means function, that makes the
   # process as a whole slower in the cases we tried. So, we are doing this after sampling.
-  nrow_before_filter <- nrow(df)
+  df_before_filter <- df
+  nrow_before_filter <- nrow(df_before_filter)
   filtered_df <- preprocess_factanal_data_before_sample(df, selected_cols)
-  excluded_nrow <- nrow_before_filter - nrow(filtered_df)
   selected_cols <- attr(filtered_df, 'predictors') # predictors are updated (removed) in preprocess_factanal_data_before_sample. Sync with it.
   df <- filtered_df
-  # Rows actually analyzed (post NA-filter, post sampling), for the report's
-  # 分析条件とデータの確認 table (tam#37681, x$n_rows_used below).
-  n_rows_used <- nrow(df)
 
   # Always compute the normal (elbow_method_mode = FALSE) results
   kmeans_model_df <- df %>% build_kmeans.cols(!!!rlang::syms(selected_cols),
@@ -303,12 +300,31 @@ exp_kmeans <- function(df, ...,
                                                    sample_idx = g_sample_idx)
       }
       x$sampled_nrow <- sampled_nrow
-      x$excluded_nrow <- excluded_nrow
+      # These values must be calculated from the model's own data. For a grouped input,
+      # `excluded_nrow` and `nrow(filtered_df)` above describe all groups combined, while
+      # `x$df` contains only this group's rows.
+      n_rows_used <- nrow(x$df)
+      if (length(grouped_cols) > 0) {
+        same_group <- rep(TRUE, nrow(df_before_filter))
+        for (group_col in grouped_cols) {
+          group_value <- x$df[[group_col]][[1]]
+          source_values <- df_before_filter[[group_col]]
+          same_group <- same_group & if (is.na(group_value)) {
+            is.na(source_values)
+          } else {
+            !is.na(source_values) & source_values == group_value
+          }
+        }
+        nrow_before_model <- sum(same_group)
+      } else {
+        nrow_before_model <- nrow_before_filter
+      }
+      x$excluded_nrow <- nrow_before_model - n_rows_used
       # 分析条件とデータの確認 table inputs (tam#37681): row count actually used and the
       # final (post-drop) variable list, read by tidy.prcomp_exploratory's
       # analysis_conditions branch in prcomp.R.
       x$n_rows_used <- n_rows_used
-      x$selected_cols <- selected_cols
+      x$selected_cols <- colnames(y$centers)
       if (!is.null(elbow_result)) {
         x$elbow_result <- elbow_result
       }

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -573,7 +573,29 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     # (issue #37019). English-canonical Description sentences + language-neutral status tokens;
     # the client translates. Empty typed tibble for k-means / old saved models (no report data).
     cfg <- prcomp_report_config()
-    if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
+    if (!is.null(x$kmeans)) {
+      # K-Means: 5-row 分析条件とデータの確認 table (tam#37681). 変数の数/変数名/クラス
+      # ターの数 are also available as pure client bind vars (AnalysisExplanationAPI.js
+      # kmeans case), but 行数/削除された行数 need the model's post-NA-filter counts,
+      # which only R has -- the whole table is built here so it has one source of truth,
+      # matching the PCA precedent above instead of re-deriving the same numbers in JS.
+      n_variables <- length(x$selected_cols)
+      variable_names_display <- if (n_variables == 0) "N/A" else paste(x$selected_cols, collapse = ", ")
+      n_rows_used <- if (!is.null(x$n_rows_used)) x$n_rows_used else NA_integer_
+      n_excluded <- if (!is.null(x$excluded_nrow)) x$excluded_nrow else NA_integer_
+      n_clusters <- length(unique(x$kmeans$cluster))
+      res <- tibble::tibble(
+        Metric = c("Number of Variables", "Variable Names", "Row Count", "Rows Removed", "Number of Clusters"),
+        Value = c(
+          as.character(n_variables),
+          variable_names_display,
+          if (is.na(n_rows_used)) "N/A" else as.character(n_rows_used),
+          if (is.na(n_excluded)) "N/A" else as.character(n_excluded),
+          as.character(n_clusters)
+        )
+      )
+    }
+    else if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
       res <- tibble::tibble(Metric = character(0), Value = character(0),
                             Description = character(0), status = character(0))
     }

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -573,7 +573,10 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
     # (issue #37019). English-canonical Description sentences + language-neutral status tokens;
     # the client translates. Empty typed tibble for k-means / old saved models (no report data).
     cfg <- prcomp_report_config()
-    if (!is.null(x$kmeans)) {
+    if (!is.null(x$kmeans) &&
+        !is.null(x$selected_cols) && length(x$selected_cols) > 0 &&
+        length(x$n_rows_used) == 1L && !is.na(x$n_rows_used) &&
+        length(x$excluded_nrow) == 1L && !is.na(x$excluded_nrow)) {
       # K-Means: 5-row 分析条件とデータの確認 table (tam#37681). 変数の数/変数名/クラス
       # ターの数 are also available as pure client bind vars (AnalysisExplanationAPI.js
       # kmeans case), but 行数/削除された行数 need the model's post-NA-filter counts,
@@ -594,6 +597,12 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
           as.character(n_clusters)
         )
       )
+    }
+    else if (!is.null(x$kmeans)) {
+      # K-Means models saved before tam#37681 have no report metadata. Returning a
+      # partially populated table would turn missing values into misleading analytics.
+      res <- tibble::tibble(Metric = character(0), Value = character(0),
+                            Description = character(0), status = character(0))
     }
     else if (is.null(x$input_diagnostics) && is.null(x$parallel)) {
       res <- tibble::tibble(Metric = character(0), Value = character(0),

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -116,11 +116,18 @@ test_that("new report tidy types return expected columns and tokens", {
   expect_true(all(r2$kaiser_status == "na"))
 })
 
-test_that("new report tidy types return empty typed tibbles for kmeans fits", {
+test_that("new report tidy types return empty typed tibbles for kmeans fits (except analysis_conditions, tam#37681)", {
   km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
+  # analysis_conditions is POPULATED for kmeans (tam#37681's 分析条件とデータの確認
+  # table) -- unlike the other PCA-only report types below, which stay empty.
   ac <- km %>% tidy_rowwise(model, type = "analysis_conditions")
-  expect_equal(colnames(ac), c("Metric", "Value", "Description", "status"))
-  expect_equal(nrow(ac), 0)
+  expect_equal(colnames(ac), c("Metric", "Value"))
+  expect_equal(nrow(ac), 5)
+  expect_equal(ac$Metric, c("Number of Variables", "Variable Names", "Row Count",
+                            "Rows Removed", "Number of Clusters"))
+  expect_true(all(c("mpg", "cyl", "disp") %in% strsplit(ac$Value[ac$Metric == "Variable Names"], ", ")[[1]]))
+  expect_equal(ac$Value[ac$Metric == "Number of Variables"], "3")
+  expect_equal(ac$Value[ac$Metric == "Number of Clusters"], "2")
   ps <- km %>% tidy_rowwise(model, type = "parallel_screeplot")
   expect_equal(colnames(ps), c("Component", "Eigenvalue", "Random Data Eigenvalue"))
   expect_equal(nrow(ps), 0)
@@ -308,12 +315,17 @@ test_that("report tidy types handle 2-variable input", {
   expect_true(all(apply(m, 1, function(r) all(diff(r) >= -1e-9))))
 })
 
-test_that("all 8 report tidy types return 0-row typed tibbles for a kmeans fit", {
+test_that("all 8 report tidy types return 0-row typed tibbles for a kmeans fit, except analysis_conditions (tam#37681)", {
   km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, hp, centers = 2)
   for (ty in names(PRCOMP_REPORT_TYPE_COLS)) {
     res <- km %>% tidy_rowwise(model, type = ty)
-    expect_equal(nrow(res), 0, info = ty)
-    expect_true(all(PRCOMP_REPORT_TYPE_COLS[[ty]] %in% colnames(res)), info = ty)
+    if (ty == "analysis_conditions") {
+      expect_gt(nrow(res), 0, label = ty)
+      expect_equal(colnames(res), c("Metric", "Value"), info = ty)
+    } else {
+      expect_equal(nrow(res), 0, info = ty)
+      expect_true(all(PRCOMP_REPORT_TYPE_COLS[[ty]] %in% colnames(res)), info = ty)
+    }
   }
 })
 

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -138,6 +138,40 @@ test_that("new report tidy types return empty typed tibbles for kmeans fits (exc
   expect_equal(nrow(vj), 0)
 })
 
+test_that("kmeans analysis conditions use per-group row metadata", {
+  df <- tibble::tibble(
+    segment = rep(c("a", "b"), each = 5),
+    x = c(1, 2, NA, 4, 5, 10, 11, NA, 13, 14),
+    y = c(2, 3, 4, 5, 6, 11, 12, 13, 14, 15)
+  )
+  km <- df %>%
+    dplyr::group_by(segment) %>%
+    exploratory:::exp_kmeans(x, y, centers = 2)
+
+  conditions <- km %>% tidy_rowwise(model, type = "analysis_conditions")
+  values_by_group <- split(conditions$Value, conditions$segment)
+
+  expect_equal(values_by_group$a[conditions$Metric[conditions$segment == "a"] == "Row Count"], "4")
+  expect_equal(values_by_group$b[conditions$Metric[conditions$segment == "b"] == "Row Count"], "4")
+  expect_equal(values_by_group$a[conditions$Metric[conditions$segment == "a"] == "Rows Removed"], "1")
+  expect_equal(values_by_group$b[conditions$Metric[conditions$segment == "b"] == "Rows Removed"], "1")
+})
+
+test_that("analysis conditions remain empty for legacy kmeans models without report fields", {
+  km <- mtcars %>% exploratory:::exp_kmeans(mpg, cyl, disp, centers = 2)
+  legacy_fit <- km$model[[1]]
+  legacy_fit$n_rows_used <- NULL
+  legacy_fit$selected_cols <- NULL
+
+  conditions <- exploratory:::tidy.prcomp_exploratory(
+    legacy_fit,
+    type = "analysis_conditions"
+  )
+
+  expect_equal(nrow(conditions), 0)
+  expect_equal(colnames(conditions), c("Metric", "Value", "Description", "status"))
+})
+
 test_that("component_profiles / loadings_signed / contributions", {
   model_df <- mtcars %>% do_prcomp(mpg, cyl, disp, hp, drat, wt, retained_components = 3)
   res <- model_df %>% tidy_rowwise(model, type = "component_profiles")


### PR DESCRIPTION
## Summary
Populates the `analysis_conditions` tidy type (`tidy.prcomp_exploratory`'s
分析条件とデータの確認 branch, currently always empty for k-means) for K-Means
fits, so the paired tam PR can render a
Number of Variables / Variable Names / Row Count / Rows Removed / Number of
Clusters table -- matching the Factor Analysis / PCA report pattern.

- `R/kmeans.R`: `exp_kmeans()` now attaches `n_rows_used` (post-NA-filter
  row count) and `selected_cols` (final, post-drop variable list) onto the
  merged model, alongside the existing `excluded_nrow`/`sampled_nrow`.
- `R/prcomp.R`: `tidy.prcomp_exploratory`'s `analysis_conditions` branch
  gets a new `!is.null(x$kmeans)` case, checked before the existing
  PCA-empty branch. The PCA path (variances_judged, loadings, etc. — and
  PCA's own, richer `analysis_conditions` table) is untouched.

No package version bump: new field on an existing model list + a new
`else if` branch in an existing dispatcher, no new exported function, no
schema change to any existing tidy type's non-kmeans output.

## Verification
- Live-R (`pkgload::load_all` + hand-built fixture, 1 excluded row) —
  `analysis_conditions` on a kmeans fit returns exactly the 5 expected
  rows/values; PCA path unaffected (still returns its own 7-row table).
- `test_kmeans_1.R` / `test_prcomp.R` pass. Updated 2 pre-existing
  `test_prcomp.R` assertions that stated `analysis_conditions` stays empty
  for kmeans — that assumption is exactly what this PR changes.
- `test_kmeans_2.R` fails on an unrelated pre-existing environment issue
  (Dropbox fixture download / missing `digest` package) — not a regression,
  reproduces the same way on `origin/master`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)