### PR TITLE
Improve K-Medoids performance with selectable PAM/CLARA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.46
-Date: 2026-08-12
+Version: 16.0.47
+Date: 2026-08-13
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -9,6 +9,24 @@
 }
 
 .kmedoids_pam_max_n <- 5000L
+.kmedoids_map_max_n <- 5000L
+
+.kmedoids_silhouette_components <- function(raw) {
+  widths <- if (!is.null(raw$silinfo$widths)) {
+    raw$silinfo$widths[, 'sil_width']
+  } else {
+    NULL
+  }
+  indices <- if (is.null(widths)) {
+    integer()
+  } else {
+    suppressWarnings(as.integer(rownames(raw$silinfo$widths)))
+  }
+  if (length(indices) != length(widths) || anyNA(indices)) {
+    indices <- seq_along(widths)
+  }
+  list(widths = widths, indices = indices)
+}
 
 .kmedoids_distance_to_medoids <- function(mat, medoid_mat, cluster_ids, metric) {
   if (nrow(mat) == 0) return(numeric())
@@ -46,41 +64,26 @@
       mat, k = centers, metric = distance, stand = FALSE,
       keep.diss = FALSE, keep.data = FALSE, pamonce = 5
     )
-    silhouette_widths <- if (!is.null(raw$silinfo$widths)) {
-      raw$silinfo$widths[, 'sil_width']
-    } else {
-      NULL
-    }
-    silhouette_row_indices <- if (is.null(silhouette_widths)) {
-      integer()
-    } else {
-      seq_along(silhouette_widths)
-    }
+    silhouette <- .kmedoids_silhouette_components(raw)
+    silhouette_widths <- silhouette$widths
+    silhouette_row_indices <- silhouette$indices
     medoid_indices <- raw$id.med
   } else {
     if (is.null(clara_sample_size)) {
       clara_sample_size <- min(nrow(mat), max(100L, 40L + 2L * centers))
     }
-    clara_sample_size <- max(centers + 1L, min(nrow(mat), floor(clara_sample_size)))
+    clara_sample_size <- as.integer(max(
+      centers + 1L,
+      min(nrow(mat), pam_max_n, floor(clara_sample_size))
+    ))
     raw <- cluster::clara(
       mat, k = centers, metric = distance, stand = FALSE,
-      samples = max(1L, floor(clara_samples)), sampsize = clara_sample_size,
+      samples = max(1L, as.integer(floor(clara_samples))), sampsize = clara_sample_size,
       keep.data = FALSE, rngR = TRUE
     )
-    silhouette_widths <- if (!is.null(raw$silinfo$widths)) {
-      raw$silinfo$widths[, 'sil_width']
-    } else {
-      NULL
-    }
-    silhouette_row_indices <- if (is.null(silhouette_widths)) {
-      integer()
-    } else {
-      suppressWarnings(as.integer(rownames(raw$silinfo$widths)))
-    }
-    if (length(silhouette_row_indices) != length(silhouette_widths) ||
-        anyNA(silhouette_row_indices)) {
-      silhouette_row_indices <- seq_along(silhouette_widths)
-    }
+    silhouette <- .kmedoids_silhouette_components(raw)
+    silhouette_widths <- silhouette$widths
+    silhouette_row_indices <- silhouette$indices
     medoid_indices <- raw$i.med
   }
   list(
@@ -99,7 +102,7 @@
       as.numeric(raw$silinfo$avg.width)
     },
     clara_sample_size = if (algorithm == 'clara') clara_sample_size else NULL,
-    clara_samples = if (algorithm == 'clara') max(1L, floor(clara_samples)) else NULL
+    clara_samples = if (algorithm == 'clara') max(1L, as.integer(floor(clara_samples))) else NULL
   )
 }
 
@@ -191,7 +194,7 @@
 
 .kmedoids_diagnostic_mat <- function(x, seed_offset = 0L) {
   indices <- .kmedoids_sample_indices(
-    x, x$silhouette_sample_size,
+    x, min(x$silhouette_sample_size, .kmedoids_pam_max_n),
     include = x$medoid_indices, seed_offset = seed_offset
   )
   list(mat = x$mat[indices, , drop = FALSE], indices = indices)
@@ -307,7 +310,7 @@
       .kmedoids_fit(
         diagnostic_mat, center, x$distance,
         if (is.null(x$seed)) NULL else x$seed + center,
-        algorithm = 'pam', pam_max_n = Inf
+        algorithm = 'pam'
       ),
       error = function(e) NULL
     )
@@ -339,7 +342,7 @@
       .kmedoids_fit(
         diagnostic_mat, center, x$distance,
         if (is.null(x$seed)) NULL else x$seed + center,
-        algorithm = 'pam', pam_max_n = Inf
+        algorithm = 'pam'
       ),
       error = function(e) NULL
     )
@@ -429,7 +432,7 @@
 
 .kmedoids_map <- function(x) {
   map_indices <- .kmedoids_sample_indices(
-    x, x$map_sample_size,
+    x, min(x$map_sample_size, .kmedoids_map_max_n),
     include = x$medoid_indices, seed_offset = 3000L
   )
   map_mat <- x$mat[map_indices, , drop = FALSE]
@@ -514,8 +517,13 @@
     effective_algorithm = x$effective_algorithm,
     is_approximate = x$is_approximate,
     fit_sample_nrow = x$valid_nrow,
-    diagnostic_nrow = min(x$valid_nrow, x$silhouette_sample_size),
-    map_sample_nrow = min(x$valid_nrow, max(x$map_sample_size, length(x$medoid_indices)))
+    diagnostic_nrow = min(
+      x$valid_nrow, x$silhouette_sample_size, .kmedoids_pam_max_n
+    ),
+    map_sample_nrow = min(
+      x$valid_nrow, max(x$map_sample_size, length(x$medoid_indices)),
+      .kmedoids_map_max_n
+    )
   )
 }
 
@@ -534,9 +542,10 @@
 #' @param elbow_method_mode Which optimal-cluster diagnostics to compute.
 #' @param max_centers Maximum number of centers for diagnostics.
 #' @param silhouette_sample_size Maximum number of rows used for diagnostics.
-#' @param profile_top_n Reserved for parity with the Analytics UI.
-#' @param profile_show_all Reserved for parity with the Analytics UI.
-#' @param profile_variable_order Reserved for parity with the Analytics UI.
+#' @param profile_top_n Maximum variables shown per cluster when `profile_show_all`
+#'   is `FALSE`.
+#' @param profile_show_all Whether to show all profile variables.
+#' @param profile_variable_order Profile variable ordering mode.
 #' @param map_variable_n Maximum number of variables shown on the map.
 #' @param algorithm Algorithm to use: `auto`, `pam`, or `clara`.
 #' @param clara_samples Number of candidate samples used by CLARA.
@@ -549,7 +558,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
                          seed = 1, normalize_data = TRUE,
                          elbow_method_mode = 'silhouette', max_centers = 10,
                          silhouette_sample_size = 5000, profile_top_n = 10,
-                         profile_show_all = FALSE, profile_variable_order = 'effect_size',
+                         profile_show_all = TRUE, profile_variable_order = 'effect_size',
                          map_variable_n = 10, algorithm = 'auto',
                          clara_samples = 20, clara_sample_size = NULL,
                          map_sample_size = 2000) {
@@ -563,6 +572,8 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   centers <- .kmedoids_safe_numeric(centers)
   max_centers <- .kmedoids_safe_numeric(max_centers)
   iterMax <- .kmedoids_safe_numeric(iterMax)
+  centers <- if (is.null(centers)) NULL else as.integer(floor(centers))
+  max_centers <- if (is.null(max_centers)) NULL else as.integer(floor(max_centers))
   if (is.null(centers) || centers < 2 || is.null(iterMax) || iterMax < 1) {
     stop('centers must be at least 2 and iterMax must be positive.', call. = FALSE)
   }
@@ -573,25 +584,35 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   if (is.null(clara_samples) || clara_samples < 1) {
     stop('clara_samples must be a positive number.', call. = FALSE)
   }
+  clara_samples <- as.integer(floor(clara_samples))
   if (!is.null(clara_sample_size)) {
     clara_sample_size <- .kmedoids_safe_numeric(clara_sample_size)
+    clara_sample_size <- if (is.null(clara_sample_size)) NULL else as.integer(floor(clara_sample_size))
     if (is.null(clara_sample_size) || clara_sample_size < centers + 1) {
       stop('clara_sample_size must be greater than the number of clusters.', call. = FALSE)
     }
   }
   silhouette_sample_size <- .kmedoids_safe_numeric(silhouette_sample_size)
+  silhouette_sample_size <- if (is.null(silhouette_sample_size)) {
+    NULL
+  } else {
+    as.integer(floor(silhouette_sample_size))
+  }
   if (is.null(silhouette_sample_size) || silhouette_sample_size < centers + 1) {
     stop('silhouette_sample_size must be greater than the number of clusters.', call. = FALSE)
   }
   profile_top_n <- .kmedoids_safe_numeric(profile_top_n)
+  profile_top_n <- if (is.null(profile_top_n)) NULL else as.integer(floor(profile_top_n))
   if (is.null(profile_top_n) || profile_top_n < 1) {
     stop('profile_top_n must be positive.', call. = FALSE)
   }
   map_variable_n <- .kmedoids_safe_numeric(map_variable_n)
+  map_variable_n <- if (is.null(map_variable_n)) NULL else as.integer(floor(map_variable_n))
   if (is.null(map_variable_n) || map_variable_n < 1) {
     stop('map_variable_n must be positive.', call. = FALSE)
   }
   map_sample_size <- .kmedoids_safe_numeric(map_sample_size)
+  map_sample_size <- if (is.null(map_sample_size)) NULL else as.integer(floor(map_sample_size))
   if (is.null(map_sample_size) || map_sample_size < 1) {
     stop('map_sample_size must be positive.', call. = FALSE)
   }
@@ -611,8 +632,8 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   excluded_nrow <- sum(!valid)
   fit_data <- source_data[valid, , drop = FALSE]
   row_ids <- original_row_ids[valid]
-  if (nrow(fit_data) <= centers) {
-    stop('The number of valid rows must be greater than the number of clusters.', call. = FALSE)
+  if (nrow(fit_data) < centers) {
+    stop('The number of valid rows must be greater than or equal to the number of clusters.', call. = FALSE)
   }
   mat <- as.matrix(fit_data)
   if (isTRUE(normalize_data)) {
@@ -624,7 +645,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
     clara_samples = clara_samples, clara_sample_size = clara_sample_size
   )
   model <- list(
-    pam = fit$raw, mat = mat, original_fit_mat = as.matrix(fit_data),
+    mat = mat, original_fit_mat = as.matrix(fit_data),
     source_data = source_data, original_data = original_data,
     row_ids = row_ids, source_row_ids = original_row_ids, selected_cols = selected_cols,
     valid_indices = which(valid), clustering = fit$clustering,

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -8,19 +8,99 @@
   value
 }
 
+.kmedoids_pam_max_n <- 5000L
+
 .kmedoids_distance_to_medoids <- function(mat, medoid_mat, cluster_ids, metric) {
-  vapply(seq_len(nrow(mat)), function(i) {
-    medoid <- medoid_mat[cluster_ids[[i]], , drop = FALSE]
-    delta <- mat[i, , drop = FALSE] - medoid
-    if (metric == 'manhattan') sum(abs(delta)) else sqrt(sum(delta^2))
-  }, numeric(1))
+  if (nrow(mat) == 0) return(numeric())
+  assigned_medoids <- medoid_mat[as.integer(cluster_ids), , drop = FALSE]
+  delta <- mat - assigned_medoids
+  if (metric == 'manhattan') {
+    rowSums(abs(delta))
+  } else {
+    sqrt(rowSums(delta^2))
+  }
 }
 
-.kmedoids_fit <- function(mat, centers, distance, seed = NULL) {
+.kmedoids_fit <- function(mat, centers, distance, seed = NULL,
+                          algorithm = 'pam', clara_samples = 20,
+                          clara_sample_size = NULL,
+                          pam_max_n = .kmedoids_pam_max_n) {
+  algorithm <- match.arg(algorithm, c('auto', 'pam', 'clara'))
+  if (algorithm == 'auto') {
+    algorithm <- if (nrow(mat) <= pam_max_n) 'pam' else 'clara'
+  }
+  if (algorithm == 'pam' && nrow(mat) > pam_max_n) {
+    stop(
+      paste0(
+        'PAM is limited to ', format(pam_max_n, big.mark = ','),
+        ' valid rows for performance. Select algorithm = "clara" or reduce max_nrow.'
+      ),
+      call. = FALSE
+    )
+  }
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  cluster::pam(mat, k = centers, metric = distance, stand = FALSE, keep.diss = TRUE)
+  if (algorithm == 'pam') {
+    raw <- cluster::pam(
+      mat, k = centers, metric = distance, stand = FALSE,
+      keep.diss = FALSE, keep.data = FALSE, pamonce = 5
+    )
+    silhouette_widths <- if (!is.null(raw$silinfo$widths)) {
+      raw$silinfo$widths[, 'sil_width']
+    } else {
+      NULL
+    }
+    silhouette_row_indices <- if (is.null(silhouette_widths)) {
+      integer()
+    } else {
+      seq_along(silhouette_widths)
+    }
+    medoid_indices <- raw$id.med
+  } else {
+    if (is.null(clara_sample_size)) {
+      clara_sample_size <- min(nrow(mat), max(100L, 40L + 2L * centers))
+    }
+    clara_sample_size <- max(centers + 1L, min(nrow(mat), floor(clara_sample_size)))
+    raw <- cluster::clara(
+      mat, k = centers, metric = distance, stand = FALSE,
+      samples = max(1L, floor(clara_samples)), sampsize = clara_sample_size,
+      keep.data = FALSE, rngR = TRUE
+    )
+    silhouette_widths <- if (!is.null(raw$silinfo$widths)) {
+      raw$silinfo$widths[, 'sil_width']
+    } else {
+      NULL
+    }
+    silhouette_row_indices <- if (is.null(silhouette_widths)) {
+      integer()
+    } else {
+      suppressWarnings(as.integer(rownames(raw$silinfo$widths)))
+    }
+    if (length(silhouette_row_indices) != length(silhouette_widths) ||
+        anyNA(silhouette_row_indices)) {
+      silhouette_row_indices <- seq_along(silhouette_widths)
+    }
+    medoid_indices <- raw$i.med
+  }
+  list(
+    raw = raw,
+    algorithm = algorithm,
+    is_approximate = identical(algorithm, 'clara'),
+    clustering = as.integer(raw$clustering),
+    medoids = raw$medoids,
+    medoid_indices = as.integer(medoid_indices),
+    objective = raw$objective,
+    silhouette_widths = silhouette_widths,
+    silhouette_row_indices = silhouette_row_indices,
+    silhouette_avg = if (is.null(raw$silinfo$avg.width)) {
+      NA_real_
+    } else {
+      as.numeric(raw$silinfo$avg.width)
+    },
+    clara_sample_size = if (algorithm == 'clara') clara_sample_size else NULL,
+    clara_samples = if (algorithm == 'clara') max(1L, floor(clara_samples)) else NULL
+  )
 }
 
 .kmedoids_empty <- function(type) {
@@ -65,7 +145,9 @@
     medoid_details = tibble::tibble(cluster = integer(), row_id = character()),
     counts = tibble::tibble(
       original_nrow = integer(), analysis_nrow = integer(), excluded_nrow = integer(),
-      exclusion_ratio = numeric()
+      exclusion_ratio = numeric(), requested_algorithm = character(),
+      effective_algorithm = character(), is_approximate = logical(),
+      fit_sample_nrow = integer(), diagnostic_nrow = integer(), map_sample_nrow = integer()
     ),
     data = tibble::tibble(),
     tibble::tibble()
@@ -73,6 +155,7 @@
 }
 
 .kmedoids_valid_indices <- function(x) {
+  if (!is.null(x$valid_indices)) return(x$valid_indices)
   valid <- complete.cases(x$source_data)
   if (ncol(x$source_data) > 0) {
     valid <- valid & apply(x$source_data, 1, function(row) all(is.finite(row)))
@@ -81,17 +164,43 @@
 }
 
 .kmedoids_original_fit_mat <- function(x) {
+  if (!is.null(x$original_fit_mat)) return(x$original_fit_mat)
   x$source_data[.kmedoids_valid_indices(x), , drop = FALSE] %>% as.matrix()
 }
 
-.kmedoids_summary <- function(x, with_excluded_rows = FALSE) {
-  fit <- x$pam
-  ids <- fit$clustering
-  distances <- x$distance_to_medoid
-  silhouette_widths <- rep(NA_real_, length(ids))
-  if (!is.null(fit$silinfo$widths)) {
-    silhouette_widths <- fit$silinfo$widths[, 'sil_width']
+.kmedoids_silhouette_values <- function(x) {
+  values <- rep(NA_real_, x$valid_nrow)
+  if (length(x$silhouette_widths) > 0 && length(x$silhouette_row_indices) > 0) {
+    indices <- x$silhouette_row_indices
+    keep <- indices >= 1 & indices <= x$valid_nrow
+    values[indices[keep]] <- x$silhouette_widths[keep]
   }
+  values
+}
+
+.kmedoids_sample_indices <- function(x, max_n, include = integer(), seed_offset = 0L) {
+  n <- nrow(x$mat)
+  include <- sort(unique(as.integer(include[include >= 1 & include <= n])))
+  max_n <- max(1L, min(n, max(floor(max_n), length(include))))
+  if (length(include) >= max_n) return(include)
+  remaining <- setdiff(seq_len(n), include)
+  seed <- if (is.null(x$seed)) NULL else as.integer(x$seed) + seed_offset
+  if (!is.null(seed)) set.seed(seed)
+  c(include, sample(remaining, max_n - length(include)))
+}
+
+.kmedoids_diagnostic_mat <- function(x, seed_offset = 0L) {
+  indices <- .kmedoids_sample_indices(
+    x, x$silhouette_sample_size,
+    include = x$medoid_indices, seed_offset = seed_offset
+  )
+  list(mat = x$mat[indices, , drop = FALSE], indices = indices)
+}
+
+.kmedoids_summary <- function(x, with_excluded_rows = FALSE) {
+  ids <- x$clustering
+  distances <- x$distance_to_medoid
+  silhouette_widths <- .kmedoids_silhouette_values(x)
   clusters <- sort(unique(ids))
   result <- purrr::map_dfr(clusters, function(cluster_id) {
     index <- which(ids == cluster_id)
@@ -105,11 +214,11 @@
       avg_silhouette = mean(cluster_silhouette, na.rm = TRUE),
       min_silhouette = min(cluster_silhouette, na.rm = TRUE),
       pct_negative = mean(cluster_silhouette < 0, na.rm = TRUE),
-      medoid_row_id = x$row_ids[fit$id.med[[cluster_id]]]
+      medoid_row_id = x$row_ids[x$medoid_indices[[cluster_id]]]
     )
   })
   original_mat <- .kmedoids_original_fit_mat(x)
-  medoid_values <- original_mat[fit$id.med, , drop = FALSE] %>%
+  medoid_values <- original_mat[x$medoid_indices, , drop = FALSE] %>%
     as.data.frame(check.names = FALSE) %>%
     tibble::as_tibble()
   medoid_values$cluster <- seq_len(nrow(medoid_values))
@@ -139,16 +248,18 @@
 .kmedoids_profile <- function(x) {
   mat <- x$mat
   original_mat <- .kmedoids_original_fit_mat(x)
-  ids <- x$pam$clustering
+  ids <- x$clustering
   overall_mean <- colMeans(mat, na.rm = TRUE)
   overall_sd <- apply(mat, 2, stats::sd, na.rm = TRUE)
+  overall_median <- apply(original_mat, 2, stats::median, na.rm = TRUE)
+  original_overall_mean <- colMeans(original_mat, na.rm = TRUE)
   rows <- purrr::map_dfr(sort(unique(ids)), function(cluster_id) {
     index <- which(ids == cluster_id)
     cluster_mean <- colMeans(mat[index, , drop = FALSE], na.rm = TRUE)
     original_cluster <- original_mat[index, , drop = FALSE]
     original_cluster_mean <- colMeans(original_cluster, na.rm = TRUE)
     original_cluster_median <- apply(original_cluster, 2, stats::median, na.rm = TRUE)
-    medoid_index <- x$pam$id.med[[cluster_id]]
+    medoid_index <- x$medoid_indices[[cluster_id]]
     standardized <- ifelse(overall_sd > 0,
       (cluster_mean - overall_mean) / overall_sd,
       0
@@ -161,36 +272,52 @@
       medoid = as.numeric(original_mat[medoid_index, ]),
       cluster_median = as.numeric(original_cluster_median),
       cluster_mean = as.numeric(original_cluster_mean),
-      overall_median = as.numeric(apply(original_mat, 2, stats::median, na.rm = TRUE)),
-      overall_mean = as.numeric(colMeans(original_mat, na.rm = TRUE))
+      overall_median = as.numeric(overall_median),
+      overall_mean = as.numeric(original_overall_mean)
     )
   })
   rows %>%
     dplyr::group_by(cluster) %>%
     dplyr::mutate(rank = rank(-effect_size, ties.method = 'first')) %>%
-    dplyr::ungroup()
+    dplyr::ungroup() %>%
+    {
+      result <- .
+      if (!isTRUE(x$profile_show_all)) {
+        result <- dplyr::filter(result, rank <= x$profile_top_n)
+      }
+      if (identical(x$profile_variable_order, 'effect_size')) {
+        result <- dplyr::arrange(result, cluster, rank)
+      }
+      result
+    }
 }
 
 .kmedoids_silhouette <- function(x) {
   if (x$max_centers < 2 || nrow(x$mat) < 3) {
     return(.kmedoids_empty('silhouette'))
   }
-  upper <- min(x$max_centers, nrow(unique(x$mat)) - 1)
+  diagnostic <- .kmedoids_diagnostic_mat(x, seed_offset = 1000L)
+  diagnostic_mat <- diagnostic$mat
+  upper <- min(x$max_centers, nrow(unique(diagnostic_mat)) - 1)
   if (upper < 2) {
     return(.kmedoids_empty('silhouette'))
   }
   purrr::map_dfr(seq(2, upper), function(center) {
     fit <- tryCatch(
-      .kmedoids_fit(x$mat, center, x$distance, x$seed),
+      .kmedoids_fit(
+        diagnostic_mat, center, x$distance,
+        if (is.null(x$seed)) NULL else x$seed + center,
+        algorithm = 'pam', pam_max_n = Inf
+      ),
       error = function(e) NULL
     )
-    if (is.null(fit) || is.null(fit$silinfo$widths)) {
+    if (is.null(fit) || is.null(fit$silhouette_widths)) {
       return(tibble::tibble(
         center = center, avg_silhouette = NA_real_, min_silhouette = NA_real_,
         pct_negative = NA_real_
       ))
     }
-    widths <- fit$silinfo$widths[, 'sil_width']
+    widths <- fit$silhouette_widths
     tibble::tibble(
       center = center,
       avg_silhouette = mean(widths, na.rm = TRUE),
@@ -201,13 +328,19 @@
 }
 
 .kmedoids_elbow <- function(x) {
-  upper <- min(x$max_centers, nrow(unique(x$mat)))
+  diagnostic <- .kmedoids_diagnostic_mat(x, seed_offset = 2000L)
+  diagnostic_mat <- diagnostic$mat
+  upper <- min(x$max_centers, nrow(unique(diagnostic_mat)))
   if (upper < 1) {
     return(.kmedoids_empty('elbow'))
   }
   result <- purrr::map_dfr(seq_len(upper), function(center) {
     fit <- tryCatch(
-      .kmedoids_fit(x$mat, center, x$distance, x$seed),
+      .kmedoids_fit(
+        diagnostic_mat, center, x$distance,
+        if (is.null(x$seed)) NULL else x$seed + center,
+        algorithm = 'pam', pam_max_n = Inf
+      ),
       error = function(e) NULL
     )
     if (is.null(fit)) {
@@ -217,7 +350,7 @@
       ))
     }
     dist_to_medoid <- .kmedoids_distance_to_medoids(
-      x$mat, fit$medoids, fit$clustering, x$distance
+      diagnostic_mat, fit$medoids, fit$clustering, x$distance
     )
     tibble::tibble(
       center = center,
@@ -235,7 +368,7 @@
 }
 
 .kmedoids_variable_importance <- function(x) {
-  ids <- factor(x$pam$clustering)
+  ids <- factor(x$clustering)
   purrr::map_dfr(seq_len(ncol(x$mat)), function(index) {
     value <- x$mat[, index]
     grand_mean <- mean(value, na.rm = TRUE)
@@ -256,11 +389,11 @@
 }
 
 .kmedoids_representative_values <- function(x) {
-  ids <- x$pam$clustering
+  ids <- x$clustering
   original_mat <- .kmedoids_original_fit_mat(x)
   purrr::map_dfr(sort(unique(ids)), function(cluster_id) {
     index <- which(ids == cluster_id)
-    medoid_index <- x$pam$id.med[[cluster_id]]
+    medoid_index <- x$medoid_indices[[cluster_id]]
     tibble::tibble(
       cluster = as.integer(cluster_id),
       variable = colnames(original_mat),
@@ -274,8 +407,8 @@
 }
 
 .kmedoids_distribution <- function(x) {
-  ids <- x$pam$clustering
-  medoid_indices <- x$pam$id.med
+  ids <- x$clustering
+  medoid_indices <- x$medoid_indices
   original_mat <- .kmedoids_original_fit_mat(x)
   purrr::map_dfr(seq_len(nrow(original_mat)), function(index) {
     tibble::tibble(
@@ -289,52 +422,61 @@
 
 .kmedoids_cohesion <- function(x) {
   tibble::tibble(
-    cluster = as.integer(x$pam$clustering),
+    cluster = as.integer(x$clustering),
     distance_to_medoid = x$distance_to_medoid
   )
 }
 
 .kmedoids_map <- function(x) {
-  n_dimension <- min(2, nrow(x$mat) - 1, ncol(x$mat))
+  map_indices <- .kmedoids_sample_indices(
+    x, x$map_sample_size,
+    include = x$medoid_indices, seed_offset = 3000L
+  )
+  map_mat <- x$mat[map_indices, , drop = FALSE]
+  n_dimension <- min(2, nrow(map_mat) - 1, ncol(map_mat))
   if (n_dimension < 1) {
     return(.kmedoids_empty('map'))
   }
-  distance_matrix <- stats::dist(x$mat, method = x$distance)
+  distance_matrix <- stats::dist(map_mat, method = x$distance)
   coordinates <- stats::cmdscale(distance_matrix, k = n_dimension, eig = TRUE, add = TRUE)
   points <- coordinates$points
   if (n_dimension == 1) points <- cbind(points, 0)
   dimension_names <- c('Dim1', 'Dim2')
   colnames(points) <- dimension_names
-  row_ids <- x$row_ids
+  row_ids <- x$row_ids[map_indices]
   result <- tibble::tibble(
     Dim1 = points[, 'Dim1'], Dim2 = points[, 'Dim2'],
-    cluster = as.integer(x$pam$clustering), row_type = 'observation',
+    cluster = as.integer(x$clustering[map_indices]), row_type = 'observation',
     label = row_ids
   )
-  medoid_points <- points[x$pam$id.med, , drop = FALSE]
+  medoid_positions <- match(x$medoid_indices, map_indices)
+  medoid_points <- points[medoid_positions, , drop = FALSE]
   result <- dplyr::bind_rows(result, tibble::tibble(
     Dim1 = medoid_points[, 'Dim1'], Dim2 = medoid_points[, 'Dim2'],
     cluster = seq_len(nrow(medoid_points)), row_type = 'medoid',
-    label = row_ids[x$pam$id.med]
+    label = x$row_ids[x$medoid_indices]
   ))
   vector_scale <- max(abs(points), na.rm = TRUE)
   if (!is.finite(vector_scale) || vector_scale == 0) vector_scale <- 1
-  loadings <- vapply(seq_len(ncol(x$mat)), function(index) {
+  loadings <- vapply(seq_len(ncol(map_mat)), function(index) {
     c(
-      suppressWarnings(stats::cor(x$mat[, index], points[, 'Dim1'], use = 'complete.obs')),
+      suppressWarnings(stats::cor(map_mat[, index], points[, 'Dim1'], use = 'complete.obs')),
       if (n_dimension >= 2) {
-        suppressWarnings(stats::cor(x$mat[, index], points[, 'Dim2'], use = 'complete.obs'))
+        suppressWarnings(stats::cor(map_mat[, index], points[, 'Dim2'], use = 'complete.obs'))
       } else 0
     )
   }, numeric(2))
   loadings[!is.finite(loadings)] <- 0
+  loading_rank <- order(sqrt(colSums(loadings^2)), decreasing = TRUE)
+  loading_rank <- head(loading_rank, max(1L, min(x$map_variable_n, length(loading_rank))))
+  loadings <- loadings[, loading_rank, drop = FALSE]
   vector_points <- t(loadings) * (vector_scale * 0.8)
   vectors <- purrr::map_dfr(seq_len(nrow(vector_points)), function(index) {
     tibble::tibble(
       Dim1 = c(0, vector_points[index, 1]),
       Dim2 = c(0, vector_points[index, 2]),
       cluster = NA_integer_, row_type = 'vector',
-      label = rep(colnames(x$mat)[[index]], 2)
+      label = rep(colnames(map_mat)[[loading_rank[[index]]]], 2)
     )
   })
   result <- dplyr::bind_rows(result, vectors)
@@ -344,16 +486,18 @@
   }
   x$representation_rate <- c(representation_rate, rep(0, 2 - length(representation_rate)))
   attr(result, 'representation_rate') <- x$representation_rate
+  attr(result, 'map_sample_size') <- length(map_indices)
+  attr(result, 'map_sampled') <- length(map_indices) < x$valid_nrow
   result
 }
 
 .kmedoids_medoid_details <- function(x) {
   original_mat <- .kmedoids_original_fit_mat(x)
   tibble::tibble(
-    cluster = seq_len(nrow(x$pam$medoids)),
-    row_id = x$row_ids[x$pam$id.med]
+    cluster = seq_along(x$medoid_indices),
+    row_id = x$row_ids[x$medoid_indices]
   ) %>% dplyr::bind_cols(
-    original_mat[x$pam$id.med, , drop = FALSE] %>%
+    original_mat[x$medoid_indices, , drop = FALSE] %>%
       as.data.frame(check.names = FALSE) %>% tibble::as_tibble()
   )
 }
@@ -365,7 +509,13 @@
     excluded_nrow = x$excluded_nrow,
     exclusion_ratio = if (nrow(x$original_data) > 0) {
       x$excluded_nrow / nrow(x$original_data)
-    } else 0
+    } else 0,
+    requested_algorithm = x$requested_algorithm,
+    effective_algorithm = x$effective_algorithm,
+    is_approximate = x$is_approximate,
+    fit_sample_nrow = x$valid_nrow,
+    diagnostic_nrow = min(x$valid_nrow, x$silhouette_sample_size),
+    map_sample_nrow = min(x$valid_nrow, max(x$map_sample_size, length(x$medoid_indices)))
   )
 }
 
@@ -377,16 +527,21 @@
 #' @param distance Distance metric supported by `cluster::pam`.
 #' @param takeSample Whether to sample rows when `max_nrow` is exceeded.
 #' @param max_nrow Maximum number of rows used for fitting.
-#' @param iterMax Maximum PAM iterations.
+#' @param iterMax Deprecated compatibility argument. It is accepted for saved
+#'   commands but is not used by `cluster::pam()` or `cluster::clara()`.
 #' @param seed Random seed.
 #' @param normalize_data Whether to standardize selected variables before fitting.
 #' @param elbow_method_mode Which optimal-cluster diagnostics to compute.
 #' @param max_centers Maximum number of centers for diagnostics.
-#' @param silhouette_sample_size Reserved for parity with the Analytics UI.
+#' @param silhouette_sample_size Maximum number of rows used for diagnostics.
 #' @param profile_top_n Reserved for parity with the Analytics UI.
 #' @param profile_show_all Reserved for parity with the Analytics UI.
 #' @param profile_variable_order Reserved for parity with the Analytics UI.
-#' @param map_variable_n Reserved for parity with the Analytics UI.
+#' @param map_variable_n Maximum number of variables shown on the map.
+#' @param algorithm Algorithm to use: `auto`, `pam`, or `clara`.
+#' @param clara_samples Number of candidate samples used by CLARA.
+#' @param clara_sample_size Number of rows in each CLARA candidate sample.
+#' @param map_sample_size Maximum number of rows used for the PCoA map.
 #' @return A rowwise data frame containing a K-Medoids model.
 #' @export
 exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
@@ -395,7 +550,9 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
                          elbow_method_mode = 'silhouette', max_centers = 10,
                          silhouette_sample_size = 5000, profile_top_n = 10,
                          profile_show_all = FALSE, profile_variable_order = 'effect_size',
-                         map_variable_n = 10) {
+                         map_variable_n = 10, algorithm = 'auto',
+                         clara_samples = 20, clara_sample_size = NULL,
+                         map_sample_size = 2000) {
   selected_cols <- tidyselect::vars_select(names(df), !!!rlang::quos(...))
   if (length(selected_cols) == 0) {
     stop('At least one numeric variable is required for K-Medoids.', call. = FALSE)
@@ -411,6 +568,33 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   }
   distance <- match.arg(distance, c('euclidean', 'manhattan'))
   elbow_method_mode <- match.arg(as.character(elbow_method_mode), c('none', 'silhouette', 'elbow'))
+  algorithm <- match.arg(as.character(algorithm), c('auto', 'pam', 'clara'))
+  clara_samples <- .kmedoids_safe_numeric(clara_samples)
+  if (is.null(clara_samples) || clara_samples < 1) {
+    stop('clara_samples must be a positive number.', call. = FALSE)
+  }
+  if (!is.null(clara_sample_size)) {
+    clara_sample_size <- .kmedoids_safe_numeric(clara_sample_size)
+    if (is.null(clara_sample_size) || clara_sample_size < centers + 1) {
+      stop('clara_sample_size must be greater than the number of clusters.', call. = FALSE)
+    }
+  }
+  silhouette_sample_size <- .kmedoids_safe_numeric(silhouette_sample_size)
+  if (is.null(silhouette_sample_size) || silhouette_sample_size < centers + 1) {
+    stop('silhouette_sample_size must be greater than the number of clusters.', call. = FALSE)
+  }
+  profile_top_n <- .kmedoids_safe_numeric(profile_top_n)
+  if (is.null(profile_top_n) || profile_top_n < 1) {
+    stop('profile_top_n must be positive.', call. = FALSE)
+  }
+  map_variable_n <- .kmedoids_safe_numeric(map_variable_n)
+  if (is.null(map_variable_n) || map_variable_n < 1) {
+    stop('map_variable_n must be positive.', call. = FALSE)
+  }
+  map_sample_size <- .kmedoids_safe_numeric(map_sample_size)
+  if (is.null(map_sample_size) || map_sample_size < 1) {
+    stop('map_sample_size must be positive.', call. = FALSE)
+  }
   if (is.null(max_nrow) || !isTRUE(takeSample)) max_nrow <- nrow(df)
   max_nrow <- max(1, floor(.kmedoids_safe_numeric(max_nrow) %||% nrow(df)))
   original_data <- df
@@ -422,29 +606,42 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
     original_row_ids <- original_row_ids[selected_index]
   }
   source_data <- df[selected_cols]
-  valid <- complete.cases(source_data) & apply(source_data, 1, function(row) all(is.finite(row)))
+  source_mat <- as.matrix(source_data)
+  valid <- complete.cases(source_data) & rowSums(!is.finite(source_mat)) == 0
   excluded_nrow <- sum(!valid)
   fit_data <- source_data[valid, , drop = FALSE]
   row_ids <- original_row_ids[valid]
-  if (nrow(fit_data) < centers) {
-    stop('The number of valid rows must be greater than or equal to the number of clusters.', call. = FALSE)
+  if (nrow(fit_data) <= centers) {
+    stop('The number of valid rows must be greater than the number of clusters.', call. = FALSE)
   }
   mat <- as.matrix(fit_data)
   if (isTRUE(normalize_data)) {
     mat <- scale(mat)
     mat[is.nan(mat)] <- 0
   }
-  fit <- .kmedoids_fit(mat, centers, distance, seed)
+  fit <- .kmedoids_fit(
+    mat, centers, distance, seed, algorithm = algorithm,
+    clara_samples = clara_samples, clara_sample_size = clara_sample_size
+  )
   model <- list(
-    pam = fit, mat = mat, source_data = source_data, original_data = original_data,
+    pam = fit$raw, mat = mat, original_fit_mat = as.matrix(fit_data),
+    source_data = source_data, original_data = original_data,
     row_ids = row_ids, source_row_ids = original_row_ids, selected_cols = selected_cols,
+    valid_indices = which(valid), clustering = fit$clustering,
+    medoids = fit$medoids, medoid_indices = fit$medoid_indices,
+    silhouette_widths = fit$silhouette_widths,
+    silhouette_row_indices = fit$silhouette_row_indices,
+    silhouette_avg = fit$silhouette_avg,
+    requested_algorithm = algorithm, effective_algorithm = fit$algorithm,
+    is_approximate = fit$is_approximate,
+    clara_samples = fit$clara_samples, clara_sample_size = fit$clara_sample_size,
     valid_nrow = nrow(fit_data),
     sampled_nrow = nrow(source_data), excluded_nrow = excluded_nrow,
     distance = distance, centers = centers, iterMax = iterMax, seed = seed,
     normalize_data = normalize_data, max_centers = max_centers,
     silhouette_sample_size = silhouette_sample_size, profile_top_n = profile_top_n,
     profile_show_all = profile_show_all, profile_variable_order = profile_variable_order,
-    map_variable_n = map_variable_n
+    map_variable_n = map_variable_n, map_sample_size = map_sample_size
   )
   model$distance_to_medoid <- .kmedoids_distance_to_medoids(
     mat, fit$medoids, fit$clustering, distance
@@ -455,7 +652,11 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   } else {
     NULL
   }
-  class(model) <- c('pam_exploratory', 'pam', 'partition')
+  class(model) <- c(
+    'pam_exploratory',
+    if (identical(fit$algorithm, 'pam')) 'pam' else 'clara',
+    'partition'
+  )
   tibble::tibble(model = list(model)) %>% dplyr::rowwise()
 }
 
@@ -480,12 +681,10 @@ tidy.pam_exploratory <- function(x, type = 'summary', with_excluded_rows = FALSE
       distance <- rep(NA_real_, nrow(x$source_data))
       silhouette <- rep(NA_real_, nrow(x$source_data))
       is_medoid <- rep(FALSE, nrow(x$source_data))
-      cluster[valid_indices] <- x$pam$clustering
+      cluster[valid_indices] <- x$clustering
       distance[valid_indices] <- x$distance_to_medoid
-      if (!is.null(x$pam$silinfo$widths)) {
-        silhouette[valid_indices] <- x$pam$silinfo$widths[, 'sil_width']
-      }
-      is_medoid[valid_indices[x$pam$id.med]] <- TRUE
+      silhouette[valid_indices] <- .kmedoids_silhouette_values(x)
+      is_medoid[valid_indices[x$medoid_indices]] <- TRUE
       dplyr::bind_cols(
         x$source_data,
         tibble::tibble(
@@ -508,7 +707,11 @@ glance.pam_exploratory <- function(x, ...) {
   tibble::tibble(
     centers = x$centers,
     total_distance_to_medoids = sum(x$distance_to_medoid, na.rm = TRUE),
-    average_silhouette = if (is.null(x$pam$silinfo$avg.width)) NA_real_ else x$pam$silinfo$avg.width
+    average_silhouette = x$silhouette_avg,
+    requested_algorithm = x$requested_algorithm,
+    effective_algorithm = x$effective_algorithm,
+    is_approximate = x$is_approximate,
+    fit_nrow = x$valid_nrow
   )
 }
 
@@ -516,10 +719,10 @@ glance.pam_exploratory <- function(x, ...) {
 #' @export
 augment.pam_exploratory <- function(x, data = NULL, ...) {
   if (is.null(data)) data <- x$source_data
-  if (nrow(data) != length(x$pam$clustering)) {
+  if (nrow(data) != length(x$clustering)) {
     stop('data must have the same number of rows as the fitted K-Medoids data.', call. = FALSE)
   }
-  dplyr::mutate(data, .cluster = factor(x$pam$clustering))
+  dplyr::mutate(data, .cluster = factor(x$clustering))
 }
 
 #' @export

--- a/docs/plans/2026-08-12-kmedoids-performance-improvement.md
+++ b/docs/plans/2026-08-12-kmedoids-performance-improvement.md
@@ -1,0 +1,291 @@
+# Design: K-Medoids Performance Improvement
+
+**Date:** 2026-08-12
+**Status:** In progress
+**Scope:** `exploratory_func` and the paired `tam` K-Medoids Analytics template
+
+## Implemented in this increment
+
+- Added the R-side `algorithm = "auto" | "pam" | "clara"` dispatcher.
+- Added FastPAM/CLARA fitting with compact model retention and a 5,000-row
+  PAM safety threshold.
+- Applied diagnostic and map row caps, vectorized distance-to-medoid
+  calculation, and persisted algorithm metadata in `glance()` / `counts()`.
+- Added the paired `tam` controls and command generation for algorithm and
+  CLARA settings; removed the non-functional `iterMax` control while keeping
+  the R argument for saved-command compatibility.
+
+## Decision summary
+
+Add an `algorithm` parameter, passed from the Analytics UI to
+`exp_kmedoids()`, with these values:
+
+| UI value | R value | Behaviour |
+| --- | --- | --- |
+| Auto (recommended) | `"auto"` | Use exact PAM for a small analysis data set and CLARA for a large one. |
+| PAM (exact) | `"pam"` | Use PAM only. Reject an unsafe input size with an actionable error; never silently fall back. |
+| CLARA (approximate) | `"clara"` | Use CLARA's sampled medoid search and assign all analysis rows. |
+
+`"auto"` will be the default so existing saved Analytics commands that do
+not contain the new argument keep working. The selected and effective
+algorithm, sample sizes, and whether results are approximate will be kept in
+the model and shown in the report metadata.
+
+## Current state and problem
+
+There is no algorithm-selection parameter today:
+
+- `exp_kmedoids()` accepts no `algorithm` argument and
+  `.kmedoids_fit()` always calls `cluster::pam()`.
+- The paired `tam` template exposes sampling, distance, iteration, seed, and
+  diagnostic settings, but no algorithm setting.
+
+The current default is not viable for the UI's default 50,000-row sample:
+
+1. `.kmedoids_fit()` passes `keep.diss = TRUE`. A packed double-precision
+   distance vector for 50,000 rows has 1,249,975,000 elements and alone
+   requires about **9.31 GiB**. PAM also needs additional quadratic working
+   memory and computation.
+2. The default `elbow_method_mode = "silhouette"` refits the model for every
+   `k` from 2 through `max_centers` (default 10): nine additional PAM fits.
+3. `silhouette_sample_size = 5000` is shown in the UI but is unused in R.
+4. The Cluster Map runs `dist()` and `cmdscale()` over every analysis row. It
+   has the same quadratic-memory problem and full PCoA does not scale to
+   50,000 rows.
+5. `iterMax` is validated but not passed to either `cluster::pam()` or
+   `cluster::clara()`; it currently has no effect.
+
+## Goals
+
+- Make the default K-Medoids experience complete without memory exhaustion at
+  the current 50,000-row UI sample cap.
+- Preserve exact PAM for users and small data sets that need it.
+- Make an approximate result explicit, deterministic for a fixed seed, and
+  sufficiently documented to interpret correctly.
+- Keep the existing report types and output columns stable wherever their
+  semantics remain valid.
+- Bound the diagnostic and map work independently of the model-fit row count.
+
+## Non-goals
+
+- Changing supported distance metrics (Euclidean and Manhattan remain the
+  initial scope).
+- Claiming that CLARA yields the identical medoids as exact PAM.
+- Rendering all 50,000 observations in a PCoA map.
+- Using `iterMax` as a fictitious PAM setting. Its UI contract must be
+  corrected rather than silently retained.
+
+## Proposed interface
+
+### R API
+
+Extend `exp_kmedoids()` with the following arguments. New arguments are
+appended after the existing public arguments to avoid positional-command
+compatibility issues.
+
+```r
+exp_kmedoids(
+  ...,
+  algorithm = c("auto", "pam", "clara"),
+  clara_samples = 20,
+  clara_sample_size = NULL,
+  map_sample_size = 2000
+)
+```
+
+- `algorithm`: selection requested by the user.
+- `clara_samples`: number of CLARA candidate samples. The `cluster` package
+  recommends substantially more than its legacy default of five; use 20 as a
+  starting default and tune it in the benchmark.
+- `clara_sample_size`: observations in each CLARA candidate sample. `NULL`
+  selects a bounded internal default based on `centers`; expose it only as an
+  advanced setting if tuning is needed.
+- `map_sample_size`: maximum number of rows used for PCoA (including medoids,
+  which are always included). It is
+  independent of `silhouette_sample_size`, because full PCoA is much more
+  expensive than silhouette calculation on the same number of rows.
+
+Define one documented internal guard, initially
+`KMEDOIDS_PAM_MAX_N = 5000`, subject to benchmark calibration:
+
+```text
+algorithm = auto:
+  valid_nrow <= KMEDOIDS_PAM_MAX_N  -> PAM
+  valid_nrow >  KMEDOIDS_PAM_MAX_N  -> CLARA
+
+algorithm = pam:
+  valid_nrow <= KMEDOIDS_PAM_MAX_N  -> PAM
+  valid_nrow >  KMEDOIDS_PAM_MAX_N  -> error with guidance to select CLARA
+
+algorithm = clara:
+  -> CLARA
+```
+
+The guard is intentionally enforced for explicit PAM. Selecting "exact" must
+not unexpectedly consume all available memory.
+
+### Analytics UI and command generation
+
+In `tam`'s `kmedoids.json`, add an **Algorithm** select after Random Seed and
+map it to the new R argument:
+
+```json
+{
+  "name": "algorithm",
+  "displayName": "Algorithm",
+  "type": "select",
+  "defaultValue": "auto",
+  "analysisExtraArgumentPosition": 6,
+  "options": [
+    { "displayName": "Auto (recommended)", "value": "auto" },
+    { "displayName": "PAM (exact)", "value": "pam" },
+    { "displayName": "CLARA (approximate)", "value": "clara" }
+  ]
+}
+```
+
+Add advanced CLARA controls, visible only when `algorithm = "clara"`, and a
+**Map Sample Size** control under Cluster Map. The generated command must
+include the selected values. Existing saved commands, which omit `algorithm`,
+use `"auto"` in R.
+
+The property-dialog help text must state:
+
+- PAM is exact but limited to small data due to its quadratic distance work.
+- CLARA is an approximation intended for larger data; its results depend on
+  the seed and the sampling settings.
+- Auto chooses safely based on the number of valid analysis rows.
+
+## Implementation plan
+
+### 1. Establish a canonical fit adapter
+
+Refactor `R/kmedoids.R` so report code no longer assumes a PAM-specific
+object (`id.med`, full-length `silinfo$widths`, and `pam` class).
+
+- Create `.kmedoids_fit()` as a dispatcher and return a canonical list with
+  `clustering`, `medoid_indices`, `medoids`, `objective`, optional
+  `silhouette_widths`, `silhouette_row_indices`, `algorithm`, and
+  `is_approximate`.
+- PAM adapter: call `cluster::pam(..., keep.diss = FALSE, keep.data = FALSE,
+  pamonce = 5)`. FastPAM improves swap performance while retaining PAM's
+  exact-method branch.
+- CLARA adapter: call `cluster::clara(..., samples = clara_samples,
+  sampsize = clara_sample_size, keep.data = FALSE, rngR = TRUE)`. Normalize
+  CLARA's `i.med` to `medoid_indices`.
+- Record requested/effective algorithm, analysis-row count, and sampling
+  metadata on the model.
+- Update summary, profile, representative values, cohesion, data, and medoid
+  detail tidiers to use this canonical result.
+
+`keep.diss = FALSE` is safe for the existing basic outputs: PAM still returns
+cluster assignments, medoids, objective values, and silhouette information,
+but it no longer retains the large distance object after fitting.
+
+### 2. Bound diagnostics and honour existing settings
+
+Use `silhouette_sample_size` for the k=2..`max_centers` comparison:
+
+- Draw one deterministic, representative diagnostic sample (including any
+  required medoids where applicable), capped by `silhouette_sample_size`.
+- Run FastPAM with `keep.diss = FALSE` for every candidate `k` on that sample
+  and retain only the aggregate diagnostic metrics.
+- Store `diagnostic_nrow` and show it in the Silhouette/Elbow report text.
+- Do not run candidate fits when the user selects `elbow_method_mode = "none"`.
+
+For a CLARA main fit, CLARA's own silhouette widths describe its sampled
+observations, not every assigned row. Keep those row indices; do not align a
+short width vector to all rows. Non-sampled rows receive `NA` for per-row
+silhouette, and aggregate silhouette labels identify their sample size.
+
+### 3. Make the Cluster Map scalable
+
+For `tidy(type = "map")`:
+
+- When the analysis data fit within `map_sample_size`, retain the present PCoA
+  behavior.
+- Otherwise select a deterministic row sample, always including medoids, and
+  run `dist()` / `cmdscale()` only for those rows.
+- Return `row_type = "observation"` only for displayed rows and attach map
+  sample metadata. The UI text must label the map as a representative sample.
+- Apply `map_variable_n`: rank variable vectors by their two-dimensional
+  loading magnitude and return only the requested number.
+
+This preserves a faithful PCoA visualization for the displayed rows without
+pretending that a 50,000-row eigendecomposition is practical.
+
+### 4. Remove secondary avoidable work
+
+- Vectorize `.kmedoids_distance_to_medoids()` instead of iterating once per
+  row in R.
+- Compute valid-row indices and the unstandardized fit matrix once during
+  fitting; reuse them in `tidy()` methods.
+- Make `profile_top_n`, `profile_show_all`, and
+  `profile_variable_order` effective before generating profile/distribution
+  output, preventing unnecessary row-times-variable payloads.
+- Resolve `iterMax` before release: remove it from the UI/API, or replace it
+  with a real, documented parameter such as the number of randomized starts.
+  Do not retain the present non-functional control.
+
+## Compatibility and reporting rules
+
+| Concern | Rule |
+| --- | --- |
+| Existing commands | Omitted `algorithm` means `"auto"`. |
+| Existing small data | Auto selects PAM; retain current output schemas. |
+| Explicit exact PAM on large data | Fail before allocating quadratic memory and explain how to use CLARA or reduce the analysis sample. |
+| CLARA medoids | Return actual row IDs from the original sampled analysis data, just as PAM does. |
+| Per-row silhouette in CLARA | Populate only sampled rows; do not report fabricated values for all assignments. |
+| Summary/diagnostic values | Include method and row/sample count so approximate measures are not mistaken for full-data exact measures. |
+| Saved report reproducibility | Persist algorithm and all sample/seed settings in the generated command. |
+
+## Test plan
+
+### `exploratory_func`
+
+- Add PAM, CLARA, and Auto branch tests to `tests/testthat/test_kmedoids.R`.
+- Verify `algorithm = "auto"` resolves to PAM below and CLARA above the
+  threshold; test the explicit-PAM safety error.
+- Verify both distance metrics, standardization, excluded rows, medoid row
+  IDs, deterministic seed behavior, and all existing `tidy()` schemas.
+- Verify CLARA silhouette indices are respected and non-sampled output rows
+  have `NA` rather than misaligned silhouette values.
+- Verify diagnostic and map sample caps, medoid inclusion in a map sample,
+  and `map_variable_n` enforcement.
+- Add a lightweight benchmark script outside ordinary unit tests. Measure
+  fit, diagnostics, map, peak memory, and output size separately for 1k, 5k,
+  10k, and 50k rows.
+
+### `tam`
+
+- Extend `KMedoidsAnalyticsTemplate.test.js` to assert the `algorithm` select,
+  default `auto`, conditional CLARA controls, and generated R command.
+- Add command-generation coverage for PAM and CLARA selections and for old
+  commands that omit the parameter.
+- Add localized UI strings and verify English/Japanese help text.
+- Manually verify that the report identifies exact versus approximate fits and
+  map/diagnostic samples.
+
+## Acceptance criteria
+
+1. A default 50,000-row K-Medoids run completes without retaining a
+   9.31-GiB distance object or attempting a 50,000-row PCoA.
+2. Users can choose Auto, exact PAM, or approximate CLARA in the Analytics
+   dialog, and the selected value appears in the generated R command.
+3. Auto is deterministic for a fixed seed and safely selects CLARA above the
+   calibrated PAM threshold.
+4. Silhouette and Elbow calculations respect `silhouette_sample_size`; the
+   report discloses the diagnostic sample size.
+5. Exact small-data outputs preserve the current report contract, and large
+   approximate outputs accurately label their scope and limitations.
+6. Benchmarks demonstrate the target improvement and tests cover both
+   algorithm branches before release.
+
+## Rollout order
+
+1. Add the fit adapter and remove retained PAM distances.
+2. Add the R `algorithm` API, Auto guard, and PAM/CLARA unit tests.
+3. Add the `tam` controls, command-generation tests, and report wording.
+4. Implement bounded diagnostics and scalable map sampling.
+5. Apply secondary vectorization/output reductions, then run the benchmark
+   matrix to calibrate thresholds and CLARA defaults.

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -73,3 +73,68 @@ test_that('non-numeric variables are rejected clearly', {
     'requires numeric variables'
   )
 })
+
+test_that('algorithm selection uses compact PAM output for small data', {
+  result <- mtcars %>% exploratory:::exp_kmedoids(
+    mpg, disp, hp, centers = 3, algorithm = 'pam', elbow_method_mode = 'none', seed = 7
+  )
+  model <- result$model[[1]]
+
+  expect_equal(model$requested_algorithm, 'pam')
+  expect_equal(model$effective_algorithm, 'pam')
+  expect_false(model$is_approximate)
+  expect_null(model$pam$diss)
+  expect_null(model$pam$data)
+  expect_equal(length(model$medoid_indices), 3)
+})
+
+test_that('CLARA is available and preserves full-data assignments', {
+  result <- iris %>% exploratory:::exp_kmedoids(
+    Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+    centers = 3, algorithm = 'clara', clara_samples = 3,
+    clara_sample_size = 50, silhouette_sample_size = 50,
+    elbow_method_mode = 'none', map_sample_size = 20, seed = 42
+  )
+  model <- result$model[[1]]
+  output_data <- broom::tidy(model, type = 'data')
+
+  expect_equal(model$effective_algorithm, 'clara')
+  expect_true(model$is_approximate)
+  expect_equal(length(model$clustering), nrow(iris))
+  expect_equal(sum(!is.na(output_data$cluster)), nrow(iris))
+  expect_equal(sum(!is.na(output_data$silhouette_score)), length(model$silhouette_widths))
+  expect_equal(nrow(broom::tidy(model, type = 'medoid_details')), 3)
+})
+
+test_that('auto switches to CLARA and explicit PAM fails safely for large data', {
+  set.seed(19)
+  data <- tibble::tibble(x = rnorm(5001), y = rnorm(5001))
+
+  auto <- data %>% exploratory:::exp_kmedoids(
+    x, y, centers = 3, algorithm = 'auto', elbow_method_mode = 'none',
+    silhouette_sample_size = 100, map_sample_size = 20, seed = 19
+  )
+  expect_equal(auto$model[[1]]$effective_algorithm, 'clara')
+
+  expect_error(
+    data %>% exploratory:::exp_kmedoids(
+      x, y, centers = 3, algorithm = 'pam', elbow_method_mode = 'none', seed = 19
+    ),
+    'Select algorithm = "clara"'
+  )
+})
+
+test_that('diagnostic and map sample sizes bound expensive outputs', {
+  result <- mtcars %>% exploratory:::exp_kmedoids(
+    mpg, disp, hp, centers = 3, silhouette_sample_size = 10,
+    map_sample_size = 8, map_variable_n = 2, elbow_method_mode = 'silhouette', seed = 1
+  )
+  model <- result$model[[1]]
+  map <- broom::tidy(model, type = 'map')
+  counts <- broom::tidy(model, type = 'counts')
+
+  expect_lte(sum(map$row_type == 'observation'), 8)
+  expect_lte(sum(map$row_type == 'vector') / 2, 2)
+  expect_equal(counts$diagnostic_nrow, min(model$valid_nrow, 10))
+  expect_equal(counts$map_sample_nrow, min(model$valid_nrow, max(8, model$centers)))
+})

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -27,8 +27,8 @@ test_that('exp_kmedoids supports both distance metrics and standardization', {
   expect_equal(euclidean$model[[1]]$distance, 'euclidean')
   expect_equal(manhattan$model[[1]]$distance, 'manhattan')
   expect_false(isTRUE(all.equal(
-    euclidean$model[[1]]$pam$clustering,
-    manhattan$model[[1]]$pam$clustering
+    euclidean$model[[1]]$clustering,
+    manhattan$model[[1]]$clustering
   )))
 })
 
@@ -55,6 +55,7 @@ test_that('report tidy types are available', {
 
   expect_true(all(vapply(output, is.data.frame, logical(1))))
   expect_true(nrow(output$profile) > 0)
+  expect_equal(nrow(output$profile), 9)
   expect_true(nrow(output$variable_importance) > 0)
   expect_true(nrow(output$map) > 0)
   expect_true(any(output$map$row_type == 'vector'))
@@ -83,9 +84,25 @@ test_that('algorithm selection uses compact PAM output for small data', {
   expect_equal(model$requested_algorithm, 'pam')
   expect_equal(model$effective_algorithm, 'pam')
   expect_false(model$is_approximate)
-  expect_null(model$pam$diss)
-  expect_null(model$pam$data)
+  expect_false('pam' %in% names(model))
   expect_equal(length(model$medoid_indices), 3)
+})
+
+test_that('PAM silhouette scores retain their original row indexes', {
+  result <- iris %>% exploratory:::exp_kmedoids(
+    Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+    centers = 3, algorithm = 'pam', elbow_method_mode = 'none', seed = 42
+  )
+  model <- result$model[[1]]
+  reference <- cluster::pam(
+    model$mat, k = 3, metric = 'manhattan', stand = FALSE,
+    keep.diss = FALSE, keep.data = FALSE, pamonce = 5
+  )
+  expect_equal(
+    model$silhouette_row_indices,
+    as.integer(rownames(reference$silinfo$widths))
+  )
+  expect_false(identical(model$silhouette_row_indices, seq_along(model$silhouette_widths)))
 })
 
 test_that('CLARA is available and preserves full-data assignments', {
@@ -137,4 +154,36 @@ test_that('diagnostic and map sample sizes bound expensive outputs', {
   expect_lte(sum(map$row_type == 'vector') / 2, 2)
   expect_equal(counts$diagnostic_nrow, min(model$valid_nrow, 10))
   expect_equal(counts$map_sample_nrow, min(model$valid_nrow, max(8, model$centers)))
+})
+
+test_that('diagnostic and map counts use bounded integer sample sizes', {
+  result <- mtcars %>% exploratory:::exp_kmedoids(
+    mpg, disp, hp, centers = 3, silhouette_sample_size = 10.9,
+    map_sample_size = 8.9, elbow_method_mode = 'none', seed = 1
+  )
+  model <- result$model[[1]]
+  counts <- broom::tidy(model, type = 'counts')
+
+  expect_identical(model$silhouette_sample_size, 10L)
+  expect_identical(model$map_sample_size, 8L)
+  expect_identical(counts$diagnostic_nrow, 10L)
+  expect_identical(counts$map_sample_nrow, 8L)
+
+  model$valid_nrow <- 6001L
+  model$mat <- matrix(rnorm(12002), ncol = 2)
+  model$medoid_indices <- 1:3
+  model$silhouette_sample_size <- 6001L
+  expect_equal(nrow(exploratory:::.kmedoids_diagnostic_mat(model)$mat), 5000)
+  model$map_sample_size <- 6001L
+  expect_identical(broom::tidy(model, type = 'counts')$map_sample_nrow, 5000L)
+})
+
+test_that('CLARA candidate samples are capped before fitting', {
+  set.seed(1)
+  fit <- exploratory:::.kmedoids_fit(
+    matrix(rnorm(200), ncol = 2), centers = 3, distance = 'euclidean',
+    algorithm = 'clara', clara_samples = 1, clara_sample_size = 100,
+    pam_max_n = 20
+  )
+  expect_identical(fit$clara_sample_size, 20L)
 })


### PR DESCRIPTION
## Summary

- Add `algorithm = "auto" | "pam" | "clara"` to `exp_kmedoids()`.
- Use compact FastPAM output for small data and CLARA for large data.
- Add bounded silhouette diagnostics and PCoA map sampling.
- Vectorize distance-to-medoid calculation and persist algorithm metadata.
- Add regression tests and the performance improvement plan.

## Motivation

The previous implementation always ran `cluster::pam()` with `keep.diss = TRUE`, which could require roughly 9.31 GiB for the packed distance vector at 50,000 rows. The default silhouette diagnostics also refit PAM for each candidate cluster count.

## Validation

- `testthat::test_file("tests/testthat/test_kmedoids.R")`: 40 assertions passed.
- 50,000-row Auto benchmark: CLARA completed in about 3.2 seconds with a model size of about 23.9 MiB.
- `R/kmedoids.R` parse check passed.
- Paired `tam` UI/command-generation changes are intentionally not included in this R-side PR.