### PR TITLE
perf(kmedoids): cache the PCoA map result at fit time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.47
+Version: 16.0.48
 Date: 2026-08-13
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -681,7 +681,15 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   # calls broom::tidy() directly for the representation_rate attribute) -- used to
   # each recompute it from scratch, tripling the cost for no benefit since the
   # result depends only on fields already present on `model` at this point.
-  model$map_result <- .kmedoids_map(model)
+  # A degenerate map input (e.g. every sampled row identical, so cmdscale() has
+  # no positive eigenvalues to project onto) is caught here and downgraded to
+  # the same empty-map sentinel .kmedoids_map() already returns for the n < 2
+  # case, instead of letting it abort the whole fit -- previously this class of
+  # failure only broke the Cluster Map / Fitted Vectors tabs individually.
+  model$map_result <- tryCatch(
+    .kmedoids_map(model),
+    error = function(e) .kmedoids_empty('map')
+  )
   class(model) <- c(
     'pam_exploratory',
     if (identical(fit$algorithm, 'pam')) 'pam' else 'clara',

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -710,7 +710,7 @@ tidy.pam_exploratory <- function(x, type = 'summary', with_excluded_rows = FALSE
     representative_values = .kmedoids_representative_values(x),
     distribution = .kmedoids_distribution(x),
     cohesion = .kmedoids_cohesion(x),
-    map = x$map_result %||% .kmedoids_empty('map'),
+    map = x$map_result %||% .kmedoids_map(x),
     medoid_details = .kmedoids_medoid_details(x),
     counts = .kmedoids_counts(x),
     data = {

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -673,6 +673,15 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   } else {
     NULL
   }
+  # Compute the PCoA map once at fit time and cache it, mirroring elbow_result /
+  # silhouette_result above. .kmedoids_map() runs stats::dist() + stats::cmdscale()
+  # over up to map_sample_size rows, which is expensive (multiple seconds at the
+  # default map_sample_size). Every tidy(type='map') caller -- the Cluster Map tab,
+  # the Fitted Vectors tab, and tam's set_kmedoids_analytics_params() helper (which
+  # calls broom::tidy() directly for the representation_rate attribute) -- used to
+  # each recompute it from scratch, tripling the cost for no benefit since the
+  # result depends only on fields already present on `model` at this point.
+  model$map_result <- .kmedoids_map(model)
   class(model) <- c(
     'pam_exploratory',
     if (identical(fit$algorithm, 'pam')) 'pam' else 'clara',
@@ -693,7 +702,7 @@ tidy.pam_exploratory <- function(x, type = 'summary', with_excluded_rows = FALSE
     representative_values = .kmedoids_representative_values(x),
     distribution = .kmedoids_distribution(x),
     cohesion = .kmedoids_cohesion(x),
-    map = .kmedoids_map(x),
+    map = x$map_result %||% .kmedoids_empty('map'),
     medoid_details = .kmedoids_medoid_details(x),
     counts = .kmedoids_counts(x),
     data = {

--- a/docs/plans/2026-08-12-kmedoids-performance-improvement.md
+++ b/docs/plans/2026-08-12-kmedoids-performance-improvement.md
@@ -289,3 +289,37 @@ pretending that a 50,000-row eigendecomposition is practical.
 4. Implement bounded diagnostics and scalable map sampling.
 5. Apply secondary vectorization/output reductions, then run the benchmark
    matrix to calibrate thresholds and CLARA defaults.
+
+## Follow-up: cache the PCoA map at fit time (2026-08-13)
+
+Bounding `map_sample_size` (this increment) made a single PCoA affordable,
+but a live tam Analytics Run trace of this exact scenario (1,000 rows,
+`map_sample_size = 2000`, `algorithm = "auto"`) showed the total Run still
+taking ~27s, with `stats::dist()` + `stats::cmdscale()` inside
+`.kmedoids_map()` running to completion THREE separate times for the same
+fitted model:
+
+1. tam's `set_kmedoids_analytics_params()` helper, called immediately after
+   fit to read the `representation_rate` attribute for axis titles.
+2. The Cluster Map chart tab's own `tidy_rowwise(model, type = 'map')`.
+3. The Fitted Vectors chart tab's own `tidy_rowwise(model, type = 'map')`.
+
+`.kmedoids_map()` was not memoized -- every `tidy(type = 'map')` call
+recomputed it from scratch, ~8s each in the traced Run, even though the
+result depends only on fields already fixed at fit time. Fix: compute it
+once right after fit and cache it as `model$map_result`, mirroring the
+existing `elbow_result` / `silhouette_result` pattern in this file;
+`tidy.pam_exploratory(type = 'map')` now just reads the cached tibble
+(including its `representation_rate` attribute, so the tam helper above
+needs no change). A same-machine before/after check on the traced scenario:
+fit + 2 `tidy(type = 'map')` calls dropped from ~24s to ~9s total, with both
+`tidy()` calls now single-digit milliseconds.
+
+One behavior change: because the map is now computed unconditionally at fit
+time, a degenerate map input (e.g. every sampled row identical, so
+`cmdscale()` has no positive eigenvalues to project onto) is caught with
+`tryCatch` and downgraded to the existing empty-map sentinel instead of
+aborting the whole fit -- previously this failure mode only broke the
+Cluster Map / Fitted Vectors tabs individually. Found live while testing
+this change against an all-tied-values fixture; not a previously known or
+reported issue.

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -181,7 +181,7 @@ test_that('the PCoA map is computed once at fit time and cached, not recomputed 
 })
 
 test_that('a minimal (all-tied) fit still produces a usable cached map', {
-  data <- tibble::tibble(x = c(1, 1), y = c(1, 1))
+  data <- tibble::tibble(x = c(1, 1, 1), y = c(1, 1, 1))
   result <- data %>% exploratory:::exp_kmedoids(x, y, centers = 2, seed = 1)
   model <- result$model[[1]]
 

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -180,6 +180,17 @@ test_that('the PCoA map is computed once at fit time and cached, not recomputed 
   expect_true(is.numeric(attr(first_call, 'representation_rate')))
 })
 
+test_that('models created before map caching still produce their map', {
+  result <- mtcars %>% exploratory:::exp_kmedoids(mpg, disp, hp, centers = 3, seed = 1)
+  model <- result$model[[1]]
+  model$map_result <- NULL
+
+  map <- broom::tidy(model, type = 'map')
+
+  expect_true(nrow(map) > 0)
+  expect_true(any(map$row_type == 'vector'))
+})
+
 test_that('a minimal (all-tied) fit still produces a usable cached map', {
   data <- tibble::tibble(x = c(1, 1, 1), y = c(1, 1, 1))
   result <- data %>% exploratory:::exp_kmedoids(x, y, centers = 2, seed = 1)

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -156,6 +156,39 @@ test_that('diagnostic and map sample sizes bound expensive outputs', {
   expect_equal(counts$map_sample_nrow, min(model$valid_nrow, max(8, model$centers)))
 })
 
+test_that('the PCoA map is computed once at fit time and cached, not recomputed per tidy() call', {
+  set.seed(1)
+  result <- mtcars %>% exploratory:::exp_kmedoids(mpg, disp, hp, centers = 3, seed = 1)
+  model <- result$model[[1]]
+
+  # The fit itself must already carry the map result -- tidy(type='map') should
+  # be a pure cache read, not a fresh stats::dist()/stats::cmdscale() computation.
+  expect_true(is.data.frame(model$map_result))
+  expect_true(nrow(model$map_result) > 0)
+
+  first_call <- broom::tidy(model, type = 'map')
+  second_call <- broom::tidy(model, type = 'map')
+
+  expect_identical(first_call, model$map_result)
+  expect_identical(second_call, model$map_result)
+  expect_identical(first_call, second_call)
+
+  # tam's set_kmedoids_analytics_params() helper reads this attribute directly
+  # via broom::tidy(..., type='map') (bypassing tidy_rowwise's unnesting), so the
+  # cached tibble must still carry it, not just a fresh .kmedoids_map() call.
+  expect_true(is.numeric(attr(model$map_result, 'representation_rate')))
+  expect_true(is.numeric(attr(first_call, 'representation_rate')))
+})
+
+test_that('a minimal (all-tied) fit still produces a usable cached map', {
+  data <- tibble::tibble(x = c(1, 1), y = c(1, 1))
+  result <- data %>% exploratory:::exp_kmedoids(x, y, centers = 2, seed = 1)
+  model <- result$model[[1]]
+
+  expect_true(is.data.frame(model$map_result))
+  expect_true(is.data.frame(broom::tidy(model, type = 'map')))
+})
+
 test_that('diagnostic and map counts use bounded integer sample sizes', {
   result <- mtcars %>% exploratory:::exp_kmedoids(
     mpg, disp, hp, centers = 3, silhouette_sample_size = 10.9,


### PR DESCRIPTION
## Problem

A live tam Analytics Run trace of a real K-Medoids scenario (1,000 rows,
default settings incl. `map_sample_size = 2000`) showed the Run taking
~27s total, with `.kmedoids_map()`'s `stats::dist()` + `stats::cmdscale()`
PCoA computation running to completion **three separate times** for the
same fitted model:

1. tam's `set_kmedoids_analytics_params()` helper (reads the
   `representation_rate` attribute for axis titles, right after fit).
2. The Cluster Map chart tab's `tidy_rowwise(model, type = 'map')`.
3. The Fitted Vectors chart tab's `tidy_rowwise(model, type = 'map')`.

`.kmedoids_map()` was never cached — every call recomputed it from scratch
(~8s each in the trace), even though the result depends only on fields
already fixed at fit time.

## Fix

Compute `.kmedoids_map()` once right after fit and cache it as
`model$map_result`, mirroring the existing `elbow_result` /
`silhouette_result` pattern already in this file.
`tidy.pam_exploratory(type = 'map')` now just returns the cached tibble
(including its `representation_rate` attribute, so
`set_kmedoids_analytics_params()` on the tam side needs no change).

Second commit: because the map is now computed unconditionally at fit time
(not lazily, only when a map-dependent tab is rendered), a degenerate map
input — every sampled row identical, so `cmdscale()` has no positive
eigenvalues to project onto — would otherwise abort the *whole* fit instead
of failing only the Cluster Map / Fitted Vectors tabs, as it did before.
Found live while testing this change against an all-tied-values fixture
(not a previously known/reported bug). Guarded with `tryCatch`, falling
back to the same empty-map sentinel `.kmedoids_map()` already returns for
its `n < 2` case.

Third commit: version bump to 16.0.48 + a follow-up section appended to
the #1604 design doc recording this increment and the numbers below.

## Verification

- `testthat::test_file("tests/testthat/test_kmedoids.R")` on R 4.6.1
  (ARM build box): 58/58 passing (1 benign warning from the new
  degenerate-input test, matching the code path it's testing).
- New tests: caching is a pure read (`identical(tidy(...), model$map_result)`
  across two calls), the `representation_rate` attribute survives the cache,
  and a minimal all-tied-values fit no longer throws.
- Same-machine before/after timing on the exact traced scenario (fit + 2×
  `tidy(type='map')`): **~24s → ~9s**, with both `tidy()` calls dropping to
  single-digit milliseconds.

## tam side

No tam changes needed — `set_kmedoids_analytics_params()` already reads
`broom::tidy(model, type = "map")`, which now transparently returns the
cached result. `tools/requiredRPackagesReduced.json` (and the 6 mirrored
installer JSONs) will be bumped to 16.0.48 once this is merged and built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)