### PR TITLE
feat(kmedoids): add the analysis_conditions tidy type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.48
+Version: 16.0.49
 Date: 2026-08-13
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -114,6 +114,7 @@
       avg_silhouette = numeric(), min_silhouette = numeric(),
       pct_negative = numeric(), medoid_row_id = character()
     ),
+    analysis_conditions = tibble::tibble(Metric = character(), Value = character()),
     profile = tibble::tibble(
       variable = character(), cluster = integer(), standardized_mean = numeric(),
       effect_size = numeric(), rank = integer(), medoid = numeric(),
@@ -505,6 +506,34 @@
   )
 }
 
+#' "Analysis Conditions and Data" table of a K-Medoids model (tam#30961). One row per
+#' condition, Metric/Value, matching the shape K-Modes (kmodes_analysis_conditions_table)
+#' and K-Means (tidy.prcomp_exploratory's analysis_conditions branch) already return, so the
+#' report's 分析条件とデータの確認 section looks the same across every clustering type.
+#' Every value is a plain string -- a count or a comma-joined name list -- so the viz side
+#' needs no per-column number formatting.
+#'
+#' Row Count is the number of rows actually clustered and Rows Removed the number dropped
+#' for missing/non-finite values, matching the sibling implementations. Both come from the
+#' model rather than being re-derived client-side so the table has one source of truth.
+#' @param x A pam_exploratory model.
+#' @return A tibble with `Metric` and `Value` columns.
+.kmedoids_analysis_conditions <- function(x) {
+  variable_names <- as.character(x$selected_cols)
+  n_variables <- length(variable_names)
+  tibble::tibble(
+    Metric = c("Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+               "Number of Clusters"),
+    Value = c(
+      as.character(n_variables),
+      if (n_variables == 0) "N/A" else paste(variable_names, collapse = ", "),
+      as.character(x$valid_nrow),
+      as.character(x$excluded_nrow),
+      as.character(x$centers)
+    )
+  )
+}
+
 .kmedoids_counts <- function(x) {
   tibble::tibble(
     original_nrow = nrow(x$original_data),
@@ -703,6 +732,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
 tidy.pam_exploratory <- function(x, type = 'summary', with_excluded_rows = FALSE, ...) {
   switch(type,
     summary = .kmedoids_summary(x, with_excluded_rows),
+    analysis_conditions = .kmedoids_analysis_conditions(x),
     profile = .kmedoids_profile(x),
     silhouette = x$silhouette_result %||% .kmedoids_empty('silhouette'),
     elbow = x$elbow_result %||% .kmedoids_empty('elbow'),

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -48,7 +48,7 @@ test_that('report tidy types are available', {
   model <- result$model[[1]]
   types <- c('profile', 'silhouette', 'elbow', 'variable_importance',
     'representative_values', 'distribution', 'cohesion', 'map',
-    'medoid_details', 'counts', 'data')
+    'medoid_details', 'counts', 'analysis_conditions', 'data')
 
   output <- lapply(types, function(type) broom::tidy(model, type = type))
   names(output) <- types
@@ -66,6 +66,31 @@ test_that('report tidy types are available', {
   expect_equal(output$counts$original_nrow, nrow(mtcars))
   expect_true(all(c('row_id', 'cluster', 'is_medoid', 'distance_to_medoid',
     'silhouette_score', 'is_excluded') %in% colnames(output$data)))
+})
+
+test_that('analysis_conditions returns the shared Metric/Value shape', {
+  data <- tibble::tibble(
+    x = c(1, 2, 3, 4, 5, 6, NA),
+    y = c(1, 2, 4, 5, 7, 8, 9),
+    z = c(2, 3, 1, 6, 4, 9, 5)
+  )
+  result <- data %>% exploratory:::exp_kmedoids(x, y, z, centers = 2, seed = 1)
+  conditions <- broom::tidy(result$model[[1]], type = 'analysis_conditions')
+
+  # Same five rows, in the same order, as kmodes_analysis_conditions_table() and
+  # tidy.prcomp_exploratory()'s K-Means branch -- the report translates these cells by
+  # exact string match, so the wording is part of the contract.
+  expect_equal(colnames(conditions), c('Metric', 'Value'))
+  expect_equal(conditions$Metric,
+    c('Number of Variables', 'Variable Names', 'Row Count', 'Rows Removed',
+      'Number of Clusters'))
+  expect_true(is.character(conditions$Value))
+  expect_equal(conditions$Value[[1]], '3')
+  expect_equal(conditions$Value[[2]], 'x, y, z')
+  # Row Count is the rows actually clustered, Rows Removed the ones dropped for the NA.
+  expect_equal(conditions$Value[[3]], '6')
+  expect_equal(conditions$Value[[4]], '1')
+  expect_equal(conditions$Value[[5]], '2')
 })
 
 test_that('non-numeric variables are rejected clearly', {


### PR DESCRIPTION
## Problem

K-Medoids is the only clustering type without an `analysis_conditions`
tidy type. Its 分析条件とデータの確認 report section therefore had to be
built from the `counts` table, and rendered as a wide 4-column table
(Original Rows / Analysis Rows / Excluded Rows / Exclusion Ratio) —
visibly different from the Metric/Value table that PCA, K-Means,
K-Modes, Cronbach's Alpha and Correlation all show in that same section.

| | |
|---|---|
| K-Means (and every other type) | 項目 / 値 rows: 変数の数, 変数名, 行数, 削除された行数, クラスターの数 |
| K-Medoids (before) | wide columns: 元の行数, 分析対象行数, 除外行数, 除外割合 |

## Fix

`.kmedoids_analysis_conditions()` returns the same five rows in the same
order as `kmodes_analysis_conditions_table()` and
`tidy.prcomp_exploratory()`'s K-Means branch:

```
Number of Variables | 3
Variable Names      | x, y, z
Row Count           | 6
Rows Removed        | 1
Number of Clusters  | 2
```

The Metric strings are fixed English, matching the siblings **exactly**,
because the client translates these report cells by exact string match —
so the existing 変数の数 / 変数名 / 行数 / 削除された行数 / クラスターの数
UILabel entries apply with no new translations.

`Row Count` is the rows actually clustered and `Rows Removed` the ones
dropped for missing/non-finite values, same semantics as the siblings.
Both are read off the model rather than re-derived client-side, so the
table has one source of truth — the same reasoning the K-Means and
K-Modes implementations record in their own comments.

Also registers the type in the empty-tibble sentinel so an unknown or
degenerate model returns the same shape.

## Verification

`testthat::test_file("tests/testthat/test_kmedoids.R")` on R 4.6.1
(ARM build box): all passing (the single warning is the pre-existing
degenerate-map test, unrelated).

New test pins the exact row set, order, and the Row Count / Rows Removed
semantics against a fixture with one NA row.

## tam side

The paired tam change swaps the `data_counts` viz for an
`analysis_conditions` one whose options mirror kmeans.json's
`data_conditions_table` (項目 header template, column widths,
translate targets), so the two reports render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)