### PR TITLE
Add nstart trial-count support to K-Medoids PAM fitting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.49
+Version: 16.0.50
 Date: 2026-08-13
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -326,7 +326,7 @@
       .kmedoids_fit(
         diagnostic_mat, center, x$distance,
         if (is.null(x$seed)) NULL else x$seed + center,
-        algorithm = 'pam'
+        algorithm = 'pam', nstart = x$nstart
       ),
       error = function(e) NULL
     )
@@ -358,7 +358,7 @@
       .kmedoids_fit(
         diagnostic_mat, center, x$distance,
         if (is.null(x$seed)) NULL else x$seed + center,
-        algorithm = 'pam'
+        algorithm = 'pam', nstart = x$nstart
       ),
       error = function(e) NULL
     )

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -41,7 +41,7 @@
 
 .kmedoids_fit <- function(mat, centers, distance, seed = NULL,
                           algorithm = 'pam', clara_samples = 20,
-                          clara_sample_size = NULL,
+                          clara_sample_size = NULL, nstart = 1,
                           pam_max_n = .kmedoids_pam_max_n) {
   algorithm <- match.arg(algorithm, c('auto', 'pam', 'clara'))
   if (algorithm == 'auto') {
@@ -60,10 +60,25 @@
     set.seed(seed)
   }
   if (algorithm == 'pam') {
-    raw <- cluster::pam(
-      mat, k = centers, metric = distance, stand = FALSE,
-      keep.diss = FALSE, keep.data = FALSE, pamonce = 5
-    )
+    # medoids = if(is.numeric(nstart)) "random" -- cluster::pam() switches from
+    # its default deterministic "build" algorithm to random-start search the
+    # instant ANY numeric nstart is passed. Forward nstart only when the user
+    # asked for more than one trial, so nstart = 1 (the default) stays
+    # byte-identical to the pre-nstart call and every existing saved analytics
+    # keeps its current medoids.
+    pam_nstart <- as.integer(round(nstart %||% 1))
+    raw <- if (!is.na(pam_nstart) && pam_nstart > 1) {
+      cluster::pam(
+        mat, k = centers, metric = distance, stand = FALSE,
+        keep.diss = FALSE, keep.data = FALSE, pamonce = 5,
+        medoids = 'random', nstart = pam_nstart
+      )
+    } else {
+      cluster::pam(
+        mat, k = centers, metric = distance, stand = FALSE,
+        keep.diss = FALSE, keep.data = FALSE, pamonce = 5
+      )
+    }
     silhouette <- .kmedoids_silhouette_components(raw)
     silhouette_widths <- silhouette$widths
     silhouette_row_indices <- silhouette$indices
@@ -577,6 +592,11 @@
 #' @param profile_variable_order Profile variable ordering mode.
 #' @param map_variable_n Maximum number of variables shown on the map.
 #' @param algorithm Algorithm to use: `auto`, `pam`, or `clara`.
+#' @param nstart Number of random-medoid trials for PAM; the best result is
+#'   kept. Values greater than 1 switch `cluster::pam()` from its default
+#'   deterministic "build" medoid selection to random-start search (mirrors
+#'   `nstart` in `kmeans()`). Ignored when the effective algorithm is CLARA,
+#'   which already samples multiple candidate sets via `clara_samples`.
 #' @param clara_samples Number of candidate samples used by CLARA.
 #' @param clara_sample_size Number of rows in each CLARA candidate sample.
 #' @param map_sample_size Maximum number of rows used for the PCoA map.
@@ -588,7 +608,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
                          elbow_method_mode = 'silhouette', max_centers = 10,
                          silhouette_sample_size = 5000, profile_top_n = 10,
                          profile_show_all = TRUE, profile_variable_order = 'effect_size',
-                         map_variable_n = 10, algorithm = 'auto',
+                         map_variable_n = 10, algorithm = 'auto', nstart = 1,
                          clara_samples = 20, clara_sample_size = NULL,
                          map_sample_size = 2000) {
   selected_cols <- tidyselect::vars_select(names(df), !!!rlang::quos(...))
@@ -609,6 +629,11 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
   distance <- match.arg(distance, c('euclidean', 'manhattan'))
   elbow_method_mode <- match.arg(as.character(elbow_method_mode), c('none', 'silhouette', 'elbow'))
   algorithm <- match.arg(as.character(algorithm), c('auto', 'pam', 'clara'))
+  nstart <- .kmedoids_safe_numeric(nstart)
+  if (is.null(nstart) || nstart < 1) {
+    stop('nstart must be a positive number.', call. = FALSE)
+  }
+  nstart <- as.integer(floor(nstart))
   clara_samples <- .kmedoids_safe_numeric(clara_samples)
   if (is.null(clara_samples) || clara_samples < 1) {
     stop('clara_samples must be a positive number.', call. = FALSE)
@@ -670,7 +695,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
     mat[is.nan(mat)] <- 0
   }
   fit <- .kmedoids_fit(
-    mat, centers, distance, seed, algorithm = algorithm,
+    mat, centers, distance, seed, algorithm = algorithm, nstart = nstart,
     clara_samples = clara_samples, clara_sample_size = clara_sample_size
   )
   model <- list(
@@ -687,7 +712,7 @@ exp_kmedoids <- function(df, ..., centers = 3, distance = 'manhattan',
     clara_samples = fit$clara_samples, clara_sample_size = fit$clara_sample_size,
     valid_nrow = nrow(fit_data),
     sampled_nrow = nrow(source_data), excluded_nrow = excluded_nrow,
-    distance = distance, centers = centers, iterMax = iterMax, seed = seed,
+    distance = distance, centers = centers, iterMax = iterMax, nstart = nstart, seed = seed,
     normalize_data = normalize_data, max_centers = max_centers,
     silhouette_sample_size = silhouette_sample_size, profile_top_n = profile_top_n,
     profile_show_all = profile_show_all, profile_variable_order = profile_variable_order,

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -321,3 +321,33 @@ test_that('exp_kmedoids validates nstart and forwards it through to the fit', {
   model <- result$model[[1]]
   expect_identical(model$nstart, 5L)
 })
+
+test_that('nstart is forwarded to PAM diagnostic fits', {
+  calls <- list()
+  original_fit <- exploratory:::.kmedoids_fit
+  testthat::local_mocked_bindings(
+    .kmedoids_fit = function(...) {
+      call <- list(...)
+      calls[[length(calls) + 1L]] <<- call
+      original_fit(...)
+    },
+    .package = 'exploratory'
+  )
+
+  set.seed(12)
+  data <- as.data.frame(matrix(rnorm(120), ncol = 3))
+  names(data) <- c('v1', 'v2', 'v3')
+  data %>% exploratory:::exp_kmedoids(
+    v1, v2, v3, centers = 3, nstart = 5, max_centers = 4,
+    elbow_method_mode = 'silhouette', silhouette_sample_size = 40,
+    map_sample_size = 20, seed = 1
+  )
+  data %>% exploratory:::exp_kmedoids(
+    v1, v2, v3, centers = 3, nstart = 5, max_centers = 4,
+    elbow_method_mode = 'elbow', silhouette_sample_size = 40,
+    map_sample_size = 20, seed = 1
+  )
+
+  expect_gt(length(calls), 2L)
+  expect_true(all(vapply(calls, function(call) identical(call$nstart, 5L), logical(1))))
+})

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -256,3 +256,68 @@ test_that('CLARA candidate samples are capped before fitting', {
   )
   expect_identical(fit$clara_sample_size, 20L)
 })
+
+test_that('PAM with the default nstart matches calling cluster::pam() with no nstart at all', {
+  set.seed(11)
+  mat <- matrix(rnorm(150), ncol = 3)
+
+  set.seed(5)
+  fit_default <- exploratory:::.kmedoids_fit(mat, centers = 3, distance = 'euclidean', algorithm = 'pam')
+  set.seed(5)
+  raw <- cluster::pam(mat, k = 3, metric = 'euclidean', stand = FALSE, keep.diss = FALSE, keep.data = FALSE, pamonce = 5)
+
+  expect_identical(as.integer(fit_default$clustering), as.integer(raw$clustering))
+  expect_identical(fit_default$medoid_indices, as.integer(raw$id.med))
+
+  set.seed(5)
+  fit_explicit_one <- exploratory:::.kmedoids_fit(mat, centers = 3, distance = 'euclidean', algorithm = 'pam', nstart = 1)
+  expect_identical(as.integer(fit_explicit_one$clustering), as.integer(raw$clustering))
+})
+
+test_that('PAM nstart > 1 switches to random-start search and returns a valid clustering', {
+  set.seed(11)
+  mat <- matrix(rnorm(150), ncol = 3)
+
+  set.seed(5)
+  fit_nstart <- exploratory:::.kmedoids_fit(mat, centers = 3, distance = 'euclidean', algorithm = 'pam', nstart = 10)
+
+  expect_length(fit_nstart$medoid_indices, 3)
+  expect_length(unique(fit_nstart$medoid_indices), 3)
+  expect_setequal(unique(fit_nstart$clustering), 1:3)
+
+  # cluster::pam(medoids = 'random', nstart = N) is a distinct algorithm from
+  # the default deterministic "build" -- confirm the underlying raw fit
+  # actually used random medoid initialization for nstart > 1.
+  expect_identical(as.character(fit_nstart$raw$call$medoids), 'random')
+  expect_false(is.null(fit_nstart$raw$call$nstart))
+})
+
+test_that('CLARA ignores nstart entirely', {
+  set.seed(3)
+  mat <- matrix(rnorm(200), ncol = 2)
+
+  set.seed(7)
+  fit_a <- exploratory:::.kmedoids_fit(
+    mat, centers = 3, distance = 'euclidean', algorithm = 'clara', clara_samples = 5
+  )
+  set.seed(7)
+  fit_b <- exploratory:::.kmedoids_fit(
+    mat, centers = 3, distance = 'euclidean', algorithm = 'clara', clara_samples = 5, nstart = 25
+  )
+  expect_identical(as.integer(fit_a$clustering), as.integer(fit_b$clustering))
+})
+
+test_that('exp_kmedoids validates nstart and forwards it through to the fit', {
+  set.seed(4)
+  df <- as.data.frame(matrix(rnorm(90), ncol = 3))
+  names(df) <- c('v1', 'v2', 'v3')
+
+  expect_error(
+    df %>% exploratory:::exp_kmedoids(v1, v2, v3, centers = 3, algorithm = 'pam', nstart = 0),
+    'nstart must be a positive number'
+  )
+
+  result <- df %>% exploratory:::exp_kmedoids(v1, v2, v3, centers = 3, algorithm = 'pam', nstart = 5, seed = 1)
+  model <- result$model[[1]]
+  expect_identical(model$nstart, 5L)
+})


### PR DESCRIPTION
## Summary
- `exp_kmedoids()`'s UI-exposed "Max Iterations" (`iterMax`) has no effect -- neither `cluster::pam()` nor `cluster::clara()` has an iteration-count argument (confirmed live against `cluster` 2.1.8.2 on R 4.6.1). The R side already documents `iterMax` as a deprecated compatibility argument kept only for saved-command backward compatibility.
- Adds a real `nstart` parameter to `.kmedoids_fit()`/`exp_kmedoids()`, mirroring `kmeans()`'s `nstart` (and K-Means's existing tam UI field of the same name): run PAM's medoid search from `nstart` random starts, keep the best.
- `nstart` is forwarded to `cluster::pam()` **only when `> 1`**, because passing any numeric `nstart` flips `pam()`'s `medoids` argument to `"random"` (`medoids = if (is.numeric(nstart)) "random"`), abandoning the default deterministic "build" algorithm. So `nstart = 1` (the default) is byte-identical to today's call -- no change for any existing saved analytics.
- CLARA has no iteration/trial-count concept and already achieves the same "try multiple candidates, keep the best" via its existing `clara_samples` parameter, so `nstart` is silently ignored on that path.

## Verification
- Live-executed against the real `cluster` package (not just generated-string assertions, per this repo's `r-codegen-fix-live-execution-required` convention):
  - default / `nstart = 1` produce the exact same clustering + medoid indices as calling `cluster::pam()` with no `medoids`/`nstart` at all.
  - `nstart = 10` runs successfully via the random-start path (`raw$call$medoids == "random"`).
  - CLARA clustering is identical with and without `nstart` set.
  - `exp_kmedoids(..., nstart = 0)` errors with a clear message; `nstart = 5` round-trips into `model$nstart`.
- Full `tests/testthat/test_kmedoids.R` (existing + 4 new test blocks) run against the real installed package namespace on the R 4.6 test box: all green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>