### PR TITLE
build_polr: surface a numerically singular Hessian as perfect collinearity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.50
-Date: 2026-08-13
+Version: 16.0.51
+Date: 2026-08-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -656,6 +656,27 @@ calc_vif_polr <- function(model) {
     stop("model contains fewer than 2 terms")
   }
 
+  # A numerically singular Hessian (e.g. a near-tautological predictor/target
+  # relationship, such as an "age decade" predictor used against an age-binned
+  # target -- clm's own warning: "Hessian is numerically singular: parameters
+  # are not uniquely determined") makes vcov() come back with NA/Inf entries.
+  # Unlike the rank-deficient case above, no single term is cleanly "dropped"
+  # here -- every surviving coefficient is implicated, and cov2cor()/det() on
+  # an NA-laced matrix silently propagate NA through EVERY term's GVIF with no
+  # error at all. Left unchecked, calc_vif_polr() "succeeds" with a matrix of
+  # all-NA VIF values, so the caller's `'error' %in% class(x$model[[1]]$vif)`
+  # check never fires -- the Collinearity chart and Analytics Guide prose then
+  # silently render as if VIF were simply absent, instead of explaining why.
+  # Surfaced with the SAME message/marker as perfect collinearity so the
+  # existing caller-side handling (report chart + guide prose) covers this
+  # case identically, without needing its own separate detection.
+  if (any(!is.finite(v))) {
+    stop(paste0(
+      "Variables causing perfect collinearity : ",
+      paste(all_term_labels[term_ids], collapse = ", ")
+    ))
+  }
+
   R <- stats::cov2cor(v)
   detR <- det(R)
   result <- matrix(0, n_terms, 3)

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -656,25 +656,19 @@ calc_vif_polr <- function(model) {
     stop("model contains fewer than 2 terms")
   }
 
-  # A numerically singular Hessian (e.g. a near-tautological predictor/target
-  # relationship, such as an "age decade" predictor used against an age-binned
-  # target -- clm's own warning: "Hessian is numerically singular: parameters
-  # are not uniquely determined") makes vcov() come back with NA/Inf entries.
-  # Unlike the rank-deficient case above, no single term is cleanly "dropped"
-  # here -- every surviving coefficient is implicated, and cov2cor()/det() on
-  # an NA-laced matrix silently propagate NA through EVERY term's GVIF with no
-  # error at all. Left unchecked, calc_vif_polr() "succeeds" with a matrix of
-  # all-NA VIF values, so the caller's `'error' %in% class(x$model[[1]]$vif)`
-  # check never fires -- the Collinearity chart and Analytics Guide prose then
-  # silently render as if VIF were simply absent, instead of explaining why.
-  # Surfaced with the SAME message/marker as perfect collinearity so the
-  # existing caller-side handling (report chart + guide prose) covers this
-  # case identically, without needing its own separate detection.
+  # A numerically singular Hessian can make vcov() return NA/Inf entries even
+  # when the predictor design is full rank (for example, under complete or
+  # quasi separation). That is not evidence of perfect collinearity, so keep
+  # the existing collinearity message only for a rank-deficient design and use
+  # a neutral diagnostic for the full-rank case.
   if (any(!is.finite(v))) {
-    stop(paste0(
-      "Variables causing perfect collinearity : ",
-      paste(all_term_labels[term_ids], collapse = ", ")
-    ))
+    if (qr(mm)$rank < ncol(mm)) {
+      stop(paste0(
+        "Variables causing perfect collinearity : ",
+        paste(all_term_labels[term_ids], collapse = ", ")
+      ))
+    }
+    stop("Numerically singular Hessian: VIF cannot be calculated")
   }
 
   R <- stats::cov2cor(v)

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -447,16 +447,10 @@ test_that("tidy(type='vif') survives a term MASS::polr itself drops for rank-def
   expect_true(is.numeric(east_model$vif))
 })
 
-test_that("tidy(type='vif') surfaces a numerically singular Hessian as perfect collinearity, not silent all-NA VIF", {
-  # Distinct from BOTH VIF failure modes above: no term is dropped by clm's own
-  # rank-deficiency handling (every coefficient survives into coef_names/vcov),
-  # but the design is still degenerate enough that clm's optimizer converges
-  # only loosely ("Hessian is numerically singular: parameters are not uniquely
-  # determined") -- vcov() then comes back with NA/Inf entries and
-  # cov2cor()/det() silently propagate NA through EVERY term's GVIF with no
-  # error at all. Reported live (#37700 follow-up): an "age decade" predictor
-  # used alongside a target that is itself age binned into quantiles is
-  # near-tautological and reliably triggers this.
+test_that("tidy(type='vif') reports a numerical singularity without calling it perfect collinearity", {
+  # The predictors are full rank, but the age-decade predictor nearly determines
+  # the ordinal target. clm can therefore produce a non-finite vcov() without
+  # any structural collinearity in the design matrix.
   set.seed(7)
   n <- 300
   age <- round(stats::runif(n, 20, 65))
@@ -468,25 +462,43 @@ test_that("tidy(type='vif') surfaces a numerically singular Hessian as perfect c
     stringsAsFactors = FALSE
   )
   df$age_bin <- cut(df$age, breaks = stats::quantile(df$age, probs = seq(0, 1, length.out = 4)),
-                     include.lowest = TRUE, ordered_result = TRUE)
+                    include.lowest = TRUE, ordered_result = TRUE)
 
   trial <- suppressWarnings(df %>% build_polr(age_bin, decade, other,
     predictor_funs = list(decade = "none", other = "none"), test_split_type = "random"))
-  m1 <- trial$model[[1]]
+  model <- trial$model[[1]]
+  design <- stats::model.matrix(model)$X
 
-  # Without the fix, m1$vif is a matrix/array of all-NA GVIF values (no error
-  # class at all) -- calc_vif_polr() "succeeds" with unusable output.
-  expect_true(inherits(m1$vif, "error"))
-  expect_true(grepl("perfect collinearity", conditionMessage(m1$vif), fixed = TRUE))
-  # No single term is cleanly at fault here (unlike the rank-deficiency case
-  # above) -- every surviving term is implicated, so all of them are listed.
-  expect_true(grepl("decade", conditionMessage(m1$vif), fixed = TRUE))
-  expect_true(grepl("other", conditionMessage(m1$vif), fixed = TRUE))
+  expect_equal(qr(design)$rank, ncol(design))
+  expect_true(inherits(model$vif, "error"))
+  expect_match(conditionMessage(model$vif), "Numerically singular Hessian")
+  expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
+  expect_equal(nrow(tidy_rowwise(trial, model, type = "vif")), 0)
+})
 
-  # tidy_rowwise(type='vif') must skip this group instead of returning a
-  # data frame full of NA VIF values that looks like real data downstream.
-  vif_df <- tidy_rowwise(trial, model, type = "vif")
-  expect_equal(nrow(vif_df), 0)
+test_that("tidy(type='vif') does not mislabel full-rank separation as collinearity", {
+  # x completely separates the three ordered outcome levels; z is independent,
+  # so the predictor design remains full rank while the ordinal Hessian is
+  # numerically singular.
+  set.seed(1)
+  n <- 300
+  x <- stats::rnorm(n)
+  z <- stats::rnorm(n)
+  df <- data.frame(
+    y = ordered(cut(x, breaks = c(-Inf, -0.5, 0.5, Inf),
+                    labels = c("Low", "Medium", "High"))),
+    x = x,
+    z = z
+  )
+
+  trial <- suppressWarnings(df %>% build_polr(y, x, z))
+  model <- trial$model[[1]]
+  design <- stats::model.matrix(model)$X
+
+  expect_equal(qr(design)$rank, ncol(design))
+  expect_true(inherits(model$vif, "error"))
+  expect_match(conditionMessage(model$vif), "Numerically singular Hessian")
+  expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
 })
 
 test_that("evaluate_polr() reports the ordinal-aware metrics the spec requires", {

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -447,6 +447,48 @@ test_that("tidy(type='vif') survives a term MASS::polr itself drops for rank-def
   expect_true(is.numeric(east_model$vif))
 })
 
+test_that("tidy(type='vif') surfaces a numerically singular Hessian as perfect collinearity, not silent all-NA VIF", {
+  # Distinct from BOTH VIF failure modes above: no term is dropped by clm's own
+  # rank-deficiency handling (every coefficient survives into coef_names/vcov),
+  # but the design is still degenerate enough that clm's optimizer converges
+  # only loosely ("Hessian is numerically singular: parameters are not uniquely
+  # determined") -- vcov() then comes back with NA/Inf entries and
+  # cov2cor()/det() silently propagate NA through EVERY term's GVIF with no
+  # error at all. Reported live (#37700 follow-up): an "age decade" predictor
+  # used alongside a target that is itself age binned into quantiles is
+  # near-tautological and reliably triggers this.
+  set.seed(7)
+  n <- 300
+  age <- round(stats::runif(n, 20, 65))
+  decade <- paste0(floor(age / 10) * 10, "s")
+  df <- data.frame(
+    age = age,
+    decade = decade,
+    other = round(stats::rnorm(n), 2),
+    stringsAsFactors = FALSE
+  )
+  df$age_bin <- cut(df$age, breaks = stats::quantile(df$age, probs = seq(0, 1, length.out = 4)),
+                     include.lowest = TRUE, ordered_result = TRUE)
+
+  trial <- suppressWarnings(df %>% build_polr(age_bin, decade, other,
+    predictor_funs = list(decade = "none", other = "none"), test_split_type = "random"))
+  m1 <- trial$model[[1]]
+
+  # Without the fix, m1$vif is a matrix/array of all-NA GVIF values (no error
+  # class at all) -- calc_vif_polr() "succeeds" with unusable output.
+  expect_true(inherits(m1$vif, "error"))
+  expect_true(grepl("perfect collinearity", conditionMessage(m1$vif), fixed = TRUE))
+  # No single term is cleanly at fault here (unlike the rank-deficiency case
+  # above) -- every surviving term is implicated, so all of them are listed.
+  expect_true(grepl("decade", conditionMessage(m1$vif), fixed = TRUE))
+  expect_true(grepl("other", conditionMessage(m1$vif), fixed = TRUE))
+
+  # tidy_rowwise(type='vif') must skip this group instead of returning a
+  # data frame full of NA VIF values that looks like real data downstream.
+  vif_df <- tidy_rowwise(trial, model, type = "vif")
+  expect_equal(nrow(vif_df), 0)
+})
+
 test_that("evaluate_polr() reports the ordinal-aware metrics the spec requires", {
   df <- make_ordinal_test_df(n = 200)
   trial <- df %>% build_polr(`満足度`, `年齢`, `部署 名!#`)


### PR DESCRIPTION
Root-caused a real report bug: build_polr()'s VIF (多重共線性/Collinearity) chart could render broken/empty (labels present, no bars, degenerate axis) with no explanation, whenever the ordinal model's Hessian is numerically singular — clm's own warning: "Hessian is numerically singular: parameters are not uniquely determined". Live-reproduced with the reporting user's real data (age-decade predictor + target = age binned into quantiles — a near-tautological relationship).

**Root cause:** `calc_vif_polr()` computed a GVIF matrix from `vcov(model)` without checking that `vcov()` actually succeeded. On a singular Hessian, `vcov()` returns NA/Inf entries, and `cov2cor()`/`det()` silently propagate NA through EVERY term's GVIF — no error thrown at all. So `model$vif` "succeeds" with an all-NA matrix, the caller's `'error' %in% class(model$vif)` check never fires, and the report renders as if VIF were just absent (no message).

**Fix:** after computing `vcov()`, check for any non-finite entry and `stop()` with the SAME `"Variables causing perfect collinearity : ..."` message/marker the pre-existing rank-deficiency case already uses. This reuses 100% of the existing downstream handling (tam's report chart no-data overlay + Analytics Guide `has_perfect_collinearity` prose) — **zero caller-side (tam) changes needed.**

**Verification:**
- Live-reproduced against the real project parquet data that triggered the bug (`Hessian is numerically singular` warning, all-NA GVIF matrix pre-fix → correct "Variables causing perfect collinearity" error post-fix, confirmed via a monkey-patched install of just `calc_vif_polr`).
- Minimal synthetic repro added as a new `testthat` regression test.
- Full `test_build_polr.R` suite re-run before/after: **zero new failures**. 8 pre-existing, unrelated failures (functions absent from the locally installed package binary — `augment.clm_exploratory_0`, `polr_report_basic_info`, etc., newer source than the installed build) are identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)