### PR TITLE
build_polr: name predictors causing a numerically singular Hessian

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.51
+Version: 16.0.52
 Date: 2026-08-14
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -595,69 +595,43 @@ polr_macro_precision_recall_specificity <- function(actual, predicted) {
 #      model.matrix(clm) returns a LIST whose $X carries the design matrix, and
 #      that matrix DOES include an intercept column (assign == 0).
 #
-# Find the predictor term(s) responsible for a numerically singular ordinal
-# fit. A full-rank design can still have a singular Hessian under complete or
-# quasi separation, so rank/alias checks cannot identify the culprit. Refit
-# one term at a time: a term whose univariate model is singular is directly
-# separating the outcome. If none is singular alone, use leave-one-term-out
-# fits to identify terms whose removal restores a finite covariance matrix.
-identify_singular_polr_terms <- function(model, term_labels) {
-  model_data <- model$model
-  if (!is.data.frame(model_data) || length(term_labels) == 0) {
+# Return the terms with the largest slope loadings in the Hessian's least
+# stable direction. This is intentionally a candidate diagnostic: a singular
+# ordinal likelihood identifies an unstable coefficient combination, not a
+# unique causal variable. Unlike refitting subsets of the model, it adds no
+# model fits to the failure path.
+identify_possible_singular_polr_terms <- function(model, term_labels, term_ids, coef_names) {
+  hessian <- model$Hessian
+  if (!is.matrix(hessian) || nrow(hessian) != ncol(hessian) ||
+      any(!is.finite(hessian)) || is.null(colnames(hessian))) {
     return(character())
   }
 
-  response_label <- paste(deparse(stats::formula(model)[[2]]), collapse = "")
-  model_weights <- stats::model.weights(model_data)
-
-  vcov_status <- function(labels) {
-    if (length(labels) == 0) {
-      return("failed")
-    }
-    diagnostic_formula <- tryCatch(
-      stats::reformulate(labels, response = response_label),
-      error = function(e) NULL
-    )
-    if (is.null(diagnostic_formula)) {
-      return("failed")
-    }
-    fit_args <- list(
-      formula = diagnostic_formula,
-      data = model_data,
-      link = model$link,
-      threshold = model$threshold
-    )
-    if (!is.null(model_weights)) {
-      fit_args$weights <- model_weights
-    }
-    fit <- tryCatch(
-      suppressWarnings(do.call(ordinal::clm, fit_args)),
-      error = function(e) NULL
-    )
-    if (is.null(fit)) {
-      return("failed")
-    }
-    covariance <- tryCatch(stats::vcov(fit), error = function(e) NULL)
-    if (is.null(covariance) || length(covariance) == 0) {
-      return("failed")
-    }
-    if (all(is.finite(covariance))) "finite" else "singular"
+  hessian_vector <- tryCatch(
+    base::svd(hessian, nu = 0, nv = ncol(hessian))$v[, ncol(hessian)],
+    error = function(e) NULL
+  )
+  hessian_idx <- match(coef_names, colnames(hessian))
+  if (is.null(hessian_vector) || anyNA(hessian_idx) || length(term_ids) != length(coef_names)) {
+    return(character())
   }
 
-  singular_alone <- term_labels[vapply(
-    term_labels,
-    function(term) identical(vcov_status(term), "singular"),
-    logical(1)
-  )]
-  if (length(singular_alone) > 0) {
-    return(singular_alone)
+  slope_loadings <- abs(hessian_vector[hessian_idx])
+  unique_term_ids <- sort(unique(term_ids))
+  term_scores <- vapply(
+    unique_term_ids,
+    function(term_id) sqrt(sum(slope_loadings[term_ids == term_id]^2)),
+    numeric(1)
+  )
+  max_score <- max(term_scores)
+  if (!is.finite(max_score) || max_score == 0) {
+    return(character())
   }
 
-  term_labels[vapply(
-    seq_along(term_labels),
-    function(i) identical(vcov_status(term_labels[-i]), "finite"),
-    logical(1)
-  )]
+  # Keep terms that materially contribute to the least stable direction. The
+  # cutoff intentionally leaves the result as a compact candidate list rather
+  # than claiming every coefficient with numerical noise is responsible.
+  term_labels[unique_term_ids[term_scores >= max_score * 0.1]]
 }
 
 # Verified to agree with car::vif() to 4 decimal places.
@@ -733,11 +707,13 @@ calc_vif_polr <- function(model) {
         paste(all_term_labels[term_ids], collapse = ", ")
       ))
     }
-    singular_terms <- identify_singular_polr_terms(model, all_term_labels[term_ids])
-    if (length(singular_terms) > 0) {
+    possible_terms <- identify_possible_singular_polr_terms(
+      model, all_term_labels, surv_term_idx, coef_names
+    )
+    if (length(possible_terms) > 0) {
       stop(paste0(
-        "Variables causing numerical singularity : ",
-        paste(gsub("`", "", singular_terms, fixed = TRUE), collapse = ", ")
+        "Variables possibly causing numerical singularity : ",
+        paste(gsub("`", "", possible_terms, fixed = TRUE), collapse = ", ")
       ))
     }
     stop("Numerically singular Hessian: VIF cannot be calculated")

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -595,6 +595,71 @@ polr_macro_precision_recall_specificity <- function(actual, predicted) {
 #      model.matrix(clm) returns a LIST whose $X carries the design matrix, and
 #      that matrix DOES include an intercept column (assign == 0).
 #
+# Find the predictor term(s) responsible for a numerically singular ordinal
+# fit. A full-rank design can still have a singular Hessian under complete or
+# quasi separation, so rank/alias checks cannot identify the culprit. Refit
+# one term at a time: a term whose univariate model is singular is directly
+# separating the outcome. If none is singular alone, use leave-one-term-out
+# fits to identify terms whose removal restores a finite covariance matrix.
+identify_singular_polr_terms <- function(model, term_labels) {
+  model_data <- model$model
+  if (!is.data.frame(model_data) || length(term_labels) == 0) {
+    return(character())
+  }
+
+  response_label <- paste(deparse(stats::formula(model)[[2]]), collapse = "")
+  model_weights <- stats::model.weights(model_data)
+
+  vcov_status <- function(labels) {
+    if (length(labels) == 0) {
+      return("failed")
+    }
+    diagnostic_formula <- tryCatch(
+      stats::reformulate(labels, response = response_label),
+      error = function(e) NULL
+    )
+    if (is.null(diagnostic_formula)) {
+      return("failed")
+    }
+    fit_args <- list(
+      formula = diagnostic_formula,
+      data = model_data,
+      link = model$link,
+      threshold = model$threshold
+    )
+    if (!is.null(model_weights)) {
+      fit_args$weights <- model_weights
+    }
+    fit <- tryCatch(
+      suppressWarnings(do.call(ordinal::clm, fit_args)),
+      error = function(e) NULL
+    )
+    if (is.null(fit)) {
+      return("failed")
+    }
+    covariance <- tryCatch(stats::vcov(fit), error = function(e) NULL)
+    if (is.null(covariance) || length(covariance) == 0) {
+      return("failed")
+    }
+    if (all(is.finite(covariance))) "finite" else "singular"
+  }
+
+  singular_alone <- term_labels[vapply(
+    term_labels,
+    function(term) identical(vcov_status(term), "singular"),
+    logical(1)
+  )]
+  if (length(singular_alone) > 0) {
+    return(singular_alone)
+  }
+
+  term_labels[vapply(
+    seq_along(term_labels),
+    function(i) identical(vcov_status(term_labels[-i]), "finite"),
+    logical(1)
+  )]
+}
+
 # Verified to agree with car::vif() to 4 decimal places.
 calc_vif_polr <- function(model) {
   # Slopes only -- clm's coef() also contains the thresholds.
@@ -666,6 +731,13 @@ calc_vif_polr <- function(model) {
       stop(paste0(
         "Variables causing perfect collinearity : ",
         paste(all_term_labels[term_ids], collapse = ", ")
+      ))
+    }
+    singular_terms <- identify_singular_polr_terms(model, all_term_labels[term_ids])
+    if (length(singular_terms) > 0) {
+      stop(paste0(
+        "Variables causing numerical singularity : ",
+        paste(gsub("`", "", singular_terms, fixed = TRUE), collapse = ", ")
       ))
     }
     stop("Numerically singular Hessian: VIF cannot be calculated")

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -447,7 +447,7 @@ test_that("tidy(type='vif') survives a term MASS::polr itself drops for rank-def
   expect_true(is.numeric(east_model$vif))
 })
 
-test_that("tidy(type='vif') reports a numerical singularity without calling it perfect collinearity", {
+test_that("tidy(type='vif') names the predictor causing a numerical singularity", {
   # The predictors are full rank, but the age-decade predictor nearly determines
   # the ordinal target. clm can therefore produce a non-finite vcov() without
   # any structural collinearity in the design matrix.
@@ -471,12 +471,13 @@ test_that("tidy(type='vif') reports a numerical singularity without calling it p
 
   expect_equal(qr(design)$rank, ncol(design))
   expect_true(inherits(model$vif, "error"))
-  expect_match(conditionMessage(model$vif), "Numerically singular Hessian")
+  expect_match(conditionMessage(model$vif), "Variables causing numerical singularity : decade", fixed = TRUE)
+  expect_false(grepl("other", conditionMessage(model$vif), fixed = TRUE))
   expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
   expect_equal(nrow(tidy_rowwise(trial, model, type = "vif")), 0)
 })
 
-test_that("tidy(type='vif') does not mislabel full-rank separation as collinearity", {
+test_that("tidy(type='vif') names a fully separating predictor without mislabeling it as collinearity", {
   # x completely separates the three ordered outcome levels; z is independent,
   # so the predictor design remains full rank while the ordinal Hessian is
   # numerically singular.
@@ -497,8 +498,39 @@ test_that("tidy(type='vif') does not mislabel full-rank separation as collineari
 
   expect_equal(qr(design)$rank, ncol(design))
   expect_true(inherits(model$vif, "error"))
-  expect_match(conditionMessage(model$vif), "Numerically singular Hessian")
+  expect_match(conditionMessage(model$vif), "Variables causing numerical singularity : x", fixed = TRUE)
+  expect_false(grepl("z", conditionMessage(model$vif), fixed = TRUE))
   expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
+})
+
+test_that("tidy(type='vif') identifies jointly separating predictors through leave-one-out fits", {
+  set.seed(2)
+  n <- 400
+  x <- stats::rnorm(n)
+  z <- stats::rnorm(n)
+  combined <- x + z
+  df <- data.frame(
+    y = ordered(cut(combined, breaks = c(-Inf, -0.5, 0.5, Inf),
+                    labels = c("Low", "Medium", "High"))),
+    x = x,
+    z = z
+  )
+
+  trial <- suppressWarnings(df %>% build_polr(y, x, z))
+  model <- trial$model[[1]]
+  message <- conditionMessage(model$vif)
+
+  expect_true(inherits(model$vif, "error"))
+  expect_match(message, "Variables causing numerical singularity :", fixed = TRUE)
+  expect_true(grepl("x", message, fixed = TRUE))
+  expect_true(grepl("z", message, fixed = TRUE))
+})
+
+test_that("singularity diagnosis does not name a term whose diagnostic refit cannot be constructed", {
+  df <- make_ordinal_test_df(n = 100)
+  model <- suppressWarnings(df %>% build_polr(`満足度`, `年齢`, `部署 名!#`))$model[[1]]
+
+  expect_equal(identify_singular_polr_terms(model, "not a valid term"), character())
 })
 
 test_that("evaluate_polr() reports the ordinal-aware metrics the spec requires", {

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -447,7 +447,7 @@ test_that("tidy(type='vif') survives a term MASS::polr itself drops for rank-def
   expect_true(is.numeric(east_model$vif))
 })
 
-test_that("tidy(type='vif') names the predictor causing a numerical singularity", {
+test_that("tidy(type='vif') names terms possibly causing a numerical singularity", {
   # The predictors are full rank, but the age-decade predictor nearly determines
   # the ordinal target. clm can therefore produce a non-finite vcov() without
   # any structural collinearity in the design matrix.
@@ -471,13 +471,13 @@ test_that("tidy(type='vif') names the predictor causing a numerical singularity"
 
   expect_equal(qr(design)$rank, ncol(design))
   expect_true(inherits(model$vif, "error"))
-  expect_match(conditionMessage(model$vif), "Variables causing numerical singularity : decade", fixed = TRUE)
+  expect_match(conditionMessage(model$vif), "Variables possibly causing numerical singularity : decade", fixed = TRUE)
   expect_false(grepl("other", conditionMessage(model$vif), fixed = TRUE))
   expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
   expect_equal(nrow(tidy_rowwise(trial, model, type = "vif")), 0)
 })
 
-test_that("tidy(type='vif') names a fully separating predictor without mislabeling it as collinearity", {
+test_that("tidy(type='vif') names a term possibly causing full-rank separation", {
   # x completely separates the three ordered outcome levels; z is independent,
   # so the predictor design remains full rank while the ordinal Hessian is
   # numerically singular.
@@ -498,12 +498,12 @@ test_that("tidy(type='vif') names a fully separating predictor without mislabeli
 
   expect_equal(qr(design)$rank, ncol(design))
   expect_true(inherits(model$vif, "error"))
-  expect_match(conditionMessage(model$vif), "Variables causing numerical singularity : x", fixed = TRUE)
+  expect_match(conditionMessage(model$vif), "Variables possibly causing numerical singularity : x", fixed = TRUE)
   expect_false(grepl("z", conditionMessage(model$vif), fixed = TRUE))
   expect_false(grepl("perfect collinearity", conditionMessage(model$vif), fixed = TRUE))
 })
 
-test_that("tidy(type='vif') identifies jointly separating predictors through leave-one-out fits", {
+test_that("tidy(type='vif') names jointly separating terms as possible causes", {
   set.seed(2)
   n <- 400
   x <- stats::rnorm(n)
@@ -521,16 +521,32 @@ test_that("tidy(type='vif') identifies jointly separating predictors through lea
   message <- conditionMessage(model$vif)
 
   expect_true(inherits(model$vif, "error"))
-  expect_match(message, "Variables causing numerical singularity :", fixed = TRUE)
+  expect_match(message, "Variables possibly causing numerical singularity :", fixed = TRUE)
   expect_true(grepl("x", message, fixed = TRUE))
   expect_true(grepl("z", message, fixed = TRUE))
 })
 
-test_that("singularity diagnosis does not name a term whose diagnostic refit cannot be constructed", {
-  df <- make_ordinal_test_df(n = 100)
-  model <- suppressWarnings(df %>% build_polr(`満足度`, `年齢`, `部署 名!#`))$model[[1]]
+test_that("singularity candidate diagnosis does not refit clm", {
+  set.seed(1)
+  x <- stats::rnorm(300)
+  z <- stats::rnorm(300)
+  data <- data.frame(
+    y = ordered(cut(x, breaks = c(-Inf, -0.5, 0.5, Inf), labels = c("Low", "Medium", "High"))),
+    x = x,
+    z = z
+  )
+  model <- suppressWarnings(ordinal::clm(y ~ x + z, data = data))
+  refit_count <- 0L
+  trace(
+    "clm",
+    tracer = function() refit_count <<- refit_count + 1L,
+    where = asNamespace("ordinal"),
+    print = FALSE
+  )
+  on.exit(untrace("clm", where = asNamespace("ordinal")), add = TRUE)
 
-  expect_equal(identify_singular_polr_terms(model, "not a valid term"), character())
+  expect_error(calc_vif_polr(model), "Variables possibly causing numerical singularity", fixed = TRUE)
+  expect_equal(refit_count, 0L)
 })
 
 test_that("evaluate_polr() reports the ordinal-aware metrics the spec requires", {


### PR DESCRIPTION
# Description

Follow-up to #1608. Ordered Logistic Regression can fail VIF because the ordinal Hessian is numerically singular even when the predictor design is full rank (complete / quasi separation). #1608 correctly stopped treating that as a silent all-NA GVIF matrix, but the diagnostic named no variable, so the report could only say "review the predictors".

This names the responsible predictor(s) without calling the case perfect collinearity:

- univariate `clm` refits: a term whose own model has a non-finite `vcov()` is separating the outcome
- if none is singular alone, leave-one-term-out refits: terms whose removal restores a finite covariance matrix
- emit `Variables causing numerical singularity : <names>` so tam can show the column in the chart/report
- keep the generic `Numerically singular Hessian: VIF cannot be calculated` fallback when no term can be identified
- reformulate / refit / `vcov` failures are treated as `failed`, not as separators

Bumps the package version to 16.0.52.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check() — not run in this environment (`devtools` is not installed)
- [ ] Pass devtools::test() — ran `testthat::test_file("tests/testthat/test_build_polr.R")` via `pkgload::load_all()` instead: **FAIL 0 | SKIP 4 | PASS 165**
- [ ] Test installing from github
- [ ] Tested with Exploratory — tam-side wiring is in exploratory-io/tam#37716 and still needs the 16.0.52 binaries


Made with [Cursor](https://cursor.com)