### PR TITLE
fix: honor original Factor/Logical category order in Correspondence Analysis (#37847)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.52
-Date: 2026-08-14
+Version: 16.0.53
+Date: 2026-08-17
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/corresp.R
+++ b/R/corresp.R
@@ -94,9 +94,21 @@ exp_mca <- function(df, ..., max_nrow = NULL, allow_single_column = FALSE, ncp =
       var_names_map <- colnames(cleaned_df)
       names(var_names_map) <- paste0("V", 1:length(var_names_map))
       # Prefix category values with the column index so they are unique across columns.
+      # Build the prefixed factor with EXPLICIT levels (via ca_get_category_levels(),
+      # #37847) instead of as.factor() -- as.factor() on a plain character vector
+      # always re-sorts alphabetically, which would discard the source column's own
+      # Factor level order (or its Logical TRUE/FALSE order, or its raw row order)
+      # even though FactoMineR::MCA's category_id rownames -- and therefore every
+      # section-5 report table/chart's display order -- come straight from these
+      # factor levels.
       for (i in 1:length(cleaned_df)) {
         if (colnames(cleaned_df)[i] %in% selected_cols) {
-          cleaned_df[i] <- as.factor(paste0("V", i, ":", cleaned_df[[i]]))
+          original_col <- cleaned_df[[i]]
+          ordered_levels <- ca_get_category_levels(original_col)
+          cleaned_df[i] <- factor(
+            paste0("V", i, ":", as.character(original_col)),
+            levels = paste0("V", i, ":", ordered_levels)
+          )
         }
       }
       quanti_sup_idx <- which(colnames(cleaned_df) %in% quanti_sups)

--- a/R/corresp.R
+++ b/R/corresp.R
@@ -104,9 +104,14 @@ exp_mca <- function(df, ..., max_nrow = NULL, allow_single_column = FALSE, ncp =
       for (i in 1:length(cleaned_df)) {
         if (colnames(cleaned_df)[i] %in% selected_cols) {
           original_col <- cleaned_df[[i]]
+          category_values <- as.character(original_col)
+          category_values[is.na(category_values)] <- "NA"
           ordered_levels <- ca_get_category_levels(original_col)
+          if (anyNA(original_col) && !"NA" %in% ordered_levels) {
+            ordered_levels <- c(ordered_levels, "NA")
+          }
           cleaned_df[i] <- factor(
-            paste0("V", i, ":", as.character(original_col)),
+            paste0("V", i, ":", category_values),
             levels = paste0("V", i, ":", ordered_levels)
           )
         }

--- a/R/corresp.R
+++ b/R/corresp.R
@@ -597,7 +597,11 @@ tidy.ca_exploratory <- function(x, type = "categories", ...) {
   m <- x$section5$all_metrics
   wide <- m %>%
     dplyr::filter(dimension %in% c(1, 2)) %>%
-    dplyr::select(variable, category, dimension, coordinate, contribution_pct, cos2, count, share) %>%
+    # variable_order/category_order are kept only to order the rows below; they
+    # are dropped again by the closing transmute() so the column contract is
+    # unchanged.
+    dplyr::select(variable_order, category_order, variable, category, dimension,
+                  coordinate, contribution_pct, cos2, count, share) %>%
     tidyr::pivot_wider(
       names_from = dimension,
       values_from = c(coordinate, contribution_pct, cos2),
@@ -608,9 +612,14 @@ tidy.ca_exploratory <- function(x, type = "categories", ...) {
     if (!col %in% names(wide)) wide[[col]] <- NA_real_
   }
   wide %>%
+    # #37847: the 2D category map colors by Variable, whose legend is built by
+    # a group_by()/arrange() that sorts a character column by codepoint. Carry
+    # the source order as factor levels so the legend follows the variable
+    # selection order instead of an alphabetical one.
+    dplyr::arrange(variable_order, category_order) %>%
     dplyr::transmute(
-      Variable = variable,
-      Category = category,
+      Variable = factor(variable, levels = unique(variable)),
+      Category = factor(category, levels = unique(category)),
       `Dimension 1` = coordinate_1,
       `Dimension 2` = coordinate_2,
       Count = count,

--- a/R/corresp_report.R
+++ b/R/corresp_report.R
@@ -13,10 +13,13 @@
 # Section 3 / 4: helpers
 # ============================================================
 
-# Category display order: factor -> defined levels, character -> first appearance.
+# Category display order: factor -> defined levels, logical -> TRUE before FALSE,
+# character/other -> first appearance in the data.
 ca_get_category_levels <- function(x) {
   if (is.factor(x)) {
     levels(droplevels(x))
+  } else if (is.logical(x)) {
+    intersect(c("TRUE", "FALSE"), unique(as.character(x[!is.na(x)])))
   } else {
     unique(as.character(x[!is.na(x)]))
   }
@@ -189,7 +192,14 @@ ca_analyze_one_variable_pair_from_counts <- function(
   cramers_v <- ca_calculate_cramers_v(contingency_table, chi_square_statistic)
   association_strength <- ca_classify_cramers_v(cramers_v, nrow(contingency_table), ncol(contingency_table))
 
-  cell_results <- as.data.frame(as.table(contingency_table), stringsAsFactors = FALSE)
+  # stringsAsFactors=TRUE keeps row_category/column_category as factors whose
+  # levels mirror contingency_table's own dimnames order (already the correct
+  # original-data order via ca_get_category_levels() above) -- as.data.frame.table
+  # never re-sorts dimnames, only as.character() would discard the order. tam's
+  # pivot/bar chart rendering sorts a character column alphabetically but respects
+  # a factor's level order, so this is required for the tam-side report to honor
+  # the original data order (#37847).
+  cell_results <- as.data.frame(as.table(contingency_table), stringsAsFactors = TRUE)
   names(cell_results) <- c("row_category", "column_category", "observed_count")
   n <- sum(contingency_table)
 
@@ -720,12 +730,15 @@ ca_build_dimension_matrix_long <- function(metrics, max_dimensions = 5, only_def
 # 5-3 details
 ca_build_category_details <- function(metrics) {
   metrics %>%
+    # Arrange by variable_order/category_order (the original data order, #37847)
+    # BEFORE transmute, not by the plain `variable`/`category` text -- arranging
+    # by the text columns would re-sort alphabetically, discarding the order.
+    dplyr::arrange(dimension, variable_order, category_order) %>%
     dplyr::transmute(
       dimension, explained_pct, cumulative_pct, variable, category, side,
       coordinate, contribution_pct, expected_contribution_pct, contribution_above_average,
       contribution_rank, cos2, cos2_quality, count, share, low_frequency_status, default_display
-    ) %>%
-    dplyr::arrange(dimension, variable, category)
+    )
 }
 
 # Public: build all section-5 outputs from a FactoMineR result

--- a/R/corresp_report.R
+++ b/R/corresp_report.R
@@ -724,7 +724,22 @@ ca_build_dimension_matrix_long <- function(metrics, max_dimensions = 5, only_def
       expected_contribution_pct = round(expected_contribution_pct, 1),
       contribution_above_average, cos2_quality, count, share
     ) %>%
-    dplyr::arrange(variable_order, category_order, dimension)
+    dplyr::arrange(variable_order, category_order, dimension) %>%
+    # #37847: the tam "Dimension x Category" report renders this as a PIVOT
+    # (rowh0 = Variable, rowh1 = Category, colh0 = Dimension). A pivot builds
+    # its headers with dplyr::group_by() + arrange(), which sorts a CHARACTER
+    # column by codepoint and only honors a declared order for a FACTOR --
+    # so arranging the flat rows above is NOT sufficient on its own. Carry the
+    # order as factor LEVELS as well, or the rendered table re-sorts
+    # alphabetically even though these rows are already in the right order.
+    # unique() after the arrange() yields exactly the desired level order.
+    # dimension_header is included because it is the column header and a
+    # character sort would place "Dimension 10 (..)" before "Dimension 2 (..)".
+    dplyr::mutate(
+      variable = factor(variable, levels = unique(variable)),
+      category = factor(category, levels = unique(category)),
+      dimension_header = factor(dimension_header, levels = unique(dimension_header))
+    )
 }
 
 # 5-3 details

--- a/tests/testthat/test_corresp_5.R
+++ b/tests/testthat/test_corresp_5.R
@@ -75,6 +75,22 @@ test_that("MCA (3+ variables): dimension_matrix and category_details keep the so
   expect_equal(dm_churn, c("TRUE", "FALSE"))
 })
 
+test_that("MCA: missing categories retain their prefixed category ids", {
+  df <- data.frame(
+    plan = factor(c("Free", NA, "Standard", "Professional", "Enterprise"),
+                  levels = plan_levels),
+    churn = c(FALSE, TRUE, FALSE, TRUE, FALSE),
+    resptime = factor(c("1 hour or less", "2-3 days", NA, "4+ days", "2-3 days"),
+                      levels = c("1 hour or less", "2-3 days", "4+ days")),
+    stringsAsFactors = FALSE
+  )
+  model <- (df %>% exp_mca(plan, churn, resptime, ncp = 2))$model[[1]]
+  lookup <- model$category_lookup
+
+  expect_true(all(grepl("^V[0-9]+:", lookup$category_id)))
+  expect_equal(lookup$variable[lookup$category == "NA"], c("plan", "resptime"))
+})
+
 test_that("CA (2 variables): dimension_matrix and category_details keep the source factor's level order", {
   df <- make_order_data()
   m <- df %>% exp_mca(plan, resptime, ncp = 5)

--- a/tests/testthat/test_corresp_5.R
+++ b/tests/testthat/test_corresp_5.R
@@ -63,16 +63,16 @@ test_that("MCA (3+ variables): dimension_matrix and category_details keep the so
 
   dm_plan <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(dm_plan, plan_levels)
+  expect_equal(as.character(dm_plan), plan_levels)
 
   cd_plan <- (m %>% tidy_rowwise(model, type = "category_details") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(cd_plan, plan_levels)
+  expect_equal(as.character(cd_plan), plan_levels)
 
   # Logical variable: TRUE before FALSE in both report tables too.
   dm_churn <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
     dplyr::filter(variable == "churn", dimension == 1))$category
-  expect_equal(dm_churn, c("TRUE", "FALSE"))
+  expect_equal(as.character(dm_churn), c("TRUE", "FALSE"))
 })
 
 test_that("MCA: missing categories retain their prefixed category ids", {
@@ -99,11 +99,11 @@ test_that("CA (2 variables): dimension_matrix and category_details keep the sour
 
   dm_plan <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(dm_plan, plan_levels)
+  expect_equal(as.character(dm_plan), plan_levels)
 
   cd_plan <- (m %>% tidy_rowwise(model, type = "category_details") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(cd_plan, plan_levels)
+  expect_equal(as.character(cd_plan), plan_levels)
 })
 
 test_that("residual_cells: row_category/column_category are factors ordered like the source columns", {
@@ -148,7 +148,7 @@ test_that("exp_mca_aggregated (wide) and exp_mca_aggregated_long already honor t
   m_wide <- wide_df %>% exp_mca_aggregated(plan, A, B, column_variable_name = "Segment", ncp = 2)
   dm_wide <- (m_wide %>% tidy_rowwise(model, type = "dimension_matrix") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(dm_wide, plan_levels)
+  expect_equal(as.character(dm_wide), plan_levels)
 
   long_df <- expand.grid(plan = plan_levels, seg = c("A", "B"), stringsAsFactors = FALSE)
   long_df$plan <- factor(long_df$plan, levels = plan_levels)
@@ -156,5 +156,92 @@ test_that("exp_mca_aggregated (wide) and exp_mca_aggregated_long already honor t
   m_long <- long_df %>% exp_mca_aggregated_long(plan, seg, count, ncp = 2)
   dm_long <- (m_long %>% tidy_rowwise(model, type = "dimension_matrix") %>%
     dplyr::filter(variable == "plan", dimension == 1))$category
-  expect_equal(dm_long, plan_levels)
+  expect_equal(as.character(dm_long), plan_levels)
+})
+
+# ------------------------------------------------------------------
+# The tam report renders dimension_matrix as a PIVOT (rowh0 = Variable,
+# rowh1 = Category) and category_map as a scatter coloured by Variable.
+# Both build their headers/legend with dplyr::group_by() + arrange(), which
+# sorts a CHARACTER column alphabetically and only honors a declared order
+# for a FACTOR. Arranging the flat rows is therefore NOT sufficient: the
+# order must be carried as factor LEVELS, or the rendered table re-sorts
+# alphabetically even though the returned rows were in the right order.
+#
+# sort(unique(x)) below is a faithful stand-in for what arrange() does:
+# it follows level order for a factor and codepoint order for a character.
+# ------------------------------------------------------------------
+
+test_that("dimension_matrix: variable/category carry their order as FACTOR levels, not just row order", {
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, churn, resptime, ncp = 5)
+  model <- m$model[[1]]
+  dm <- m %>% tidy_rowwise(model, type = "dimension_matrix")
+
+  expect_true(is.factor(dm$variable))
+  expect_true(is.factor(dm$category))
+
+  # Selection order, not alphabetical (alphabetical: churn, plan, resptime).
+  expect_equal(as.character(sort(unique(dm$variable))), c("plan", "churn", "resptime"))
+
+  # Each variable's own declared order (alphabetical for plan would be
+  # Enterprise, Free, Professional, Standard).
+  expect_equal(as.character(sort(unique(dm$category[dm$variable == "plan"]))), plan_levels)
+  expect_equal(as.character(sort(unique(dm$category[dm$variable == "churn"]))), c("TRUE", "FALSE"))
+  expect_equal(as.character(sort(unique(dm$category[dm$variable == "resptime"]))),
+               c("1 hour or less", "2-3 days", "4+ days"))
+})
+
+test_that("dimension_matrix (CA branch): variable/category carry their order as FACTOR levels", {
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, resptime, ncp = 5)
+  model <- m$model[[1]]
+  expect_equal(model$analysis_type, "CA")
+  dm <- m %>% tidy_rowwise(model, type = "dimension_matrix")
+
+  expect_true(is.factor(dm$variable))
+  expect_true(is.factor(dm$category))
+  expect_equal(as.character(sort(unique(dm$variable))), c("plan", "resptime"))
+  expect_equal(as.character(sort(unique(dm$category[dm$variable == "plan"]))), plan_levels)
+})
+
+test_that("dimension_matrix: dimension_header sorts by dimension NUMBER, not as text", {
+  # A character "Dimension 10 (..)" sorts before "Dimension 2 (..)", so this
+  # only reproduces with 10+ dimensions. 4 variables x 5 categories = 20
+  # categories - 4 variables = 16 available dimensions.
+  set.seed(3)
+  n <- 600
+  lv <- c("L1", "L2", "L3", "L4", "L5")
+  df <- data.frame(
+    a = factor(sample(lv, n, replace = TRUE), levels = lv),
+    b = factor(sample(lv, n, replace = TRUE), levels = lv),
+    c = factor(sample(lv, n, replace = TRUE), levels = lv),
+    d = factor(sample(lv, n, replace = TRUE), levels = lv),
+    stringsAsFactors = FALSE
+  )
+  m <- df %>% exp_mca(a, b, c, d, ncp = 12)
+  model <- m$model[[1]]
+  dm <- m %>% tidy_rowwise(model, type = "dimension_matrix")
+  expect_true(max(dm$dimension) >= 10)
+
+  expected <- (dm %>% dplyr::distinct(dimension, dimension_header) %>%
+    dplyr::arrange(dimension))$dimension_header
+  expect_equal(as.character(sort(unique(dm$dimension_header))), as.character(expected))
+})
+
+test_that("category_map: Variable/Category carry their order as FACTOR levels (legend order)", {
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, churn, resptime, ncp = 5)
+  model <- m$model[[1]]
+  cm <- m %>% tidy_rowwise(model, type = "category_map")
+
+  expect_true(is.factor(cm$Variable))
+  expect_true(is.factor(cm$Category))
+  expect_equal(as.character(sort(unique(cm$Variable))), c("plan", "churn", "resptime"))
+  expect_equal(as.character(sort(unique(cm$Category[cm$Variable == "plan"]))), plan_levels)
+
+  # colnames contract from #37086 must not change.
+  expect_equal(colnames(cm),
+               c("Variable", "Category", "Dimension 1", "Dimension 2", "Count", "Share",
+                 "Contribution 1", "Contribution 2", "Cos2 1", "Cos2 2"))
 })

--- a/tests/testthat/test_corresp_5.R
+++ b/tests/testthat/test_corresp_5.R
@@ -1,0 +1,144 @@
+context("test correspondence analysis category order preservation (#37847)")
+
+# Regression coverage for #37847: crosstab pivot/bar chart headers and the
+# dimension/category report tables were re-sorting categories alphabetically
+# instead of honoring the original Factor level order (or, for a Logical
+# column, TRUE before FALSE).
+
+test_that("ca_get_category_levels: factor keeps its own level order", {
+  x <- factor(c("Standard", "Free", "Professional", "Enterprise"),
+              levels = c("Free", "Standard", "Professional", "Enterprise"))
+  expect_equal(ca_get_category_levels(x), c("Free", "Standard", "Professional", "Enterprise"))
+})
+
+test_that("ca_get_category_levels: factor drops declared-but-unobserved levels", {
+  x <- factor(c("Standard", "Free"),
+              levels = c("Free", "Standard", "Professional", "Enterprise"))
+  expect_equal(ca_get_category_levels(x), c("Free", "Standard"))
+})
+
+test_that("ca_get_category_levels: logical orders TRUE before FALSE regardless of first appearance", {
+  # FALSE appears first in the raw data -- the returned order must still be
+  # TRUE, FALSE (not first-appearance, not alphabetical -- "FALSE" < "TRUE").
+  x <- c(FALSE, FALSE, TRUE, FALSE)
+  expect_equal(ca_get_category_levels(x), c("TRUE", "FALSE"))
+})
+
+test_that("ca_get_category_levels: logical with only one observed value keeps that single value", {
+  expect_equal(ca_get_category_levels(c(FALSE, FALSE)), "FALSE")
+  expect_equal(ca_get_category_levels(c(TRUE, TRUE)), "TRUE")
+})
+
+test_that("ca_get_category_levels: character/other keeps first-appearance order, not alphabetical", {
+  x <- c("Zebra", "Apple", "Zebra", "Mango")
+  expect_equal(ca_get_category_levels(x), c("Zebra", "Apple", "Mango"))
+})
+
+test_that("ca_get_category_levels: NA values are dropped from the level order", {
+  x <- c("b", NA, "a")
+  expect_equal(ca_get_category_levels(x), c("b", "a"))
+})
+
+# Deliberately non-alphabetical level order so an alphabetical-sort bug is
+# always visible: alphabetical would be Enterprise, Free, Professional, Standard.
+plan_levels <- c("Free", "Standard", "Professional", "Enterprise")
+
+make_order_data <- function(n = 600, seed = 7) {
+  set.seed(seed)
+  data.frame(
+    plan = factor(sample(plan_levels, n, replace = TRUE, prob = c(.35, .3, .2, .15)),
+                  levels = plan_levels),
+    churn = sample(c(FALSE, TRUE), n, replace = TRUE, prob = c(.4, .6)),
+    resptime = factor(sample(c("1 hour or less", "2-3 days", "4+ days"), n, replace = TRUE),
+                       levels = c("1 hour or less", "2-3 days", "4+ days")),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("MCA (3+ variables): dimension_matrix and category_details keep the source factor's level order", {
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, churn, resptime, ncp = 5)
+  model <- m$model[[1]]
+  expect_equal(model$analysis_type, "MCA")
+
+  dm_plan <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(dm_plan, plan_levels)
+
+  cd_plan <- (m %>% tidy_rowwise(model, type = "category_details") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(cd_plan, plan_levels)
+
+  # Logical variable: TRUE before FALSE in both report tables too.
+  dm_churn <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
+    dplyr::filter(variable == "churn", dimension == 1))$category
+  expect_equal(dm_churn, c("TRUE", "FALSE"))
+})
+
+test_that("CA (2 variables): dimension_matrix and category_details keep the source factor's level order", {
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, resptime, ncp = 5)
+  model <- m$model[[1]]
+  expect_equal(model$analysis_type, "CA")
+
+  dm_plan <- (m %>% tidy_rowwise(model, type = "dimension_matrix") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(dm_plan, plan_levels)
+
+  cd_plan <- (m %>% tidy_rowwise(model, type = "category_details") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(cd_plan, plan_levels)
+})
+
+test_that("residual_cells: row_category/column_category are factors ordered like the source columns", {
+  # tam's pivot/bar chart headers group by this column via dplyr::group_by()+
+  # arrange(), which sorts a character column alphabetically but respects a
+  # factor's level order -- so the value returned to tam MUST be a factor
+  # (not a character) with the correct level order, not merely have its raw
+  # rows arranged in the correct order.
+  df <- make_order_data()
+  m <- df %>% exp_mca(plan, churn, resptime, ncp = 5)
+  model <- m$model[[1]]
+
+  rc <- m %>% tidy_rowwise(model, type = "residual_cells")
+  expect_true(is.factor(rc$row_category))
+  expect_true(is.factor(rc$column_category))
+
+  plan_vs_churn <- rc %>% dplyr::filter(pair_id == "plan × churn")
+  expect_equal(levels(droplevels(plan_vs_churn$row_category)), plan_levels)
+  expect_equal(levels(droplevels(plan_vs_churn$column_category)), c("TRUE", "FALSE"))
+})
+
+test_that("residual_cells: character (non-factor) categorical column keeps first-appearance order", {
+  set.seed(11)
+  n <- 200
+  # "Zebra" deliberately appears before "Apple" in raw row order.
+  region <- sample(c("Zebra", "Apple", "Mango"), n, replace = TRUE, prob = c(.5, .3, .2))
+  outcome <- sample(c("Yes", "No"), n, replace = TRUE)
+  df <- data.frame(region = region, outcome = outcome, stringsAsFactors = FALSE)
+
+  m <- df %>% exp_mca(region, outcome, ncp = 5)
+  model <- m$model[[1]]
+  rc <- m %>% tidy_rowwise(model, type = "residual_cells")
+  expect_equal(levels(droplevels(rc$row_category)), c("Zebra", "Apple", "Mango"))
+})
+
+test_that("exp_mca_aggregated (wide) and exp_mca_aggregated_long already honor the source order (no regression)", {
+  wide_df <- data.frame(
+    plan = factor(plan_levels, levels = plan_levels),
+    A = c(10, 20, 5, 8),
+    B = c(4, 15, 12, 6)
+  )
+  m_wide <- wide_df %>% exp_mca_aggregated(plan, A, B, column_variable_name = "Segment", ncp = 2)
+  dm_wide <- (m_wide %>% tidy_rowwise(model, type = "dimension_matrix") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(dm_wide, plan_levels)
+
+  long_df <- expand.grid(plan = plan_levels, seg = c("A", "B"), stringsAsFactors = FALSE)
+  long_df$plan <- factor(long_df$plan, levels = plan_levels)
+  long_df$count <- c(10, 20, 5, 8, 4, 15, 12, 6)
+  m_long <- long_df %>% exp_mca_aggregated_long(plan, seg, count, ncp = 2)
+  dm_long <- (m_long %>% tidy_rowwise(model, type = "dimension_matrix") %>%
+    dplyr::filter(variable == "plan", dimension == 1))$category
+  expect_equal(dm_long, plan_levels)
+})


### PR DESCRIPTION
## Problem

In Correspondence Analysis / MCA's report, the crosstab (residual heatmap,
proportion table/chart) and the Dimension × Category tables re-sorted
Factor-type category values **alphabetically** instead of respecting the
original data's Factor level order (or, for a Logical column, TRUE/FALSE
order). Reported against tam issue
[exploratory-io/tam#37847](https://github.com/exploratory-io/tam/issues/37847).

## Root causes (3 independent bugs)

1. **`exp_mca()`'s MCA branch (3+ variables)** built each column's
   `"V<i>:"`-prefixed factor via `as.factor(paste0(...))`, which always
   re-sorts alphabetically, discarding the source column's Factor level
   order. `FactoMineR::MCA`'s `category_id` rownames — and therefore every
   section-5 report table's display order — come straight from these
   levels.
2. **`ca_analyze_one_variable_pair_from_counts()`** built
   `row_category`/`column_category` via
   `as.data.frame(as.table(contingency_table), stringsAsFactors = FALSE)`,
   discarding the contingency table's own (already correctly-ordered)
   dimnames order down to a plain character column. tam's pivot/bar chart
   rendering groups by this column via `dplyr::group_by()`+`arrange()`,
   which sorts a character column alphabetically but respects a factor's
   level order — so the residual heatmap and proportion table/chart
   headers were always alphabetical.
3. **`ca_build_category_details()`** arranged by the raw `variable`/
   `category` text columns instead of the already-computed
   `variable_order`/`category_order` ranks.

Also: `ca_get_category_levels()` now special-cases Logical columns to
always order `TRUE` before `FALSE`, instead of first-appearance order.

The 2-variable CA branch and `exp_mca_aggregated()`/
`exp_mca_aggregated_long()` already used `ca_get_category_levels()`
correctly and needed no change beyond the shared Logical-ordering fix.

## Verification

Verified **live** against a real `FactoMineR` CA/MCA fit (not just
generated-code assertions), with a deliberately non-alphabetical Factor
level order (`Free, Standard, Professional, Enterprise`), per this repo's
established `r-codegen-fix-live-execution-required` convention — confirmed
each of the 3 bugs individually reproduces the alphabetical mis-order, and
that the fix resolves it, via `pkgload::load_all()` + `testthat`.

New regression tests: `tests/testthat/test_corresp_5.R` (21 assertions),
confirmed to FAIL on the pre-fix code (`git stash`) and pass after.

All pre-existing correspondence-analysis tests
(`test_corresp_1.R`–`test_corresp_4.R`) still pass — no regressions.

## Next step (tam side)

This is a pure-R fix with no compiled code. Once merged, the app's pinned
`exploratory` package version needs a bump in tam's
`tools/requiredRPackagesReduced.json` (+ a rebuild of the bundled R
package binaries) before it reaches users — tracked in the tam issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: second round — `dimension_matrix` (Dimension × Category table)

The first round fixed the crosstab but the Dimension × Category table was
**still alphabetical** after a rebuild + re-run.

**Why the first round missed it:** `dimension_matrix` was verified by printing
the returned tibble's flat **row order**, which `arrange(variable_order,
category_order, dimension)` had already made correct. But that table renders as
a **pivot** (`rowh0=Variable`, `rowh1=Category`, `colh0=Dimension`), and a pivot
builds its headers with `group_by()` + `arrange()` — which **discards row order**
and sorts by the column's **class**. `variable`/`category` were plain character,
so they were re-sorted by codepoint.

Proof from the rendered artifact after a Run — same pivot engine, both tables:

| table | rendered order |
|---|---|
| `residual_cells` (round 1, factor) | `1時間以内, 当日中, 翌日, 2〜3日, 4日以上, 未解決` ✅ source order |
| `dimension_matrix` (character) | `1時間以内, 2〜3日, 4日以上, NA, 当日中, 未解決, 翌日` ❌ codepoint |

So the pivot *does* honor factor levels — the column just had to be a factor.

### Fixes in this round

1. **`ca_build_dimension_matrix_long()`** — `variable`, `category` and
   `dimension_header` are now factors whose levels come from `unique()` applied
   after the existing `arrange()`. `dimension_header` is included because a
   character sort places `"Dimension 10 (..)"` before `"Dimension 2 (..)"`, a
   latent bug reachable today since the `ncp` property has `min: 2` and **no
   upper bound** (regression-tested at `ncp = 12`).
2. **`.tidy_category_map()`** — orders by `variable_order`/`category_order` and
   returns `Variable`/`Category` as factors, so the 2D map's colour legend
   follows variable selection order. Found by **auditing every sibling viz**,
   not from a report. Column contract unchanged (asserted).

### General rule established

| marker | headers/legend built by | what controls order |
|---|---|---|
| `pivot`, `bar`, any `group_by`'d shelf | `group_by()`+`arrange()` | column **class** → must be a **factor** |
| `table` | renders R rows as-is | **row order** → `arrange()` suffices |
| `scatter`, `line` | numeric position | irrelevant except a `color` legend |

Every viz in the report was audited against this; the remaining ones
(`analysis_summary`, `dimension_summary`, `category_details`,
`pairwise_association`, `featured_combinations`, `scree_plot`, `table`) are
either `table`-marker (row order, already handled) or intentionally ordered by
significance.

### Verification

New tests use `sort(unique(x))` — a faithful stand-in for `arrange()`, since it
follows level order for a factor and codepoint order for a character — so they
fail on a character column even when the row order is right. All 10 new
assertions confirmed **failing** before the fix and passing after; full
`test_corresp_1..5` suite green. Also simulated the real tam preprocessor plus
the pivot's own `group_by()/arrange()` against Japanese data matching the
reported screenshot.
