### PR TITLE
build_polr: treatment contrasts + readable dummy-term names (#37862)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.53
-Date: 2026-08-17
+Version: 16.0.54
+Date: 2026-08-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -74,9 +74,23 @@ build_polr <- function(df,
   }
 
   # make character predictors factor sorted by frequency, mirroring build_glm()/build_lm.fast().
+  # A factor predictor that is already ORDERED (e.g. a column that went through "Set Category
+  # Values and Order" upstream) must also be un-ordered before modeling (issue #37862) -- R's
+  # default contrasts for an ORDERED factor are polynomial (contr.poly), which produces one term
+  # per polynomial degree (".L"/".Q"/".C"/...) instead of one term per non-reference LEVEL, and
+  # those polynomial term names never match xlevels_to_base_level_table()'s join key (a plain
+  # <variable><level> string), so the fitted model's Base Level column comes out entirely blank
+  # for that predictor. An UNORDERED factor uses treatment contrasts (one dummy term per
+  # non-reference level, readable term names, a real base level) -- exactly the same fix
+  # build_lm.R/build_glm() already apply to their own predictor columns (see build_lm.R's factor
+  # branch: "if it is ordered factor, turn it into unordered"). Level ORDER -- and therefore
+  # which level becomes the reference/base level -- is preserved; only the "ordered" class (and
+  # its polynomial-contrast side effect) is dropped.
   for (col in orig_selected_cols) {
     if (is.character(df[[col]])) {
       df[[col]] <- forcats::fct_infreq(df[[col]])
+    } else if (is.factor(df[[col]]) && is.ordered(df[[col]])) {
+      df[[col]] <- factor(df[[col]], levels = levels(df[[col]]), ordered = FALSE)
     }
   }
 
@@ -866,6 +880,38 @@ partial_dependence.polr_exploratory <- function(fit, target, vars = colnames(dat
   pd
 }
 
+# Reformat a categorical predictor's raw dummy-variable term (e.g. "契約プランStandard" --
+# the variable name directly concatenated with its non-reference level, backtick-quoted when
+# the variable name needs it, exactly the shape terms() gives a treatment-contrast factor) into
+# build_glm()-style "<Variable>: <Level>" text (e.g. "契約プラン: Standard"), issue #37862.
+# `xlevels` is the fitted model's own $xlevels (list of ALL levels per factor predictor, as
+# used by xlevels_to_base_level_table() above) -- every VARIABLE name in it is a candidate
+# prefix to strip off each term. Longest-variable-name-first so a variable name that is itself
+# a prefix of another variable name (e.g. "x" and "x2") cannot match the wrong one. A term with
+# no matching prefix (a numeric predictor, or a threshold/intercept term) is returned unchanged.
+prettify_polr_factor_terms <- function(term, xlevels) {
+  if (length(xlevels) == 0) {
+    return(term)
+  }
+  vnames <- names(xlevels)
+  vnames <- vnames[order(-nchar(vnames))]
+  purrr::map_chr(term, function(one_term) {
+    for (vname in vnames) {
+      # Mirrors xlevels_to_base_level_table()'s own backtick-quoting rule so the prefix we
+      # strip here matches exactly what that function (and R's own term-labeling) produces.
+      quoted <- if (grepl("[ ~!@#$%^&*()+={}|:;'<>,/?\"\\[\\]\\-\\\\]", vname, perl = TRUE)) {
+        paste0("`", vname, "`")
+      } else {
+        vname
+      }
+      if (startsWith(one_term, quoted) && nchar(one_term) > nchar(quoted)) {
+        return(paste0(vname, ": ", substring(one_term, nchar(quoted) + 1)))
+      }
+    }
+    one_term
+  })
+}
+
 #' Coefficient / odds-ratio table for an Ordered Logistic Regression model.
 #' @param x A model built by build_polr(), with class clm_exploratory_0.
 #' @param type What to return: "coefficients" (default), "vif", "importance",
@@ -986,6 +1032,16 @@ tidy.clm_exploratory_0 <- function(x, type = "coefficients", conf.int = TRUE, co
   if (length(x$xlevels) > 0) {
     base_level_table <- xlevels_to_base_level_table(x$xlevels)
     ret <- ret %>% dplyr::left_join(base_level_table, by = "term")
+    # Reformat a categorical predictor's raw dummy term ("<var><level>", the same shape the
+    # join above just matched on) into build_glm()-style "<var>: <level>" text (issue #37862),
+    # e.g. "契約プラン: Standard" instead of "契約プランStandard" -- matches Logistic
+    # Regression's own coefficient table exactly. Must run AFTER the base_level_table join
+    # (which needs the RAW term text) and BEFORE the pretty.name rename below (which only
+    # touches column names, not values). build_polr() fits directly on the original
+    # (backtick-quoted where needed) column names -- unlike build_lm()/build_glm(), which
+    # rename predictors to "c1_"/"c2_"/... internally and map back via map_terms_to_orig() --
+    # so that existing helper's "^c[0-9]+_" prefix match does not apply here.
+    ret$term <- prettify_polr_factor_terms(ret$term, x$xlevels)
   }
 
   if (pretty.name) {

--- a/R/build_polr.R
+++ b/R/build_polr.R
@@ -893,9 +893,17 @@ prettify_polr_factor_terms <- function(term, xlevels) {
   if (length(xlevels) == 0) {
     return(term)
   }
+  # Only terms that are exact entries in the factor-term table are eligible for
+  # prettification. A prefix-only check would misclassify an unrelated numeric
+  # predictor (for example, `age` when a factor predictor is named `a`) as a
+  # factor dummy term.
+  factor_terms <- xlevels_to_base_level_table(xlevels)$term
   vnames <- names(xlevels)
   vnames <- vnames[order(-nchar(vnames))]
   purrr::map_chr(term, function(one_term) {
+    if (!(one_term %in% factor_terms)) {
+      return(one_term)
+    }
     for (vname in vnames) {
       # Mirrors xlevels_to_base_level_table()'s own backtick-quoting rule so the prefix we
       # strip here matches exactly what that function (and R's own term-labeling) produces.

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -430,6 +430,25 @@ test_that("prettify_polr_factor_terms() reformats a factor dummy term and leaves
   expect_equal(prettify_polr_factor_terms(terms, list()), terms)
 })
 
+test_that("factor-term prettification does not rewrite a numeric predictor with a matching prefix", {
+  set.seed(12)
+  n <- 200
+  df <- data.frame(
+    y = factor(sample(c("Low", "Medium", "High"), n, TRUE),
+               levels = c("Low", "Medium", "High"), ordered = TRUE),
+    a = factor(sample(c("No", "Yes"), n, TRUE), levels = c("No", "Yes")),
+    age = stats::rnorm(n),
+    check.names = FALSE
+  )
+
+  trial <- df %>% build_polr(y, a, age)
+  tidied <- tidy_rowwise(trial, model, pretty.name = TRUE)
+
+  expect_true("age" %in% tidied$Term)
+  expect_false("a: ge" %in% tidied$Term)
+  expect_true(is.na(tidied$`Base Level`[tidied$Term == "age"]))
+})
+
 test_that("evaluate_polr() carries a Max VIF column, matching build_lm.R's convention", {
   df <- make_ordinal_test_df(n = 150)
   trial <- df %>% build_polr(`満足度`, `年齢`, `部署 名!#`)

--- a/tests/testthat/test_build_polr.R
+++ b/tests/testthat/test_build_polr.R
@@ -364,14 +364,15 @@ test_that("tidy() joins the reference (base) level for each categorical predicto
 
   expect_true("Base Level" %in% colnames(tidied))
 
-  # The model's term names carry backticks for a column whose name needs quoting,
-  # so match on the model's OWN dummy terms rather than a hand-built string.
   model <- trial$model[[1]]
   dept_levels <- model$xlevels[["部署 名!#"]]
   expect_false(is.null(dept_levels))
-  dummy_terms <- names(stats::coef(model))
-  dummy_terms <- dummy_terms[grepl("部署", dummy_terms, fixed = TRUE)]
-  dummy_rows <- tidied[tidied$Term %in% dummy_terms, ]
+
+  # #37862: tidy.clm_exploratory_0() now prettifies a categorical predictor's dummy term
+  # into "<Variable>: <Level>" (matching build_glm()'s own coefficient-table convention),
+  # so match on that format rather than the model's raw (unprettified) coefficient names.
+  expected_dummy_terms <- paste0("部署 名!#: ", dept_levels[-1])
+  dummy_rows <- tidied[tidied$Term %in% expected_dummy_terms, ]
   expect_true(nrow(dummy_rows) > 0)
 
   # The reference level is whichever level ends up FIRST after build_polr's
@@ -385,6 +386,48 @@ test_that("tidy() joins the reference (base) level for each categorical predicto
   # A numeric predictor and the intercept (threshold) rows have no base level.
   expect_true(is.na(tidied$`Base Level`[tidied$Term == "年齢"]))
   expect_true(all(is.na(tidied$`Base Level`[tidied$Type == "intercept"])))
+})
+
+test_that("an ORDERED-factor predictor gets treatment contrasts (readable terms + a base level), not polynomial ones (#37862)", {
+  # Reproduces the reported bug: a predictor column that is already an ORDERED factor
+  # (e.g. built via "Set Category Values and Order" upstream) used to keep R's default
+  # contr.poly contrasts, producing opaque ".L"/".Q"/".C" term suffixes and leaving Base
+  # Level entirely blank (the join key never matches a polynomial-contrast term).
+  set.seed(11)
+  n <- 200
+  df <- data.frame(
+    `満足度` = factor(sample(c("Low", "Medium", "High"), n, TRUE),
+                      levels = c("Low", "Medium", "High"), ordered = TRUE),
+    `年齢` = stats::rnorm(n, 40, 10),
+    `契約プラン` = factor(sample(c("Free", "Standard", "Professional"), n, TRUE),
+                          levels = c("Free", "Standard", "Professional"), ordered = TRUE),
+    check.names = FALSE
+  )
+  expect_true(is.ordered(df[["契約プラン"]]))
+
+  trial <- df %>% build_polr(`満足度`, `年齢`, `契約プラン`)
+  tidied <- tidy_rowwise(trial, model, pretty.name = TRUE)
+
+  # No polynomial-contrast codes -- one readable "<Variable>: <Level>" term per
+  # non-reference level, exactly like build_glm()'s own coefficient table.
+  expect_false(any(grepl("契約プラン\\.[LQC]$", tidied$Term)))
+  expect_true(all(c("契約プラン: Standard", "契約プラン: Professional") %in% tidied$Term))
+
+  # Base Level is populated (the reference/first level after un-ordering, "Free").
+  plan_rows <- tidied[tidied$Term %in% c("契約プラン: Standard", "契約プラン: Professional"), ]
+  expect_equal(nrow(plan_rows), 2)
+  expect_true(all(plan_rows$`Base Level` == "Free"))
+})
+
+test_that("prettify_polr_factor_terms() reformats a factor dummy term and leaves everything else untouched", {
+  xlevels <- list(plan = c("Free", "Standard", "Professional"), `a b` = c("x", "y"))
+  terms <- c("Low|Mid", "age", "planStandard", "planProfessional", "`a b`y")
+  expect_equal(
+    prettify_polr_factor_terms(terms, xlevels),
+    c("Low|Mid", "age", "plan: Standard", "plan: Professional", "a b: y")
+  )
+  # No factor predictors at all (numeric-only model) -- every term passes through unchanged.
+  expect_equal(prettify_polr_factor_terms(terms, list()), terms)
 })
 
 test_that("evaluate_polr() carries a Max VIF column, matching build_lm.R's convention", {


### PR DESCRIPTION
## Summary
Fixes the two bugs reported in tam#37862's "Factor型の変数" section:

- **Base Level not output** for a categorical predictor's dummy row.
- **Strange variable name** (`.L`/`.Q`/`.C` polynomial-contrast suffixes).

## Root cause
`build_polr.R`'s predictor-prep loop only un-ordered CHARACTER predictors
(`forcats::fct_infreq`). A predictor column that is already a FACTOR **and
ORDERED** (e.g. produced by a prior "Set Category Values and Order" step)
was left untouched, so R's default `contr.poly` (polynomial) contrasts
applied — producing `.L`/`.Q`/`.C` term suffixes instead of one term per
non-reference level, and `xlevels_to_base_level_table()`'s join (keyed on
the raw `<var><level>` term) never matches a polynomial-contrast term, so
`Base Level` comes out entirely blank for that predictor.

## Fix
- Un-order an already-ordered factor predictor before fitting — mirrors
  `build_lm.R`/`build_glm()`'s own predictor handling ("if it is ordered
  factor, turn it into unordered"). Level order (and therefore which level
  becomes the reference/base level) is preserved.
- Add `prettify_polr_factor_terms()`: reformats a categorical predictor's
  raw dummy term (`"<var><level>"`) into `"<Variable>: <Level>"` text,
  matching `build_glm()`'s own coefficient-table convention
  (`map_terms_to_orig()`) — this is what tam's PR requests to keep the two
  models' coefficient tables visually consistent. Runs right after the
  `base_level_table` join (which needs the raw term text) and, mirroring
  `tidy.glm_exploratory()`'s own `map_terms_to_orig()` call, unconditionally
  of `pretty.name`.

## Testing
- Extended `tests/testthat/test_build_polr.R`:
  - Updated the existing base-level test to match on the new
    `"<Variable>: <Level>"` term format.
  - New test: an ORDERED-factor predictor gets treatment contrasts (no
    `.L`/`.Q`/`.C`, a populated Base Level).
  - New unit test for `prettify_polr_factor_terms()` directly (factor
    dummy term, numeric term, threshold term, backtick-quoted special-char
    variable name, no-factor-predictors case).
- Live-verified via `pkgload::load_all()` against: an ordered-factor
  predictor (the reported bug), a character predictor, a numeric-only
  model, and this repo's multibyte/symbol column-name stress test.
- Confirmed the 3 new/updated tests FAIL on the pre-fix code (`git stash`
  on `R/build_polr.R` only, reran, restored) — not tautological.
- Full `test_build_polr.R` suite: 55/55 passing, 0 errors, no regressions.
- Verified `odds_ratio_bar`'s own independent preprocessor (used by tam's
  `build_polr.json`) still filters/renders correctly against prettified
  terms.

Paired tam PR: implements the report-table column reorder/rename/delete
and row-name reformatting on top of this (`coefficient_table` in
`build_polr.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)