### PR TITLE
Fix: preserve NA rows in exp_multiple_answers_to_longer (#37922)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.54
+Version: 16.0.55
 Date: 2026-08-18
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/util.R
+++ b/R/util.R
@@ -3841,8 +3841,11 @@ pivot_wider <- function(data, names_from, values_from = NULL, ...) {
 #'   Default "Answer".
 #' @param trim_ws Trim leading/trailing whitespace around each split choice.
 #'   Default TRUE.
-#' @param exclude_empty Drop blank/NA choices (e.g. from "A,,B" or a fully
-#'   blank cell) instead of emitting an empty-string row. Default TRUE.
+#' @param exclude_empty Drop blank-token choices produced by splitting a
+#'   non-empty cell (e.g. the middle "" of "A,,B") instead of emitting an
+#'   empty-string row. Does NOT drop a row whose original cell is genuinely
+#'   NA (no answer at all) -- that row is always kept, with `NA` in
+#'   `answer_col`, regardless of this option (#37922). Default TRUE.
 #' @param dedupe_within_row Collapse a choice repeated within the same
 #'   original cell (e.g. "A,A,B") down to one row. Default TRUE.
 #' @param add_row_id Add a column identifying which original row each output
@@ -3931,7 +3934,13 @@ exp_multiple_answers_to_longer <- function(df, ...,
       piece$value <- trimws(piece$value)
     }
     if (exclude_empty) {
-      piece <- piece[!is.na(piece$value) & piece$value != "", , drop = FALSE]
+      # A genuine NA (a cell with no answer at all) was never split by
+      # separate_rows() -- it survives as its own single-row piece. Only
+      # drop blank *tokens* produced by splitting an otherwise-answered
+      # cell (e.g. the middle "" of "A,,B"); a genuinely missing cell must
+      # still produce a row so the original row is not silently dropped
+      # from the output (#37922).
+      piece <- piece[is.na(piece$value) | piece$value != "", , drop = FALSE]
     }
     if (dedupe_within_row) {
       piece <- piece[!duplicated(piece[c(row_id_col_internal, "value")]), , drop = FALSE]

--- a/tests/testthat/test_multiple_answers_to_longer.R
+++ b/tests/testthat/test_multiple_answers_to_longer.R
@@ -66,6 +66,53 @@ test_that("exclude_empty = FALSE keeps blank answers", {
   expect_true("" %in% result$Answer)
 })
 
+test_that("exclude_empty = TRUE (default) still preserves a row whose target column is genuinely NA (#37922)", {
+  # A respondent who left the question entirely blank (NA, not a blank
+  # token from splitting) must still show up as a row, matching the Chart
+  # side's "(NA)" category (#37591) -- exclude_empty only governs blank
+  # tokens produced by splitting a non-empty cell, never a missing cell.
+  df <- data.frame(
+    id = c(1, 2, 3),
+    store = c("Yamada,Edion", NA, "Bic Camera"),
+    stringsAsFactors = FALSE
+  )
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")
+
+  expect_equal(nrow(result), 4)
+  expect_equal(result$`Original Row ID`, c(1, 1, 2, 3))
+  expect_true(is.na(result$Answer[result$`Original Row ID` == 2]))
+  expect_equal(result$id[result$`Original Row ID` == 2], 2)
+  expect_equal(sort(result$Answer[!is.na(result$Answer)]), c("Bic Camera", "Edion", "Yamada"))
+})
+
+test_that("a genuinely-NA target column keeps its row even when a SECOND target column has real values (#37922)", {
+  # Two Multiple-Answers columns on the same original row: one left blank,
+  # one answered. Each column's own piece is independent (stacked, not
+  # cross-joined), so the NA column must still surface a Question=NA-column,
+  # Answer=NA row alongside the other column's normal split rows.
+  df <- data.frame(
+    id = c(1),
+    q13 = NA_character_,
+    q14 = c("Design,Price"),
+    stringsAsFactors = FALSE
+  )
+  result <- df %>% exp_multiple_answers_to_longer(q13, q14, sep = ",")
+
+  expect_equal(nrow(result), 3)
+  expect_true(is.na(result$Answer[result$Question == "q13"]))
+  expect_equal(sort(result$Answer[result$Question == "q14"]), c("Design", "Price"))
+})
+
+test_that("exclude_empty = TRUE still drops a blank TOKEN (not NA) from an otherwise-answered cell (#37922 regression guard)", {
+  # Distinguishes the #37922 fix (NA is always kept) from the pre-existing
+  # "drops blank answers" behavior (a "" token from splitting IS dropped).
+  df <- data.frame(id = c(1), store = c("Yamada,,Edion"), stringsAsFactors = FALSE)
+  result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")
+  expect_equal(nrow(result), 2)
+  expect_false(any(is.na(result$Answer)))
+  expect_false("" %in% result$Answer)
+})
+
 test_that("dedupe_within_row = TRUE (default) collapses a repeated answer in one cell to one row", {
   df <- data.frame(id = c(1), store = c("Yamada,Yamada,Edion"), stringsAsFactors = FALSE)
   result <- df %>% exp_multiple_answers_to_longer(store, sep = ",")


### PR DESCRIPTION
## Problem
`exp_multiple_answers_to_longer()` (the R function backing tam's "Separate Multiple-Response Values into Rows" / 複数の値を行に分割 Data Wrangling step) drops a whole original row from the output when its target Multiple-Answers column is genuinely `NA` (no answer at all). `exclude_empty = TRUE` (default) was filtering out `is.na(value)` along with blank split-tokens ("").

The Chart-side expansion already keeps a genuine-NA cell as its own `(NA)` category (#37591 / tam `DataQueryTranslator.buildMultipleAnswersExpansionExpressions`); the Data Wrangling step should behave the same way — the row must survive, not disappear.


## Fix
One-line scope change: `exclude_empty` now only drops blank *tokens* produced by splitting an otherwise-answered cell (e.g. the middle "" of "A,,B"), never a genuinely missing (NA) cell.

```diff
- piece <- piece[!is.na(piece$value) & piece$value != "", , drop = FALSE]
+ piece <- piece[is.na(piece$value) | piece$value != "", , drop = FALSE]
```

## Tests
Added 3 new `testthat` cases to `test_multiple_answers_to_longer.R`:
- all-NA target column row is preserved (Answer = NA)
- NA in one of two target columns still surfaces alongside the other column's normal rows
- existing blank-*token* exclusion (not NA) still works — regression guard distinguishing the two cases

Full suite (`test_multiple_answers_to_longer.R`, 60 assertions) green.

Version bumped to 16.0.55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)