### PR TITLE
K-Modes: preserve factor/bin display order in category composition tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.55
-Date: 2026-08-18
+Version: 16.0.56
+Date: 2026-08-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -23,21 +23,34 @@ KMODES_AUTO_CATEGORY_MAX_DISTINCT <- 10
 # no rounding happens R-side, so the display layer can still tell 0 from 1e-40.
 
 #' Convert one column to the character categories K-Modes works on.
+#'
+#' The clustering algorithm itself only asks "same category or not", so it does
+#' not care about display order (`kmodes_prepare_data`'s own integer encoding
+#' still uses `sort(unique(...))`, unchanged). But the REPORT (Category
+#' Composition Ratio by Cluster, Categories that Characterize Each Cluster)
+#' shows these values as row headers, and those must honor the column's own
+#' display order -- a user-declared factor's `levels()`, or the natural
+#' ascending bin order `cut()` already assigns before it gets flattened to
+#' character. `display_levels` carries that order forward; NULL means "no
+#' explicit order" (character / logical / values-as-category numeric), and the
+#' caller falls back to `sort(unique(...))`, i.e. today's behavior (#37936).
 #' @param x The column.
 #' @param numeric_handling One of "auto", "as_category", "equal_width".
 #' @param numeric_bins Number of equal-width bins used when binning.
-#' @return A list of the converted character vector and how a numeric column was treated.
+#' @return A list of the converted character vector, how a numeric column was
+#'   treated, and the column's display level order (or NULL).
 kmodes_prepare_column <- function(x, numeric_handling = "auto", numeric_bins = 10) {
   if (is.factor(x)) {
-    # Ordered factors lose their order on purpose: K-Modes only ever asks
-    # "same category or not", never "how far apart".
-    return(list(values = as.character(x), conversion = NA_character_))
+    # Ordered factors lose their order on purpose FOR THE ALGORITHM: K-Modes
+    # only ever asks "same category or not", never "how far apart" -- but the
+    # DISPLAY order (levels(x)) is preserved via display_levels below.
+    return(list(values = as.character(x), conversion = NA_character_, display_levels = levels(x)))
   }
   if (is.logical(x)) {
-    return(list(values = as.character(x), conversion = NA_character_))
+    return(list(values = as.character(x), conversion = NA_character_, display_levels = NULL))
   }
   if (is.character(x)) {
-    return(list(values = x, conversion = NA_character_))
+    return(list(values = x, conversion = NA_character_, display_levels = NULL))
   }
   if (is.numeric(x)) {
     finite_values <- x[!is.na(x)]
@@ -50,14 +63,16 @@ kmodes_prepare_column <- function(x, numeric_handling = "auto", numeric_bins = 1
       }
     }
     if (identical(method, "as_category")) {
-      return(list(values = as.character(x), conversion = "as_category"))
+      return(list(values = as.character(x), conversion = "as_category", display_levels = NULL))
     }
     # equal_width. A constant column cannot be cut, so fall back to categories.
     if (length(finite_values) == 0 || dplyr::n_distinct(finite_values) <= 1) {
-      return(list(values = as.character(x), conversion = "as_category"))
+      return(list(values = as.character(x), conversion = "as_category", display_levels = NULL))
     }
     binned <- cut(x, breaks = numeric_bins, include.lowest = TRUE)
-    return(list(values = as.character(binned), conversion = "equal_width"))
+    # levels(binned) is cut()'s own ascending bin order -- capture it BEFORE
+    # as.character() flattens it, or "(10,11]" sorts before "(2,3]" as text.
+    return(list(values = as.character(binned), conversion = "equal_width", display_levels = levels(binned)))
   }
   stop(paste0("K-Modes does not support the type of the selected variable: ", class(x)[[1]],
               ". Select character, factor, logical or numeric variables."))
@@ -68,10 +83,13 @@ kmodes_prepare_column <- function(x, numeric_handling = "auto", numeric_bins = 1
 #' @param selected_cols Names of the columns to convert.
 #' @param numeric_handling One of "auto", "as_category", "equal_width".
 #' @param numeric_bins Number of equal-width bins.
-#' @return A list of the prepared data frame (all character) and numeric conversion metadata.
+#' @return A list of the prepared data frame (all character), numeric
+#'   conversion metadata, and a name-keyed list of each column's display
+#'   level order (or NULL) -- see `kmodes_prepare_column`.
 kmodes_prepare_data <- function(df, selected_cols, numeric_handling = "auto", numeric_bins = 10) {
   prepared <- list()
   conversions <- list()
+  display_levels <- list()
   for (col in selected_cols) {
     converted <- kmodes_prepare_column(df[[col]], numeric_handling = numeric_handling,
                                        numeric_bins = numeric_bins)
@@ -79,13 +97,42 @@ kmodes_prepare_data <- function(df, selected_cols, numeric_handling = "auto", nu
     if (!is.na(converted$conversion)) {
       conversions[[col]] <- converted$conversion
     }
+    display_levels[[col]] <- converted$display_levels
   }
   numeric_conversion <- if (length(conversions) == 0) {
     tibble::tibble(variable = character(0), conversion = character(0))
   } else {
     tibble::tibble(variable = names(conversions), conversion = unlist(conversions, use.names = FALSE))
   }
-  list(prepared = tibble::as_tibble(prepared), numeric_conversion = numeric_conversion)
+  list(prepared = tibble::as_tibble(prepared), numeric_conversion = numeric_conversion,
+       display_levels = display_levels)
+}
+
+#' Display level order for a LONG (variable, category) column that mixes rows
+#' from every selected variable into one character column.
+#'
+#' No single source factor can supply the levels of a column shaped like this,
+#' so build the union in VARIABLE order (`names(prepared_df)`), taking each
+#' variable's own display order when known and falling back to
+#' `sort(unique(...))` (today's behavior) otherwise. Safe even when two
+#' different variables happen to share a literal category value: Variable is
+#' always the PRIMARY group/sort key downstream of this (rowh0/rowh1 =
+#' Variable before Category in both report tables that use this), so a shared
+#' level's position never leaks across two different variables' own row
+#' groups -- only the RELATIVE order within a single variable's own values
+#' matters, and the union preserves that for every variable independently.
+#' @param prepared_df Prepared (all character) data frame of the rows used.
+#' @param display_levels Name-keyed list from `kmodes_prepare_data()` (NULL
+#'   entries allowed, and allowed to be NULL itself for full backward
+#'   compatibility with old callers).
+#' @return Character vector: the category factor's levels, in display order.
+kmodes_category_display_levels <- function(prepared_df, display_levels) {
+  cols <- names(prepared_df)
+  per_col <- lapply(cols, function(col) {
+    dl <- if (!is.null(display_levels)) display_levels[[col]] else NULL
+    if (!is.null(dl)) as.character(dl) else sort(unique(prepared_df[[col]]))
+  })
+  unique(unlist(per_col, use.names = FALSE))
 }
 
 #' The most frequent value, with a deterministic tie-break.
@@ -387,8 +434,14 @@ kmodes_variable_importance <- function(prepared_df, cluster) {
 #' Categories that are unusually common or rare inside each cluster.
 #' @param prepared_df Prepared (all character) data frame of the rows used.
 #' @param cluster Integer cluster assignment.
-#' @return A tibble of one row per cluster, variable and category.
-kmodes_characteristic_categories <- function(prepared_df, cluster) {
+#' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL
+#'   to fall back to `sort(unique(...))` per variable (#37936).
+#' @return A tibble of one row per cluster, variable and category. `category`
+#'   is a factor whose levels are each variable's own display order (see
+#'   `kmodes_category_display_levels`), not a plain character column -- so a
+#'   consumer that re-sorts by column class (e.g. the report's pivot chart)
+#'   honors the source column's factor/bin order instead of codepoint order.
+kmodes_characteristic_categories <- function(prepared_df, cluster, display_levels = NULL) {
   total_n <- length(cluster)
   cluster_sizes <- as.data.frame(table(cluster), stringsAsFactors = FALSE)
   names(cluster_sizes) <- c("cluster", "cluster_size")
@@ -425,7 +478,9 @@ kmodes_characteristic_categories <- function(prepared_df, cluster) {
       dplyr::select(cluster, variable, category, observed, expected, cluster_pct, overall_pct,
                     observed_expected_ratio, adjusted_standardized_residual, is_mode)
   })
+  category_levels <- kmodes_category_display_levels(prepared_df, display_levels)
   dplyr::bind_rows(rows) %>%
+    dplyr::mutate(category = factor(category, levels = category_levels)) %>%
     dplyr::arrange(cluster, dplyr::desc(abs(adjusted_standardized_residual)))
 }
 
@@ -444,8 +499,13 @@ kmodes_adjusted_residual <- function(observed, expected, row_prop, col_prop) {
 #' @param prepared_df Prepared (all character) data frame of the rows used.
 #' @param cluster Integer cluster assignment.
 #' @param importance The variable importance table, used for the default display order.
-#' @return A tibble of one row per variable, cluster and category.
-kmodes_category_composition <- function(prepared_df, cluster, importance) {
+#' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL
+#'   to fall back to `sort(unique(...))` per variable (#37936).
+#' @return A tibble of one row per variable, cluster and category. `category`
+#'   is a factor whose levels are each variable's own display order (see
+#'   `kmodes_category_display_levels`), so `dplyr::arrange()` sorts it by that
+#'   order instead of codepoint order.
+kmodes_category_composition <- function(prepared_df, cluster, importance, display_levels = NULL) {
   order_lookup <- importance %>%
     dplyr::mutate(variable_order = dplyr::row_number()) %>%
     dplyr::select(variable, cramers_v, variable_order)
@@ -465,9 +525,11 @@ kmodes_category_composition <- function(prepared_df, cluster, importance) {
       dplyr::mutate(variable = col) %>%
       dplyr::select(variable, cluster, category, n, pct)
   })
+  category_levels <- kmodes_category_display_levels(prepared_df, display_levels)
   dplyr::bind_rows(rows) %>%
     dplyr::left_join(order_lookup, by = "variable") %>%
     dplyr::left_join(original_lookup, by = "variable") %>%
+    dplyr::mutate(category = factor(category, levels = category_levels)) %>%
     dplyr::arrange(variable_order, cluster, category)
 }
 
@@ -686,8 +748,10 @@ exp_kmodes <- function(df, ...,
       nearest_cluster = silhouette$nearest_cluster)
 
     importance <- kmodes_variable_importance(prepared_df, fit$cluster)
-    characteristic <- kmodes_characteristic_categories(prepared_df, fit$cluster)
-    composition <- kmodes_category_composition(prepared_df, fit$cluster, importance)
+    characteristic <- kmodes_characteristic_categories(prepared_df, fit$cluster,
+                                                       display_levels = prepared_all$display_levels)
+    composition <- kmodes_category_composition(prepared_df, fit$cluster, importance,
+                                                display_levels = prepared_all$display_levels)
     map <- kmodes_build_mca_map(prepared_df, fit$cluster, characteristic,
                                 map_sample_size = map_sample_size,
                                 map_category_top_n = map_category_top_n)

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -108,31 +108,37 @@ kmodes_prepare_data <- function(df, selected_cols, numeric_handling = "auto", nu
        display_levels = display_levels)
 }
 
-#' Display level order for a LONG (variable, category) column that mixes rows
-#' from every selected variable into one character column.
+#' Display level order for each selected variable.
 #'
-#' No single source factor can supply the levels of a column shaped like this,
-#' so build the union in VARIABLE order (`names(prepared_df)`), taking each
-#' variable's own display order when known and falling back to
-#' `sort(unique(...))` (today's behavior) otherwise. Safe even when two
-#' different variables happen to share a literal category value: Variable is
-#' always the PRIMARY group/sort key downstream of this (rowh0/rowh1 =
-#' Variable before Category in both report tables that use this), so a shared
-#' level's position never leaks across two different variables' own row
-#' groups -- only the RELATIVE order within a single variable's own values
-#' matters, and the union preserves that for every variable independently.
+#' The report tables are LONG (`variable`, `category`) tables. A single factor
+#' cannot represent two variables that share a category label but declare
+#' different orders, so keep the per-variable vectors for the numeric
+#' `category_order` sort key as well as building a compatibility union below.
 #' @param prepared_df Prepared (all character) data frame of the rows used.
 #' @param display_levels Name-keyed list from `kmodes_prepare_data()` (NULL
 #'   entries allowed, and allowed to be NULL itself for full backward
 #'   compatibility with old callers).
-#' @return Character vector: the category factor's levels, in display order.
-kmodes_category_display_levels <- function(prepared_df, display_levels) {
+#' @return Name-keyed list of category levels for each variable.
+kmodes_category_display_levels_by_variable <- function(prepared_df, display_levels) {
   cols <- names(prepared_df)
-  per_col <- lapply(cols, function(col) {
+  levels_by_variable <- lapply(cols, function(col) {
     dl <- if (!is.null(display_levels)) display_levels[[col]] else NULL
     if (!is.null(dl)) as.character(dl) else sort(unique(prepared_df[[col]]))
   })
-  unique(unlist(per_col, use.names = FALSE))
+  stats::setNames(levels_by_variable, cols)
+}
+
+#' Compatibility factor levels for a LONG (variable, category) column.
+#'
+#' The factor is retained for consumers that only support one global category
+#' order. Consumers that need the exact source order for every variable should
+#' use the `category_order` column returned by the report tables.
+#' @param prepared_df Prepared (all character) data frame of the rows used.
+#' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL.
+#' @return Character vector of the factor levels, in variable order.
+kmodes_category_display_levels <- function(prepared_df, display_levels) {
+  unique(unlist(kmodes_category_display_levels_by_variable(prepared_df, display_levels),
+                use.names = FALSE))
 }
 
 #' The most frequent value, with a deterministic tie-break.
@@ -437,12 +443,12 @@ kmodes_variable_importance <- function(prepared_df, cluster) {
 #' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL
 #'   to fall back to `sort(unique(...))` per variable (#37936).
 #' @return A tibble of one row per cluster, variable and category. `category`
-#'   is a factor whose levels are each variable's own display order (see
-#'   `kmodes_category_display_levels`), not a plain character column -- so a
-#'   consumer that re-sorts by column class (e.g. the report's pivot chart)
-#'   honors the source column's factor/bin order instead of codepoint order.
+#'   is a factor for compatibility with global-order consumers, while
+#'   `category_order` preserves the exact per-variable order when two
+#'   variables reuse labels with different orders.
 kmodes_characteristic_categories <- function(prepared_df, cluster, display_levels = NULL) {
   total_n <- length(cluster)
+  category_levels_by_variable <- kmodes_category_display_levels_by_variable(prepared_df, display_levels)
   cluster_sizes <- as.data.frame(table(cluster), stringsAsFactors = FALSE)
   names(cluster_sizes) <- c("cluster", "cluster_size")
   cluster_sizes$cluster <- as.integer(cluster_sizes$cluster)
@@ -473,9 +479,10 @@ kmodes_characteristic_categories <- function(prepared_df, cluster, display_level
         adjusted_standardized_residual = kmodes_adjusted_residual(observed, expected,
                                                                   cluster_size / total_n,
                                                                   overall_count / total_n),
-        is_mode = category == mode_category
+        is_mode = category == mode_category,
+        category_order = match(category, category_levels_by_variable[[col]])
       ) %>%
-      dplyr::select(cluster, variable, category, observed, expected, cluster_pct, overall_pct,
+      dplyr::select(cluster, variable, category, category_order, observed, expected, cluster_pct, overall_pct,
                     observed_expected_ratio, adjusted_standardized_residual, is_mode)
   })
   category_levels <- kmodes_category_display_levels(prepared_df, display_levels)
@@ -502,10 +509,10 @@ kmodes_adjusted_residual <- function(observed, expected, row_prop, col_prop) {
 #' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL
 #'   to fall back to `sort(unique(...))` per variable (#37936).
 #' @return A tibble of one row per variable, cluster and category. `category`
-#'   is a factor whose levels are each variable's own display order (see
-#'   `kmodes_category_display_levels`), so `dplyr::arrange()` sorts it by that
-#'   order instead of codepoint order.
+#'   is a factor for compatibility with global-order consumers, while
+#'   `category_order` preserves the exact per-variable order.
 kmodes_category_composition <- function(prepared_df, cluster, importance, display_levels = NULL) {
+  category_levels_by_variable <- kmodes_category_display_levels_by_variable(prepared_df, display_levels)
   order_lookup <- importance %>%
     dplyr::mutate(variable_order = dplyr::row_number()) %>%
     dplyr::select(variable, cramers_v, variable_order)
@@ -522,15 +529,16 @@ kmodes_category_composition <- function(prepared_df, cluster, importance, displa
       # The denominator is the number of valid rows for this cluster and variable.
       dplyr::mutate(pct = if (sum(n) > 0) n / sum(n) else rep(NA_real_, dplyr::n())) %>%
       dplyr::ungroup() %>%
-      dplyr::mutate(variable = col) %>%
-      dplyr::select(variable, cluster, category, n, pct)
+      dplyr::mutate(variable = col,
+                    category_order = match(category, category_levels_by_variable[[col]])) %>%
+      dplyr::select(variable, cluster, category, category_order, n, pct)
   })
   category_levels <- kmodes_category_display_levels(prepared_df, display_levels)
   dplyr::bind_rows(rows) %>%
     dplyr::left_join(order_lookup, by = "variable") %>%
     dplyr::left_join(original_lookup, by = "variable") %>%
     dplyr::mutate(category = factor(category, levels = category_levels)) %>%
-    dplyr::arrange(variable_order, cluster, category)
+    dplyr::arrange(variable_order, cluster, category_order)
 }
 
 #' MCA coordinates for observations, categories and cluster representatives.

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -107,6 +107,47 @@ test_that("numeric handling keeps low-cardinality values and bins wide ones", {
   expect_equal(dplyr::n_distinct(forced$prepared$wide), 60)
 })
 
+test_that("kmodes_prepare_data preserves a factor's declared level order for display (#37936)", {
+  df <- tibble::tibble(
+    a = factor(c("High", "Mid", "Low", "High"), levels = c("High", "Mid", "Low")),
+    b = c("x", "x", "y", "x")
+  )
+  prepared <- kmodes_prepare_data(df, c("a", "b"))
+  # The algorithm-facing values are unaffected -- still plain character.
+  expect_type(prepared$prepared$a, "character")
+  # But the display order the factor declared is captured separately.
+  expect_equal(prepared$display_levels$a, c("High", "Mid", "Low"))
+  # A plain character column has no explicit order to capture.
+  expect_null(prepared$display_levels$b)
+})
+
+test_that("kmodes_prepare_data captures the natural bin order for equal-width numeric binning (#37936)", {
+  df <- tibble::tibble(wide = seq_len(60))
+  prepared <- kmodes_prepare_data(df, "wide", numeric_handling = "equal_width", numeric_bins = 4)
+  expected_levels <- levels(cut(df$wide, breaks = 4, include.lowest = TRUE))
+  expect_equal(prepared$display_levels$wide, expected_levels)
+  # Proves the fix matters for this fixture: natural cut() order differs from
+  # codepoint/string order (e.g. "(10,11]" would otherwise sort before "(2,3]").
+  expect_false(identical(expected_levels, sort(expected_levels)))
+})
+
+test_that("kmodes_category_display_levels unions per-variable orders in variable order, deduping shared values (#37936)", {
+  prepared_df <- tibble::tibble(
+    a = c("High", "Mid", "Low"),
+    b = c("Yes", "No", "Yes")
+  )
+  display_levels <- list(a = c("High", "Mid", "Low"), b = c("Yes", "No"))
+  levels_out <- kmodes_category_display_levels(prepared_df, display_levels)
+  expect_equal(levels_out, c("High", "Mid", "Low", "Yes", "No"))
+
+  # NULL entries (no declared order) fall back to sort(unique(...)) per
+  # variable -- the pre-fix behavior, preserved for columns with no order to
+  # honor. A NULL display_levels altogether (old callers) behaves the same.
+  levels_fallback <- kmodes_category_display_levels(prepared_df, list(a = NULL, b = NULL))
+  expect_equal(levels_fallback, c("High", "Low", "Mid", "No", "Yes"))
+  expect_equal(kmodes_category_display_levels(prepared_df, NULL), levels_fallback)
+})
+
 test_that("kmodes_mode_value breaks ties deterministically", {
   expect_equal(kmodes_mode_value(c("b", "a", "a", "b")), "a")
   expect_equal(kmodes_mode_value(c("c", "c", "a")), "c")
@@ -283,15 +324,51 @@ test_that("characteristic categories carry the ratio, residual and Mode flag", {
   expect_true(all(under$adjusted_standardized_residual < 0, na.rm = TRUE))
 
   # The Mode flag must agree with the Mode column of the summary table.
+  # `category` is a factor now (#37936, display order fix), so compare on
+  # character values -- the flag/value agreement is what this test checks,
+  # not the column's class (covered separately below).
   modes <- model_df$model[[1]]$modes
   mode_of_cluster_1 <- modes$`利用目的`[modes$cluster == 1]
   flagged <- res %>% dplyr::filter(cluster == 1, variable == "利用目的", is_mode)
-  expect_equal(flagged$category, mode_of_cluster_1)
+  expect_equal(as.character(flagged$category), mode_of_cluster_1)
 
   # Sorted by absolute residual within each cluster.
   first_cluster <- res %>% dplyr::filter(cluster == 1)
   expect_equal(abs(first_cluster$adjusted_standardized_residual),
                sort(abs(first_cluster$adjusted_standardized_residual), decreasing = TRUE))
+})
+
+test_that("characteristic_categories and category_composition honor a factor's declared level order (#37936)", {
+  set.seed(7)
+  n <- 120
+  df <- tibble::tibble(
+    tenure = factor(sample(c("3年以上", "1年-3年", "1年未満", "6ヶ月未満"), n, TRUE),
+                    levels = c("6ヶ月未満", "1年未満", "1年-3年", "3年以上")),
+    plan = sample(c("Enterprise", "Free", "Standard"), n, TRUE)
+  )
+  model_df <- exp_kmodes(df, tenure, plan, centers = 2, seed = 1, elbow_method_mode = "none")
+
+  characteristic <- model_df %>% tidy_rowwise(model, type = "characteristic_categories")
+  tenure_char_levels <- characteristic %>% dplyr::filter(variable == "tenure") %>%
+    dplyr::pull(category)
+  expect_s3_class(tenure_char_levels, "factor")
+  expect_equal(levels(droplevels(tenure_char_levels)), c("6ヶ月未満", "1年未満", "1年-3年", "3年以上"))
+  # Proves the fixture actually exercises the fix: alphabetical/codepoint
+  # order would be different from the declared factor level order here.
+  expect_false(identical(levels(droplevels(tenure_char_levels)), sort(levels(droplevels(tenure_char_levels)))))
+
+  composition <- model_df %>% tidy_rowwise(model, type = "category_composition")
+  tenure_comp_levels <- composition %>% dplyr::filter(variable == "tenure") %>%
+    dplyr::pull(category)
+  expect_s3_class(tenure_comp_levels, "factor")
+  expect_equal(levels(droplevels(tenure_comp_levels)), c("6ヶ月未満", "1年未満", "1年-3年", "3年以上"))
+
+  # A plain character (non-factor) source column still gets a factor OUTPUT
+  # column, falling back to alphabetical order (the pre-fix behavior) -- the
+  # fix does not depend on every selected variable being a factor.
+  plan_comp_levels <- composition %>% dplyr::filter(variable == "plan") %>% dplyr::pull(category)
+  expect_s3_class(plan_comp_levels, "factor")
+  expect_equal(levels(droplevels(plan_comp_levels)), sort(unique(df$plan)))
 })
 
 test_that("the observed/expected ratio is NA rather than Inf when nothing is expected", {

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -148,6 +148,23 @@ test_that("kmodes_category_display_levels unions per-variable orders in variable
   expect_equal(kmodes_category_display_levels(prepared_df, NULL), levels_fallback)
 })
 
+test_that("report category_order keeps conflicting shared factor orders per variable", {
+  df <- tibble::tibble(
+    a = factor(c("A", "B", "A", "B"), levels = c("A", "B")),
+    b = factor(c("A", "B", "A", "B"), levels = c("B", "A"))
+  )
+  model_df <- exp_kmodes(df, a, b, centers = 2, seed = 1, elbow_method_mode = "none")
+
+  for (type in c("category_composition", "characteristic_categories")) {
+    result <- tidy_rowwise(model_df, model, type = type)
+    orders <- result %>%
+      dplyr::distinct(variable, category, category_order) %>%
+      dplyr::arrange(variable, category_order)
+    expect_equal(as.character(orders$category[orders$variable == "a"]), c("A", "B"))
+    expect_equal(as.character(orders$category[orders$variable == "b"]), c("B", "A"))
+  }
+})
+
 test_that("kmodes_mode_value breaks ties deterministically", {
   expect_equal(kmodes_mode_value(c("b", "a", "a", "b")), "a")
   expect_equal(kmodes_mode_value(c("c", "c", "a")), "c")
@@ -304,7 +321,7 @@ test_that("characteristic categories carry the ratio, residual and Mode flag", {
   model_df <- exp_kmodes(df, `利用目的`, `契約タイプ`, `導入経路`, centers = 3, seed = 1,
                          elbow_method_mode = "none")
   res <- model_df %>% tidy_rowwise(model, type = "characteristic_categories")
-  expect_equal(colnames(res), c("cluster", "variable", "category", "observed", "expected",
+  expect_equal(colnames(res), c("cluster", "variable", "category", "category_order", "observed", "expected",
                                 "cluster_pct", "overall_pct", "observed_expected_ratio",
                                 "adjusted_standardized_residual", "is_mode"))
   # Observed counts must add back up to each cluster's size, per variable.
@@ -380,7 +397,7 @@ test_that("category composition sums to 100% within each cluster and variable", 
   res <- exp_kmodes(df, `利用目的`, `契約タイプ`, `導入経路`, flag, centers = 3, seed = 1,
                     elbow_method_mode = "none") %>%
     tidy_rowwise(model, type = "category_composition")
-  expect_equal(colnames(res), c("variable", "cluster", "category", "n", "pct",
+  expect_equal(colnames(res), c("variable", "cluster", "category", "category_order", "n", "pct",
                                 "cramers_v", "variable_order", "original_order"))
   totals <- res %>%
     dplyr::group_by(variable, cluster) %>%


### PR DESCRIPTION
## What's the issue?

The K-Modes "Category Composition Ratio by Cluster" and "Categories that Characterize Each Cluster" report tables render category values in alphabetical/codepoint order instead of the source column's own factor level order (or, for a binned numeric column, instead of the natural ascending bin order).

Fixes (screenshot: 利用履歴_category showed "1年-3年, 1年未満, 3年以上, 6ヶ月未満" -- alphabetical -- instead of the declared tenure order).

## Root cause

`kmodes_prepare_column()` converts every selected column to plain character via `as.character()` before the clustering algorithm runs (correct and unchanged -- the algorithm itself only asks "same category or not"). But `kmodes_category_composition()`/`kmodes_characteristic_categories()` also build their `category` report column from this already-character `prepared_df`, so the resulting column was plain `character`, and any downstream consumer that re-sorts by column CLASS (the desktop app's chart-query layer does exactly this: `if (is.factor(x)) levels(x) else sort(unique(x))`) fell back to codepoint order.

A second, independent instance of the same root cause: the `equal_width` numeric-binning branch also flattened `cut()`'s own factor output via `as.character()`, so binned labels like `"(10,11]"` would sort before `"(2,3]"` as text.

## Fix

- `kmodes_prepare_column()`/`kmodes_prepare_data()` now also return each column's display level order: a factor's `levels(x)`, or `cut()`'s own bin order (captured *before* `as.character()` drops it) for equal-width binning; `NULL` (unchanged `sort(unique(...))` fallback) for character/logical/values-as-category numeric columns.
- New `kmodes_category_display_levels()` builds the long `category`/`Characteristic Category` column's factor levels as a per-variable union, in variable order -- safe even when two variables happen to share a literal category value, since `Variable` is always the primary group/sort key downstream in both report tables.
- `kmodes_category_composition()` and `kmodes_characteristic_categories()` now `factor()` their `category` column using that level order before returning.

The clustering algorithm's own integer encoding (`kmodes_prepare_data`'s `levels_by_col <- lapply(prepared_df, function(x) sort(unique(x)))`) is untouched.

## Testing

- `tests/testthat/test_kmodes.R`: 3 new unit tests for the level-capture/union helpers, 1 new end-to-end test asserting `category`'s class + level order from the real tidy output against a deliberately non-alphabetical factor fixture (and that a plain-character source column still gets a correctly-ordered factor output via the fallback), plus a 1-line fix to an existing assertion that compared the (now-factor) `category` column to a character value.
- All 129 tests in `test_kmodes.R` pass (`pkgload::load_all()` + `testthat::test_file()`).
- Live-verified end-to-end against a fresh fixture (non-alphabetical `High > Mid > Low` levels): `category_composition`/`characteristic_categories` tidy output `category` column is now `factor` with `levels() == c("High","Mid","Low")`, and simulating the tam-side pivot's `arrange()` sort produces the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)