### PR TITLE
Factor Analysis: factor_count/parallel_screeplot use highest-adopted-factor, not leading-run count (tam#37972)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.57
+Version: 16.0.58
 Date: 2026-08-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/factanal.R
+++ b/R/factanal.R
@@ -564,6 +564,24 @@ glance.fa_exploratory <- function(x, pretty.name = FALSE, ...) {
   res
 }
 
+# The highest-numbered factor currently TRUE (adopted) in a per-factor logical vector that may
+# contain NA (not judgeable) entries -- issue tam#37972, sibling of tam#37943/#37947. Mirrors
+# library.r's judged_status_count() and FactanalReportBindUtil.js's maxFactorForStatus(): the
+# HIGHEST adopted row, NOT a count/leading-run stop, because the parallel-analysis random-data
+# threshold is a Monte-Carlo quantile and is not guaranteed to be monotonically decreasing -- a
+# real data set can show e.g. Factor 1 Not Adopted, Factor 2 Adopted, Factor 3 Not Adopted, and
+# the recommendation must point at Factor 2, not stop counting at Factor 1.
+# Returns NA_integer_ when adoption could not be judged for ANY factor (every entry NA -- caller
+# should render "Not available"), 0L when every judged factor was Not Adopted, otherwise the
+# highest adopted factor number.
+factanal_max_adopted_factor <- function(adopted) {
+  if (length(adopted) == 0 || all(is.na(adopted))) {
+    return(NA_integer_)
+  }
+  idx <- which(adopted)
+  if (length(idx) == 0) 0L else max(idx)
+}
+
 # Factor-count diagnostics shared by the normal scree plot, parallel-analysis
 # chart, and factor-count table. Keeping the alignment here prevents those three
 # report outputs from independently interpreting the parallel-analysis table.
@@ -939,10 +957,24 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   else if (type == "factor_count") {
     # Kaiser criterion always reads the plain correlation-matrix eigenvalues (issue tam#37332
     # section 10): it is a separate, well-known rule of thumb that this change does not touch.
+    # Kaiser's adoption is always a contiguous leading run (correlation eigenvalues sort
+    # descending), so a plain count IS the highest adopted row there -- no fix needed.
     eig <- eigen(x$correlation, symmetric = TRUE, only.values = TRUE)$values
     kaiser_n <- sum(eig > 1)
     par <- x$parallel
-    parallel_rec <- if (is.null(par)) "Not available" else as.character(par$recommended_n)
+    # issue tam#37972 (sibling of tam#37943/#37947): this used to read par$recommended_n, a
+    # LEADING-CONTIGUOUS-RUN count (see compute_parallel_recommended_n() above) that disagrees
+    # with variances_judged's parallel_status -- the per-factor decision table, the chart's
+    # reference line (library.r judged_status_count(), #37947) and the report prose
+    # (FactanalReportBindUtil.js, #37947) all derive from build_factor_count_diagnostics()'s raw
+    # per-factor comparison instead. Route through the SAME diagnostics/helper so this table can
+    # never disagree with those three again.
+    parallel_rec <- if (is.null(par)) {
+      "Not available"
+    } else {
+      max_adopted <- factanal_max_adopted_factor(build_factor_count_diagnostics(x)$parallel_adopted)
+      if (is.na(max_adopted)) "Not available" else as.character(max_adopted)
+    }
     # The description names which eigenvalue the Parallel Analysis row actually compared, so it
     # stays honest once the method is selectable (issue tam#37332).
     parallel_description <- if (is.null(par)) {
@@ -989,7 +1021,15 @@ tidy.fa_exploratory <- function(x, type="loadings", n_sample=NULL, pretty.name=F
   }
   else if (type == "parallel_screeplot") {
     diagnostics <- build_factor_count_diagnostics(x)
-    recommended_n <- if (is.null(x$parallel)) NA_integer_ else x$parallel$recommended_n
+    # issue tam#37972: same fix as the factor_count table above -- keep this column's semantics
+    # (highest adopted factor) identical everywhere it's named "Recommended Number of Factors",
+    # instead of par$recommended_n's leading-contiguous-run count.
+    recommended_n <- if (is.null(x$parallel)) {
+      NA_integer_
+    } else {
+      max_adopted <- factanal_max_adopted_factor(diagnostics$parallel_adopted)
+      if (is.na(max_adopted)) NA_integer_ else max_adopted
+    }
     res <- diagnostics %>% dplyr::transmute(
       Factor = factor_number,
       `Actual Data Eigenvalue` = parallel_eigenvalue,

--- a/tests/testthat/test_factanal.R
+++ b/tests/testthat/test_factanal.R
@@ -447,6 +447,80 @@ test_that("parallel analysis method: factor_model vs smc (issue #37332)", {
   expect_equal(legacy_am$Value[[which(legacy_am$Item == "Parallel Analysis Method")]], "Factor Model")
 })
 
+test_that("factanal_max_adopted_factor (issue tam#37972)", {
+  expect_true(is.na(factanal_max_adopted_factor(c(NA, NA, NA))))
+  expect_true(is.na(factanal_max_adopted_factor(logical(0))))
+  expect_equal(factanal_max_adopted_factor(c(FALSE, FALSE)), 0L)
+  expect_equal(factanal_max_adopted_factor(c(FALSE, TRUE, FALSE)), 2L)
+  expect_equal(factanal_max_adopted_factor(c(TRUE, TRUE, TRUE)), 3L)
+  # NA entries (out-of-range / not judgeable) do not stop or confuse the scan.
+  expect_equal(factanal_max_adopted_factor(c(TRUE, NA, FALSE)), 1L)
+})
+
+test_that("factor_count / parallel_screeplot report the HIGHEST adopted factor, not a leading-run count (issue tam#37972)", {
+  # Reproduces the non-contiguous adoption repro from tam#37943/#37947 (Factor 1 Not Adopted,
+  # Factor 2 Adopted, Factor 3 Not Adopted) directly against tidy.fa_exploratory(), bypassing the
+  # randomness of a real parallel analysis run. compute_parallel_recommended_n() (a
+  # LEADING-CONTIGUOUS-RUN count) stops at Factor 1 and reports 0 -- exactly the pre-fix bug, since
+  # the factor_count/parallel_screeplot tidy types used to read x$parallel$recommended_n directly --
+  # while build_factor_count_diagnostics()$parallel_adopted (a raw per-factor comparison, what
+  # variances_judged / the chart refline (library.r, #37947) / the report prose
+  # (FactanalReportBindUtil.js, #37947) already use) correctly shows Factor 2 as the highest
+  # adopted row.
+  fake_fit <- list(
+    correlation = matrix(c(1, 0.3, 0.3, 0.3, 1, 0.3, 0.3, 0.3, 1), nrow = 3),
+    factors = 2,
+    parallel = list(
+      method = "factor_model",
+      recommended_n = compute_parallel_recommended_n(c(0.5, 2, 0.5), c(1, 1, 1)), # leading-count == 0
+      table = tibble::tibble(
+        factor_number = 1:3,
+        actual_eigenvalue = c(0.5, 2, 0.5),
+        random_eigenvalue_threshold = c(1, 1, 1),
+        retained = c(FALSE, TRUE, FALSE)
+      )
+    )
+  )
+  class(fake_fit) <- "fa_exploratory"
+
+  # Pin the setup: the OLD, buggy leading-run value really is 0 here, so this test cannot pass by
+  # accident just because the new code happens to also compute 0.
+  expect_equal(fake_fit$parallel$recommended_n, 0)
+
+  diagnostics <- build_factor_count_diagnostics(fake_fit)
+  expect_equal(diagnostics$parallel_adopted, c(FALSE, TRUE, FALSE))
+  expect_equal(factanal_max_adopted_factor(diagnostics$parallel_adopted), 2L)
+
+  fc <- tidy.fa_exploratory(fake_fit, type = "factor_count")
+  expect_equal(fc$`Recommended Number of Factors`[fc$Method == "Parallel Analysis"], "2")
+  # Kaiser is untouched -- correlation eigenvalues sort descending, so its adoption is always a
+  # contiguous leading run and a plain count already equals the highest adopted row.
+  expect_equal(fc$`Recommended Number of Factors`[fc$Method == "Kaiser Criterion"],
+               as.character(sum(eigen(fake_fit$correlation, symmetric = TRUE, only.values = TRUE)$values > 1)))
+
+  ps <- tidy.fa_exploratory(fake_fit, type = "parallel_screeplot")
+  expect_equal(unique(ps$`Recommended Number of Factors`), 2)
+
+  # variances_judged (already fixed by #37947's siblings) must agree with factor_count -- the
+  # whole point of this fix is that these can never disagree again.
+  vj <- tidy.fa_exploratory(fake_fit, type = "variances_judged")
+  expect_equal(vj$parallel_status, c("not_adopted", "adopted", "not_adopted"))
+  vj_max_adopted <- max(as.integer(vj$Factor[vj$parallel_status == "adopted"]))
+  expect_equal(as.character(vj_max_adopted), fc$`Recommended Number of Factors`[fc$Method == "Parallel Analysis"])
+
+  # No parallel analysis at all -> "Not available", never "0" or NA-derived garbage.
+  no_par_fit <- fake_fit
+  no_par_fit$parallel <- NULL
+  fc_no_par <- tidy.fa_exploratory(no_par_fit, type = "factor_count")
+  expect_equal(fc_no_par$`Recommended Number of Factors`[fc_no_par$Method == "Parallel Analysis"], "Not available")
+
+  # Every factor genuinely NOT adopted -> a real "0" (distinct from "Not available").
+  none_adopted_fit <- fake_fit
+  none_adopted_fit$parallel$table$actual_eigenvalue <- c(0.1, 0.2, 0.3)
+  fc_none <- tidy.fa_exploratory(none_adopted_fit, type = "factor_count")
+  expect_equal(fc_none$`Recommended Number of Factors`[fc_none$Method == "Parallel Analysis"], "0")
+})
+
 test_that("report part 3: variances_judged, suitability P value format, analysis_method order (issue tam#37340)", {
   model_df <- mtcars %>%
     exp_factanal(mpg, cyl, disp, hp, drat, wt, qsec, nfactors = 2, fm = "minres",


### PR DESCRIPTION
## Description

Fixes https://github.com/exploratory-io/tam/issues/37972 — a follow-up to tam#37943 / tam PR https://github.com/exploratory-io/tam/pull/37947, which fixed the Parallel Analysis chart's reference line and the report's "推奨因子数" prose sentence but left a third, independent sibling unfixed: the desktop app's "推奨因子数" summary TABLE (`factor_count` tidy type, Method / Recommended Number of Factors / Description).

## Root Cause

`tidy.fa_exploratory(type="factor_count")` read `x$parallel$recommended_n`, produced by `compute_parallel_recommended_n()` — a **leading-contiguous-run count** (stops at the first factor whose eigenvalue does not exceed the random-data threshold). This disagrees with `build_factor_count_diagnostics()$parallel_adopted`, a raw per-factor `>` comparison, which is what `variances_judged`'s `parallel_status` — the decision table, the chart refline (library.r `judged_status_count()`, #37947), and the report prose (`FactanalReportBindUtil.js`, #37947) — all derive from.

tam PR #37947 explicitly noted "no exploratory_func package version bump needed" — correct for what it touched (pure tam JS/R-codegen), but it means this table's own R-side computation was out of scope for that PR.

`build_factor_count_diagnostics()`'s own doc comment already documents the intended invariant this fixes: "Factor-count diagnostics shared by the normal scree plot, parallel-analysis chart, and factor-count table. Keeping the alignment here prevents those three report outputs from independently interpreting the parallel-analysis table."

## Fix

- New `factanal_max_adopted_factor(adopted)` helper: highest-numbered TRUE in a logical vector that may contain NA. Returns `NA_integer_` when nothing is judgeable (caller renders "Not available"), `0L` when every judged factor was not adopted, else the max adopted index.
- `type=="factor_count"`: Parallel Analysis row now derives from `factanal_max_adopted_factor(build_factor_count_diagnostics(x)$parallel_adopted)` instead of `x$parallel$recommended_n`. Kaiser is untouched (its adoption is always a contiguous leading run — correlation eigenvalues sort descending — so a plain count already equals the max-adopted row there; no bug).
- `type=="parallel_screeplot"`: the same-named `Recommended Number of Factors` column gets the identical fix, for the same shared-diagnostics-alignment reason (currently unused by tam's UI, but the column exists and is named identically — keeping it consistent prevents a future consumer from picking up the wrong value).
- `compute_parallel_recommended_n()` itself is UNCHANGED — it's still used internally by `compute_parallel_analysis()`'s `$table$retained`, which no tam-visible tidy type reads. Only the two display-facing consumers above were repointed.
- Deliberately did **not** touch `do_prcomp`'s own `fit$recommended_components`/`fit$retained_components` (`R/prcomp.R`), which reuses `compute_parallel_analysis()$recommended_n` for a materially different purpose — it drives the DEFAULT number of components auto-retained when the user doesn't set one explicitly, not just a display value. Changing that default silently is a separate, higher-blast-radius concern deserving its own issue/spec review; `PrcompReportBindUtil.js`'s own report-prose already uses a count-based approach independent of this field. Flagging as a known related gap, out of scope here.

## Tests

- New `factanal_max_adopted_factor()` unit test (6 cases: empty, all-NA, none-adopted, contiguous, non-contiguous, NA-interspersed).
- New end-to-end test reproducing the exact tam#37943 non-contiguous repro (Factor 1 Not Adopted, Factor 2 Adopted, Factor 3 Not Adopted) against `tidy.fa_exploratory()` via a synthetic `fa_exploratory` fixture (deterministic, bypasses parallel analysis's Monte-Carlo randomness):
  - Pins that the OLD leading-count value really is `0` for this fixture (so the test can't pass by accident).
  - Asserts `factor_count`'s Parallel Analysis row is `"2"`.
  - Asserts `parallel_screeplot`'s column is `2`.
  - Asserts `factor_count` and `variances_judged` agree (the whole point of the fix).
  - Asserts `"Not available"` when parallel analysis wasn't computed at all, and a real `"0"` (distinct from `"Not available"`) when every factor was judged but none adopted.
- Verified the new tests genuinely depend on the fix: without `factanal_max_adopted_factor()` present, the new test errors immediately (`could not find function`); the fixture is constructed so the OLD field value (`0`) and the NEW correct value (`2`) are both directly asserted and diverge on the same input.
- Ran `tests/testthat/test_factanal.R` locally (`pkgload::load_all()` + `testthat`) — pre-existing, unrelated environment failures only (missing `Rcsdp`/`digest` system packages, no network access in this sandbox — reproduced identically on `origin/master` before this change). All new/touched assertions pass.

## Build Impact

Pure R logic change inside `exploratory_func`. No new dependencies. Requires bumping the pinned `exploratory` version in tam's `tools/requiredRPackagesReduced.json` (+ rebuilding per-platform binaries) once merged, per this package's usual release flow, before the desktop app picks it up — flagged as a follow-up on tam#37972, not done in this PR.
