### PR TITLE
chore: bump exploratory R package to 16.0.59

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.58
+Version: 16.0.59
 Date: 2026-08-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func


### PR DESCRIPTION
Bumps `DESCRIPTION` `Version:` for #1617 (already merged), which fixed the
Decision Tree (CART) target-column-name-with-a-comma crash reported in
[tam#37985](https://github.com/exploratory-io/tam/issues/37985).

## What's included

- `07d20cf3` "Resolve model target column against cleaned training data" (#1617) --
  `resolve_model_target_col`/`relocate_target_col_last`, 13 call sites across
  rpart/ranger/xgboost/lightgbm/catboost.
- `ae82dcb9` "fix: prefer original target column name when available" -- a
  follow-up landed directly on master after #1617 merged: when a `map_name =
  TRUE` model's data has BOTH the original and a cleaned-alias name present
  (e.g. a predictor happens to be literally named `c1_`), the original target
  name must win, or the resolver can match the wrong column. New collision
  regression test included.

## Verification

- `devtools::test(filter="model_target_col_name_cleaning")`: 43/43 passing on
  this exact branch (re-run after the bump, not just before it).
- Local install + live re-verification of the originally reported crash
  (target column name containing a comma, `exp_rpart` + `prediction(data=
  'training_and_test')`): builds, predicts, and relocates the target column
  correctly with zero errors.

## Rollout

Per the established chain: this version bump PR → build+upload per-platform
binaries to `download2.exploratory.io/bin/*/contrib/4.6/` (no compiled code,
so the Mac Intel/ARM `.tgz` is one build) → bump
`tools/requiredRPackagesReduced.json` + regenerate installer JSONs in tam
(separate tam PR) → scheduler/server deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
