### PR TITLE
Bump version to 16.0.59

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.58
+Version: 16.0.59
 Date: 2026-08-19
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func


### PR DESCRIPTION
## Summary
- bump exploratory package version from 16.0.58 to 16.0.59

## Verification
- target model column-name cleaning tests passed with .libPaths() set to ~/.exploratory/R/4.6_ARM
- Mac ARM/Intel and Windows 16.0.59 binaries built and uploaded to download2