### PR TITLE
perf: replace cmdscale(add=TRUE) and vectorize distribution in K-Medoids (tam#38004)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.59
-Date: 2026-08-19
+Version: 16.0.60
+Date: 2026-08-20
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -440,20 +440,29 @@
 #' (both ultimately reduce to `scale()`, with the identical NaN-from-zero-variance case
 #' already replaced by 0 at fit time, `mat[is.nan(mat)] <- 0`); when FALSE it is the raw
 #' value again, same as `value`.
+#' tam#38004: vectorized replacement for the previous purrr::map_dfr() loop that built one
+#' tibble per source row (3,600 row-tibble allocations for 36,000 output rows on the
+#' issue's fixture, ~0.95s per tidy() call). This is a strict reshape of the same two
+#' matrices -- row-major flatten via t(), cluster/is_medoid recycled per variable -- and
+#' was verified byte-identical (`identical()`) against the old implementation across the
+#' non-degenerate row/column ranges this function is ever called with; the two disagree
+#' only in the unreachable nrow(original_mat) == 0 case (exp_kmedoids() requires at least
+#' `centers` >= 2 valid rows before this is called), where this version returns the
+#' correctly-typed 0-row schema instead of purrr::map_dfr()'s columnless empty tibble.
 .kmedoids_distribution <- function(x) {
   ids <- x$clustering
   medoid_indices <- x$medoid_indices
   original_mat <- .kmedoids_original_fit_mat(x)
   standardized_mat <- x$mat
-  purrr::map_dfr(seq_len(nrow(original_mat)), function(index) {
-    tibble::tibble(
-      cluster = as.integer(ids[[index]]),
-      variable = colnames(original_mat),
-      value = as.numeric(original_mat[index, ]),
-      standardized_value = as.numeric(standardized_mat[index, ]),
-      is_medoid = index %in% medoid_indices
-    )
-  })
+  n <- nrow(original_mat)
+  p <- ncol(original_mat)
+  tibble::tibble(
+    cluster = rep(as.integer(ids), each = p),
+    variable = rep(colnames(original_mat), times = n),
+    value = as.numeric(t(original_mat)),
+    standardized_value = as.numeric(t(standardized_mat)),
+    is_medoid = rep(seq_len(n) %in% medoid_indices, each = p)
+  )
 }
 
 .kmedoids_cohesion <- function(x) {
@@ -461,6 +470,74 @@
     cluster = as.integer(x$clustering),
     distance_to_medoid = x$distance_to_medoid
   )
+}
+
+#' Classical (Torgerson) PCoA of a distance object, returning the top `k` principal
+#' coordinates plus the full eigenvalue spectrum of the double-centred matrix `B`.
+#'
+#' `stats::cmdscale(add = TRUE)` is deliberately NOT used here (tam#38004). Its Cailliez
+#' additive constant -- needed to make a non-Euclidean metric like Manhattan embeddable
+#' with non-negative eigenvalues -- requires an eigendecomposition of a 2n x 2n
+#' NON-symmetric matrix, roughly 10x the cost of the n x n symmetric problem classical
+#' PCoA actually needs. That made the Cluster Map ~90% of exp_kmedoids() runtime at the
+#' default map_sample_size = 2000 (measured: 55s of a 61s run at 3,600 fitted rows).
+#' Manhattan distances are not Euclidean, so `B` has some negative eigenvalues; they are
+#' simply not projected onto, matching every existing consumer here (`eig[eig > 0]`) and
+#' the `add = FALSE` convention used by `ape::pcoa()` / `vegan`.
+#'
+#' The top `k` eigenpairs (k is 1 or 2 here) are found with a randomized subspace
+#' iteration rather than a full `eigen()`: a Gaussian sketch of `B`, a few power
+#' iterations to sharpen the leading subspace, then an exact small `eigen()` on the
+#' projected matrix. This reproduces the exact top-2 eigenpairs to machine precision on
+#' every fixture tried, at a fraction of the cost. The full spectrum (values only, no
+#' eigenvectors) is still computed exactly, so `representation_rate` -- which sums over
+#' every positive eigenvalue, not just the displayed two -- stays exact.
+#'
+#' For small `n` (below `fallback_n`) the sketch has no headroom over an exact solve, so
+#' this falls back to `stats::cmdscale(..., add = FALSE)` directly; the same fallback is
+#' used if the sketch ever produces a non-finite result.
+#'
+#' @param distance_matrix A `dist` object.
+#' @param k Number of coordinates to return (1 or 2 in this module).
+#' @param seed Optional seed for the random sketch, for reproducibility.
+#' @param fallback_n Below this many points, use `stats::cmdscale()` directly.
+#' @return A list with `points` (n x k matrix) and `eig` (full eigenvalue spectrum,
+#'   decreasing).
+.kmedoids_pcoa <- function(distance_matrix, k = 2L, seed = NULL, fallback_n = 50L) {
+  n <- attr(distance_matrix, 'Size') %||% nrow(as.matrix(distance_matrix))
+  exact_fallback <- function() {
+    coordinates <- stats::cmdscale(distance_matrix, k = k, eig = TRUE, add = FALSE)
+    points <- coordinates$points
+    if (ncol(points) < k) points <- cbind(points, matrix(0, nrow(points), k - ncol(points)))
+    list(points = points, eig = coordinates$eig)
+  }
+  if (n < fallback_n) {
+    return(exact_fallback())
+  }
+  d <- as.matrix(distance_matrix)
+  d2 <- d * d
+  row_mean <- rowMeans(d2)
+  b <- -0.5 * (d2 - row_mean[row(d2)] - row_mean[col(d2)] + mean(d2))
+  q <- min(n - 1L, as.integer(k) + 12L)
+  if (!is.null(seed)) set.seed(as.integer(seed))
+  sketch <- matrix(stats::rnorm(n * q), n, q)
+  y <- b %*% sketch
+  for (i in seq_len(3L)) y <- b %*% (b %*% y)
+  basis <- qr.Q(qr(y))
+  projected <- t(basis) %*% b %*% basis
+  projected <- (projected + t(projected)) / 2
+  small_eigen <- eigen(projected, symmetric = TRUE)
+  top_n <- min(as.integer(k), length(small_eigen$values))
+  order_desc <- order(small_eigen$values, decreasing = TRUE)[seq_len(top_n)]
+  top_values <- small_eigen$values[order_desc]
+  top_vectors <- basis %*% small_eigen$vectors[, order_desc, drop = FALSE]
+  points <- top_vectors %*% diag(sqrt(pmax(top_values, 0)), nrow = top_n)
+  if (ncol(points) < k) points <- cbind(points, matrix(0, nrow(points), k - ncol(points)))
+  full_eig <- tryCatch(eigen(b, symmetric = TRUE, only.values = TRUE)$values, error = function(e) NULL)
+  if (!all(is.finite(points)) || is.null(full_eig) || !all(is.finite(full_eig))) {
+    return(exact_fallback())
+  }
+  list(points = points, eig = full_eig)
 }
 
 .kmedoids_map <- function(x) {
@@ -474,7 +551,8 @@
     return(.kmedoids_empty('map'))
   }
   distance_matrix <- stats::dist(map_mat, method = x$distance)
-  coordinates <- stats::cmdscale(distance_matrix, k = n_dimension, eig = TRUE, add = TRUE)
+  pcoa_seed <- if (is.null(x$seed)) NULL else as.integer(x$seed) + 4000L
+  coordinates <- .kmedoids_pcoa(distance_matrix, k = n_dimension, seed = pcoa_seed)
   points <- coordinates$points
   if (n_dimension == 1) points <- cbind(points, 0)
   dimension_names <- c('Dim1', 'Dim2')

--- a/docs/plans/2026-08-20-kmedoids-pcoa-map-performance.md
+++ b/docs/plans/2026-08-20-kmedoids-pcoa-map-performance.md
@@ -1,0 +1,201 @@
+# Design: K-Medoids Performance — the PCoA Cluster Map (tam#38004)
+
+**Date:** 2026-08-20
+**Status:** Proposed
+**Scope:** `exploratory_func` `R/kmedoids.R` (`.kmedoids_map()`); no `tam` code change required
+**Follows:** `docs/plans/2026-08-12-kmedoids-performance-improvement.md` (PR #1604)
+
+## Summary
+
+PR #1604 bounded the fit, the diagnostics and the map row count, and cached the map at
+fit time. It never touched the cost of the PCoA itself. That is now essentially the whole
+runtime: at the reported 3,600 x 24 scale, **`stats::cmdscale(..., add = TRUE)` is ~90% of
+`exp_kmedoids()`**.
+
+Measured end-to-end with `exploratory` 16.0.59, 3,600 rows x 10 selected Likert columns,
+the exact argument set from the issue (`centers = 3, distance = "manhattan",
+elbow_method_mode = "silhouette", max_centers = 10, silhouette_sample_size = 5000,
+map_sample_size = 2000`):
+
+| Stage | Elapsed |
+| --- | --- |
+| `cluster::pam()` main fit (k = 3, n = 3,600) | 0.23 s |
+| Silhouette diagnostics (9 PAM fits, k = 2..10, n = 3,600) | 2.9 s |
+| `stats::dist()` for the map (n = 2,000) | 0.01 s |
+| **`stats::cmdscale(eig = TRUE, add = TRUE)` (n = 2,000)** | **~55 s** |
+| `tidy(type = "distribution")` (36,000 rows), per call | 0.95 s |
+| all other `tidy()` types | < 0.02 s each |
+| **`exp_kmedoids()` total** | **60.8 s** |
+
+## Root cause
+
+`.kmedoids_map()` (R/kmedoids.R:474) calls:
+
+```r
+coordinates <- stats::cmdscale(distance_matrix, k = n_dimension, eig = TRUE, add = TRUE)
+```
+
+`add = TRUE` requests the Cailliez additive constant, which makes a non-Euclidean metric
+(here Manhattan) embeddable with non-negative eigenvalues. To find it, `cmdscale()` builds
+a **2n x 2n non-symmetric** block matrix and calls `eigen(Z, symmetric = FALSE)` on it.
+For the map sample that is a 4,000 x 4,000 general eigenproblem — an order of magnitude
+more expensive than the n x n symmetric decomposition classical MDS actually needs.
+
+Cost is cubic in the map sample size, which is exactly why 600 rows feels fine and 3,600
+does not — the map sample is `min(map_sample_size, valid_nrow)`:
+
+| map sample n | `add = TRUE` | `add = FALSE` |
+| --- | --- | --- |
+| 600 | 2.0 s | 0.15 s |
+| 1,000 | 7.2 s | 0.66 s |
+| 1,500 | 23.3 s | 2.37 s |
+| 2,000 | 64.3 s | 6.03 s |
+
+So the user's 600-row case caps the map at 600 rows (2 s); the 3,600-row case saturates
+`map_sample_size = 2000` (55–64 s). The row count of the *fit* is almost irrelevant.
+
+This also explains the residual ~8 s per map call recorded in the #1604 follow-up note at
+1,000 rows — that was this same `add = TRUE` eigenproblem, not `dist()`.
+
+## Proposed change
+
+Replace the `cmdscale(add = TRUE)` call in `.kmedoids_map()` with an in-house classical
+PCoA on the doubly-centred matrix `B = -0.5 * J D^2 J`:
+
+1. **Drop the Cailliez correction (`add = FALSE` semantics).** Classical PCoA on a
+   non-Euclidean metric yields some negative eigenvalues; they are simply not projected
+   onto. This is what `ape::pcoa()` and `vegan` report by default, and `.kmedoids_map()`
+   already only ever consumes `coordinates$eig[coordinates$eig > 0]`. On clustered Likert
+   data (n = 2,000, 10 vars) the coordinates are visually the same map:
+   `cor(Dim1) = 0.998`, `cor(Dim2) = 0.994` against today's output.
+2. **Take the top 2 eigenpairs with a randomized subspace iteration** instead of a full
+   `eigen()`. `B` is n x n symmetric; a `(k + 12)`-column Gaussian sketch with 3 power
+   iterations plus a QR and a small dense `eigen()` on the projected matrix reproduces the
+   exact top-2 eigenvalues and eigenvectors to machine precision (`cor = 1.0000`,
+   eigenvalues identical to 7+ significant digits in every trial run).
+3. **Keep `representation_rate` exact** by taking the full spectrum via
+   `eigen(B, symmetric = TRUE, only.values = TRUE)` (values only, no eigenvectors) for the
+   `sum(eig[eig > 0])` denominator.
+
+Prototype, n = 2,000, same data:
+
+| Path | Elapsed | Top-2 eigenvalues | Dim1/Dim2 correlation vs `cmdscale(add=FALSE)` |
+| --- | --- | --- | --- |
+| `cmdscale(add = TRUE)` (today) | 55.4 s | — | 0.998 / 0.994 |
+| `cmdscale(add = FALSE)` | 5.19 s | reference | 1 / 1 |
+| **Proposed in-house PCoA** | **1.57 s** | identical to reference | **1 / 1** |
+
+`exp_kmedoids()` at 3,600 x 10 goes from **60.8 s to roughly 7 s**, and the map stops
+being the dominant term.
+
+### Deliberate behaviour change: `representation_rate`
+
+Dropping the additive constant changes the reported representation rate, because the
+Cailliez constant inflates the total inertia. On the same fixture:
+
+| Convention | Dim1 | Dim1+Dim2 |
+| --- | --- | --- |
+| today (`add = TRUE`, positive-eigenvalue denominator) | 5.1% | 7.8% |
+| proposed (`add = FALSE`, positive-eigenvalue denominator) | 26.0% | 37.8% |
+
+Today's numbers are not a better answer that we are trading away for speed — they are the
+share of an inertia total that the correction term dominates, which is why a well-separated
+3-cluster fixture reports a 5% first axis. The proposed value is the standard PCoA relative
+eigenvalue. This is user-visible in the Cluster Map / Fitted Vectors axis titles that
+`tam`'s `set_kmedoids_analytics_params()` reads from the `representation_rate` attribute;
+no `tam` code change is needed, but the displayed percentage will rise. Call it out in the
+release note.
+
+## Implementation plan
+
+### Phase 1 — replace the PCoA (the whole win)
+
+In `R/kmedoids.R`, add an internal helper and call it from `.kmedoids_map()`:
+
+```r
+# Classical PCoA (Torgerson) of a distance object, returning the top `k` principal
+# coordinates plus the full eigenvalue spectrum.
+#
+# stats::cmdscale(add = TRUE) is NOT used: the Cailliez constant it computes requires an
+# eigendecomposition of a 2n x 2n NON-symmetric matrix, which is ~10x the cost of the n x n
+# symmetric problem classical MDS needs and made the Cluster Map ~90% of exp_kmedoids()
+# runtime at map_sample_size = 2000 (tam#38004: 55s of a 61s run). Manhattan distances are
+# not Euclidean, so B has some negative eigenvalues; they are dropped, exactly as every
+# consumer here already does (`eig[eig > 0]`).
+.kmedoids_pcoa <- function(distance_matrix, k = 2L, seed = NULL) {
+  d <- as.matrix(distance_matrix)
+  n <- nrow(d)
+  d2 <- d * d
+  row_mean <- rowMeans(d2)
+  b <- -0.5 * (d2 - row_mean[row(d2)] - row_mean[col(d2)] + mean(d2))
+  # Randomized subspace iteration for the top k eigenpairs of the symmetric b.
+  ...
+  list(points = points, eig = eigenvalues)
+}
+```
+
+- Oversampling `q = min(n - 1L, k + 12L)`, 3 power iterations. Seed it from `x$seed`
+  (offset, like `.kmedoids_sample_indices()` does) so a fixed seed stays reproducible.
+- Fall back to `stats::cmdscale(distance_matrix, k = k, eig = TRUE, add = FALSE)` when
+  `n` is small (say `n < 50`, where the sketch has no headroom) or when the sketch produces
+  a non-finite result. The fallback is cheap at those sizes.
+- Preserve every existing downstream contract in `.kmedoids_map()`: the `n_dimension == 1`
+  padding, `points` column names `Dim1`/`Dim2`, the `medoid_positions <- match(...)` lookup,
+  the loadings/vector rows, and the `representation_rate` / `map_sample_size` /
+  `map_sampled` attributes.
+
+### Phase 2 — secondary, only if still warranted after Phase 1
+
+- **`.kmedoids_distribution()` (R/kmedoids.R:445)**: `purrr::map_dfr()` over one tibble per
+  row — 3,600 allocations for 36,000 output rows, 0.95 s per `tidy()` call. The whole thing
+  is a `rep()`/`t()` reshape; a vectorized version measures 0.00 s and is a strict rewrite,
+  no semantics change.
+- **Silhouette diagnostics (2.9 s)**: nine PAM fits over the full 3,600 rows, because
+  `silhouette_sample_size = 5000` never binds below the 5,000-row PAM cap. Passing a
+  precomputed `stats::dist()` does **not** help (measured 3.4 s vs 2.9 s — the swap phase
+  dominates, not the distance build). If this needs to come down, the lever is capping the
+  diagnostic sample (e.g. 2,000 rows -> ~1 s), which changes diagnostic values and so needs
+  a product decision. Recommend leaving it alone for now.
+- **`.kmedoids_map_max_n`** is 5,000 while `tam` passes `map_sample_size = 2000`. After
+  Phase 1 the exact-denominator `eigen(only.values = TRUE)` is ~1.4 s at n = 2,000 but
+  ~28 s at n = 5,000, so the cap is still meaningful. Either lower `.kmedoids_map_max_n` to
+  3,000, or switch the denominator to `sum(diag(B))` (O(n), a further convention change) if
+  we ever want 5,000-row maps. Not needed for this issue.
+
+## Test plan
+
+Extend `tests/testthat/test_kmedoids.R` (existing map coverage is at lines 232–282):
+
+- `.kmedoids_pcoa()` reproduces `stats::cmdscale(..., add = FALSE)` on a fixture: top-2
+  eigenvalues within tolerance and `abs(cor())` of each axis ~ 1 (sign is free in PCoA —
+  assert on `abs(cor())`, never on raw coordinates).
+- Same seed -> byte-identical map; different seed for the row sample still yields a stable
+  spectrum.
+- Degenerate inputs keep returning the empty-map sentinel rather than erroring: all-tied
+  rows, single valid row, one variable, `n_dimension == 1`.
+- `representation_rate` remains a length-2 finite numeric, non-decreasing, `<= 1`, and is
+  still attached to both `model$map_result` and `broom::tidy(model, type = 'map')`.
+- Medoid rows are still present in the map (`row_type == 'medoid'`) and `map_variable_n`
+  still bounds the `row_type == 'vector'` rows.
+- A timing guard is deliberately not added to the unit tests; record before/after in the PR
+  description instead.
+
+## Acceptance criteria
+
+1. `exp_kmedoids()` on 3,600 rows x 10 numeric columns with the issue's arguments completes
+   in under ~10 s (from 60.8 s), on the same machine.
+2. Cluster Map coordinates correlate > 0.99 with the current output on a clustered fixture.
+3. `representation_rate` is exact for the new convention and the change is documented in the
+   release note.
+4. `testthat::test_file("tests/testthat/test_kmedoids.R")` passes with the new assertions.
+
+## Risks
+
+- **Visible percentage shift** in the map axis titles (see above). Product-visible; needs a
+  release note, not a code change in `tam`.
+- **Randomized eigensolver** is approximate in principle. Mitigated by the size of the
+  spectral gap at k = 2 in this use, the oversampling, the power iterations, and the
+  small-n / non-finite fallback to `cmdscale()`. Every trial so far matched the exact
+  solution to machine precision.
+- **Map coordinates change slightly** (cor 0.998 rather than 1.0) for saved analytics that
+  are re-run. The map is a visualization, and axis signs already flip freely between runs.

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -408,3 +408,103 @@ test_that('nstart is forwarded to PAM diagnostic fits', {
   expect_gt(length(calls), 2L)
   expect_true(all(vapply(calls, function(call) identical(call$nstart, 5L), logical(1))))
 })
+
+# tam#38004: .kmedoids_pcoa() replaces stats::cmdscale(add = TRUE) in .kmedoids_map() --
+# the Cailliez additive constant made the Cluster Map ~90% of exp_kmedoids() runtime at
+# the default map_sample_size (measured ~55s of a ~61s run at 3,600 fitted rows). These
+# tests cover the replacement directly (against the add = FALSE convention it now
+# matches) and the end-to-end map contract it still has to satisfy.
+
+test_that('.kmedoids_pcoa reproduces cmdscale(add = FALSE) above the exact-fallback threshold', {
+  # Three non-collinear cluster centers so BOTH of the top two axes carry real signal --
+  # a two-center fixture leaves the second axis pure noise, making its correlation
+  # unstable and an unreliable check of the sketch's accuracy.
+  set.seed(11)
+  n <- 400
+  centers <- matrix(
+    c(rep(4, 6), rep(1, 6), c(rep(4, 3), rep(1, 3))),
+    nrow = 3, byrow = TRUE
+  )
+  raw <- centers[sample(1:3, n, TRUE), ] + matrix(rnorm(n * 6, 0, 0.6), n, 6)
+  mat <- scale(raw)
+  d <- stats::dist(mat, method = 'manhattan')
+
+  reference <- stats::cmdscale(d, k = 2, eig = TRUE, add = FALSE)
+  fit <- exploratory:::.kmedoids_pcoa(d, k = 2, seed = 1)
+
+  expect_equal(dim(fit$points), c(n, 2))
+  # PCoA axis signs are arbitrary -- compare magnitude of correlation, not raw coordinates.
+  expect_gt(abs(cor(fit$points[, 1], reference$points[, 1])), 0.99)
+  expect_gt(abs(cor(fit$points[, 2], reference$points[, 2])), 0.99)
+  expect_equal(sort(fit$eig, decreasing = TRUE)[1:2], reference$eig[1:2], tolerance = 1e-4)
+})
+
+test_that('.kmedoids_pcoa is deterministic for a fixed seed and varies with a different one', {
+  set.seed(21)
+  n <- 200
+  mat <- scale(matrix(rnorm(n * 5), n, 5))
+  d <- stats::dist(mat, method = 'euclidean')
+
+  same_seed_a <- exploratory:::.kmedoids_pcoa(d, k = 2, seed = 5)
+  same_seed_b <- exploratory:::.kmedoids_pcoa(d, k = 2, seed = 5)
+  other_seed <- exploratory:::.kmedoids_pcoa(d, k = 2, seed = 6)
+
+  expect_identical(same_seed_a$points, same_seed_b$points)
+  # A different random sketch can still converge to the same subspace on well-separated
+  # data, so assert on eigenvalues (exact regardless of seed) rather than requiring the
+  # point coordinates to differ.
+  expect_equal(sort(same_seed_a$eig, decreasing = TRUE)[1:2],
+               sort(other_seed$eig, decreasing = TRUE)[1:2], tolerance = 1e-4)
+})
+
+test_that('.kmedoids_pcoa falls back to cmdscale for small n and degenerate input', {
+  small <- tibble::tibble(x = c(1, 2, 3, 10, 11), y = c(1, 2, 1, 10, 9))
+  d_small <- stats::dist(small, method = 'euclidean')
+  fit_small <- exploratory:::.kmedoids_pcoa(d_small, k = 2, seed = 1, fallback_n = 50L)
+  reference_small <- stats::cmdscale(d_small, k = 2, eig = TRUE, add = FALSE)
+  expect_equal(fit_small$points, reference_small$points)
+
+  tied <- tibble::tibble(x = rep(1, 60), y = rep(1, 60))
+  d_tied <- stats::dist(tied, method = 'euclidean')
+  fit_tied <- exploratory:::.kmedoids_pcoa(d_tied, k = 2, seed = 1)
+  expect_true(all(is.finite(fit_tied$points)))
+  expect_true(all(fit_tied$points == 0))
+})
+
+test_that('the cached PCoA map keeps its full contract after replacing cmdscale(add = TRUE)', {
+  set.seed(31)
+  n <- 400
+  centers <- matrix(c(rep(4, 8), rep(1, 8), c(rep(4, 4), rep(1, 4))), nrow = 3, byrow = TRUE)
+  raw <- centers[sample(1:3, n, TRUE), ] + matrix(rnorm(n * 8, 0, 0.6), n, 8)
+  df <- as.data.frame(raw)
+  names(df) <- paste0('v', 1:8)
+
+  result <- df %>% exploratory:::exp_kmedoids(
+    v1, v2, v3, v4, v5, v6, v7, v8, centers = 3, distance = 'manhattan',
+    seed = 1, map_sample_size = 200, map_variable_n = 4
+  )
+  model <- result$model[[1]]
+  map <- broom::tidy(model, type = 'map')
+
+  expect_true(is.data.frame(map))
+  expect_true(all(c('medoid', 'observation', 'vector') %in% map$row_type))
+  expect_equal(sum(map$row_type == 'medoid'), 3)
+  expect_equal(sum(map$row_type == 'vector'), 4 * 2)
+  expect_false(anyNA(map$Dim1))
+  expect_false(anyNA(map$Dim2))
+
+  rate <- attr(map, 'representation_rate')
+  expect_length(rate, 2)
+  expect_true(all(is.finite(rate)))
+  expect_true(all(rate >= 0 & rate <= 1))
+  expect_gte(rate[2], rate[1])
+
+  # Same seed -> byte-identical cached map (reproducibility of the randomized sketch).
+  result2 <- df %>% exploratory:::exp_kmedoids(
+    v1, v2, v3, v4, v5, v6, v7, v8, centers = 3, distance = 'manhattan',
+    seed = 1, map_sample_size = 200, map_variable_n = 4
+  )
+  map2 <- broom::tidy(result2$model[[1]], type = 'map')
+  expect_identical(map$Dim1, map2$Dim1)
+  expect_identical(map$Dim2, map2$Dim2)
+})


### PR DESCRIPTION
## Summary

Follow-up to #1604 (algorithm selection, sampling, bounded diagnostics/map).
This PR removes the remaining bottleneck: the Cluster Map's PCoA step, plus a
secondary vectorization of the distribution tidier.

- Replace `stats::cmdscale(..., add = TRUE)` with a new `.kmedoids_pcoa()`
  helper: classical (Torgerson) PCoA on the double-centred distance matrix,
  dropping the Cailliez additive constant, top-2 eigenpairs found via a
  randomized subspace iteration. Falls back to `stats::cmdscale(add = FALSE)`
  below `n = 50` or on a non-finite result.
- Vectorize `.kmedoids_distribution()` (was one `tibble` allocation per source
  row via `purrr::map_dfr()`).

## Motivation

tam#38004: `exp_kmedoids()` was slow on ordinary data (3,600 rows x 24 cols).
Investigation found `cmdscale(add = TRUE)` — used only for the Cluster Map —
was ~90% of total runtime. Its Cailliez correction requires an
eigendecomposition of a 2n x 2n **non-symmetric** matrix (n = map sample
size, default 2,000), roughly 10x the cost of the n x n symmetric problem
classical PCoA actually needs, and the cost is cubic in that sample size:

| map sample n | `add = TRUE` | `add = FALSE` |
| --- | --- | --- |
| 600 | 2.0 s | 0.15 s |
| 1,000 | 7.2 s | 0.66 s |
| 2,000 | 64.3 s | 6.03 s |

This is why a 600-row analysis feels fine (under the map sample cap) and a
3,600-row one does not (the map sample saturates at `map_sample_size = 2000`)
— the *fit* row count barely matters.

Full design doc: `docs/plans/2026-08-20-kmedoids-pcoa-map-performance.md`.

## Results

Measured end-to-end on the issue's exact argument set (3,600 rows x 10
selected numeric columns, `centers = 3`, `distance = "manhattan"`,
`elbow_method_mode = "silhouette"`, `max_centers = 10`,
`silhouette_sample_size = 5000`, `map_sample_size = 2000`):

| | Before | After |
| --- | --- | --- |
| `exp_kmedoids()` total | 60.8 s | **~5 s** |
| `tidy(type = "map")` PCoA (n = 2,000) | ~55 s | ~1.5 s |
| `tidy(type = "distribution")` (36,000 rows) | 0.95 s | 0.001 s |

Accuracy of the new PCoA vs. today's `cmdscale(add = TRUE)`: `cor(Dim1) =
0.998`, `cor(Dim2) = 0.994` on a clustered fixture. `.kmedoids_distribution()`
was verified `identical()` against the old row-by-row implementation across
every non-degenerate input tried.

## User-visible change

`representation_rate` (the Cluster Map / Fitted Vectors axis-title
percentage) **increases**. The Cailliez constant was inflating its
denominator; dropping it is the standard PCoA convention (`ape::pcoa()` /
`vegan` use the same `add = FALSE` denominator). On a synthetic 3-cluster
fixture: 5.1%/7.8% -> 25.8%/38.0%. Map point *positions* are essentially
unchanged (see accuracy numbers above) — only the reported percentage moves.
Worth a release note; no `tam` code change needed since it just reads the
`representation_rate` attribute.

## Test plan

- `testthat::test_file("tests/testthat/test_kmedoids.R")`: 122 assertions
  passed (1 pre-existing, unrelated warning on an all-tied-values fixture,
  present before this change too).
- New tests: `.kmedoids_pcoa()` vs. `cmdscale(add = FALSE)` accuracy and
  determinism, small-n/degenerate fallback, and an end-to-end map contract
  check (medoid/vector row counts, no `NA` coordinates, valid
  `representation_rate`, same-seed reproducibility).
- `R/kmedoids.R` parse check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
