### PR TITLE
Bump version to 16.0.61

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.60
-Date: 2026-08-20
+Version: 16.0.61
+Date: 2026-08-26
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory


### PR DESCRIPTION
Five latent K-Modes/K-Medoids clustering defects fixed and regression-tested in #1621 (found by tam's analytics harness loop, tam#38102):

- K-Modes: the auto numeric-handling threshold now follows the configured `numeric_bins` instead of a hardcoded 10.
- K-Modes: a non-finite value (Inf/-Inf/NaN) no longer aborts the analytics in `cut()`.
- K-Medoids: too few rows for the requested cluster count now reports in the caller's own terms instead of `pam()`'s internal message.
- K-Medoids: a stale `clara_sample_size` no longer blocks a PAM/auto run.
- K-Medoids: `silhouette_sample_size` is only validated when a silhouette is actually computed.

No functional change beyond the version/date bump. Requires rebuilt+bundled per-platform binaries uploaded to download2 contrib/4.6 (mac intel, mac arm, windows) — exploratory has no compiled code, so the Mac Intel/ARM tgz is one build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)