### PR TITLE
fix(kmodes): locale-independent radix sort for category encoding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.61
+Version: 16.0.62
 Date: 2026-08-26
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -133,7 +133,7 @@ kmodes_category_display_levels_by_variable <- function(prepared_df, display_leve
   cols <- names(prepared_df)
   levels_by_variable <- lapply(cols, function(col) {
     dl <- if (!is.null(display_levels)) display_levels[[col]] else NULL
-    if (!is.null(dl)) as.character(dl) else sort(unique(prepared_df[[col]]))
+    if (!is.null(dl)) as.character(dl) else sort(unique(prepared_df[[col]]), method = "radix")
   })
   stats::setNames(levels_by_variable, cols)
 }
@@ -154,7 +154,12 @@ kmodes_category_display_levels <- function(prepared_df, display_levels) {
 #' The most frequent value, with a deterministic tie-break.
 #'
 #' Ties go to the value that sorts first so that the same input always yields
-#' the same Mode regardless of row order.
+#' the same Mode regardless of row order -- and, for character labels,
+#' regardless of platform: `sort()`'s default method collates by locale, which
+#' Windows resolves differently from Mac/Linux for multibyte category labels
+#' and silently changes which tied category wins. `method = "radix"` sorts by
+#' raw code point instead, so the tie-break (and everything fed by it) is
+#' identical on every platform.
 #' @param x A vector of category codes or labels.
 #' @return The modal value.
 kmodes_mode_value <- function(x) {
@@ -170,7 +175,7 @@ kmodes_mode_value <- function(x) {
   if (is.numeric(x)) {
     return(sort(as.numeric(best))[[1]])
   }
-  sort(best)[[1]]
+  sort(best, method = "radix")[[1]]
 }
 
 #' Mismatch count between every row of a code matrix and one Mode.
@@ -737,7 +742,13 @@ exp_kmodes <- function(df, ...,
 
     # Encode to integer codes once. Every later step -- fitting, the distance
     # matrix, the Modes -- works on these codes, and the levels map them back.
-    levels_by_col <- lapply(prepared_df, function(x) sort(unique(x)))
+    # method = "radix" pins the code assigned to each category to its raw code
+    # point instead of the platform's locale collation: with the default
+    # method, Windows can order multibyte category labels differently from
+    # Mac/Linux, which reassigns which category gets the lowest code and
+    # silently changes kmodes_mode_value()'s numeric tie-break, and from there
+    # the whole clustering result (#windows-kmodes-chart-test-882c62).
+    levels_by_col <- lapply(prepared_df, function(x) sort(unique(x), method = "radix"))
     mat <- vapply(names(prepared_df), function(col) {
       match(prepared_df[[col]], levels_by_col[[col]])
     }, integer(nrow(prepared_df)))

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -18,6 +18,16 @@
 # renders it as "< 0.001". Kept here only as documentation of the contract --
 # no rounding happens R-side, so the display layer can still tell 0 from 1e-40.
 
+#' Sort character labels in a platform-independent order.
+#'
+#' Radix sorting requires UTF-8, Latin-1 or byte-encoded strings. Normalize
+#' native-encoded input first, then sort by UTF-8 byte order.
+#' @param x A character vector.
+#' @return `x` sorted by UTF-8 byte order.
+kmodes_sort_character <- function(x) {
+  sort(enc2utf8(x), method = "radix")
+}
+
 #' Convert one column to the character categories K-Modes works on.
 #'
 #' The clustering algorithm itself only asks "same category or not", so it does
@@ -133,7 +143,7 @@ kmodes_category_display_levels_by_variable <- function(prepared_df, display_leve
   cols <- names(prepared_df)
   levels_by_variable <- lapply(cols, function(col) {
     dl <- if (!is.null(display_levels)) display_levels[[col]] else NULL
-    if (!is.null(dl)) as.character(dl) else sort(unique(prepared_df[[col]]), method = "radix")
+    if (!is.null(dl)) as.character(dl) else kmodes_sort_character(unique(prepared_df[[col]]))
   })
   stats::setNames(levels_by_variable, cols)
 }
@@ -155,11 +165,9 @@ kmodes_category_display_levels <- function(prepared_df, display_levels) {
 #'
 #' Ties go to the value that sorts first so that the same input always yields
 #' the same Mode regardless of row order -- and, for character labels,
-#' regardless of platform: `sort()`'s default method collates by locale, which
-#' Windows resolves differently from Mac/Linux for multibyte category labels
-#' and silently changes which tied category wins. `method = "radix"` sorts by
-#' raw code point instead, so the tie-break (and everything fed by it) is
-#' identical on every platform.
+#' regardless of platform: the default `sort()` method collates by locale,
+#' which Windows resolves differently from Mac/Linux for multibyte category
+#' labels and silently changes which tied category wins.
 #' @param x A vector of category codes or labels.
 #' @return The modal value.
 kmodes_mode_value <- function(x) {
@@ -175,7 +183,7 @@ kmodes_mode_value <- function(x) {
   if (is.numeric(x)) {
     return(sort(as.numeric(best))[[1]])
   }
-  sort(best, method = "radix")[[1]]
+  kmodes_sort_character(best)[[1]]
 }
 
 #' Mismatch count between every row of a code matrix and one Mode.
@@ -742,13 +750,13 @@ exp_kmodes <- function(df, ...,
 
     # Encode to integer codes once. Every later step -- fitting, the distance
     # matrix, the Modes -- works on these codes, and the levels map them back.
-    # method = "radix" pins the code assigned to each category to its raw code
-    # point instead of the platform's locale collation: with the default
-    # method, Windows can order multibyte category labels differently from
-    # Mac/Linux, which reassigns which category gets the lowest code and
+    # kmodes_sort_character() pins the code assigned to each category to its
+    # UTF-8 byte order instead of the platform's locale collation: with the
+    # default method, Windows can order multibyte category labels differently
+    # from Mac/Linux, which reassigns which category gets the lowest code and
     # silently changes kmodes_mode_value()'s numeric tie-break, and from there
     # the whole clustering result (#windows-kmodes-chart-test-882c62).
-    levels_by_col <- lapply(prepared_df, function(x) sort(unique(x), method = "radix"))
+    levels_by_col <- lapply(prepared_df, function(x) kmodes_sort_character(unique(x)))
     mat <- vapply(names(prepared_df), function(col) {
       match(prepared_df[[col]], levels_by_col[[col]])
     }, integer(nrow(prepared_df)))

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -207,6 +207,26 @@ test_that("kmodes_category_display_levels unions per-variable orders in variable
   expect_equal(kmodes_category_display_levels(prepared_df, NULL), levels_fallback)
 })
 
+test_that("character category sorting normalizes native encodings", {
+  values <- c("ア", "あ", "é", "a")
+  Encoding(values) <- "unknown"
+
+  expect_equal(kmodes_sort_character(values), c("a", "é", "あ", "ア"))
+  expect_equal(kmodes_mode_value(rep(values[1:2], each = 2)), "あ")
+
+  japanese <- rep(c("あ", "ア"), each = 20)
+  Encoding(japanese) <- "unknown"
+  df <- tibble::tibble(
+    japanese = japanese,
+    segment = rep(c("x", "y"), each = 20)
+  )
+  expect_error(
+    exp_kmodes(df, japanese, segment, centers = 2, seed = 1,
+               elbow_method_mode = "none", map_sample_size = 0),
+    NA
+  )
+})
+
 test_that("report category_order keeps conflicting shared factor orders per variable", {
   df <- tibble::tibble(
     a = factor(c("A", "B", "A", "B"), levels = c("A", "B")),


### PR DESCRIPTION
## Problem

K-Modes can produce different cluster assignments on Windows when categorical labels use multibyte characters. The default character sort follows the process locale, so Windows can assign category codes in a different order from Mac or Linux. That changes tied Mode selection and can cascade into silhouette differences.

## Fix

- Add kmodes_sort_character(), which converts native-encoded labels with enc2utf8() before using locale-independent radix sorting.
- Use the helper for category-code generation, character Mode tie-breaking, and display-level fallback.
- Add a regression test for unknown-encoded Japanese labels, including an end-to-end K-Modes run.

## Version

Bump exploratory to 16.0.62.

## Testing

- Windows R 4.6.1: tests/testthat/test_kmodes.R ran successfully for the changed behavior and reports only the three pre-existing MCA-map failures.
- Dedicated checks cover unknown-encoded Japanese labels, tied Mode selection, and an end-to-end exp_kmodes() run.