### PR TITLE
fix(cronbach): check_keys did nothing for Polychoric/Mixed correlation

### DIFF
--- a/R/reliability.R
+++ b/R/reliability.R
@@ -560,10 +560,6 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
     total_missing_n <- sum(is.na(cleaned_df))
     rows_with_missing_n <- sum(!stats::complete.cases(cleaned_df))
 
-    standardized_alpha <- reliability_alpha_from_correlation(r)
-    average_r <- mean(r[upper.tri(r)], na.rm = TRUE)
-    median_r <- stats::median(r[upper.tri(r)], na.rm = TRUE)
-
     coefficient_name <- switch(selected_method,
       pearson = "Cronbach's Alpha",
       polychoric = "Ordinal Alpha",
@@ -576,7 +572,17 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
       error = function(e) NULL)
 
     # psych determines reverse keys from the first principal component. Apply
-    # the same keys to every matrix-based statistic, not just alpha itself.
+    # the same keys to every matrix-based statistic -- standardized_alpha,
+    # average_r and median_r included, not just matrix_alpha_object itself.
+    # These three MUST be (re)computed from the possibly-reversed `r` BELOW,
+    # not the original one above: for a non-pearson correlation_method,
+    # display_alpha <- standardized_alpha (see below), so computing it from
+    # the pre-correction matrix made check_keys a silent no-op for
+    # Polychoric/Mixed correlation -- verified live, identical Ordinal Alpha
+    # with check_keys FALSE vs TRUE on a fixture with one reverse-worded
+    # ordinal item. item_stats' r.drop/r.cor already used the corrected `r`
+    # (computed further down from this same variable), so only these three
+    # summary-level numbers were stale.
     key_signs <- reliability_extract_key_signs(matrix_alpha_object, colnames(r))
     if (isTRUE(check_keys) && any(key_signs < 0)) {
       key_matrix <- diag(key_signs)
@@ -587,6 +593,10 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
                                       warnings = FALSE)),
         error = function(e) NULL)
     }
+
+    standardized_alpha <- reliability_alpha_from_correlation(r)
+    average_r <- mean(r[upper.tri(r)], na.rm = TRUE)
+    median_r <- stats::median(r[upper.tri(r)], na.rm = TRUE)
 
     g6 <- if (!is.null(matrix_alpha_object)) {
       reliability_safe_number(matrix_alpha_object$total[["G6(smc)"]])

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -198,6 +198,49 @@ test_that("check_keys reverses reverse-worded items across report statistics", {
   expect_true(all(!is.na(with_keys$model[[1]]$alpha_if_deleted$alpha_if_dropped)))
 })
 
+test_that("check_keys reverses reverse-worded items for polychoric and mixed too (tam#38107)", {
+  # Regression test for a defect the tam analytics-harness-loop found with no
+  # bug report: standardized_alpha/average_r/median_r used to be computed from
+  # the correlation matrix BEFORE the check_keys reverse-sign correction was
+  # applied to it (the correction only ran a few lines later). For pearson
+  # this was invisible -- display_alpha uses raw_alpha, a completely separate
+  # computation that always respected check_keys correctly. But
+  # display_alpha <- standardized_alpha for every OTHER correlation_method, so
+  # check_keys silently did nothing at all for polychoric/mixed: the same
+  # (stale) Ordinal/Mixed-Correlation Alpha came back whether check_keys was
+  # TRUE or FALSE. item_stats' r.drop/r.cor were unaffected (they read `r`
+  # AFTER the correction, further down), which is why the bug hid behind
+  # otherwise-correct-looking item-level output.
+  set.seed(11)
+  n <- 200
+  latent <- rnorm(n)
+  make_ordinal <- function(coef) {
+    raw <- coef * latent + rnorm(n, sd = 0.6)
+    breaks <- quantile(raw, probs = c(0, 1 / 3, 2 / 3, 1))
+    breaks[1] <- -Inf; breaks[4] <- Inf
+    ordered(c("low", "mid", "high")[cut(raw, breaks = breaks, labels = FALSE,
+                                        include.lowest = TRUE)],
+            levels = c("low", "mid", "high"))
+  }
+  df <- tibble::tibble(
+    q1 = make_ordinal(1), q2 = make_ordinal(1),
+    q3 = make_ordinal(-1)  # reverse-worded relative to q1/q2
+  )
+
+  for (method in c("polychoric", "mixed")) {
+    without_keys <- exp_cronbach_alpha(df, dplyr::everything(),
+                                       correlation_method = method, check_keys = FALSE)
+    with_keys <- exp_cronbach_alpha(df, dplyr::everything(),
+                                    correlation_method = method, check_keys = TRUE)
+    expect_gt(with_keys$model[[1]]$alpha, without_keys$model[[1]]$alpha,
+              label = paste0(method, ": check_keys=TRUE alpha"))
+    expect_gt(with_keys$model[[1]]$alpha, 0.5,
+              label = paste0(method, ": check_keys=TRUE alpha should be a healthy positive value"))
+    expect_gt(with_keys$model[[1]]$average_r, without_keys$model[[1]]$average_r,
+              label = paste0(method, ": check_keys=TRUE average_r"))
+  }
+})
+
 test_that("exp_cronbach_alpha handles mixed correlation", {
   df <- make_reliability_df() %>%
     dplyr::mutate(


### PR DESCRIPTION
Found by the tam analytics-harness-loop while building a regression harness for `exp_cronbach_alpha` (tam#38107) -- no bug had been reported.

## Bug

`standardized_alpha`, `average_r`, and `median_r` were computed from the correlation matrix **before** the `check_keys` reverse-sign correction was applied to it a few lines later. For `correlation_method="pearson"` this was invisible, since `display_alpha` uses `raw_alpha` (a separate `psych::alpha(cleaned_df, check.keys=...)` call that always respected `check_keys` correctly). But `display_alpha <- standardized_alpha` for every other method, so the "Reverse-code items automatically" checkbox silently did **nothing at all** for Polychoric or Mixed correlation: the same (stale) Ordinal Alpha / Mixed-Correlation Alpha came back whether `check_keys` was TRUE or FALSE.

`item_stats`' `r.drop`/`r.cor` were unaffected (already read the corrected `r` further down), which is why this hid behind otherwise-correct item-level output.

## Fix

Move the `standardized_alpha`/`average_r`/`median_r` computation to *after* the key-sign correction block, so they read whichever `r` (original or sign-corrected) `matrix_alpha_object` itself ends up using. Pure reordering, no new logic.

## Verification

- New regression test in `test_reliability.R` (`check_keys reverses reverse-worded items for polychoric and mixed too`) -- proven to **fail without the fix** (6 failures, verified by `git stash`-ing just `R/reliability.R` and re-running) and pass with it.
- Full `test_reliability.R` suite passes (existing pearson-only `check_keys` test unaffected).
- Live-verified before/after: a 3-ordinal-item fixture with one reverse-worded item went from identical Ordinal Alpha regardless of `check_keys` (-1.53 / -1.53) to correctly reflecting it (-1.53 / 0.89) after the fix.

## Follow-up needed

This branch is not merged and the fix is not built/released -- `tools/requiredRPackagesReduced.json` in tam still pins the pre-fix package version. Someone should review, merge, bump the `exploratory` package version, rebuild per-platform binaries, and regenerate `requiredRPackagesReduced.json` (see the `exploratory-r-release` skill in tam). Flagged as a follow-up task in the tam PR building the `exp_cronbach_alpha` harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)