### PR TITLE
fix: tidy(type="data") mis-names its coordinate column when only 1 CA/MCA dimension was fit

### DIFF
--- a/R/corresp.R
+++ b/R/corresp.R
@@ -433,12 +433,25 @@ exp_mca_aggregated_long <- function(df, row_category, column_category, count,
     dplyr::ungroup()
 }
 
+# FactoMineR drops a *$coord matrix (row/col/ind/var) to a plain NAMED VECTOR
+# whenever only 1 dimension was fit (ncp=1, or a contingency table capped to
+# min(dim)-1==1 -- e.g. a 2x2 aggregated cross tab). as.data.frame() on that
+# bare vector names its one column after the DEPARSED EXPRESSION passed in
+# (e.g. "x$row$coord"), not "Dim 1" -- as.data.frame.default's fallback for an
+# atomic vector with no other naming hint. Always coerce to an explicitly
+# "Dim 1"-named matrix first so every consumer sees the same shape regardless
+# of how many dimensions were computed.
+.ca_coord_as_matrix <- function(coord) {
+  if (is.matrix(coord)) {
+    return(coord)
+  }
+  matrix(as.numeric(coord), ncol = 1, dimnames = list(names(coord), "Dim 1"))
+}
+
 # Coerce a CA part matrix/vector (coord or contrib) to a wide tibble with
 # category + Dimension 1..k columns, guaranteeing Dimension 1 and Dimension 2 exist.
 .ca_part_coord_wide <- function(mat, variable_name) {
-  if (!is.matrix(mat)) {
-    mat <- matrix(as.numeric(mat), ncol = 1, dimnames = list(names(mat), "Dim 1"))
-  }
+  mat <- .ca_coord_as_matrix(mat)
   res <- tibble::rownames_to_column(as.data.frame(mat, check.names = FALSE), var = "category")
   res <- res %>% dplyr::rename_with(~gsub("^Dim ", "Dimension ", .), dplyr::starts_with("Dim "))
   if (!"Dimension 1" %in% names(res)) res$`Dimension 1` <- 0
@@ -524,14 +537,18 @@ tidy.ca_exploratory <- function(x, type = "categories", ...) {
   else if (type == "data") {
     if (analysis_type == "CA") {
       # Join each observation's row-variable category coordinates (dimension scores).
-      coord <- tibble::rownames_to_column(as.data.frame(x$row$coord), var = ".__row_cat")
+      # .ca_coord_as_matrix guards the 1-dimension case, where x$row$coord is a
+      # bare named vector rather than a 1-column matrix (see its own comment).
+      coord <- tibble::rownames_to_column(
+        as.data.frame(.ca_coord_as_matrix(x$row$coord), check.names = FALSE), var = ".__row_cat")
       coord <- coord %>% dplyr::rename_with(~gsub("Dim ", "Dimension ", .), dplyr::starts_with("Dim "))
       res <- x$df
       res$.__row_cat <- as.character(res[[x$row_variable_name]])
       res <- res %>% dplyr::left_join(coord, by = ".__row_cat") %>% dplyr::select(-.__row_cat)
       return(res)
     }
-    res <- as.data.frame(x$ind$coord)
+    # Same 1-dimension guard as the CA branch above, for MCA's x$ind$coord.
+    res <- as.data.frame(.ca_coord_as_matrix(x$ind$coord), check.names = FALSE)
     res <- x$df %>% dplyr::bind_cols(res)
     res <- res %>% dplyr::rename_with(~gsub("Dim ", "Dimension ", .), dplyr::starts_with("Dim "))
     return(res)

--- a/tests/testthat/test_corresp_3.R
+++ b/tests/testthat/test_corresp_3.R
@@ -179,6 +179,27 @@ test_that("exp_mca_aggregated clamps the number of dimensions to the table size"
   expect_error(model %>% (function(m) m$section5$dimension_summary), NA)
 })
 
+test_that("tidy(type='data') names its coordinate column 'Dimension 1' even when only 1 dimension was fit", {
+  # A 2-row-category cross tab (min(dim)-1 == 1) makes FactoMineR::CA()
+  # return $row$coord as a bare named numeric vector instead of a 1-column
+  # matrix -- as.data.frame() on that vector names the column after the
+  # deparsed expression ("x$row$coord") rather than "Dim 1", since a plain
+  # atomic vector carries no column-name hint of its own. The multi-dimension
+  # fixture used by "produces every report tidy type" above never exercises
+  # this shape (its table is 4x4, 3 usable dimensions), so this gap survived
+  # undetected.
+  df <- data.frame(brand = c("A", "B"), x = c(70, 40), y = c(30, 60),
+                   stringsAsFactors = FALSE)
+  model_df <- df %>% exp_mca_aggregated(brand, x, y)
+  expect_equal(model_df$model[[1]]$n_dims, 1)
+
+  data_out <- model_df %>% tidy_rowwise(model, type = "data")
+  expect_true("Dimension 1" %in% colnames(data_out),
+             info = paste0("expected a 'Dimension 1' column, got: ",
+                            paste(colnames(data_out), collapse = ", ")))
+  expect_false(any(grepl("coord", colnames(data_out), fixed = TRUE)))
+})
+
 test_that("exp_mca_aggregated works with Repeat By", {
   wide <- make_ca_wide_data()
   grouped <- dplyr::bind_rows(


### PR DESCRIPTION
## Summary

`tidy.ca_exploratory()`/`tidy.mca_exploratory()`'s `type="data"` branch names its dimension-coordinate column after a deparsed R expression (`x$row$coord`) instead of `Dimension 1` whenever the fitted CA/MCA model has only **1 computed dimension** -- e.g. a 2-row-category aggregated cross tab, where `min(dim(contingency_table)) - 1 == 1` regardless of the requested `ncp`.

## Root cause

`FactoMineR::CA()`/`MCA()` return `$row$coord`/`$ind$coord` as a **plain named numeric vector** (not a 1-column matrix) whenever only 1 dimension was fit. `as.data.frame()` on a bare atomic vector with no other naming hint falls back to `deparse(substitute(x))` for the column name -- so `as.data.frame(x$row$coord)` produces a column literally named `"x$row$coord"`.

`.ca_part_coord_wide()` (used by the `"categories"`/`"contrib"` tidy types) already guards this exact shape:
```r
if (!is.matrix(mat)) {
  mat <- matrix(as.numeric(mat), ncol = 1, dimnames = list(names(mat), "Dim 1"))
}
```
but the `type="data"` branch has its own, separate inline logic that never got the same treatment.

## Fix

Extract the guard into a shared `.ca_coord_as_matrix()` helper and apply it in both `type="data"` sub-branches (CA's `x$row$coord`, MCA's `x$ind$coord`), plus have `.ca_part_coord_wide()` call the same helper instead of duplicating the check.

## How this was found

Found while building a "regression harness" for tam's `exp_mca_aggregated` analytics type. A minimal 2x2 aggregated cross tab (`effective_ncp = min(5, min(2,2)-1) = 1`) produced a "Data" report table whose coordinate column showed the raw text `x$row$coord` as its header instead of `Dimension 1`.

The existing `test_corresp_3.R` test `"exp_mca_aggregated produces every report tidy type"` only asserts `tidy_rowwise(model, type="data")` does not *error* -- it never inspects the resulting column names -- and its own fixture (`make_ca_wide_data()`, a 4-brand x 4-age table) fits 3 dimensions, so it never exercises the 1-dimension vector-vs-matrix shape. The dedicated `"clamps the number of dimensions to the table size"` test (2 rows x 3 columns, 1 dimension) never calls `tidy(type="data")` at all. The two tests' fixtures never overlapped on this specific combination.

## Testing

Added `test_corresp_3.R`: `"tidy(type='data') names its coordinate column 'Dimension 1' even when only 1 dimension was fit"`.

- Confirmed it **fails** without the fix: `expected a 'Dimension 1' column, got: brand, x, y, x$row$coord`.
- Confirmed it **passes** with the fix.
- Ran `test_corresp_1.R`, `test_corresp_2.R`, `test_corresp_3.R`, `test_corresp_4.R` (via `pkgload::load_all()`), all pass except 2 pre-existing failures unrelated to this change (`build_pairwise_association_results`/`ca_get_category_levels` "could not find function" -- an `export_all=FALSE` visibility artifact of calling unexported internal functions bare from a top-level test file under `pkgload::load_all`, reproduced identically on unmodified `origin/master`).

Not yet built into a released package binary -- flagged in the tam-side harness spec (`src/test/analytics-harness/specs/exp_mca_aggregated.json`, `knownDefect` block) as pinning **current shipped** (buggy) behavior for the affected answer CSV until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
