### PR TITLE
PCA: render every loadings chart on the Pearson branch, and judge Kaiser for a categorical correlation (tam#38107)

### DIFF
--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -370,17 +370,34 @@ do_prcomp <- function(df, ..., normalize_data=TRUE, max_nrow = NULL, allow_singl
       fit$rotation <- sweep(fit$rotation, 2, sign_multiplier, "*")
       fit$x <- sweep(fit$x, 2, sign_multiplier, "*")
 
-      if (isTRUE(fit$is_categorical_correlation)) {
-        # Cache the signed loadings AFTER the sign sweep. Every report branch reads them through
-        # prcomp_signed_loadings() so no branch silently recomputes a FRESH PEARSON
-        # cor(cleaned_df, x$x) on top of a polychoric solution -- and so a factor column, which
-        # cor() cannot take at all, never reaches cor(). (issue #37294)
-        fit$signed_loadings <- tryCatch({
-          loadings <- fit$rotation %*% diag(fit$sdev, nrow = length(fit$sdev))
-          dimnames(loadings) <- list(rownames(fit$rotation), colnames(fit$rotation))
-          loadings
-        }, error = function(e) NULL)
-      }
+      # Cache the signed loadings AFTER the sign sweep. Every report branch reads them through
+      # prcomp_signed_loadings() so no branch silently recomputes a FRESH PEARSON
+      # cor(cleaned_df, x$x) on top of a polychoric solution -- and so a factor column, which
+      # cor() cannot take at all, never reaches cor(). (issue #37294)
+      #
+      # Cached for EVERY report-data fit, not just the categorical ones (issue tam#38107). The
+      # Pearson branch used to fall through to prcomp_signed_loadings()'s own
+      # cor(x$df[, names(variable_sd)], x$x), and x$df is the UN-ENCODED frame -- so the one
+      # branch that reached cor() was the one branch whose input could still be categorical.
+      # A Likert PCA whose correlation resolves to Pearson (which Auto does whenever an ordered
+      # factor has six or more categories, and which the Correlation Type dropdown can select
+      # outright) therefore aborted component_profiles / loadings_signed / loadings_signed_wide /
+      # representation / variable_map with a bare "'x' must be numeric" -- exactly the error this
+      # helper was introduced to prevent. Computing from `encoded_df` fixes that with no change
+      # to the all-numeric case: encode_factanal_data() is a no-op there, so encoded_df is
+      # cleaned_df and cor(encoded_df, fit$x) is the identical matrix the fallback produced.
+      fit$signed_loadings <- tryCatch({
+        loadings <- if (isTRUE(fit$is_categorical_correlation)) {
+          # A correlation-matrix PCA has no exact scores to correlate against; the component
+          # loading IS eigenvector * sqrt(eigenvalue), which is that same correlation.
+          out <- fit$rotation %*% diag(fit$sdev, nrow = length(fit$sdev))
+          dimnames(out) <- list(rownames(fit$rotation), colnames(fit$rotation))
+          out
+        } else {
+          cor(encoded_df, fit$x)
+        }
+        loadings
+      }, error = function(e) NULL)
 
       fit$parallel <- tryCatch(
         # method = "pca": keep PCA's own parallel analysis on plain (untouched-diagonal) correlation
@@ -762,7 +779,15 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       pct_variance <- eigenvalue / total_variance * 100
       cum_pct_variance <- cumsum(pct_variance)
       component <- paste0("PC", seq_len(n_comp))
-      normalized <- isTRUE(x$normalize_data)
+      # A categorical correlation is standardized by construction (the analysis runs on the
+      # correlation matrix), so the Kaiser criterion applies whatever normalize_data says --
+      # the SAME rule the analysis_conditions and analysis_method branches above use, and the
+      # same one do_prcomp() itself uses to decide whether to compute fit$kaiser_components.
+      # Without the is_categorical_correlation clause a Polychoric/Tetrachoric/Mixed fit with
+      # normalization unchecked blanked this whole column while the Analysis Conditions table
+      # one tab away reported the data AS normalized -- on identical eigenvalues, since
+      # normalize_data cannot change a correlation-matrix decomposition. (issue tam#38107)
+      normalized <- isTRUE(x$normalize_data) || isTRUE(x$is_categorical_correlation)
 
       # Parallel Analysis: adopt when actual eigenvalue > random threshold, keyed by component
       # index (factor_number). NULL parallel -> Not Available / na.

--- a/tests/testthat/test_prcomp.R
+++ b/tests/testthat/test_prcomp.R
@@ -527,8 +527,89 @@ test_that("do_prcomp Pearson output is unchanged by the polychoric support (issu
   # Same decomposition as a plain prcomp() on the raw data (up to the sign stabilization sweep).
   expect_equal(fit$sdev, reference$sdev, tolerance = 1e-10)
   expect_equal(abs(unname(fit$rotation)), abs(unname(reference$rotation)), tolerance = 1e-10)
-  # The Pearson path keeps recomputing the loadings from the data, so no cache is attached.
-  expect_null(fit$signed_loadings)
+  # The Pearson path now caches its signed loadings too (issue tam#38107), and for all-numeric
+  # input that cache is bit-identical to the cor(data, scores) the old fallback recomputed on
+  # every read -- which is what makes the change invisible to an existing Pearson analysis.
+  expect_false(is.null(fit$signed_loadings))
+  expect_equal(unname(fit$signed_loadings), unname(cor(df, fit$x)), tolerance = 1e-12)
+  expect_equal(unname(exploratory:::prcomp_signed_loadings(fit)),
+               unname(cor(df, fit$x)), tolerance = 1e-12)
+})
+
+test_that("Pearson-resolved categorical input still renders every loadings chart (issue tam#38107)", {
+  # An ordered factor with SIX OR MORE categories makes select_factor_correlation_type() choose
+  # Pearson under Auto, so this combination -- categorical columns on the Pearson branch --
+  # needs no manual override to reach. Before the fix prcomp_signed_loadings() fell through to
+  # cor() on the UN-ENCODED x$df and every chart below aborted with "'x' must be numeric".
+  set.seed(38107)
+  n <- 300
+  latent <- rnorm(n)
+  to_seven <- function(z) factor(pmin(7L, pmax(1L, as.integer(round(4 + 1.2 * z)))),
+                                 levels = 1:7, ordered = TRUE)
+  df <- data.frame(a = to_seven(latent + rnorm(n, 0, 0.45)),
+                   b = to_seven(latent + rnorm(n, 0, 0.60)),
+                   c = to_seven(latent + rnorm(n, 0, 0.75)))
+
+  model_df <- df %>% do_prcomp(a, b, c)
+  fit <- model_df$model[[1]]
+  expect_equal(fit$correlation_type, "pearson")
+  expect_false(isTRUE(fit$is_categorical_correlation))
+
+  for (ty in c("component_profiles", "loadings_signed", "loadings_signed_wide",
+               "representation", "variable_map")) {
+    res <- model_df %>% tidy_rowwise(model, type = ty)
+    expect_gt(nrow(res), 0)
+  }
+
+  # The cached loadings must come from the ENCODED (numeric-coded) frame, i.e. the same data the
+  # decomposition itself ran on -- not from the raw factor columns, which cor() cannot take.
+  encoded <- as.data.frame(lapply(df, function(column) as.numeric(as.integer(column))))
+  expect_equal(unname(fit$signed_loadings), unname(cor(encoded, fit$x)), tolerance = 1e-12)
+
+  # Selecting Pearson by hand on a 5-point scale is the same shape, and was equally broken.
+  to_five <- function(z) factor(pmin(5L, pmax(1L, as.integer(round(3 + 1.0 * z)))),
+                                levels = 1:5, ordered = TRUE)
+  five <- data.frame(a = to_five(latent + rnorm(n, 0, 0.45)),
+                     b = to_five(latent + rnorm(n, 0, 0.60)),
+                     c = to_five(latent + rnorm(n, 0, 0.75)))
+  forced <- five %>% do_prcomp(a, b, c, cor_type = "pearson")
+  expect_equal(forced$model[[1]]$correlation_type, "pearson")
+  expect_gt(nrow(forced %>% tidy_rowwise(model, type = "representation")), 0)
+})
+
+test_that("a categorical correlation judges Kaiser even with normalize_data = FALSE (issue tam#38107)", {
+  # A correlation-matrix PCA is standardized by construction, so normalize_data cannot change
+  # its eigenvalues -- and must not change whether the Kaiser criterion is reported. Before the
+  # fix the Component Selection table blanked the column while the Analysis Conditions table
+  # reported the same fit AS normalized.
+  df <- make_ordinal_survey()
+  off <- df %>% do_prcomp(q1, q2, q3, q4, q5, q6, cor_type = "polychoric", normalize_data = FALSE)
+  on <- df %>% do_prcomp(q1, q2, q3, q4, q5, q6, cor_type = "polychoric", normalize_data = TRUE)
+
+  vj_off <- off %>% tidy_rowwise(model, type = "variances_judged")
+  vj_on <- on %>% tidy_rowwise(model, type = "variances_judged")
+
+  # Identical eigenvalues are what make a differing judgment a contradiction.
+  expect_equal(vj_off$Eigenvalue, vj_on$Eigenvalue, tolerance = 1e-12)
+  expect_equal(vj_off$`Kaiser Criterion`, vj_on$`Kaiser Criterion`)
+  expect_equal(vj_off$kaiser_status, vj_on$kaiser_status)
+  expect_false(any(vj_off$kaiser_status == "na"))
+
+  # And it agrees with the Analysis Conditions table's own Normalization row.
+  conditions <- off %>% tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(conditions$Value[conditions$Metric == "Normalization"], "TRUE")
+})
+
+test_that("a PEARSON fit with normalize_data = FALSE still reports no Kaiser judgment", {
+  # The control for the case above: on the Pearson branch normalize_data really does change the
+  # basis (covariance, not correlation), so blanking the column there is correct.
+  set.seed(38107)
+  n <- 200
+  df <- data.frame(a = rnorm(n, 0, 100), b = rnorm(n), c = rnorm(n))
+  vj <- df %>% do_prcomp(a, b, c, normalize_data = FALSE) %>%
+    tidy_rowwise(model, type = "variances_judged")
+  expect_true(all(vj$kaiser_status == "na"))
+  expect_true(all(vj$`Kaiser Criterion` == "-"))
 })
 
 test_that("do_prcomp rejects nominal categorical variables", {


### PR DESCRIPTION
Two defects found by the analytics-harness-loop pass over do_prcomp (tam#38107),
both by writing the spec's expectations first and then measuring the shipped
16.0.60 package. Neither had been reported.

1. Categorical variables on the Pearson branch crashed four report charts.

   prcomp_signed_loadings() returns the cached x$signed_loadings when it exists
   and otherwise computes cor(x$df[, names(variable_sd)], x$x). x$df is the
   UN-ENCODED frame -- factor columns are still factors; only encoded_df is
   numeric. The cache was populated only inside
   if (isTRUE(fit$is_categorical_correlation)), which is FALSE exactly when the
   resolved correlation is Pearson -- so the one branch that fell through to
   cor() was the one branch whose input could still be categorical.

   component_profiles, loadings_signed, loadings_signed_wide, representation and
   variable_map therefore all aborted with a bare "'x' must be numeric" while the
   other report types rendered normally, leaving a half-broken report.

   No manual setting is needed to reach it: select_factor_correlation_type()
   returns Pearson for all-ordinal input whenever a variable has six or more
   categories, so a 7-point agreement scale imported as an ordered factor hits it
   at the default Correlation Type of Auto. Choosing "Pearson Correlation" by
   hand on 5-point items does the same. Supporting exactly this input is what
   issue #37294 added `factor` to the analytics' own column types for, and the
   helper's header comment says it exists to stop a factor column reaching cor().

   Fix: cache the signed loadings for every report-data fit, computing the
   Pearson case from encoded_df. encode_factanal_data() is a no-op for
   all-numeric input, so encoded_df is cleaned_df there and the cached matrix is
   bit-identical to what the fallback recomputed -- an existing numeric PCA sees
   no change. exp_kmeans is untouched: it passes with_report_data = FALSE, and
   this block only runs when that is TRUE.

2. A categorical correlation blanked its Kaiser Criterion column when
   normalization was off.

   Three places decide "was this analysis standardized?" and only two agreed.
   do_prcomp()'s own Kaiser computation guards with
   (normalize_data || isTRUE(fit$is_categorical_correlation)), and tidy()'s
   analysis_conditions and analysis_method branches both compute
   isTRUE(x$normalize_data) || isTRUE(x$is_categorical_correlation). The
   variances_judged branch -- the Component Selection table, whose whole purpose
   is to show the three retention judgments side by side -- used
   isTRUE(x$normalize_data) alone.

   So a Polychoric/Tetrachoric/Mixed analysis with "Normalize Variable Columns"
   unchecked (a natural thing to uncheck for Likert items already on one scale)
   dropped one of its three judgments, while the Analysis Conditions table one
   tab away reported the data AS normalized. The eigenvalues are identical with
   normalization on or off -- the analysis runs on the correlation matrix either
   way -- so the criterion was perfectly applicable in both runs and only the
   gate differed.

   Fix: use the same condition as its two siblings and as the fit-time guard.

Tests: four new cases in tests/testthat/test_prcomp.R, each confirmed to fail
without the source change (6 failures across them) and to pass with it --
including a control asserting a PEARSON fit with normalize_data = FALSE still
correctly reports no Kaiser judgment, since there the basis really does change.
The pre-existing "Pearson output is unchanged" test now asserts the cache equals
cor(data, scores) instead of asserting it is absent. test_kmeans_1/2,
test_factanal and test_factanal_correlation all still pass.


Found by the analytics-harness-loop pass for tam#38107 (https://github.com/exploratory-io/tam/issues/38107). The tam-side harness pins both as CURRENT behaviour until this ships: `src/test/analytics-harness/specs/do_prcomp.json` (`categoricalPearsonSignedLoadingsDefect`, `categoricalCorrelationKaiserGateDefect`) and `src/js/translator/AnalyticsHarnessPrcompValidation.test.js`.
