### PR TITLE
kmeans: make the iteration cap reach the fit, and cap the elbow sweep by distinct rows

### DIFF
--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -7,9 +7,17 @@ iterate_kmeans <- function(df, max_centers = 10,
                            normalize_data = TRUE,
                            seed = NULL
                            ) {
-  # Limit the numbers of centers to search up to nrow(df) - 1.
-  # Otherwise we will get "Centers should be less than rows" error.
-  n_centers <- seq(min(max_centers, nrow(df) - 1))
+  # Cap k by the number of DISTINCT data points, not just the row count:
+  # stats::kmeans() errors with "more cluster centers than distinct data points"
+  # long before it runs out of rows, and any repeated row makes the two differ
+  # (a few coarse-grained numeric variables produce duplicates immediately).
+  # Hitting that error here aborts the whole exp_kmeans() call, so the user
+  # loses every chart rather than just the elbow one. iterate_silhouette() below
+  # already caps this way; this is its sibling. (tam#38107)
+  # max(1, ...) because seq(0) is c(1, 0), not an empty sequence: data with a
+  # single distinct row would otherwise ask for centers = 0.
+  mat_for_cap <- as_numeric_matrix_(df, columns = colnames(df))
+  n_centers <- seq_len(max(1, min(max_centers, nrow(unique(mat_for_cap)) - 1)))
   ret <- data.frame(center = n_centers)
   ret <- ret %>% dplyr::mutate(model = purrr::map(center, function(x) {
     tryCatch({

--- a/R/model_builder.R
+++ b/R/model_builder.R
@@ -97,7 +97,7 @@ build_kmeans.kv_ <- function(df,
     }
     rownames(mat) <- NULL # this prevents warning about discarding row names of the matrix
     kmeans_ret <- tryCatch({
-      kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)},
+      kmeans(mat, centers = centers, iter.max = iter.max, nstart = nstart, algorithm = algorithm, trace = trace)},
       error = function(e){
         if(e$message == "cannot take a sample larger than the population when 'replace = FALSE'"){
           # falls into here when group is 2 and centers > 2
@@ -210,7 +210,7 @@ build_kmeans.cols <- function(df, ...,
         # Replace them with 0.
         mat[is.nan(mat)] <- 0
       }
-      kmeans(mat, centers = centers, iter.max = 10, nstart = nstart, algorithm = algorithm, trace = trace)
+      kmeans(mat, centers = centers, iter.max = iter.max, nstart = nstart, algorithm = algorithm, trace = trace)
     }, error = function(e) {
       if(e$message == "invalid first argument"){
         stop("Created matrix is invalid")

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -39,30 +39,23 @@ expect_error_with_context <- function(expr, pattern) {
 # Phase 1: K-means error handling tests
 # =============================================================================
 
-test_that("iterate_kmeans reports error with centers context", {
-  # Create data with only 2 distinct points - will fail for centers > 2
-  # This triggers an error inside the purrr::map in iterate_kmeans
+test_that("iterate_kmeans caps the sweep before duplicate-center errors", {
+  # Create data with only 2 distinct points. The sweep is now capped at
+  # distinct rows - 1, so it should complete instead of reaching an invalid k.
   df <- data.frame(x = c(1, 1, 1, 2, 2, 2), y = c(1, 1, 1, 2, 2, 2))
 
-  # The error message should contain "centers=" to indicate which center value failed
-  # Note: iterate_kmeans is an internal function, accessed via :::
-  expect_error_with_context(
-    exploratory:::iterate_kmeans(df, max_centers = 5),
-    "centers="
-  )
+  result <- exploratory:::iterate_kmeans(df, max_centers = 5)
+  expect_equal(result$center, 1L)
 })
 
-test_that("exp_kmeans elbow method reports error with centers context", {
-  # Create data where elbow method iteration will fail
-  # Only 2 distinct points, so centers > 2 will fail in iterate_kmeans
+test_that("exp_kmeans elbow method completes with duplicate rows", {
+  # With only 2 distinct points, the elbow sweep should contain only k = 1.
   df <- data.frame(x = c(1, 1, 1, 2, 2, 2), y = c(1, 1, 1, 2, 2, 2))
 
-  # Use centers=1 for the main k-means (which will succeed)
-  # but max_centers=5 for elbow method (which will fail at centers=3)
-  expect_error_with_context(
-    exploratory:::exp_kmeans(df, x, y, centers = 1, elbow_method_mode = TRUE, max_centers = 5),
-    "centers="
+  result <- exploratory:::exp_kmeans(
+    df, x, y, centers = 1, elbow_method_mode = TRUE, max_centers = 5
   )
+  expect_equal(result$model[[1]]$elbow_result$center, 1L)
 })
 
 test_that("exp_kmeans normal operation works correctly", {

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -69,8 +69,9 @@ test_that("exp_kmeans elbow method mode", {
   df <- df %>% head(9)
   model_df <- exp_kmeans(df, cyl, mpg, hp, elbow_method_mode=TRUE)
   res <- model_df$model[[1]]$elbow_result
-  # Search should be limited up to 8 (9 - 1).
-  expect_equal(nrow(res), 8)
+  # Search is limited by distinct rows, not raw row count. This fixture has
+  # seven distinct (cyl, mpg, hp) rows, so the sweep ends at 6.
+  expect_equal(nrow(res), nrow(unique(df[, c("cyl", "mpg", "hp")])) - 1)
 })
 
 test_that("exp_kmeans silhouette method mode", {

--- a/tests/testthat/test_kmeans_3.R
+++ b/tests/testthat/test_kmeans_3.R
@@ -1,0 +1,77 @@
+# how to run this test:
+# devtools::test(filter="kmeans_3")
+#
+# Self-contained (no network) regression tests for two K-Means defects found by
+# tam#38107's analytics harness. Both were verified to FAIL against the shipped
+# 16.0.62 before the fix.
+
+context("test kmeans settings that must reach the fit (tam#38107)")
+
+test_that("build_kmeans.cols honours iter.max instead of a hardcoded 10", {
+  # Lloyd needs three passes to converge on this data, so a one-iteration cap
+  # must produce a DIFFERENT partition from an uncapped run. Hartigan-Wong is
+  # deliberately not used: its inner optimization often reaches the same
+  # partition in one pass, which cannot distinguish an honored cap from an
+  # ignored one.
+  set.seed(38107)
+  n <- 300
+  segment <- rep(1:3, length.out = n)
+  df <- data.frame(
+    a = rnorm(n, c(0, 6, 12)[segment], 1.2),
+    b = rnorm(n, c(0, 5, 10)[segment], 1.2),
+    c = rnorm(n, c(0, 4, 8)[segment], 1.2)
+  )
+
+  fit <- function(iter_max) {
+    df %>%
+      build_kmeans.cols(dplyr::everything(), centers = 3, iter.max = iter_max,
+                        nstart = 1, algorithm = "Lloyd", normalize_data = TRUE,
+                        keep.source = FALSE, augment = FALSE, seed = 1,
+                        na.rm = FALSE) %>%
+      dplyr::pull(model) %>% purrr::pluck(1)
+  }
+
+  capped <- suppressWarnings(fit(1))
+  uncapped <- fit(50)
+
+  # Before the fix these were byte-identical, because kmeans() was always
+  # called with the literal iter.max = 10.
+  expect_false(identical(capped$cluster, uncapped$cluster))
+  expect_equal(capped$iter, 2)
+
+  # The default is 10 either way, so default-settings behaviour must not move.
+  expect_identical(fit(10)$cluster, uncapped$cluster)
+})
+
+test_that("iterate_kmeans caps k by distinct rows, so repeated rows do not abort the analytics", {
+  # 60 rows, 4 distinct. stats::kmeans() refuses more centers than there are
+  # distinct data points; capping on nrow() instead reached k = 5 and aborted
+  # the whole exp_kmeans() call, losing every chart rather than just the elbow.
+  pts <- data.frame(x = c(1, 1, 9, 9), y = c(1, 9, 1, 9))
+  idx <- rep(seq_len(nrow(pts)), length.out = 60)
+  df <- data.frame(x = pts$x[idx], y = pts$y[idx])
+
+  res <- iterate_kmeans(df, max_centers = 10, normalize_data = TRUE, seed = NULL)
+  expect_equal(res$center, 1:3)
+
+  # A single distinct row must still ask for at least one centre: seq(0) is
+  # c(1, 0), not an empty sequence.
+  flat <- data.frame(x = rep(1, 5), y = rep(2, 5))
+  expect_equal(iterate_kmeans(flat, max_centers = 10, normalize_data = TRUE, seed = NULL)$center, 1)
+
+  # Data with no repeats is unaffected.
+  set.seed(38107)
+  wide <- data.frame(x = rnorm(200), y = rnorm(200))
+  expect_equal(iterate_kmeans(wide, max_centers = 6, normalize_data = TRUE, seed = NULL)$center, 1:6)
+})
+
+test_that("elbow mode completes end to end on data with repeated rows", {
+  pts <- data.frame(x = c(1, 1, 9, 9), y = c(1, 9, 1, 9))
+  idx <- rep(seq_len(nrow(pts)), length.out = 60)
+  df <- data.frame(x = pts$x[idx], y = pts$y[idx])
+
+  model_df <- df %>% exp_kmeans(x, y, centers = 3, seed = 1,
+                                elbow_method_mode = "elbow", max_centers = 10)
+  elbow <- model_df %>% dplyr::pull(model) %>% purrr::pluck(1, "elbow_result")
+  expect_equal(elbow$center, 1:3)
+})


### PR DESCRIPTION
Found by the K-Means analytics regression harness added in tam#38107 — both are the `parallel-component-bug-scope` shape: a guard or forwarded argument correct in every sibling site but one.

### 1. "Max Iteration Times" never reached the fit

`build_kmeans.cols()` (and `build_kmeans.kv()`) accept `iter.max`, document it, and it is threaded all the way from the Analytics view's **Max Iteration Times** field — and then `kmeans()` was called with the literal `iter.max = 10`.

Measured against 16.0.62, 600 rows, three well-separated clusters:

| | clusters | `iter` | warning |
|---|---|---|---|
| `exp_kmeans(algorithm="Lloyd", iter.max=1)` | A | 3 | none |
| `exp_kmeans(algorithm="Lloyd", iter.max=50)` | A (identical) | 3 | none |
| `stats::kmeans(mat, 3, iter.max=1, algorithm="Lloyd")` | B (different) | 2 | `did not converge in 1 iteration` |

`iterate_kmeans()` and `iterate_silhouette()` were already forwarding `iter.max` correctly, so the elbow/silhouette diagnostics honoured a setting the model being diagnosed did not.

The hardcoded literal equals the formal's own default, so **no default-settings result moves** — verified: `iter.max = 10` after the fix is identical to shipped behaviour.

### 2. Elbow mode aborted the whole analytics on data with repeated rows

`iterate_kmeans()` capped the sweep at `nrow(df) - 1`. `stats::kmeans()`'s real constraint is `centers <= the number of DISTINCT data points`, and any repeated row makes the two differ — a few coarse-grained numeric variables (a 1–5 score, a small count) produce duplicates immediately.

60 rows / 4 distinct / `max_centers = 10`:

- `elbow_method_mode = "elbow"` → aborts at `centers=5`; **no chart renders at all**, because the error escapes `exp_kmeans()` before the model list is built.
- `elbow_method_mode = "silhouette"` → succeeds, tries k = 2 and 3, because `iterate_silhouette()` already caps at `nrow(unique(mat)) - 1` with a comment naming the exact constraint.

`seq_len(max(1, ...))` rather than `seq(...)`: `seq(0)` is `c(1, 0)`, so a single distinct row would otherwise ask for `centers = 0`.

### Tests

`tests/testthat/test_kmeans_3.R` is self-contained (no network). Confirmed to fail 4 of 5 assertions against the unpatched package and pass 7/7 with the fix.

### Related

- tam#38107 — the harness spec (`src/test/analytics-harness/specs/kmeans.json`) records both, plus a third K-Means finding left documented rather than patched: at `nstart = 1` the elbow/silhouette sweeps report a *worse* clustering at k = 3 than the k = 3 model beside them (489.857 vs 126.167 within-cluster SS), because each k is a single random start from an arbitrary RNG state. That one needs a product decision, not a transcription fix.
- exploratory_func#1621 — the K-Modes/K-Medoids defects from the same harness family.
