### PR TITLE
WIP: Analytics: Cronbach's Alpha: Reserve the values for Factor variable

### DIFF
--- a/R/reliability.R
+++ b/R/reliability.R
@@ -97,10 +97,21 @@ reliability_detect_item_type <- function(x) {
   if (is.logical(x)) {
     return("dichotomous")
   }
+  # Factor / ordered-factor items must be classified from their DECLARED category
+  # levels, not from how many distinct values happen to be observed in this
+  # (possibly row-sampled, see max_nrow above) data (issue #38122). Using
+  # unique_count here silently collapsed a genuinely multi-category factor to
+  # "dichotomous" whenever only two of its levels were observed -- e.g. a
+  # 5-level Likert factor sampled down to two responses -- discarding the other
+  # declared categories from the item-type decision (and, downstream, from the
+  # correlation-method selection in reliability_select_method). nlevels(x)
+  # reflects every level the factor was defined with, observed or not, mirroring
+  # the type-based classification already used for Factor Analysis / PCA in
+  # inspect_factor_variable() (factanal_correlation.R, issue #37344).
   if (is.ordered(x)) {
-    if (unique_count <= 2) "dichotomous" else "ordinal"
+    if (nlevels(x) <= 2) "dichotomous" else "ordinal"
   } else if (is.factor(x)) {
-    if (unique_count <= 2) "dichotomous" else "nominal"
+    if (nlevels(x) <= 2) "dichotomous" else "nominal"
   } else if (is.numeric(x) || is.integer(x)) {
     if (unique_count <= 2) "dichotomous" else "continuous"
   } else {

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -276,6 +276,41 @@ test_that("exp_cronbach_alpha rejects nominal (unordered, 3+ level) factor colum
                "nominal")
 })
 
+test_that("reliability_detect_item_type classifies factor/ordered items from their DECLARED levels, not the values observed in this data (tam#38122)", {
+  # A factor's category space is what it was DEFINED with (levels()); which of
+  # those categories happen to appear in a particular (possibly row-sampled --
+  # see max_nrow in exp_cronbach_alpha) slice of data must not change the item
+  # type. Only 2 of the 5 declared levels are observed below.
+  sparse_ordered <- factor(c("2", "2", "4", "4", "2"), levels = as.character(1:5), ordered = TRUE)
+  expect_equal(reliability_detect_item_type(sparse_ordered), "ordinal")
+
+  sparse_nominal <- factor(c("A", "A", "C", "C", "A"), levels = c("A", "B", "C"))
+  expect_equal(reliability_detect_item_type(sparse_nominal), "nominal")
+
+  # A genuinely 2-level factor still reports dichotomous.
+  two_level <- factor(c("Yes", "No", "Yes"), levels = c("Yes", "No"))
+  expect_equal(reliability_detect_item_type(two_level), "dichotomous")
+
+  # Numeric items have no declared "levels" -- they are still classified from
+  # the values actually observed (the type-based, not value-shape, exception
+  # documented for the 0/1 dummy case, matching Factor Analysis/PCA).
+  expect_equal(reliability_detect_item_type(c(1, 2, 1, 2, 1)), "dichotomous")
+  expect_equal(reliability_detect_item_type(c(1, 2, 3, 1, 2)), "continuous")
+})
+
+test_that("exp_cronbach_alpha rejects a nominal factor even when only 2 of its 3 declared levels are observed (tam#38122)", {
+  # `部署` declares 3 unordered categories but this data only ever shows "A"/"B" --
+  # before the fix, unique_count()<=2 misclassified it "dichotomous", which is
+  # NOT in the nominal/unsupported reject list, so it silently slipped into the
+  # correlation matrix as if it were an ordered/binary item. It must still be
+  # rejected as nominal, exactly like the fully-observed 3-level case above.
+  df <- make_reliability_df() %>%
+    dplyr::mutate(`部署` = factor(rep(c("A", "B"), length.out = dplyr::n()),
+                                  levels = c("A", "B", "C")))
+  expect_error(exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "auto"),
+               "nominal")
+})
+
 test_that("exp_cronbach_alpha treats all-factor Likert columns as ordinal under auto/polychoric", {
   df <- make_reliability_df() %>%
     dplyr::mutate(dplyr::across(dplyr::everything(), ~ factor(.x)))


### PR DESCRIPTION
Fixes exploratory-io/tam#38122

## Root cause

`reliability_detect_item_type()` (`R/reliability.R`), the item-type classifier
used by Cronbach's Alpha (`exp_cronbach_alpha`), decided whether a factor or
ordered-factor item is `dichotomous` vs. `ordinal`/`nominal` from
`length(unique(non_missing))` — the count of **distinct values observed** in
the (possibly row-sampled, via `max_nrow`) data — instead of the factor's own
**declared category levels** (`nlevels(x)`).

Consequence: a factor variable with 3+ declared levels, but only 2 of those
levels actually observed in the data (or in the sampled slice used for a
large data set), got silently downgraded to `dichotomous`:

- For an **ordered** factor, this collapses a genuinely multi-category
  ordinal item into a 2-category one for correlation-method selection
  (`reliability_select_method`), discarding the item's real category count.
- For an **unordered** factor, `dichotomous` is *not* in the
  `nominal`/`unsupported` reject list `exp_cronbach_alpha` uses to refuse
  genuinely nominal (unordered, 3+ category) columns — so a nominal item
  could silently slip past that guard and get folded into a Pearson/mixed
  correlation matrix as if it were an ordered/binary item, which is
  statistically invalid for unordered categories.

This matches the Japanese issue title: 「Factor型のときは、全ての値を保持するべき」
("For Factor type, all [declared] values should be retained") — the
classifier must key on the column's *declared type* (its levels), never the
*shape of the values it happens to hold* in a given sample. This is the exact
same bug class already fixed for Factor Analysis / PCA's
`inspect_factor_variable()` in `factanal_correlation.R` (issue #37344,
documented in tam's `.claude/rules/global/r-integration.md#classify-by-column-type-not-by-value-shape`)
— Cronbach's Alpha has its own, independent item-type classifier that never
picked up that fix.

## Fix

`reliability_detect_item_type()` now uses `nlevels(x)` (the factor's declared
category count) instead of the observed-unique-value count for both the
`is.ordered(x)` and `is.factor(x)` branches. The `is.numeric(x)`/`is.integer(x)`
branch is unchanged — numeric columns have no declared "levels" concept, so
they keep the existing observed-value-count classification (with the
pre-existing 0/1-dummy → `dichotomous` exception, matching the Factor
Analysis/PCA precedent).

## Testing / verification

**No Rserve/R runtime is available in the sandbox this fix was written in**,
so the tests below have **not been executed live** — verification here is by
careful code tracing against the two places `item_types` is consumed
(`reliability_select_method()`, and the `nominal`/`unsupported` rejection
guard in `exp_cronbach_alpha()`), not by running the suite. Please run
`devtools::test(filter="reliability")` before merging.

Added to `tests/testthat/test_reliability.R`:

1. A direct unit test of `reliability_detect_item_type()`:
   - a 5-level ordered factor with only 2 levels observed → still `"ordinal"`
   - a 3-level unordered factor with only 2 levels observed → still `"nominal"`
   - a genuine 2-level factor → `"dichotomous"` (unchanged boundary case)
   - numeric items → unchanged, still observed-value-based (`"dichotomous"`/`"continuous"`)
2. An integration test: `exp_cronbach_alpha()` with a 3-level unordered
   factor column (`部署`) whose sample only ever shows 2 of its 3 declared
   levels, mixed with continuous numeric items — asserts it is rejected with
   a "nominal" error, exactly like the pre-existing fully-observed 3-level
   case. Traced through the source: before this fix, this exact input was
   misclassified `dichotomous` and passed silently through the rejection
   guard (no error raised) — after the fix it correctly errors.

## Not covered / follow-ups

- This fix is R-package-side only. No tam (desktop) changes were needed —
  `exp_cronbach_alpha`'s selectable column types (`numeric`/`factor`/`logical`)
  and the analytics template are unaffected by this classification fix.
- Per `.claude/rules/global/r-integration.md#library-r-no-datablog-scheduler-copy-script`
  conventions in the sibling `tam` repo, once this package version is bumped
  in `tam`, the usual R-package rebuild/version-bump/binary-rebuild/deploy
  chain applies before scheduled/server-side Cronbach's Alpha runs pick it up.
- Live-R verification and a real render/report check against the tam Analytics
  view are still outstanding — flagging per this project's
  `r-codegen-fix-live-execution-required`/`analytics-harness-loop` convention
  for whoever picks this up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018QZGRmV4JCmgUrvDtC9YSU)_