### PR TITLE
fix: put the new combined column first (tam #38097 follow-up)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.65
+Version: 16.0.66
 Date: 2026-08-27
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/multiple_response.R
+++ b/R/multiple_response.R
@@ -96,5 +96,11 @@ combine_multiple_response_column <- function(
     data <- data[, setdiff(names(data), columns), drop = FALSE]
   }
 
+  # Put the newly-created combined column FIRST, matching the desktop app's
+  # own "this is a new column" highlight convention -- easier to spot the
+  # result next to the columns that produced it than buried after the
+  # (possibly still-present) source columns.
+  data <- data[, c(output_column, setdiff(names(data), output_column)), drop = FALSE]
+
   data
 }

--- a/tests/testthat/test_multiple_response.R
+++ b/tests/testthat/test_multiple_response.R
@@ -95,6 +95,27 @@ test_that("combine_multiple_response_column with custom separator and no_selecti
   expect_equal(ret$combined, c("a / b", "None Selected"))
 })
 
+test_that("combine_multiple_response_column puts the new column first when remove_original = FALSE too", {
+  df <- data.frame(
+    id = 1:2,
+    q_a = c(1, 0),
+    q_b = c(0, 1),
+    other = c("x", "y"),
+    stringsAsFactors = FALSE
+  )
+
+  ret <- combine_multiple_response_column(
+    df,
+    columns = c("q_a", "q_b"),
+    output_column = "combined",
+    option_name_type = "remove_prefix",
+    option_name_prefix = "q_",
+    remove_original = FALSE
+  )
+
+  expect_equal(names(ret), c("combined", "id", "q_a", "q_b", "other"))
+})
+
 test_that("combine_multiple_response_column with remove_original = TRUE drops source columns", {
   df <- data.frame(
     id = 1:2,
@@ -113,7 +134,9 @@ test_that("combine_multiple_response_column with remove_original = TRUE drops so
     remove_original = TRUE
   )
 
-  expect_equal(names(ret), c("id", "other", "combined"))
+  # The new combined column comes FIRST -- matches the desktop app's own
+  # "highlight this as a new column" convention (tam #38097 follow-up).
+  expect_equal(names(ret), c("combined", "id", "other"))
   expect_equal(ret$combined, c("a", "b"))
 })
 


### PR DESCRIPTION
## Description

Follow-up to #1629 (tam issue-38097). Requested during manual UI verification.

`combine_multiple_response_column()` appended the new combined column at the end of `data` (`data[[output_column]] <- result`), so it landed after every source/passthrough column. The desktop app highlights this column as "new" (orange header indicator); with it buried at the end, the user has to scroll right to see it next to the indicator.

## Change

Reorders columns to put `output_column` FIRST, applied *after* the `remove_original` drop so it operates on the final column set in both cases.

## Testing

- Live-verified via `Rscript` against the bundled package for both `remove_original = TRUE` and `FALSE`.
- Updated the existing column-order assertion (`c("id", "other", "combined")` → `c("combined", "id", "other")`).
- Added a new test covering the `remove_original = FALSE` case.
- Full `test_multiple_response.R` suite: 20/20 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)