### PR TITLE
fix: put the new combined column at the first selected column's position

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.67
+Version: 16.1.0
 Date: 2026-08-27
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.0.66
+Version: 16.0.67
 Date: 2026-08-27
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/multiple_response.R
+++ b/R/multiple_response.R
@@ -76,6 +76,12 @@ combine_multiple_response_column <- function(
     option_names <- columns
   }
 
+  # Position of the FIRST selected source column in the ORIGINAL column
+  # order -- the new combined column lands there, not always at position 1.
+  # e.g. selecting columns 2-5 puts the new column at position 2.
+  orig_names <- names(data)
+  first_selected_index <- min(match(columns, orig_names))
+
   values <- data[, columns, drop = FALSE]
   sel_mat <- do.call(cbind, lapply(values, function(value) {
     !is.na(value) & (value == selected_value)
@@ -96,11 +102,17 @@ combine_multiple_response_column <- function(
     data <- data[, setdiff(names(data), columns), drop = FALSE]
   }
 
-  # Put the newly-created combined column FIRST, matching the desktop app's
-  # own "this is a new column" highlight convention -- easier to spot the
-  # result next to the columns that produced it than buried after the
-  # (possibly still-present) source columns.
-  data <- data[, c(output_column, setdiff(names(data), output_column)), drop = FALSE]
+  # Reassemble: columns that originally sat before the first selected
+  # column (and are still present -- some may have been dropped by
+  # remove_original) keep their order and go before the new column;
+  # everything else -- from the first selected column onward, still
+  # present, in original order -- goes after. `setdiff` preserves the
+  # order of its first argument, so this never needs an explicit sort.
+  remaining_names <- setdiff(names(data), output_column)
+  names_before <- intersect(orig_names[seq_len(first_selected_index - 1)], remaining_names)
+  names_after <- setdiff(remaining_names, names_before)
+
+  data <- data[, c(names_before, output_column, names_after), drop = FALSE]
 
   data
 }

--- a/tests/testthat/test_multiple_response.R
+++ b/tests/testthat/test_multiple_response.R
@@ -95,7 +95,7 @@ test_that("combine_multiple_response_column with custom separator and no_selecti
   expect_equal(ret$combined, c("a / b", "None Selected"))
 })
 
-test_that("combine_multiple_response_column puts the new column first when remove_original = FALSE too", {
+test_that("combine_multiple_response_column puts the new column at the first selected column's position when remove_original = FALSE too", {
   df <- data.frame(
     id = 1:2,
     q_a = c(1, 0),
@@ -113,7 +113,9 @@ test_that("combine_multiple_response_column puts the new column first when remov
     remove_original = FALSE
   )
 
-  expect_equal(names(ret), c("combined", "id", "q_a", "q_b", "other"))
+  # q_a is the first SELECTED column, and it originally sat at position 2
+  # (after id) -- the new column lands there, not at position 1.
+  expect_equal(names(ret), c("id", "combined", "q_a", "q_b", "other"))
 })
 
 test_that("combine_multiple_response_column with remove_original = TRUE drops source columns", {
@@ -134,10 +136,48 @@ test_that("combine_multiple_response_column with remove_original = TRUE drops so
     remove_original = TRUE
   )
 
-  # The new combined column comes FIRST -- matches the desktop app's own
-  # "highlight this as a new column" convention (tam #38097 follow-up).
-  expect_equal(names(ret), c("combined", "id", "other"))
+  # The new combined column still lands at the first selected column's
+  # original position (tam #38097 follow-up), which here is position 2.
+  expect_equal(names(ret), c("id", "combined", "other"))
   expect_equal(ret$combined, c("a", "b"))
+})
+
+test_that("combine_multiple_response_column places the new column first when the first selected column is the data frame's first column", {
+  df <- data.frame(
+    q_a = c(1, 0),
+    id = 1:2,
+    other = c("x", "y"),
+    stringsAsFactors = FALSE
+  )
+
+  ret <- combine_multiple_response_column(
+    df,
+    columns = c("q_a"),
+    output_column = "combined",
+    option_name_type = "full_column_name",
+    remove_original = FALSE
+  )
+
+  expect_equal(names(ret), c("combined", "q_a", "id", "other"))
+})
+
+test_that("combine_multiple_response_column places the new column last when the (only) selected column is last and removed", {
+  df <- data.frame(
+    id = 1:2,
+    other = c("x", "y"),
+    q_a = c(1, 0),
+    stringsAsFactors = FALSE
+  )
+
+  ret <- combine_multiple_response_column(
+    df,
+    columns = c("q_a"),
+    output_column = "combined",
+    option_name_type = "full_column_name",
+    remove_original = TRUE
+  )
+
+  expect_equal(names(ret), c("id", "other", "combined"))
 })
 
 test_that("combine_multiple_response_column treats NA as not selected", {


### PR DESCRIPTION
Fixes exploratory-io/tam#38097 (follow-up to #1633).

## Description

#1633 always put the new combined column at position 1. Per further spec refinement, it should land at the position of the FIRST SELECTED source column instead -- e.g. selecting columns 2-5 puts the new column at position 2.

## How to Test

`tests/testthat/test_multiple_response.R` covers: mid-selection with/without `remove_original`, first-column selection, and last-column-selected+removed. Live-verified via Rscript against the real function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)