### PR TITLE
feat: expose latent class posterior probabilities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.1
+Version: 16.1.2
 Date: 2026-08-27
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/lca.R
+++ b/R/lca.R
@@ -241,11 +241,16 @@ lca_profile_table <- function(fit, observed, cols) {
 }
 
 lca_assignment_table <- function(original, used_row_ids, fit) {
-  assigned <- tibble::tibble(
-    .lca_row_id = used_row_ids,
-    `Latent Class` = factor(paste("Class", fit$predclass), levels = paste("Class", seq_along(fit$P))),
-    `Assignment Confidence` = apply(fit$posterior, 1, max),
-    `Is Excluded` = FALSE
+  class_probabilities <- tibble::as_tibble(fit$posterior, .name_repair = "minimal")
+  names(class_probabilities) <- paste("Class", seq_len(ncol(fit$posterior)), "Probability")
+  assigned <- dplyr::bind_cols(
+    tibble::tibble(
+      .lca_row_id = used_row_ids,
+      `Latent Class` = factor(paste("Class", fit$predclass), levels = paste("Class", seq_along(fit$P))),
+      `Assignment Confidence` = apply(fit$posterior, 1, max)
+    ),
+    class_probabilities,
+    tibble::tibble(`Is Excluded` = FALSE)
   )
   original %>%
     dplyr::left_join(assigned, by = ".lca_row_id") %>%

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -51,7 +51,10 @@ test_that("exp_lca selects a BIC-minimum categorical model and exposes its repor
                paste("Class", max.col(posterior, ties.method = "first")))
   expect_equal(unname(assignments$`Assignment Confidence`[included]), unname(apply(posterior, 1, max)), tolerance = 1e-8)
   expect_true(all(is.na(as.matrix(assignments[!included, probability_columns, drop = FALSE]))))
-  expect_true(nrow(tidy(model, type = "relationship")) > 0)
+  relationship <- tidy(model, type = "relationship")
+  expect_true(nrow(relationship) > 0)
+  expect_equal(as.integer(tapply(relationship$rows, relationship$class, sum)),
+               tabulate(model$selected_fit$predclass, nbins = glance(model)$selected_classes))
 })
 
 test_that("exp_lca respects the requested lower class bound for tiny data", {

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -63,6 +63,11 @@ test_that("exp_lca respects the requested lower class bound for tiny data", {
                    nrep = 1, maxiter = 20)$model[[1]]
 
   expect_equal(tidy(model, type = "class_selection")$number_of_classes, 2L)
+  assignments <- tidy(model, type = "data")
+  probability_columns <- c("Class 1 Probability", "Class 2 Probability")
+  expect_true(all(probability_columns %in% names(assignments)))
+  expect_equal(unname(rowSums(as.matrix(assignments[, probability_columns]))),
+               rep(1, nrow(assignments)), tolerance = 1e-8)
 })
 
 test_that("exp_lca does not report convergence when maxiter is reached", {

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -42,6 +42,15 @@ test_that("exp_lca selects a BIC-minimum categorical model and exposes its repor
   expect_true(any(assignments$`Is Excluded`))
   expect_true(all(is.na(assignments$`Latent Class`[assignments$`Is Excluded`])))
   expect_true(all(assignments$`Assignment Confidence`[!assignments$`Is Excluded`] >= 0))
+  probability_columns <- paste("Class", seq_len(glance(model)$selected_classes), "Probability")
+  expect_true(all(probability_columns %in% names(assignments)))
+  included <- !assignments$`Is Excluded`
+  posterior <- as.matrix(assignments[included, probability_columns, drop = FALSE])
+  expect_equal(unname(rowSums(posterior)), rep(1, sum(included)), tolerance = 1e-8)
+  expect_equal(as.character(assignments$`Latent Class`[included]),
+               paste("Class", max.col(posterior, ties.method = "first")))
+  expect_equal(unname(assignments$`Assignment Confidence`[included]), unname(apply(posterior, 1, max)), tolerance = 1e-8)
+  expect_true(all(is.na(as.matrix(assignments[!included, probability_columns, drop = FALSE]))))
   expect_true(nrow(tidy(model, type = "relationship")) > 0)
 })
 


### PR DESCRIPTION
## Summary
- add one posterior membership-probability column per selected latent class to row-level LCA output
- keep excluded rows unassigned with posterior values as NA
- bump exploratory package version to 16.1.2

## Verification
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test_lca.R")'`\n\n## Follow-up\n- Publish 16.1.2 artifacts for macOS Intel/ARM and Windows, then update TAM required-R-package manifests so the desktop app installs the new columns.