### PR TITLE
Keep unused Factor levels in Cronbach's Answer Distribution

### DIFF
--- a/R/reliability.R
+++ b/R/reliability.R
@@ -385,9 +385,14 @@ reliability_numeric_response_values <- function(x) {
   format_cut_output(binned_values, decimal.digits = 2, right = TRUE)
 }
 
+# Factor items must keep THEIR OWN declared levels, including unused ones
+# (count 0). Summary View already shows this (tam#38122: 上司との関係 has
+# level 1 with 0 rows). Do not borrow levels from sibling variables.
 reliability_response_values <- function(x) {
   if (is.numeric(x)) {
     reliability_numeric_response_values(x)
+  } else if (is.factor(x)) {
+    factor(as.character(x[!is.na(x)]), levels = levels(x), ordered = is.ordered(x))
   } else {
     x[!is.na(x)]
   }

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -159,6 +159,28 @@ test_that("response distribution uses Summary View numeric binning", {
   expect_equal(nrow(missing), 0)
 })
 
+test_that("response distribution keeps unused declared Factor levels of that column (tam#38122)", {
+  # 上司との関係 is Factor with levels 1:5 plus A. Level 1 (and A) exist but have
+  # 0 rows -- Summary View already shows this. Answer Distribution must reserve
+  # those declared levels rather than dropping them or borrowing from siblings.
+  df <- tibble::tibble(
+    `上司との関係` = factor(
+      c(rep("2", 4), rep("3", 2), rep("4", 1), rep("5", 1)),
+      levels = c("1", "2", "3", "4", "5", "A")
+    ),
+    `残業は適切か` = c(2L, 2L, 3L, 4L, 5L, 5L, 2L, 3L)
+  )
+
+  res <- reliability_response_distribution(df)
+  boss <- res %>% dplyr::filter(variable == "上司との関係")
+  expect_equal(as.character(boss$response), c("1", "2", "3", "4", "5", "A"))
+  expect_equal(boss$count, c(0L, 4L, 2L, 1L, 1L, 0L))
+
+  # Numeric still uses observed min-max, not Factor levels from another column.
+  overtime <- res %>% dplyr::filter(variable == "残業は適切か")
+  expect_equal(as.character(overtime$response), c("2", "3", "4", "5"))
+})
+
 test_that("exp_cronbach_alpha auto-selects polychoric for ordered factors (Ordinal Alpha)", {
   df <- make_reliability_df() %>% dplyr::mutate(dplyr::across(dplyr::everything(), ~ ordered(.x)))
 


### PR DESCRIPTION
Fixes exploratory-io/tam#38122

# Description

Cronbach's Alpha Answer Distribution was dropping Factor categories that exist on the column but have 0 rows (e.g. 「上司との関係」 has declared level `1` with 0 observations). Each Factor is now tabulated against its own `levels()`, so unused declared values stay as count 0. Sibling variables are not used to fill in categories.

# Checklist
Make sure you have performed the following items before submitting this pull request.
If not, please describe the reason.

- [x] Add test cases for this fix/enhancement
- [ ] Pass `devtools::check()` — not run in this environment
- [x] Pass reliability tests (`testthat` `test_reliability.R`, 83 passed)
- [ ] Test installing from github — not done
- [ ] Tested with Exploratory — R-side unit test only; desktop render still outstanding


Made with [Cursor](https://cursor.com)