### PR TITLE
Keep unused declared Factor levels in K-Modes category composition (tam#38122)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.2
-Date: 2026-08-27
+Version: 16.1.3
+Date: 2026-08-29
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmodes.R
+++ b/R/kmodes.R
@@ -531,10 +531,14 @@ kmodes_adjusted_residual <- function(observed, expected, row_prop, col_prop) {
 #' @param importance The variable importance table, used for the default display order.
 #' @param display_levels Name-keyed list from `kmodes_prepare_data()`, or NULL
 #'   to fall back to `sort(unique(...))` per variable (#37936).
+#' @param numeric_conversion Optional tibble from `kmodes_prepare_data()` with
+#'   `variable` / `conversion`. Used to skip unused-level expansion for
+#'   `equal_width` bins (empty cut() bins are not declared Factor levels).
 #' @return A tibble of one row per variable, cluster and category. `category`
 #'   is a factor for compatibility with global-order consumers, while
 #'   `category_order` preserves the exact per-variable order.
-kmodes_category_composition <- function(prepared_df, cluster, importance, display_levels = NULL) {
+kmodes_category_composition <- function(prepared_df, cluster, importance, display_levels = NULL,
+                                        numeric_conversion = NULL) {
   category_levels_by_variable <- kmodes_category_display_levels_by_variable(prepared_df, display_levels)
   order_lookup <- importance %>%
     dplyr::mutate(variable_order = dplyr::row_number()) %>%
@@ -543,8 +547,25 @@ kmodes_category_composition <- function(prepared_df, cluster, importance, displa
   original_lookup <- tibble::tibble(variable = names(prepared_df),
                                     original_order = seq_along(names(prepared_df)))
 
+  # equal_width numeric conversion stores every cut() bin in display_levels,
+  # including bins that never appear. Those are not user-declared Factor
+  # levels; keep omitting them. Factor columns (conversion NA) keep unused
+  # declared levels as n=0 so Category Composition can reserve them.
+  binned_vars <- character(0)
+  if (!is.null(numeric_conversion) && nrow(numeric_conversion) > 0) {
+    binned_vars <- numeric_conversion$variable[numeric_conversion$conversion == "equal_width"]
+  }
+
   rows <- purrr::map(names(prepared_df), function(col) {
-    counts <- as.data.frame(table(cluster, prepared_df[[col]]), stringsAsFactors = FALSE)
+    values <- prepared_df[[col]]
+    levs <- category_levels_by_variable[[col]]
+    levs <- levs[!is.na(levs)]
+    counted <- if (col %in% binned_vars) {
+      values
+    } else {
+      factor(values, levels = levs)
+    }
+    counts <- as.data.frame(table(cluster, counted), stringsAsFactors = FALSE)
     names(counts) <- c("cluster", "category", "n")
     counts$cluster <- as.integer(counts$cluster)
     counts %>%
@@ -788,7 +809,8 @@ exp_kmodes <- function(df, ...,
     characteristic <- kmodes_characteristic_categories(prepared_df, fit$cluster,
                                                        display_levels = prepared_all$display_levels)
     composition <- kmodes_category_composition(prepared_df, fit$cluster, importance,
-                                                display_levels = prepared_all$display_levels)
+                                                display_levels = prepared_all$display_levels,
+                                                numeric_conversion = prepared_all$numeric_conversion)
     map <- kmodes_build_mca_map(prepared_df, fit$cluster, characteristic,
                                 map_sample_size = map_sample_size,
                                 map_category_top_n = map_category_top_n)

--- a/tests/testthat/test_kmodes.R
+++ b/tests/testthat/test_kmodes.R
@@ -467,6 +467,63 @@ test_that("characteristic_categories and category_composition honor a factor's d
   expect_equal(levels(droplevels(plan_comp_levels)), sort(unique(df$plan)))
 })
 
+test_that("category_composition keeps unused declared Factor levels (tam#38122 analog)", {
+  # Factor type keeps every declared level, including ones with 0 rows. The
+  # composition table used to call table() on as.character(factor), which
+  # dropped unused levels before they could become n=0 bars on that variable's
+  # Category Composition panel.
+  set.seed(7)
+  n <- 80
+  df <- tibble::tibble(
+    tenure = factor(sample(c("3年以上", "1年-3年"), n, TRUE),
+                    levels = c("6ヶ月未満", "1年未満", "1年-3年", "3年以上")),
+    plan = sample(c("Enterprise", "Free", "Standard"), n, TRUE)
+  )
+  expect_false("6ヶ月未満" %in% as.character(df$tenure))
+  expect_false("1年未満" %in% as.character(df$tenure))
+
+  composition <- exp_kmodes(df, tenure, plan, centers = 2, seed = 1,
+                            elbow_method_mode = "none") %>%
+    tidy_rowwise(model, type = "category_composition")
+
+  tenure_rows <- composition %>% dplyr::filter(variable == "tenure")
+  tenure_cats <- as.character(tenure_rows$category)
+  expect_true(all(c("6ヶ月未満", "1年未満", "1年-3年", "3年以上") %in% tenure_cats))
+  unused <- tenure_rows %>% dplyr::filter(category %in% c("6ヶ月未満", "1年未満"))
+  expect_true(nrow(unused) > 0)
+  expect_true(all(unused$n == 0))
+  expect_true(all(unused$pct == 0 | is.na(unused$pct)))
+
+  # Unused tenure levels must not be copied onto the sibling character variable.
+  plan_cats <- composition %>% dplyr::filter(variable == "plan") %>%
+    dplyr::pull(category) %>% as.character()
+  expect_false(any(plan_cats %in% c("6ヶ月未満", "1年未満")))
+})
+
+test_that("category_composition does not resurrect empty equal-width bins", {
+  # display_levels for a cut() numeric also lists empty bins. Those are not
+  # user-declared Factor levels; Category Composition must keep omitting them.
+  set.seed(7)
+  df <- tibble::tibble(
+    grp = sample(c("A", "B"), 80, TRUE),
+    score = sample(1:5, 80, TRUE)
+  )
+  composition <- exp_kmodes(df, grp, score, centers = 2, seed = 1,
+                            numeric_handling = "equal_width", numeric_bins = 10,
+                            elbow_method_mode = "none") %>%
+    tidy_rowwise(model, type = "category_composition")
+  score_rows <- composition %>% dplyr::filter(variable == "score")
+  expect_true(nrow(score_rows) > 0)
+  # A category can be n=0 in one cluster and still observed overall. The
+  # lock is that a cut() bin which never appears in ANY row stays omitted --
+  # 5 distinct scores cannot fill 10 equal-width bins.
+  totals <- score_rows %>%
+    dplyr::group_by(category) %>%
+    dplyr::summarize(total = sum(n), .groups = "drop")
+  expect_true(all(totals$total > 0))
+  expect_lt(nrow(totals), 10)
+})
+
 test_that("the observed/expected ratio is NA rather than Inf when nothing is expected", {
   expect_true(is.na(kmodes_adjusted_residual(1, 0, 0.5, 0.5)))
 })


### PR DESCRIPTION
# Description

Pairs with [tam#38190](https://github.com/exploratory-io/tam/pull/38190) for [tam#38122](https://github.com/exploratory-io/tam/issues/38122).

K-Modes **Category Composition** dropped unused declared Factor levels (count 0). `kmodes_prepare_column()` already keeps `levels(x)` in `display_levels`, but `kmodes_category_composition()` called `table()` on the character vector, so those unused levels never became n=0 rows. The tam chart then could not reserve them.

This emits unused declared Factor levels as n=0. Empty equal-width `cut()` bins stay omitted — those are not user-declared Factor levels.

# Checklist

- [x] Add test cases for this fix/enhancement
- [ ] Pass devtools::check()
- [x] Pass the new kmodes tests via `pkgload::load_all` + `testthat::test_file` (147 pass; 3 pre-existing MCA-map failures unrelated to this change)
- [ ] Test installing from github
- [x] Tested with Exploratory (installed into `~/.exploratory/R/4.6_ARM`; tam harness live-Rserve case for unused ゴールド passed)


Made with [Cursor](https://cursor.com)