### PR TITLE
Analytics: CHAID: Support Numerical target variable (R package)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.2
-Date: 2026-08-27
+Version: 16.1.6
+Date: 2026-08-30
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -86,9 +86,12 @@ exp_chaid <- function(df,
   }
   orig_selected_cols <- tidyselect::vars_select(names(df), !!! rlang::quos(...))
 
-  if (is.numeric(df[[target_col]])) {
-    stop("CHAID supports categorical target variables only.")
-  }
+  # tam #38166: numeric targets are supported via a One-way ANOVA F-test
+  # (see chaid_fit()/merge_categories()/compute_anova_from_stats() in
+  # chaid.R); Date/POSIXct/duration columns stay out of scope (spec section 3)
+  # even though some are numeric-backed, hence chaid_is_numeric_target()
+  # rather than a bare is.numeric() check.
+  is_numeric_target_col <- chaid_is_numeric_target(df[[target_col]])
 
   target_funs <- NULL
   if (!is.null(target_fun)) {
@@ -154,9 +157,15 @@ exp_chaid <- function(df,
                                     ordered = (test_split_type == "ordered"))
       df <- safe_slice(source_data, test_index, remove = TRUE)
 
-      unique_val <- unique(df[[clean_target_col]])
-      if (length(unique_val[!is.na(unique_val)]) <= 1) {
-        stop("Categorical Target Variable must have 2 or more unique values.")
+      # tam #38166 spec section 36: a numeric target with a single distinct
+      # value (SS_total == 0) still fits -- it simply produces a root-only
+      # tree (grow_node()'s purity check), so this categorical-only guard is
+      # skipped for a numeric target rather than erroring.
+      if (!is_numeric_target_col) {
+        unique_val <- unique(df[[clean_target_col]])
+        if (length(unique_val[!is.na(unique_val)]) <= 1) {
+          stop("Categorical Target Variable must have 2 or more unique values.")
+        }
       }
 
       model <- chaid_fit(
@@ -169,23 +178,40 @@ exp_chaid <- function(df,
         allow_resplit = allow_resplit,
         max_categories = max_categories
       )
-      model$classification_type <- if (model$target_type == "logical") "binary" else "multi"
+      model$classification_type <- if (model$target_type == "numeric") {
+        "regression"
+      } else if (model$target_type == "logical") {
+        "binary"
+      } else {
+        "multi"
+      }
       model$original_factor_levels <- original_factor_levels
 
       # Store training actual / predicted so tidy() evaluation and conf_mat can
       # reuse the shared model-agnostic evaluation helpers.
-      actual <- factor(as.character(df[[clean_target_col]]), levels = model$class_levels)
       train_all <- chaid_predict(model, df, type = "all")
-      model$y <- actual
-      model$predicted_class <- chaid_predicted_class(
-        model, train_all, binary_classification_threshold
-      )
-      model$predicted_prob <- chaid_positive_probability(model, train_all)
-      # Full class-probability matrix for report_metrics (Macro / One-vs-Rest AUCs).
-      # Column names are the raw class levels so multiclass_auc_by_class() can use them.
-      model$predicted_prob_matrix <- chaid_as_probability_matrix(
-        train_all, model$class_levels
-      )
+      if (model$target_type == "numeric") {
+        # tam #38166: no class to predict -- keep the numeric actual/predicted
+        # pair (for RMSE/R^2 evaluation) and the per-row node id (so
+        # build_chaid_tree_nodes() can build each node's target histogram,
+        # mirroring rpart's x$where).
+        model$y <- as.numeric(df[[clean_target_col]])
+        model$predicted_value <- train_all$.pred_value
+        model$predicted_class <- train_all$.pred_class
+        model$train_node_ids <- train_all$.chaid_node_id
+      } else {
+        actual <- factor(as.character(df[[clean_target_col]]), levels = model$class_levels)
+        model$y <- actual
+        model$predicted_class <- chaid_predicted_class(
+          model, train_all, binary_classification_threshold
+        )
+        model$predicted_prob <- chaid_positive_probability(model, train_all)
+        # Full class-probability matrix for report_metrics (Macro / One-vs-Rest AUCs).
+        # Column names are the raw class levels so multiclass_auc_by_class() can use them.
+        model$predicted_prob_matrix <- chaid_as_probability_matrix(
+          train_all, model$class_levels
+        )
+      }
 
       # Metadata expected by the framework.
       model$terms_mapping <- names(group_name_map)
@@ -204,20 +230,13 @@ exp_chaid <- function(df,
         max_pd_vars_eff <- as.integer(max_pd_vars)
       }
 
-      # tam#37466: `firm` derives importance from the partial-dependence curves,
-      # so unlike `permutation` it has to see the PD of EVERY predictor before it
-      # can rank them. That inverts the order of the two steps below, exactly the
-      # way exp_rpart does it: compute PD over all c_cols, run importance_firm(),
-      # then trim imp_vars and shrink the PD data back down to max_pd_vars.
-      # `identical()` keeps NULL and empty values on the permutation path, too.
-      # This matters for callers that forward an optional UI setting.
-      use_firm_importance <- identical(as.character(importance_measure), "firm") &&
-        length(c_cols) > 1
-
-      if (use_firm_importance) {
-        imp_vars <- c_cols
-      } else {
-        model$importance <- chaid_permutation_importance(
+      if (model$target_type == "numeric") {
+        # tam #38166: `firm` importance and partial dependence both go through
+        # `predict(type = "prob")`, which has no meaning for a numeric target
+        # (see chaid_predict_prepared()) -- deferred as future work (PR body).
+        # Importance uses an RMSE-drop permutation variant instead of
+        # `chaid_permutation_importance()`'s log-loss.
+        model$importance <- chaid_permutation_importance_numeric(
           model = model,
           data = importance_data,
           target = clean_target_col,
@@ -229,23 +248,21 @@ exp_chaid <- function(df,
         imp_vars <- chaid_partial_dependence_vars(
           model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
         )
-      }
+        model$partial_dependence <- NULL
+      } else {
+        # tam#37466: `firm` derives importance from the partial-dependence curves,
+        # so unlike `permutation` it has to see the PD of EVERY predictor before it
+        # can rank them. That inverts the order of the two steps below, exactly the
+        # way exp_rpart does it: compute PD over all c_cols, run importance_firm(),
+        # then trim imp_vars and shrink the PD data back down to max_pd_vars.
+        # `identical()` keeps NULL and empty values on the permutation path, too.
+        # This matters for callers that forward an optional UI setting.
+        use_firm_importance <- identical(as.character(importance_measure), "firm") &&
+          length(c_cols) > 1
 
-      # Partial dependence for Analytics Report {{variable_effect}} /
-      # local_importance_binary (same contract as exp_rpart).
-      model$partial_dependence <- partial_dependence.exploratory_chaid(
-        model, clean_target_col, vars = imp_vars, data = df,
-        n = c(pd_grid_resolution, min(nrow(df), pd_sample_size))
-      )
-
-      if (use_firm_importance) {
-        model$importance <- chaid_firm_importance(
-          # PD is always calculated from the fitted model's training rows.
-          model$partial_dependence, model, imp_vars, "Training"
-        )
-        # Fall back to permutation when FIRM could not be computed (e.g. the
-        # optional `mmpf` package is missing, so partial_dependence is NULL).
-        if (is.null(model$importance)) {
+        if (use_firm_importance) {
+          imp_vars <- c_cols
+        } else {
           model$importance <- chaid_permutation_importance(
             model = model,
             data = importance_data,
@@ -255,14 +272,44 @@ exp_chaid <- function(df,
             seed = seed,
             repeats = 10L
           )
-        }
-        imp_vars <- chaid_partial_dependence_vars(
-          model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
-        )
-        if (!is.null(model$partial_dependence)) {
-          model$partial_dependence <- shrink_partial_dependence_data(
-            model$partial_dependence, imp_vars
+          imp_vars <- chaid_partial_dependence_vars(
+            model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
           )
+        }
+
+        # Partial dependence for Analytics Report {{variable_effect}} /
+        # local_importance_binary (same contract as exp_rpart).
+        model$partial_dependence <- partial_dependence.exploratory_chaid(
+          model, clean_target_col, vars = imp_vars, data = df,
+          n = c(pd_grid_resolution, min(nrow(df), pd_sample_size))
+        )
+
+        if (use_firm_importance) {
+          model$importance <- chaid_firm_importance(
+            # PD is always calculated from the fitted model's training rows.
+            model$partial_dependence, model, imp_vars, "Training"
+          )
+          # Fall back to permutation when FIRM could not be computed (e.g. the
+          # optional `mmpf` package is missing, so partial_dependence is NULL).
+          if (is.null(model$importance)) {
+            model$importance <- chaid_permutation_importance(
+              model = model,
+              data = importance_data,
+              target = clean_target_col,
+              predictors = c_cols,
+              evaluation_data = evaluation_data_label,
+              seed = seed,
+              repeats = 10L
+            )
+          }
+          imp_vars <- chaid_partial_dependence_vars(
+            model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
+          )
+          if (!is.null(model$partial_dependence)) {
+            model$partial_dependence <- shrink_partial_dependence_data(
+              model$partial_dependence, imp_vars
+            )
+          }
         }
       }
 
@@ -652,7 +699,154 @@ chaid_permutation_importance <- function(model, data, target, predictors,
   result
 }
 
+#' Root-mean-squared-error loss for numeric CHAID predictions.
+#'
+#' @param actual Actual numeric target values.
+#' @param predicted Predicted numeric values (`.pred_value` from
+#'   `chaid_predict(type = "all")`).
+#' @return A scalar RMSE, or NA_real_ when no valid rows exist.
+chaid_rmse_loss <- function(actual, predicted) {
+  valid <- is.finite(actual) & is.finite(predicted)
+  if (!any(valid)) {
+    return(NA_real_)
+  }
+  sqrt(mean((actual[valid] - predicted[valid])^2))
+}
 
+#' Model-independent permutation importance for a numeric-target CHAID model.
+#'
+#' Mirrors [chaid_permutation_importance()] (same permutation scheme, same
+#' output schema, same "skip predictors the tree never split on" shortcut) but
+#' scores each permutation by the RMSE INCREASE rather than the log-loss
+#' increase, since a numeric target has no class probability to score. tam
+#' #38166 (spec section 32-36's numeric branch has no importance requirement
+#' of its own; this keeps `imp_vars`/the Importance report table populated
+#' with a real, non-stubbed metric instead of leaving it empty).
+#'
+#' @param model A fitted `exploratory_chaid` model with `target_type == "numeric"`.
+#' @param data Evaluation rows containing target and predictors.
+#' @param target Target column name.
+#' @param predictors Predictor column names.
+#' @param evaluation_data Label for the evaluation rows.
+#' @param seed Random seed for reproducible permutations.
+#' @param repeats Number of permutations per predictor.
+#' @return A stable permutation-importance data frame (`metric == 'rmse'`).
+chaid_permutation_importance_numeric <- function(model, data, target, predictors,
+                                                 evaluation_data = 'Training', seed = 1,
+                                                 repeats = 10L) {
+  result <- chaid_empty_permutation_importance()
+  if (!is.data.frame(data) || nrow(data) == 0 ||
+      !target %in% names(data) || length(predictors) == 0) {
+    return(result)
+  }
+
+  actual <- as.numeric(data[[target]])
+  valid <- is.finite(actual)
+  if (sum(valid) < 2L) {
+    return(result)
+  }
+  evaluation_data_frame <- data[valid, , drop = FALSE]
+  actual <- actual[valid]
+  prepared_data <- tryCatch(
+    prepare_chaid_new_data(evaluation_data_frame, model),
+    error = function(e) NULL
+  )
+  if (is.null(prepared_data)) {
+    return(result)
+  }
+  split_index <- chaid_build_split_index(model)
+  baseline_prediction <- tryCatch(
+    chaid_predict_prepared(model, prepared_data, type = 'value',
+                           split.index = split_index),
+    error = function(e) NULL
+  )
+  if (is.null(baseline_prediction)) {
+    return(result)
+  }
+  baseline_loss <- chaid_rmse_loss(actual, baseline_prediction)
+  if (!is.finite(baseline_loss)) {
+    return(result)
+  }
+
+  if (length(seed) == 1L && is.finite(seed)) {
+    set.seed(seed)
+  } else {
+    set.seed(1L)
+  }
+  repeat_count <- max(1L, as.integer(repeats))
+  split_variables <- unique(unlist(
+    lapply(model$.node_metadata, function(metadata) metadata$split_variable),
+    use.names = FALSE
+  ))
+  evaluation_row_count <- nrow(prepared_data)
+  rows <- lapply(predictors, function(variable) {
+    if (!variable %in% names(evaluation_data_frame)) {
+      return(NULL)
+    }
+    affects_prediction <- variable %in% split_variables &&
+      variable %in% names(prepared_data)
+    drops <- vapply(seq_len(repeat_count), function(iteration) {
+      permutation <- sample.int(evaluation_row_count)
+      if (!affects_prediction) {
+        return(0)
+      }
+      permuted_data <- prepared_data
+      permuted_data[[variable]] <- permuted_data[[variable]][permutation]
+      permuted_prediction <- tryCatch(
+        chaid_predict_prepared(model, permuted_data, type = 'value',
+                               split.index = split_index),
+        error = function(e) NULL
+      )
+      if (is.null(permuted_prediction)) {
+        return(NA_real_)
+      }
+      permuted_loss <- chaid_rmse_loss(actual, permuted_prediction)
+      if (is.finite(permuted_loss)) permuted_loss - baseline_loss else NA_real_
+    }, numeric(1))
+    finite_drops <- drops[is.finite(drops)]
+    if (length(finite_drops) == 0L) {
+      importance <- NA_real_
+      std_error <- NA_real_
+    } else {
+      importance <- mean(finite_drops)
+      std_error <- if (length(finite_drops) > 1L) {
+        stats::sd(finite_drops) / sqrt(length(finite_drops))
+      } else {
+        0
+      }
+    }
+    mapped_variable <- if (!is.null(model$terms_mapping) &&
+                           variable %in% names(model$terms_mapping)) {
+      unname(model$terms_mapping[[variable]])
+    } else {
+      variable
+    }
+    data.frame(
+      variable = mapped_variable,
+      importance = importance,
+      std_error = std_error,
+      metric = 'rmse',
+      evaluation_data = evaluation_data,
+      repeats = as.integer(repeat_count),
+      stringsAsFactors = FALSE
+    )
+  })
+  rows <- Filter(Negate(is.null), rows)
+  if (length(rows) == 0L) {
+    return(result)
+  }
+  result <- dplyr::bind_rows(rows)
+  result$rank <- ifelse(
+    is.finite(result$importance),
+    rank(-result$importance, ties.method = 'min'),
+    NA_integer_
+  )
+  result <- result %>%
+    dplyr::arrange(is.na(rank), rank, variable) %>%
+    dplyr::select(variable, importance, std_error, rank, metric,
+                  evaluation_data, repeats)
+  result
+}
 
 #' Choose predictor columns for CHAID partial dependence, by importance order.
 #'
@@ -818,6 +1012,32 @@ augment.exploratory_chaid <- function(x, data = NULL, newdata = NULL,
   }
 
   all_prediction <- chaid_predict(x, frame, type = "all")
+
+  if (identical(x$target_type, "numeric")) {
+    # tam #38166 spec section 19 (Prediction Data): Predicted Value, Node ID,
+    # and (when the actual target is present in `frame`) Residual = Actual -
+    # Predicted.
+    predicted_value_col <- avoid_conflict(colnames(frame), "predicted_value")
+    node_id_col <- avoid_conflict(colnames(frame), "chaid_node_id")
+    frame[[predicted_value_col]] <- all_prediction[[".pred_value"]]
+    frame[[node_id_col]] <- all_prediction[[".chaid_node_id"]]
+    target_col_in_frame <- if (!is.null(x$orig_target_col) &&
+                                x$orig_target_col %in% names(frame)) {
+      x$orig_target_col
+    } else if (!is.null(x$clean_target_col) &&
+               x$clean_target_col %in% names(frame)) {
+      x$clean_target_col
+    } else {
+      NULL
+    }
+    if (!is.null(target_col_in_frame)) {
+      residual_col <- avoid_conflict(colnames(frame), "residual")
+      frame[[residual_col]] <- as.numeric(frame[[target_col_in_frame]]) -
+        all_prediction[[".pred_value"]]
+    }
+    return(frame)
+  }
+
   predicted_label <- as.character(chaid_predicted_class(
     x, all_prediction, binary_classification_threshold
   ))
@@ -902,6 +1122,51 @@ tidy.exploratory_chaid <- function(x, type = "evaluation", pretty.name = FALSE,
     return(data.frame())
   }
   actual <- x$y
+  # tam #38166: a numeric target has no class to re-threshold/predict -- most
+  # `type`s below are classification-only and stay unreachable for it (the
+  # types CHAID's own report/prediction pipeline actually calls for a numeric
+  # model -- node_summary, rules, category_merges, split_summary,
+  # numeric_intervals, importance, evaluation -- are all target-type-aware).
+  if (identical(x$target_type, "numeric")) {
+    return(chaid_display_node_ids(switch(
+      type,
+      evaluation = {
+        if ("error" %in% class(x)) {
+          return(data.frame(Note = x$message))
+        }
+        ret <- evaluate_regression_(
+          data.frame(.pred = x$predicted_value, .actual = actual),
+          ".pred", ".actual"
+        )
+        # Mirror the pretty-name mapping used elsewhere for regression
+        # evaluation (rpart / xgboost / lightgbm regression `tidy()`).
+        if (pretty.name) {
+          ret <- ret %>%
+            dplyr::rename(
+              `R Squared` = r_squared,
+              RMSE = root_mean_square_error,
+              MAE = mean_absolute_error,
+              MAPE = mean_absolute_percentage_error
+            )
+        }
+        ret
+      },
+      tree_nodes = build_chaid_tree_nodes(x),
+      node_summary = chaid_node_summary(x),
+      rules = chaid_rule_table(x),
+      category_merges = chaid_category_merge_table(x),
+      split_summary = chaid_split_summary(x),
+      category_error_distribution = chaid_category_error_distribution(x),
+      numeric_intervals = chaid_numeric_intervals(x),
+      importance = {
+        if (is.null(x$importance)) chaid_empty_permutation_importance() else x$importance
+      },
+      partial_dependence = handle_partial_dependence(x),
+      {
+        stop(paste0("type ", type, " is not defined for a numeric CHAID target"))
+      }
+    )))
+  }
   # Re-threshold binary labels so Settings → cut point updates F1 / Accuracy etc.
   # (ROC / PR AUC use predicted_prob and are threshold-independent.)
   predicted <- if (identical(x$classification_type, "binary") &&
@@ -1005,6 +1270,7 @@ build_chaid_tree_nodes <- function(x) {
   edges <- x$edges
   root_n <- nodes$n[nodes$node_id == 1L]
   class_levels <- x$class_levels
+  is_reg <- identical(x$target_type, "numeric")
 
   map_name <- function(v) {
     tm <- x$terms_mapping
@@ -1014,7 +1280,7 @@ build_chaid_tree_nodes <- function(x) {
 
   # Positive class first for a 2-class target (SPSS-style ordering).
   ord <- seq_along(class_levels)
-  if (length(class_levels) == 2) {
+  if (!is_reg && length(class_levels) == 2) {
     up <- toupper(class_levels)
     positive_idx <- if (setequal(up, c("FALSE", "TRUE"))) which(up == "TRUE")
                     else if (setequal(up, c("NO", "YES"))) which(up == "YES")
@@ -1024,16 +1290,79 @@ build_chaid_tree_nodes <- function(x) {
     }
   }
 
+  # tam #38166: numeric-target-only. A shared-breaks target histogram per
+  # node, mirroring build_rpart_tree_nodes()'s regression branch -- every
+  # node's counts are on the SAME bins so shapes are comparable across the
+  # tree. Node membership is reconstructed from x$train_node_ids (the leaf/
+  # internal node each training row resolves to) walked up to the root via
+  # `nodes$parent_id`, since CHAID node ids are not a binary heap (no `%/% 2`
+  # shortcut the way rpart's are).
+  dist_by_id <- NULL
+  shared_breaks <- NULL
+  if (is_reg) {
+    yv <- x$y
+    train_ids <- x$train_node_ids
+    if (!is.null(yv) && length(yv) > 0 && !is.null(train_ids) &&
+        length(train_ids) == length(yv)) {
+      yfin <- yv[is.finite(yv)]
+      if (length(yfin) >= 2 && diff(range(yfin)) > 0) {
+        y_min <- min(yfin)
+        y_max <- max(yfin)
+        if (all(yfin == floor(yfin)) && (y_max - y_min) <= 30) {
+          shared_breaks <- seq(y_min - 0.5, y_max + 0.5, by = 1)
+        } else {
+          shared_breaks <- seq(y_min, y_max, length.out = 21)
+        }
+      } else if (length(yfin) >= 1) {
+        shared_breaks <- c(yfin[1] - 0.5, yfin[1] + 0.5)
+      }
+      if (!is.null(shared_breaks)) {
+        nbin <- length(shared_breaks) - 1L
+        parent_of <- stats::setNames(as.character(nodes$parent_id), as.character(nodes$node_id))
+        dist_by_id <- list()
+        for (r in seq_along(yv)) {
+          v <- yv[r]
+          if (!is.finite(v)) next
+          bi <- .bincode(v, shared_breaks, include.lowest = TRUE)
+          if (is.na(bi)) next
+          nd <- train_ids[r]
+          if (is.na(nd)) next
+          repeat {
+            key <- as.character(nd)
+            cc <- dist_by_id[[key]]
+            if (is.null(cc)) cc <- integer(nbin)
+            cc[bi] <- cc[bi] + 1L
+            dist_by_id[[key]] <- cc
+            parent_key <- parent_of[[key]]
+            if (is.null(parent_key) || is.na(parent_key)) break
+            nd <- parent_key
+          }
+        }
+      }
+    }
+  }
+  dist_json_for <- function(id) {
+    if (!is_reg || is.null(shared_breaks)) return(NA_character_)
+    cc <- dist_by_id[[as.character(id)]]
+    if (is.null(cc)) cc <- integer(length(shared_breaks) - 1L)
+    as.character(jsonlite::toJSON(list(breaks = shared_breaks, counts = cc),
+                                  digits = 10, auto_unbox = FALSE))
+  }
+
   rows <- lapply(seq_len(nrow(nodes)), function(i) {
     id <- nodes$node_id[i]
     node_n <- nodes$n[i]
-    distribution <- nodes$class_distribution[[i]]
-    counts <- as.numeric(distribution) * node_n
-    arr <- lapply(ord, function(j) {
-      list(label = class_levels[j], n = counts[j],
-           pct = if (node_n > 0) counts[j] / node_n else 0)
-    })
-    class_json <- as.character(jsonlite::toJSON(arr, auto_unbox = TRUE, digits = NA))
+    if (is_reg) {
+      class_json <- NA_character_
+    } else {
+      distribution <- nodes$class_distribution[[i]]
+      counts <- as.numeric(distribution) * node_n
+      arr <- lapply(ord, function(j) {
+        list(label = class_levels[j], n = counts[j],
+             pct = if (node_n > 0) counts[j] / node_n else 0)
+      })
+      class_json <- as.character(jsonlite::toJSON(arr, auto_unbox = TRUE, digits = NA))
+    }
 
     # Split-test stats belong to nodes that actually split; NA everywhere else
     # (leaves, and nodes whose best candidate failed the alpha_split gate).
@@ -1076,16 +1405,25 @@ build_chaid_tree_nodes <- function(x) {
       cond_column = cond_column,
       cond_operator = if (is.na(cond_column)) NA_character_ else "in",
       cond_value = cond_value,
-      mean_value = NA_real_,
-      sd_value = NA_real_,
-      rmse_value = NA_real_,
-      dist_json = NA_character_,
+      mean_value = if (is_reg) as.numeric(nodes$node_mean[i]) else NA_real_,
+      sd_value = if (is_reg) as.numeric(nodes$node_sd[i]) else NA_real_,
+      # sample SD (n-1 denominator, `node_sd`) -> population SD (n denominator)
+      # so rmse_value reads as the within-node root-mean-squared deviation
+      # from the mean, matching build_rpart_tree_nodes()'s sqrt(dev/n).
+      rmse_value = if (is_reg && node_n > 0 && is.finite(nodes$node_sd[i])) {
+        as.numeric(nodes$node_sd[i]) * sqrt(max(node_n - 1, 0) / node_n)
+      } else {
+        NA_real_
+      },
+      dist_json = dist_json_for(id),
       # CHAID split test at this node (NA for leaves). The interactive tree
       # renderer shows these on the splitting (parent) node, SPSS-style.
       p_value = if (is_split) nodes$p_value[i] else NA_real_,
       adjusted_p_value = if (is_split) nodes$adjusted_p_value[i] else NA_real_,
       split_statistic = if (is_split) nodes$split_statistic[i] else NA_real_,
       split_df = if (is_split) nodes$split_df[i] else NA_real_,
+      split_df1 = if (is_split) nodes$split_df1[i] else NA_real_,
+      split_df2 = if (is_split) nodes$split_df2[i] else NA_real_,
       stringsAsFactors = FALSE
     )
   })

--- a/R/chaid.R
+++ b/R/chaid.R
@@ -62,39 +62,73 @@ chaid_fit <- function(data,
     verbose = verbose
   )
 
+  numeric.target <- chaid_is_numeric_target(data[[target]])
+
   prepared <- prepare_chaid_data(
     data = data,
     target = target,
     predictors = validation$predictors,
-    parameters = validation$parameters
+    parameters = validation$parameters,
+    numeric_target = numeric.target
   )
-  target.factor <- prepared$data[[target]]
-  class.levels <- levels(target.factor)
-  class.counts <- tabulate(target.factor, nbins = length(class.levels))
-  predicted.class <- class.levels[which.max(class.counts)]
-  class.distribution <- if (sum(class.counts) == 0) {
-    rep(0, length(class.levels))
-  } else {
-    class.counts / sum(class.counts)
-  }
 
-  nodes <- data.frame(
-    node_id = 1L,
-    parent_id = NA_integer_,
-    depth = 0L,
-    is_terminal = TRUE,
-    n = nrow(prepared$data),
-    weighted_n = nrow(prepared$data),
-    predicted_class = predicted.class,
-    split_variable = NA_character_,
-    p_value = NA_real_,
-    adjusted_p_value = NA_real_,
-    split_statistic = NA_real_,
-    split_df = NA_real_,
-    rule = 'Root',
-    stringsAsFactors = FALSE
-  )
-  nodes$class_distribution <- list(setNames(class.distribution, class.levels))
+  if (numeric.target) {
+    root.summary <- chaid_numeric_node_summary(prepared$data[[target]])
+    class.levels <- NULL
+    nodes <- data.frame(
+      node_id = 1L,
+      parent_id = NA_integer_,
+      depth = 0L,
+      is_terminal = TRUE,
+      n = nrow(prepared$data),
+      weighted_n = nrow(prepared$data),
+      predicted_class = root.summary$label,
+      split_variable = NA_character_,
+      p_value = NA_real_,
+      adjusted_p_value = NA_real_,
+      split_statistic = NA_real_,
+      split_df = NA_real_,
+      split_df1 = NA_real_,
+      split_df2 = NA_real_,
+      node_mean = root.summary$mean,
+      node_sd = root.summary$sd,
+      rule = 'Root',
+      stringsAsFactors = FALSE
+    )
+    nodes$class_distribution <- list(NULL)
+  } else {
+    target.factor <- prepared$data[[target]]
+    class.levels <- levels(target.factor)
+    class.counts <- tabulate(target.factor, nbins = length(class.levels))
+    predicted.class <- class.levels[which.max(class.counts)]
+    class.distribution <- if (sum(class.counts) == 0) {
+      rep(0, length(class.levels))
+    } else {
+      class.counts / sum(class.counts)
+    }
+
+    nodes <- data.frame(
+      node_id = 1L,
+      parent_id = NA_integer_,
+      depth = 0L,
+      is_terminal = TRUE,
+      n = nrow(prepared$data),
+      weighted_n = nrow(prepared$data),
+      predicted_class = predicted.class,
+      split_variable = NA_character_,
+      p_value = NA_real_,
+      adjusted_p_value = NA_real_,
+      split_statistic = NA_real_,
+      split_df = NA_real_,
+      split_df1 = NA_real_,
+      split_df2 = NA_real_,
+      node_mean = NA_real_,
+      node_sd = NA_real_,
+      rule = 'Root',
+      stringsAsFactors = FALSE
+    )
+    nodes$class_distribution <- list(setNames(class.distribution, class.levels))
+  }
 
   model <- list(
     nodes = nodes,
@@ -121,7 +155,9 @@ chaid_fit <- function(data,
     numeric_binning_map = prepared$numeric_binning_map,
     class_levels = class.levels,
     target = target,
-    target_type = if (is.logical(data[[target]])) {
+    target_type = if (numeric.target) {
+      'numeric'
+    } else if (is.logical(data[[target]])) {
       'logical'
     } else if (is.factor(data[[target]])) {
       'factor'
@@ -139,8 +175,12 @@ chaid_fit <- function(data,
   )
   low.expected.split <- FALSE
   grew.tree <- FALSE
+  # Numeric targets skip the `length(class.levels) > 1` gate (there are no
+  # class levels); a numeric target with zero variance still fits, it simply
+  # produces a root-only tree (section 36: SS_total == 0 -> Terminal Node, not
+  # an error) via the purity check inside grow_node().
   if (length(prepared$predictors) > 0 && nrow(prepared$data) > 0 &&
-      length(class.levels) > 1) {
+      (numeric.target || length(class.levels) > 1)) {
     grew.tree <- TRUE
     tree <- grow_chaid_tree(
       data = prepared$data,
@@ -148,7 +188,8 @@ chaid_fit <- function(data,
       predictors = prepared$predictors,
       parameters = validation$parameters,
       predictor_info = prepared$predictor_info,
-      class_levels = class.levels
+      class_levels = class.levels,
+      numeric_target = numeric.target
     )
     tree <- chaid_renumber_nodes_bfs(tree)
     model$nodes <- tree$nodes
@@ -206,10 +247,20 @@ emit_chaid_warnings <- function(numeric_binned, root_only, low_expected) {
 #' @param target Target column name.
 #' @param predictors Predictor column names.
 #' @param parameters Validated CHAID parameters.
+#' @param numeric_target Whether the target column is numeric.
 #' @return A list containing prepared data and transformation metadata.
-prepare_chaid_data <- function(data, target, predictors, parameters) {
+prepare_chaid_data <- function(data, target, predictors, parameters,
+                               numeric_target = FALSE) {
   target.raw <- data[[target]]
-  row.keep <- !is.na(target.raw)
+  # tam #38166 spec section 36: rows whose (numeric) target is Inf/-Inf are
+  # dropped from every statistic/test, mirroring the empty-data-frame min/max
+  # rule at global/r-integration.md#r-min-max-inf-empty-dataframe -- keeping
+  # them would let a non-finite value poison every sum()/mean() downstream.
+  row.keep <- if (numeric_target) {
+    !is.na(target.raw) & is.finite(as.numeric(target.raw))
+  } else {
+    !is.na(target.raw)
+  }
   predictor.values <- list()
   predictor.info <- list()
   numeric.binning.map <- list()
@@ -280,18 +331,22 @@ prepare_chaid_data <- function(data, target, predictors, parameters) {
     ))
   }
 
-  target.levels <- if (is.factor(target.raw)) {
-    levels(target.raw)
-  } else if (is.logical(target.raw)) {
-    # Stable, deterministic order with the positive class (TRUE) first, so
-    # class_levels[1] is the positive class for binary/logical targets.
-    c('TRUE', 'FALSE')
-  } else {
-    unique(as.character(target.raw[!is.na(target.raw)]))
-  }
-  target.factor <- factor(as.character(target.raw[row.keep]), levels = target.levels)
   prepared.data <- data.frame(row.names = seq_len(sum(row.keep)))
-  prepared.data[[target]] <- target.factor
+  if (numeric_target) {
+    prepared.data[[target]] <- as.numeric(target.raw[row.keep])
+  } else {
+    target.levels <- if (is.factor(target.raw)) {
+      levels(target.raw)
+    } else if (is.logical(target.raw)) {
+      # Stable, deterministic order with the positive class (TRUE) first, so
+      # class_levels[1] is the positive class for binary/logical targets.
+      c('TRUE', 'FALSE')
+    } else {
+      unique(as.character(target.raw[!is.na(target.raw)]))
+    }
+    target.factor <- factor(as.character(target.raw[row.keep]), levels = target.levels)
+    prepared.data[[target]] <- target.factor
+  }
   for (variable in predictors.kept) {
     prepared.data[[variable]] <- predictor.values[[variable]][row.keep]
     prepared.data[[variable]] <- as.character(prepared.data[[variable]])
@@ -454,6 +509,137 @@ compute_chisq_test <- function(x, y, method = 'pearson') {
   compute_chisq_from_counts(observed, method = method)
 }
 
+#' Whether a column should be treated as a numeric CHAID target.
+#'
+#' tam #38166: numeric targets use a One-way ANOVA F-test instead of the
+#' chi-square association test. Date/POSIXct/difftime columns are explicitly
+#' out of scope (spec section 3) even though some are numeric-backed, so they
+#' are excluded by class rather than by `is.numeric()` alone.
+#'
+#' @param x A vector.
+#' @return TRUE when `x` should be fit as a numeric CHAID target.
+chaid_is_numeric_target <- function(x) {
+  is.numeric(x) && !inherits(x, c('Date', 'POSIXct', 'POSIXt', 'difftime'))
+}
+
+#' Summarize a numeric CHAID node's target values.
+#'
+#' @param y Numeric target values within one node (already NA/non-finite free).
+#' @return `list(mean, sd, label)`; `label` is a compact string for display.
+chaid_numeric_node_summary <- function(y) {
+  y <- y[is.finite(y)]
+  node.mean <- if (length(y) > 0) mean(y) else NA_real_
+  node.sd <- if (length(y) > 1) stats::sd(y) else NA_real_
+  list(
+    mean = as.numeric(node.mean),
+    sd = as.numeric(node.sd),
+    label = if (is.na(node.mean)) NA_character_ else format_chaid_break(node.mean)
+  )
+}
+
+#' Compute a one-way ANOVA F-test from per-group sufficient statistics.
+#'
+#' Mirrors [compute_chisq_from_counts()]'s role for the categorical/logical
+#' target: category merging calls this once per merge candidate and once for
+#' the overall (post-merge) split test, each time on a `stats` matrix built by
+#' summing per-CATEGORY sufficient statistics -- never by rescanning raw rows.
+#'
+#' `stats` has 3 rows (`n`, `sum`, `sumsq`) and one column per group; because
+#' sum and sum-of-squares are additive over disjoint row sets, a group's
+#' column is exactly the column-wise sum of its member categories' columns
+#' (identical to how the chi-square path sums contingency-table columns), so
+#' [merge_categories()] can reuse the very same `col_of_group()`/`rowSums()`
+#' machinery for both target types.
+#'
+#' F = MS_between / MS_within, df1 = k - 1, df2 = N - k (k = number of
+#' non-empty groups, N = total rows). For k == 2 this is algebraically
+#' identical to `t^2` from an equal-variance two-sample t-test (tam #38166
+#' spec section 4-14 / test requirement in section 38).
+#'
+#' Special cases (spec section 36), all returned WITHOUT signaling an R
+#' condition -- the caller folds a non-computable test into "not significant"
+#' via `p_value >= alpha_merge`/`alpha_split`, and NA into "not a candidate":
+#' - Fewer than 2 non-empty groups, or `df2 <= 0` (not enough rows to spare a
+#'   residual degree of freedom): the test cannot be run -> `statistic`/
+#'   `p_value` are `NA`.
+#' - `SS_within == 0` and `SS_between <= 0` (every value, in every group, is
+#'   identical -- `SS_total == 0`): no evidence of any group difference ->
+#'   `p_value = 1` (never "significant"), not an error.
+#' - `SS_within == 0` and `SS_between > 0` (perfect between-group separation,
+#'   zero within-group spread): the largest possible F -> `statistic = Inf`,
+#'   `p_value = 0` (always "significant").
+#'
+#' @param stats A numeric matrix with row names `n`, `sum`, `sumsq`; one
+#'   column per group (as produced by summing category columns).
+#' @return A list with `statistic`, `p_value`, `df1`, `df2`, `df` (alias for
+#'   `df2`, kept for parity with `compute_chisq_from_counts()`'s single `df`),
+#'   `low_expected` (always `FALSE`; the concept does not apply to ANOVA),
+#'   `group_means`, and `group_sizes`.
+compute_anova_from_stats <- function(stats) {
+  empty <- list(statistic = NA_real_, p_value = NA_real_, df1 = NA_real_,
+               df2 = NA_real_, df = NA_real_, low_expected = FALSE,
+               group_means = numeric(0), group_sizes = numeric(0))
+  keep <- stats['n', ] > 0
+  stats <- stats[, keep, drop = FALSE]
+  k <- ncol(stats)
+  if (k < 2) {
+    return(empty)
+  }
+  n.i <- as.numeric(stats['n', ])
+  sum.i <- as.numeric(stats['sum', ])
+  sumsq.i <- as.numeric(stats['sumsq', ])
+  group.means <- sum.i / n.i
+  N <- sum(n.i)
+  df1 <- k - 1
+  df2 <- N - k
+  if (df2 <= 0) {
+    empty$df1 <- as.numeric(df1)
+    empty$df2 <- as.numeric(df2)
+    empty$df <- as.numeric(df2)
+    empty$group_means <- group.means
+    empty$group_sizes <- n.i
+    return(empty)
+  }
+  grand.sum <- sum(sum.i)
+  ss.between <- sum(sum.i^2 / n.i) - (grand.sum^2) / N
+  # Per-group within-SS; clamp tiny negative floating-point noise to 0 (a
+  # mathematically-zero within-group SS, e.g. a single-row group, can compute
+  # as a small negative number due to floating point cancellation).
+  ss.within.per.group <- pmax(0, sumsq.i - (sum.i^2) / n.i)
+  ss.within <- sum(ss.within.per.group)
+  ms.between <- ss.between / df1
+  ms.within <- ss.within / df2
+  if (!is.finite(ms.within) || ms.within == 0) {
+    if (!is.finite(ms.between) || ms.between <= 0) {
+      # SS_total == 0: every value (in every group) is identical.
+      statistic <- NA_real_
+      p.value <- 1
+    } else {
+      # Zero within-group spread but a real between-group difference.
+      statistic <- Inf
+      p.value <- 0
+    }
+  } else {
+    statistic <- ms.between / ms.within
+    if (!is.finite(statistic) || statistic < 0) {
+      statistic <- NA_real_
+      p.value <- NA_real_
+    } else {
+      p.value <- stats::pf(statistic, df1 = df1, df2 = df2, lower.tail = FALSE)
+    }
+  }
+  list(
+    statistic = as.numeric(statistic),
+    p_value = as.numeric(p.value),
+    df1 = as.numeric(df1),
+    df2 = as.numeric(df2),
+    df = as.numeric(df2),
+    low_expected = FALSE,
+    group_means = group.means,
+    group_sizes = n.i
+  )
+}
+
 #' Apply Bonferroni correction to a vector of p-values.
 #'
 #' @param p_values Raw p-values.
@@ -533,6 +719,9 @@ chaid_group_pair_key <- function(a, b) {
 #' @param bonferroni Whether to correct the p-values.
 #' @param chi_square Chi-square statistic to use.
 #' @param max_resplit_size Largest nominal group that is enumerated.
+#' @param test_fn Test function taking the per-group stats/contingency matrix
+#'   and returning a list with `p_value` -- `compute_chisq_from_counts()` for a
+#'   categorical/logical target, `compute_anova_from_stats()` for numeric.
 #' @return `list(a, b, p_value, adjusted_p_value)` or NULL when it should stand.
 chaid_best_resplit <- function(group.indices,
                                col_of_group,
@@ -540,7 +729,11 @@ chaid_best_resplit <- function(group.indices,
                                alpha_merge = 0.05,
                                bonferroni = TRUE,
                                chi_square = 'pearson',
-                               max_resplit_size = 12L) {
+                               max_resplit_size = 12L,
+                               test_fn = NULL) {
+  if (is.null(test_fn)) {
+    test_fn <- function(observed) compute_chisq_from_counts(observed, method = chi_square)
+  }
   partitions <- chaid_resplit_partitions(
     group.indices, ordered = ordered, max_resplit_size = max_resplit_size
   )
@@ -549,7 +742,7 @@ chaid_best_resplit <- function(group.indices,
   }
   raw.p.values <- vapply(partitions, function(part) {
     observed <- cbind(col_of_group(part$a), col_of_group(part$b))
-    compute_chisq_from_counts(observed, method = chi_square)$p_value
+    test_fn(observed)$p_value
   }, numeric(1))
   adjusted.p.values <- adjust_p_value_bonferroni(
     raw.p.values, bonferroni = bonferroni, n_tests = length(raw.p.values)
@@ -581,6 +774,10 @@ chaid_best_resplit <- function(group.indices,
 #' @param allow_resplit Whether a compound category of 3+ original categories may
 #'   be split again when its best binary partition is significant (CHAID stage
 #'   3). Off by default, so the greedy merge behaves exactly as before.
+#' @param numeric_target Whether `target` holds numeric values for a One-way
+#'   ANOVA F-test (tam #38166), rather than categorical/logical values for the
+#'   chi-square test. Categorical behavior is completely unchanged when this
+#'   is FALSE (the default) -- every line on that path is identical to before.
 #' @return Category groups and merge/test metadata.
 merge_categories <- function(values,
                              target,
@@ -591,10 +788,16 @@ merge_categories <- function(values,
                              variable = '',
                              node_id = 1L,
                              chi_square = 'pearson',
-                             allow_resplit = FALSE) {
+                             allow_resplit = FALSE,
+                             numeric_target = FALSE) {
   values <- as.character(values)
-  target <- as.character(target)
-  valid <- !is.na(values) & !is.na(target)
+  if (numeric_target) {
+    target <- as.numeric(target)
+    valid <- !is.na(values) & !is.na(target) & is.finite(target)
+  } else {
+    target <- as.character(target)
+    valid <- !is.na(values) & !is.na(target)
+  }
   values <- values[valid]
   target <- target[valid]
   categories <- if (ordered && !is.null(ordered_levels)) {
@@ -603,14 +806,29 @@ merge_categories <- function(values,
     unique(values)
   }
 
-  # Build the target-by-category contingency table ONCE. Every pairwise merge
-  # test and the overall test are then column extractions / sums of this matrix,
-  # so no per-test pass over the raw vectors is needed (the performance fix).
-  target.levels <- unique(target)
-  contingency <- unclass(table(
-    factor(target, levels = target.levels),
-    factor(values, levels = categories)
-  ))
+  if (numeric_target) {
+    # Sufficient-statistics matrix (n, sum, sum-of-squares) per category, built
+    # ONCE. Sum and sum-of-squares are additive over disjoint row sets, so a
+    # merged group's stats are simply the column-wise sum of its member
+    # categories' columns -- the same `col_of_group()`/`rowSums()` shape the
+    # chi-square path below already uses for its contingency table.
+    contingency <- vapply(categories, function(category) {
+      y <- target[values == category]
+      c(n = length(y), sum = sum(y), sumsq = sum(y^2))
+    }, numeric(3))
+    rownames(contingency) <- c('n', 'sum', 'sumsq')
+    test_fn <- function(observed) compute_anova_from_stats(observed)
+  } else {
+    # Build the target-by-category contingency table ONCE. Every pairwise merge
+    # test and the overall test are then column extractions / sums of this matrix,
+    # so no per-test pass over the raw vectors is needed (the performance fix).
+    target.levels <- unique(target)
+    contingency <- unclass(table(
+      factor(target, levels = target.levels),
+      factor(values, levels = categories)
+    ))
+    test_fn <- function(observed) compute_chisq_from_counts(observed, method = chi_square)
+  }
 
   # Each group is a set of column indices into `categories`.
   groups <- as.list(seq_along(categories))
@@ -652,7 +870,7 @@ merge_categories <- function(values,
           next
         }
         pair.observed <- cbind(col_of_group(groups[[i]]), col_of_group(groups[[j]]))
-        test <- compute_chisq_from_counts(pair.observed, method = chi_square)
+        test <- test_fn(pair.observed)
         candidate.index <- candidate.index + 1L
         candidates[[candidate.index]] <- list(
           i = i,
@@ -700,7 +918,8 @@ merge_categories <- function(values,
           ordered = ordered,
           alpha_merge = alpha_merge,
           bonferroni = bonferroni,
-          chi_square = chi_square
+          chi_square = chi_square,
+          test_fn = test_fn
         )
         if (is.null(split)) {
           next
@@ -729,8 +948,9 @@ merge_categories <- function(values,
 
   group.category.lists <- lapply(groups, function(group.indices) categories[group.indices])
   group.labels <- vapply(group.category.lists, paste, character(1), collapse = ' + ')
-  overall.observed <- vapply(groups, col_of_group, numeric(length(target.levels)))
-  overall.test <- compute_chisq_from_counts(overall.observed, method = chi_square)
+  stat.row.count <- nrow(contingency)
+  overall.observed <- vapply(groups, col_of_group, numeric(stat.row.count))
+  overall.test <- test_fn(overall.observed)
   list(
     groups = group.category.lists,
     group_labels = group.labels,
@@ -750,9 +970,11 @@ merge_categories <- function(values,
 #' @param parameters Validated CHAID parameters.
 #' @param predictor_info Predictor metadata.
 #' @param node_id Current node ID.
+#' @param numeric_target Whether `target` is numeric (One-way ANOVA F-test)
+#'   rather than categorical/logical (chi-square test).
 #' @return Predictor evaluation or NULL when no split is possible.
 evaluate_predictor <- function(data, target, variable, parameters,
-                               predictor_info, node_id) {
+                               predictor_info, node_id, numeric_target = FALSE) {
   values <- as.character(data[[variable]])
   if (length(unique(values)) < 2) {
     return(NULL)
@@ -768,7 +990,8 @@ evaluate_predictor <- function(data, target, variable, parameters,
     variable = variable,
     node_id = node_id,
     chi_square = parameters$chi_square,
-    allow_resplit = isTRUE(parameters$allow_resplit)
+    allow_resplit = isTRUE(parameters$allow_resplit),
+    numeric_target = numeric_target
   )
   if (length(merge.result$groups) < 2 || is.na(merge.result$p_value)) {
     return(NULL)
@@ -785,10 +1008,14 @@ evaluate_predictor <- function(data, target, variable, parameters,
 #' @param predictors Prepared predictors.
 #' @param parameters Validated CHAID parameters.
 #' @param predictor_info Predictor metadata.
-#' @param class_levels Target class levels.
+#' @param class_levels Target class levels (NULL when `numeric_target` is TRUE).
+#' @param numeric_target Whether the target is numeric (One-way ANOVA F-test
+#'   splits, node prediction = mean) rather than categorical/logical
+#'   (chi-square splits, node prediction = majority class). tam #38166.
+#'   Categorical behavior is unchanged when this is FALSE (the default).
 #' @return Tree tables and traversal metadata.
 grow_chaid_tree <- function(data, target, predictors, parameters,
-                            predictor_info, class_levels) {
+                            predictor_info, class_levels, numeric_target = FALSE) {
   # An environment (reference semantics) rather than a list: grow_node recurses
   # and mutates this shared state, and nested list-`<<-` updates are prone to
   # lost updates. With an environment, `state$field <- value` mutates in place.
@@ -801,29 +1028,62 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
   state$low_expected <- FALSE
 
   grow_node <- function(node.data, node.id, parent.id, depth, rule) {
-    target.factor <- factor(as.character(node.data[[target]]), levels = class_levels)
-    counts <- tabulate(target.factor, nbins = length(class_levels))
-    distribution <- if (sum(counts) == 0) {
-      rep(0, length(class_levels))
+    if (numeric_target) {
+      y <- as.numeric(node.data[[target]])
+      summary <- chaid_numeric_node_summary(y)
+      record <- list(
+        node_id = as.integer(node.id),
+        parent_id = if (is.null(parent.id)) NA_integer_ else as.integer(parent.id),
+        depth = as.integer(depth),
+        is_terminal = TRUE,
+        n = nrow(node.data),
+        weighted_n = nrow(node.data),
+        predicted_class = summary$label,
+        class_distribution = NULL,
+        node_mean = summary$mean,
+        node_sd = summary$sd,
+        split_variable = NA_character_,
+        p_value = NA_real_,
+        adjusted_p_value = NA_real_,
+        split_statistic = NA_real_,
+        split_df = NA_real_,
+        split_df1 = NA_real_,
+        split_df2 = NA_real_,
+        rule = rule
+      )
+      # section 36: SS_total == 0 (every value in the node identical, or fewer
+      # than 2 finite values to compare) -> Terminal Node, not an error.
+      pure <- length(unique(y[is.finite(y)])) <= 1
     } else {
-      counts / sum(counts)
+      target.factor <- factor(as.character(node.data[[target]]), levels = class_levels)
+      counts <- tabulate(target.factor, nbins = length(class_levels))
+      distribution <- if (sum(counts) == 0) {
+        rep(0, length(class_levels))
+      } else {
+        counts / sum(counts)
+      }
+      record <- list(
+        node_id = as.integer(node.id),
+        parent_id = if (is.null(parent.id)) NA_integer_ else as.integer(parent.id),
+        depth = as.integer(depth),
+        is_terminal = TRUE,
+        n = nrow(node.data),
+        weighted_n = nrow(node.data),
+        predicted_class = class_levels[which.max(counts)],
+        class_distribution = setNames(distribution, class_levels),
+        node_mean = NA_real_,
+        node_sd = NA_real_,
+        split_variable = NA_character_,
+        p_value = NA_real_,
+        adjusted_p_value = NA_real_,
+        split_statistic = NA_real_,
+        split_df = NA_real_,
+        split_df1 = NA_real_,
+        split_df2 = NA_real_,
+        rule = rule
+      )
+      pure <- sum(counts > 0) <= 1
     }
-    record <- list(
-      node_id = as.integer(node.id),
-      parent_id = if (is.null(parent.id)) NA_integer_ else as.integer(parent.id),
-      depth = as.integer(depth),
-      is_terminal = TRUE,
-      n = nrow(node.data),
-      weighted_n = nrow(node.data),
-      predicted_class = class_levels[which.max(counts)],
-      class_distribution = setNames(distribution, class_levels),
-      split_variable = NA_character_,
-      p_value = NA_real_,
-      adjusted_p_value = NA_real_,
-      split_statistic = NA_real_,
-      split_df = NA_real_,
-      rule = rule
-    )
     state$node_records[[as.character(node.id)]] <- record
     state$node_metadata[[as.character(node.id)]] <- list(
       split_variable = NULL,
@@ -831,7 +1091,6 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
       group_labels = NULL
     )
 
-    pure <- sum(counts > 0) <= 1
     if (pure || depth >= parameters$max_depth ||
         nrow(node.data) < parameters$min_split || length(predictors) == 0) {
       return(invisible(NULL))
@@ -853,7 +1112,8 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
         variable = variable,
         parameters = parameters,
         predictor_info = predictor_info,
-        node_id = node.id
+        node_id = node.id,
+        numeric_target = numeric_target
       )
     })
     evaluations <- Filter(Negate(is.null), evaluations)
@@ -874,6 +1134,10 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
     current.record$adjusted_p_value <- best$adjusted_p_value
     current.record$split_statistic <- best$test$statistic
     current.record$split_df <- best$test$df
+    if (numeric_target) {
+      current.record$split_df1 <- best$test$df1
+      current.record$split_df2 <- best$test$df2
+    }
     state$node_records[[as.character(node.id)]] <- current.record
 
     if (is.na(best$p_value) || best$adjusted_p_value > parameters$alpha_split) {
@@ -940,6 +1204,10 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
       adjusted_p_value = record$adjusted_p_value,
       split_statistic = record$split_statistic,
       split_df = record$split_df,
+      split_df1 = record$split_df1 %||% NA_real_,
+      split_df2 = record$split_df2 %||% NA_real_,
+      node_mean = record$node_mean %||% NA_real_,
+      node_sd = record$node_sd %||% NA_real_,
       rule = record$rule,
       stringsAsFactors = FALSE
     )
@@ -1285,56 +1553,87 @@ chaid_class_distribution_matrix <- function(model) {
 #'
 #' @param model A fitted `exploratory_chaid` model.
 #' @param prepared.data Output of `prepare_chaid_new_data()`.
-#' @param type Prediction output type.
+#' @param type Prediction output type. `value` (numeric target only) returns
+#'   the node mean as a numeric vector -- the regression-style counterpart of
+#'   `class`.
 #' @param split.index Optional precomputed `chaid_build_split_index()` result.
 #' @return A vector or data frame of predictions.
 chaid_predict_prepared <- function(model, prepared.data,
-                                   type = c('class', 'prob', 'node', 'all'),
+                                   type = c('class', 'prob', 'node', 'all', 'value'),
                                    split.index = NULL) {
-  prediction.type <- match.arg(type, choices = c('class', 'prob', 'node', 'all'))
+  prediction.type <- match.arg(type, choices = c('class', 'prob', 'node', 'all', 'value'))
+  is.numeric.target <- identical(model$target_type, 'numeric')
   node.ids <- chaid_assign_nodes(prepared.data, model, split.index)
   node.rows <- match(node.ids, model$nodes$node_id)
   predicted.classes <- as.character(model$nodes$predicted_class[node.rows])
-  probability.matrix <- if (length(node.ids) == 0) {
-    matrix(numeric(), nrow = 0, ncol = length(model$class_levels),
-           dimnames = list(NULL, paste0('.pred_prob_', model$class_levels)))
+  predicted.values <- if (is.numeric.target) {
+    as.numeric(model$nodes$node_mean[node.rows])
   } else {
-    chaid_class_distribution_matrix(model)[node.rows, , drop = FALSE]
+    rep(NA_real_, length(node.rows))
   }
-  colnames(probability.matrix) <- paste0('.pred_prob_', model$class_levels)
 
+  if (prediction.type == 'value') {
+    return(predicted.values)
+  }
   if (prediction.type == 'class') {
     return(predicted.classes)
   }
   if (prediction.type == 'node') {
     return(as.integer(node.ids))
   }
-  probability.data <- as.data.frame(probability.matrix, stringsAsFactors = FALSE)
+
+  # A numeric target has no class-probability distribution; `prob` returns a
+  # zero-column frame and `all` skips the `.pred_prob_*` columns, gaining
+  # `.pred_value` instead.
+  if (is.numeric.target) {
+    probability.data <- data.frame(row.names = seq_along(node.ids))[, FALSE]
+  } else {
+    probability.matrix <- if (length(node.ids) == 0) {
+      matrix(numeric(), nrow = 0, ncol = length(model$class_levels),
+             dimnames = list(NULL, paste0('.pred_prob_', model$class_levels)))
+    } else {
+      chaid_class_distribution_matrix(model)[node.rows, , drop = FALSE]
+    }
+    colnames(probability.matrix) <- paste0('.pred_prob_', model$class_levels)
+    probability.data <- as.data.frame(probability.matrix, stringsAsFactors = FALSE)
+  }
   if (prediction.type == 'prob') {
     return(probability.data)
   }
-  data.frame(
-    .chaid_node_id = as.integer(node.ids),
-    .pred_class = predicted.classes,
-    .chaid_rule = model$nodes$rule[node.rows],
-    probability.data,
-    stringsAsFactors = FALSE,
-    check.names = FALSE
-  )
+  if (is.numeric.target) {
+    data.frame(
+      .chaid_node_id = as.integer(node.ids),
+      .pred_class = predicted.classes,
+      .pred_value = predicted.values,
+      .chaid_rule = model$nodes$rule[node.rows],
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+  } else {
+    data.frame(
+      .chaid_node_id = as.integer(node.ids),
+      .pred_class = predicted.classes,
+      .chaid_rule = model$nodes$rule[node.rows],
+      probability.data,
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+  }
 }
 
 #' Predict from a fitted classification CHAID tree.
 #'
 #' @param model A fitted `exploratory_chaid` model.
 #' @param new_data New predictor data.
-#' @param type Prediction output type: `class`, `prob`, `node`, or `all`.
+#' @param type Prediction output type: `class`, `prob`, `node`, `all`, or
+#'   `value` (numeric target only -- see `chaid_predict_prepared()`).
 #' @return A vector or data frame of predictions.
 #' @export
-chaid_predict <- function(model, new_data, type = c('class', 'prob', 'node', 'all')) {
+chaid_predict <- function(model, new_data, type = c('class', 'prob', 'node', 'all', 'value')) {
   if (!inherits(model, 'exploratory_chaid')) {
     stop('model must be an exploratory_chaid object')
   }
-  prediction.type <- match.arg(type, choices = c('class', 'prob', 'node', 'all'))
+  prediction.type <- match.arg(type, choices = c('class', 'prob', 'node', 'all', 'value'))
   prepared.data <- prepare_chaid_new_data(new_data, model)
   chaid_predict_prepared(model, prepared.data, type = prediction.type)
 }
@@ -1348,7 +1647,7 @@ chaid_predict <- function(model, new_data, type = c('class', 'prob', 'node', 'al
 #' @return Predictions from `chaid_predict()`.
 #' @export
 predict.exploratory_chaid <- function(object, newdata,
-                                      type = c('class', 'prob', 'node', 'all'), ...) {
+                                      type = c('class', 'prob', 'node', 'all', 'value'), ...) {
   chaid_predict(object, newdata, type = type)
 }
 
@@ -1360,6 +1659,27 @@ predict.exploratory_chaid <- function(object, newdata,
 chaid_node_summary <- function(model) {
   validate_chaid_model(model)
   root.n <- model$nodes$n[model$nodes$node_id == 1L]
+  # tam #38166: a numeric target has no predicted CLASS/distribution -- report
+  # the node's target Mean / Std. Dev. instead (spec section 20-27 "Node
+  # Statistics": Node, Mean, Std. Dev., Row Count).
+  if (identical(model$target_type, 'numeric')) {
+    return(data.frame(
+      Node = model$nodes$node_id,
+      Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule, model$terms_mapping)),
+      Rows = model$nodes$n,
+      `%` = model$nodes$n / root.n * 100,
+      Mean = model$nodes$node_mean,
+      `Std. Dev.` = model$nodes$node_sd,
+      `Split Variable` = chaid_map_display_name(model$nodes$split_variable, model$terms_mapping),
+      `F Statistic` = model$nodes$split_statistic,
+      df1 = model$nodes$split_df1,
+      df2 = model$nodes$split_df2,
+      `p-value` = model$nodes$p_value,
+      `Adjusted p-value` = model$nodes$adjusted_p_value,
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    ))
+  }
   data.frame(
     Node = model$nodes$node_id,
     # tam #37177: readable form -- no "Root & " prefix, contiguous numeric bins
@@ -1391,6 +1711,18 @@ chaid_node_summary <- function(model) {
 chaid_rule_table <- function(model) {
   validate_chaid_model(model)
   terminal <- model$nodes$is_terminal
+  if (identical(model$target_type, 'numeric')) {
+    return(data.frame(
+      Node = model$nodes$node_id[terminal],
+      Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule[terminal], model$terms_mapping)),
+      Prediction = model$nodes$predicted_class[terminal],
+      Mean = model$nodes$node_mean[terminal],
+      `Std. Dev.` = model$nodes$node_sd[terminal],
+      Rows = model$nodes$n[terminal],
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    ))
+  }
   data.frame(
     Node = model$nodes$node_id[terminal],
     # tam #37177: see chaid_node_summary(). tam#38107: map clean -> original name.
@@ -1473,6 +1805,26 @@ chaid_split_summary <- function(model) {
   validate_chaid_model(model)
   split.rows <- !model$nodes$is_terminal
   node.ids <- model$nodes$node_id[split.rows]
+  # tam #38166 spec section 27 "Split Statistics Table" (numeric target): Node,
+  # Variable, F Statistic, df1, df2, P-value, Adjusted P-value -- the ANOVA
+  # counterpart of the chi-square split summary below.
+  if (identical(model$target_type, 'numeric')) {
+    return(data.frame(
+      Depth = model$nodes$depth[split.rows],
+      Node = node.ids,
+      `Split Variable` = chaid_map_display_name(model$nodes$split_variable[split.rows], model$terms_mapping),
+      `F Statistic` = model$nodes$split_statistic[split.rows],
+      df1 = model$nodes$split_df1[split.rows],
+      df2 = model$nodes$split_df2[split.rows],
+      `p-value` = model$nodes$p_value[split.rows],
+      `Adjusted p-value` = model$nodes$adjusted_p_value[split.rows],
+      `Number of Children` = vapply(node.ids, function(node.id) {
+        sum(model$edges$parent_id == node.id)
+      }, integer(1)),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    ))
+  }
   data.frame(
     Depth = model$nodes$depth[split.rows],
     Node = node.ids,
@@ -1632,8 +1984,10 @@ chaid_tree_data <- function(model) {
 #' @param model Model to validate.
 #' @return Invisibly TRUE.
 validate_chaid_model <- function(model) {
-  if (!inherits(model, 'exploratory_chaid') ||
-      is.null(model$nodes) || is.null(model$class_levels)) {
+  # tam #38166: a numeric-target model has no class_levels (there is no target
+  # class to enumerate), so only require it for a categorical/logical target.
+  if (!inherits(model, 'exploratory_chaid') || is.null(model$nodes) ||
+      (!identical(model$target_type, 'numeric') && is.null(model$class_levels))) {
     stop('model must be an exploratory_chaid object')
   }
   invisible(TRUE)
@@ -1699,8 +2053,8 @@ validate_chaid_inputs <- function(data,
     stop('target must name an existing column')
   }
   if (!is.factor(data[[target]]) && !is.character(data[[target]]) &&
-      !is.logical(data[[target]])) {
-    stop('target must be character, factor, or logical')
+      !is.logical(data[[target]]) && !chaid_is_numeric_target(data[[target]])) {
+    stop('target must be character, factor, logical, or numeric')
   }
   if (all(is.na(data[[target]]))) {
     stop('target must contain at least one non-missing value')

--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -1482,6 +1482,13 @@ rf_evaluation_training_and_test <- function(data, type = "evaluation", pretty.na
               else if ("rpart" %in% class(model_object)) { # rpart case
                 null_model_mean <- mean(model_object$y, na.rm=TRUE)
               }
+              else if (inherits(model_object, "exploratory_chaid") &&
+                       identical(model_object$target_type, "numeric")) {
+                # Numeric CHAID stores its training target in `y`, just like
+                # rpart. It has no ranger-style `df`, so using the fallback
+                # below makes the held-out R-squared denominator NA.
+                null_model_mean <- mean(model_object$y, na.rm=TRUE)
+              }
               else { # ranger case
                 null_model_mean <- mean(model_object$df[[all.vars(model_object$formula_terms)[[1]]]], na.rm=TRUE)
               }

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -113,6 +113,24 @@ test_that("rf_evaluation_training_and_test produces training and test metrics", 
   expect_true("is_test_data" %in% colnames(summary) || any(grepl("Test", colnames(summary))) || nrow(summary) >= 2)
 })
 
+test_that("numeric CHAID produces finite held-out regression metrics", {
+  set.seed(4)
+  n <- 200
+  x <- sample(c("A", "B"), n, replace = TRUE)
+  y <- ifelse(x == "A", 10, 50) + rnorm(n)
+  df <- data.frame(y = y, x = x, stringsAsFactors = FALSE)
+
+  model_df <- suppressWarnings(exp_chaid(
+    df, y, x, test_rate = 0.3, min_split = 10, min_bucket = 5,
+    max_depth = 1
+  ))
+  summary <- model_df %>% rf_evaluation_training_and_test(pretty.name = TRUE)
+
+  expect_equal(nrow(summary), 2)
+  expect_true(all(is.finite(summary$`R Squared`)))
+  expect_true(all(is.finite(summary$RMSE)))
+})
+
 test_that("exp_chaid report_metrics adds ROC AUC / PR AUC like CART", {
   expected_binary <- c("ROC AUC", "PR AUC", "Balanced Accuracy", "Specificity")
   expected_multi <- c("Balanced Accuracy", "Macro ROC AUC", "Macro PR AUC")
@@ -371,9 +389,12 @@ test_that("exp_chaid is reproducible with a fixed seed", {
   expect_equal(m1$model[[1]]$nodes$rule, m2$model[[1]]$nodes$rule)
 })
 
-test_that("exp_chaid rejects a numeric target", {
+test_that("exp_chaid supports a numeric target", {
   df <- data.frame(y = 1:10, x = rep(c("a", "b"), 5))
-  expect_error(exp_chaid(df, y, x), "categorical target")
+  model_df <- suppressWarnings(exp_chaid(df, y, x, min_split = 2, min_bucket = 1))
+  expect_s3_class(model_df$model[[1]], "exploratory_chaid")
+  expect_equal(model_df$model[[1]]$target_type, "numeric")
+  expect_equal(model_df$model[[1]]$classification_type, "regression")
 })
 
 test_that("exp_chaid validates test split arguments", {

--- a/tests/testthat/test_chaid.R
+++ b/tests/testthat/test_chaid.R
@@ -3,7 +3,13 @@ test_that('chaid_fit rejects invalid targets and predictors', {
 
   expect_error(chaid_fit(data, target = 'missing'), 'target')
   expect_error(chaid_fit(data, target = 'target', predictors = 'missing'), 'predictor')
-  expect_error(chaid_fit(data.frame(target = 1:2, x = 1:2), target = 'target'), 'character, factor, or logical')
+  # tam #38166: numeric targets are now valid (One-way ANOVA F-test); a
+  # datetime target is explicitly out of scope (spec section 3) and still
+  # rejected -- POSIXct is double-backed with NO is.numeric.POSIXct method in
+  # base R, so a bare is.numeric() check alone would wrongly accept it.
+  expect_error(chaid_fit(data.frame(
+      target = as.POSIXct(c('2020-01-01', '2020-01-02'), tz = 'UTC'), x = 1:2),
+    target = 'target'), 'character, factor, logical, or numeric')
   expect_error(chaid_fit(data, target = 'target', min_split = 1, min_bucket = 2), 'min_split')
   expect_error(chaid_fit(data.frame(target = c(NA_character_, NA_character_), x = c('a', 'b')),
                          target = 'target'), 'non-missing')

--- a/tests/testthat/test_chaid_numeric.R
+++ b/tests/testthat/test_chaid_numeric.R
@@ -103,12 +103,12 @@ test_that('merge_categories merges the closest-mean nominal categories first (nu
 })
 
 test_that('an ordered predictor only offers ADJACENT categories as merge candidates', {
-  # Low and High are numerically the CLOSEST pair, but are NOT adjacent in
-  # the declared order (Low, Mid, High) -- they must never be compared, so no
-  # merge can happen even though Low/High "look" mergeable.
+  # Low and High have identical distributions, but are NOT adjacent in the
+  # declared order (Low, Mid, High) -- they must never be compared, so no
+  # merge can happen even though Low/High are mergeable.
   predictor <- rep(c('Low', 'Mid', 'High'), each = 10)
   low_values <- c(9, 10, 11, 9, 10, 11, 9, 10, 11, 10)
-  high_values <- c(10, 11, 12, 10, 11, 12, 10, 11, 12, 11)
+  high_values <- low_values
   mid_values <- rep(1000, 10)
   target <- c(low_values, mid_values, high_values)
 
@@ -124,8 +124,8 @@ test_that('an ordered predictor only offers ADJACENT categories as merge candida
   expect_length(ordered_result$merge_history, 0)
 
   # The SAME data treated as a NOMINAL predictor DOES compare Low and High
-  # directly, and they merge (they are close; the ordered run above proves
-  # this pair is only reachable when adjacency is not enforced).
+  # directly, and they merge. The ordered run above proves this pair is only
+  # reachable when adjacency is not enforced.
   nominal_result <- exploratory:::merge_categories(
     values = predictor, target = target, ordered = FALSE,
     alpha_merge = 0.05, bonferroni = TRUE, variable = 'seg', node_id = 1L,

--- a/tests/testthat/test_chaid_numeric.R
+++ b/tests/testthat/test_chaid_numeric.R
@@ -1,0 +1,287 @@
+# tam #38166: CHAID numeric (One-way ANOVA F-test) target support.
+#
+# These tests exercise the numeric-target statistical engine directly
+# (compute_anova_from_stats / merge_categories / chaid_fit), per the spec's
+# section 38 test list. Where possible the expected result is computed by an
+# INDEPENDENT base-R function (stats::aov(), stats::t.test()) rather than a
+# hand-derived literal, so the test does not just re-encode this PR's own
+# arithmetic.
+
+test_that('compute_anova_from_stats matches stats::aov() on known data', {
+  # 3 groups, well separated, non-zero within-group spread -- classic
+  # textbook shape (F = 27, df = (2, 6)).
+  y <- c(1, 2, 3, 4, 5, 6, 7, 8, 9)
+  g <- factor(rep(c('A', 'B', 'C'), each = 3))
+
+  fit <- stats::aov(y ~ g)
+  summary_fit <- summary(fit)[[1]]
+  expected_f <- summary_fit[['F value']][1]
+  expected_p <- summary_fit[['Pr(>F)']][1]
+  expected_df1 <- summary_fit[['Df']][1]
+  expected_df2 <- summary_fit[['Df']][2]
+
+  stats_mat <- vapply(split(y, g), function(v) {
+    c(n = length(v), sum = sum(v), sumsq = sum(v^2))
+  }, numeric(3))
+
+  result <- exploratory:::compute_anova_from_stats(stats_mat)
+
+  expect_equal(result$statistic, unname(expected_f), tolerance = 1e-8)
+  expect_equal(result$p_value, unname(expected_p), tolerance = 1e-8)
+  expect_equal(result$df1, unname(expected_df1))
+  expect_equal(result$df2, unname(expected_df2))
+  # Hand-verified expectation for this specific fixture (independent of aov()).
+  expect_equal(result$statistic, 27, tolerance = 1e-8)
+})
+
+test_that('for two groups, the ANOVA F statistic equals t^2 from an equal-variance t-test', {
+  group_a <- c(2, 4, 6)
+  group_b <- c(8, 10, 12)
+
+  t_result <- stats::t.test(group_b, group_a, var.equal = TRUE)
+  expected_f <- unname(t_result$statistic)^2
+
+  stats_mat <- cbind(
+    a = c(n = length(group_a), sum = sum(group_a), sumsq = sum(group_a^2)),
+    b = c(n = length(group_b), sum = sum(group_b), sumsq = sum(group_b^2))
+  )
+  result <- exploratory:::compute_anova_from_stats(stats_mat)
+
+  expect_equal(result$statistic, expected_f, tolerance = 1e-8)
+  expect_equal(result$df1, 1)
+  expect_equal(result$df2, length(group_a) + length(group_b) - 2)
+  # Hand-verified expectation for this specific fixture.
+  expect_equal(result$statistic, 13.5, tolerance = 1e-8)
+})
+
+test_that('compute_anova_from_stats handles the section-36 special cases without erroring', {
+  # SS_total == 0: every value, in every group, identical -> no evidence of a
+  # difference. Must not error; must resolve as "never significant" (p = 1).
+  constant_mat <- cbind(a = c(n = 3, sum = 15, sumsq = 75), b = c(n = 3, sum = 15, sumsq = 75))
+  constant_result <- exploratory:::compute_anova_from_stats(constant_mat)
+  expect_true(is.na(constant_result$statistic))
+  expect_equal(constant_result$p_value, 1)
+
+  # Zero within-group spread, non-zero between-group difference -> maximally
+  # significant (F = Inf, p = 0), not NaN/error.
+  perfect_sep_mat <- cbind(a = c(n = 3, sum = 15, sumsq = 75), b = c(n = 3, sum = 30, sumsq = 300))
+  perfect_sep_result <- exploratory:::compute_anova_from_stats(perfect_sep_mat)
+  expect_equal(perfect_sep_result$statistic, Inf)
+  expect_equal(perfect_sep_result$p_value, 0)
+
+  # Not enough rows to spare a residual degree of freedom (N <= k): the test
+  # cannot be run -> NA, not an error, not a crash.
+  insufficient_mat <- cbind(a = c(n = 1, sum = 5, sumsq = 25), b = c(n = 1, sum = 10, sumsq = 100))
+  insufficient_result <- exploratory:::compute_anova_from_stats(insufficient_mat)
+  expect_true(is.na(insufficient_result$statistic))
+  expect_true(is.na(insufficient_result$p_value))
+
+  # Fewer than 2 non-empty groups.
+  single_group_mat <- cbind(a = c(n = 3, sum = 15, sumsq = 75), b = c(n = 0, sum = 0, sumsq = 0))
+  single_result <- exploratory:::compute_anova_from_stats(single_group_mat)
+  expect_true(is.na(single_result$statistic))
+  expect_true(is.na(single_result$p_value))
+})
+
+test_that('merge_categories merges the closest-mean nominal categories first (numeric target)', {
+  predictor <- rep(c('X', 'Y', 'Z'), each = 10)
+  # X and Y share the exact same distribution (p = 1 for their pairwise
+  # test); Z is a distant constant, so X/Y must be the FIRST (and only) merge.
+  x_values <- c(9, 10, 11, 9, 10, 11, 9, 10, 11, 10)
+  target <- c(x_values, x_values, rep(100, 10))
+
+  result <- exploratory:::merge_categories(
+    values = predictor, target = target, ordered = FALSE,
+    alpha_merge = 0.05, bonferroni = TRUE, variable = 'seg', node_id = 1L,
+    numeric_target = TRUE
+  )
+
+  expect_length(result$groups, 2)
+  expect_length(result$merge_history, 1)
+  expect_setequal(result$merge_history[[1]]$original_categories, c('X', 'Y'))
+  expect_equal(result$merge_history[[1]]$merge_p_value, 1)
+})
+
+test_that('an ordered predictor only offers ADJACENT categories as merge candidates', {
+  # Low and High are numerically the CLOSEST pair, but are NOT adjacent in
+  # the declared order (Low, Mid, High) -- they must never be compared, so no
+  # merge can happen even though Low/High "look" mergeable.
+  predictor <- rep(c('Low', 'Mid', 'High'), each = 10)
+  low_values <- c(9, 10, 11, 9, 10, 11, 9, 10, 11, 10)
+  high_values <- c(10, 11, 12, 10, 11, 12, 10, 11, 12, 11)
+  mid_values <- rep(1000, 10)
+  target <- c(low_values, mid_values, high_values)
+
+  ordered_result <- exploratory:::merge_categories(
+    values = predictor, target = target, ordered = TRUE,
+    ordered_levels = c('Low', 'Mid', 'High'),
+    alpha_merge = 0.05, bonferroni = TRUE, variable = 'seg', node_id = 1L,
+    numeric_target = TRUE
+  )
+  # Mid is hugely different from both neighbors, and Low/High are never
+  # directly compared -> no candidate pair clears alpha_merge -> no merge.
+  expect_length(ordered_result$groups, 3)
+  expect_length(ordered_result$merge_history, 0)
+
+  # The SAME data treated as a NOMINAL predictor DOES compare Low and High
+  # directly, and they merge (they are close; the ordered run above proves
+  # this pair is only reachable when adjacency is not enforced).
+  nominal_result <- exploratory:::merge_categories(
+    values = predictor, target = target, ordered = FALSE,
+    alpha_merge = 0.05, bonferroni = TRUE, variable = 'seg', node_id = 1L,
+    numeric_target = TRUE
+  )
+  expect_length(nominal_result$groups, 2)
+  expect_true(any(vapply(nominal_result$merge_history, function(m) {
+    setequal(m$original_categories, c('Low', 'High'))
+  }, logical(1))))
+})
+
+test_that('a well-separated 3-category predictor produces a multi-way (3-child) split', {
+  x <- rep(c('A', 'B', 'C'), each = 30)
+  y <- c(
+    rep(c(10, 11, 9, 10), length.out = 30),
+    rep(c(50, 51, 49, 50), length.out = 30),
+    rep(c(90, 91, 89, 90), length.out = 30)
+  )
+  data <- data.frame(target = y, x = x, stringsAsFactors = FALSE)
+
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  expect_equal(model$target_type, 'numeric')
+  expect_false(model$nodes$is_terminal[model$nodes$node_id == 1])
+  expect_equal(model$nodes$split_variable[model$nodes$node_id == 1], 'x')
+  root_children <- model$edges$child_id[model$edges$parent_id == 1]
+  expect_length(root_children, 3)
+  expect_true(all(model$nodes$is_terminal[model$nodes$node_id %in% root_children]))
+  child_means <- sort(model$nodes$node_mean[model$nodes$node_id %in% root_children])
+  expect_equal(child_means, c(10, 50, 90), tolerance = 1)
+})
+
+test_that('a target with no real group difference produces no split (root-only tree)', {
+  x <- rep(c('A', 'B', 'C'), each = 20)
+  # Identical value pattern in every group -> SS_between == 0.
+  y <- rep(1:20, 3)
+  data <- data.frame(target = y, x = x, stringsAsFactors = FALSE)
+
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  expect_equal(model$target_type, 'numeric')
+  expect_true(model$nodes$is_terminal[model$nodes$node_id == 1])
+  expect_equal(nrow(model$edges), 0)
+  expect_equal(model$nodes$node_mean[model$nodes$node_id == 1], mean(y))
+})
+
+test_that('the predictor with a real target difference is chosen over an unrelated one', {
+  x1 <- rep(c('A', 'B'), each = 30)              # perfectly separates the target
+  x2 <- rep(c('P', 'Q'), times = 30)             # uncorrelated with the target
+  y <- ifelse(x1 == 'A', 10, 50)
+  data <- data.frame(target = y, x1 = x1, x2 = x2, stringsAsFactors = FALSE)
+
+  model <- chaid_fit(data, target = 'target', predictors = c('x1', 'x2'),
+                     min_split = 2, min_bucket = 1)
+
+  expect_equal(model$target_type, 'numeric')
+  expect_equal(model$nodes$split_variable[model$nodes$node_id == 1], 'x1')
+  root_children <- model$edges$child_id[model$edges$parent_id == 1]
+  expect_length(root_children, 2)
+  child_means <- sort(model$nodes$node_mean[model$nodes$node_id %in% root_children])
+  expect_equal(child_means, c(10, 50))
+})
+
+test_that('a completely constant numeric target fits as a root-only tree without erroring', {
+  data <- data.frame(target = rep(5, 40), x = rep(c('A', 'B'), each = 20),
+                     stringsAsFactors = FALSE)
+
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  expect_equal(model$target_type, 'numeric')
+  expect_true(model$nodes$is_terminal[model$nodes$node_id == 1])
+  expect_equal(model$nodes$node_mean[model$nodes$node_id == 1], 5)
+  expect_equal(model$nodes$n[model$nodes$node_id == 1], 40)
+})
+
+test_that('non-finite target values (Inf/-Inf) are excluded from fitting, per r-integration finite-guard convention', {
+  x <- rep(c('A', 'B'), each = 15)
+  y <- c(rep(10, 14), Inf, rep(50, 14), -Inf)
+  data <- data.frame(target = y, x = x, stringsAsFactors = FALSE)
+
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  expect_equal(model$target_type, 'numeric')
+  # 2 rows (one +Inf, one -Inf) dropped out of 30.
+  expect_equal(model$training_metadata$n_rows, 28)
+  expect_true(is.finite(model$nodes$node_mean[model$nodes$node_id == 1]))
+})
+
+test_that('numeric CHAID predictions return the node mean and node id', {
+  x <- rep(c('A', 'B'), each = 20)
+  y <- ifelse(x == 'A', 10, 50)
+  data <- data.frame(target = y, x = x, stringsAsFactors = FALSE)
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  values <- chaid_predict(model, data.frame(x = c('A', 'B')), type = 'value')
+  expect_equal(values, c(10, 50))
+
+  all_pred <- chaid_predict(model, data.frame(x = c('A', 'B')), type = 'all')
+  expect_true('.pred_value' %in% names(all_pred))
+  expect_true('.chaid_node_id' %in% names(all_pred))
+  expect_false(any(grepl('^\\.pred_prob_', names(all_pred))))
+})
+
+test_that('chaid_node_summary / chaid_rule_table / chaid_split_summary report Mean / F Statistic for a numeric target', {
+  x <- rep(c('A', 'B'), each = 30)
+  y <- ifelse(x == 'A', 10, 50)
+  data <- data.frame(target = y, x = x, stringsAsFactors = FALSE)
+  model <- chaid_fit(data, target = 'target', predictors = 'x',
+                     min_split = 2, min_bucket = 1)
+
+  node_summary <- chaid_node_summary(model)
+  expect_true('Mean' %in% names(node_summary))
+  expect_true('Std. Dev.' %in% names(node_summary))
+  expect_false('Predicted Class' %in% names(node_summary))
+
+  rule_table <- chaid_rule_table(model)
+  expect_true('Mean' %in% names(rule_table))
+  expect_false('Probability' %in% names(rule_table))
+
+  split_summary <- chaid_split_summary(model)
+  expect_true('F Statistic' %in% names(split_summary))
+  expect_true('df1' %in% names(split_summary))
+  expect_true('df2' %in% names(split_summary))
+})
+
+test_that('existing categorical/logical CHAID behavior is unchanged (regression guard)', {
+  # Same fixture shape as test_chaid.R's own merge test, run through the
+  # updated merge_categories()/chaid_fit() with numeric_target defaulting to
+  # FALSE -- must produce byte-identical results to before this PR.
+  values <- rep(c('a', 'b', 'c'), each = 40)
+  target <- c(
+    rep(c('yes', 'no'), 20),
+    rep(c('yes', 'no'), 20),
+    rep('yes', 40)
+  )
+  result <- exploratory:::merge_categories(
+    values = values, target = target, ordered = FALSE, alpha_merge = 0.05,
+    bonferroni = TRUE, variable = 'segment', node_id = 1L
+  )
+  expect_true(length(result$groups) < 3)
+  expect_true(any(vapply(result$merge_history, function(x) {
+    all(c('a', 'b') %in% x$original_categories)
+  }, logical(1))))
+
+  character_data <- data.frame(target = c('yes', 'no', 'yes', 'no'), x = c('a', 'a', 'b', 'b'))
+  model <- chaid_fit(character_data, target = 'target', min_split = 2, min_bucket = 1)
+  expect_equal(model$target_type, 'character')
+  expect_true(!is.null(model$class_levels))
+
+  logical_data <- data.frame(target = c(TRUE, FALSE, TRUE, FALSE), x = c('a', 'a', 'b', 'b'))
+  logical_model <- chaid_fit(logical_data, target = 'target', min_split = 2, min_bucket = 1)
+  expect_equal(logical_model$target_type, 'logical')
+  expect_true(!is.null(logical_model$class_levels))
+})


### PR DESCRIPTION
# Description

Adds a **One-way ANOVA F-test** path to CHAID's core algorithm (`R/chaid.R`, `R/build_chaid.R`) so a **numeric** target variable is supported, alongside the existing categorical/ordered-categorical/logical (chi-square) targets. It enables the numeric-target UI/report wiring.

Root cause / approach: CHAID's category-merging and split-selection machinery (`merge_categories()`) already ran every pairwise/overall test off a `target-by-category` sufficient-statistics matrix built once per node/predictor. Since sum and sum-of-squares are additive over disjoint row sets exactly like a contingency table's counts, a numeric target's sufficient stats `(n, sum, sumsq)` per category slot into the *same* `col_of_group()`/`rowSums()` merge loop the chi-square path already used — only the test function dispatched at each merge/overall-test call site changes (`compute_chisq_from_counts()` vs. the new `compute_anova_from_stats()`). Bonferroni correction, multi-way splitting, numeric-predictor binning, max depth/min node size, and missing-value handling are all reused completely unchanged. `numeric_target` defaults to `FALSE` everywhere it was threaded through, so the categorical/logical/ordered path is (by construction) byte-identical to before.

Key changes:
- `chaid_is_numeric_target()`, `compute_anova_from_stats()` (handles spec §36's special cases — constant target, zero within-group variance, insufficient rows — without ever raising an R condition).
- `merge_categories()` / `chaid_best_resplit()` / `evaluate_predictor()` / `grow_chaid_tree()` / `chaid_fit()` all gain a `numeric_target` parameter.
- Node records gain `node_mean`/`node_sd`/`split_df1`/`split_df2` (NA for a categorical/logical model).
- `chaid_predict()`/`chaid_predict_prepared()` gain `type = 'value'`.
- `chaid_node_summary()`/`chaid_rule_table()`/`chaid_split_summary()` branch to report Mean/Std. Dev./F Statistic/df1/df2 for a numeric target.
- `exp_chaid()`: numeric target no longer rejected; `classification_type` gains `"regression"`; a new RMSE-based permutation-importance function (`chaid_permutation_importance_numeric`); `augment()`/`tidy(type='evaluation')` branch for a numeric target (R²/RMSE/MAE via the existing, already-shared `evaluate_regression_()`).
- `build_chaid_tree_nodes()` (the interactive-tree JSON feed) now populates `mean_value`/`sd_value`/`rmse_value`/`dist_json` for a numeric target exactly the way `build_rpart_tree_nodes()` already does for CART's regression tree (shared-bin-edges per-node histogram) — this schema already existed with those 4 columns hardcoded NA, so **tam's interactive-tree renderer needed zero JS changes** (verified by reading `DTreeGenerator.js`: it derives regression-vs-classification display purely from whether `class_json` parsed to an empty array).

# Implemented (spec §46 completion checklist)

1–9 (numeric target selectable in R, ANOVA F-test category merging + alpha_merge + overall-group F-test + Bonferroni + adjusted-p-value best-variable selection + alpha_split + multi-way splits) — implemented in `chaid.R`, cross-checked against `stats::aov()`/`stats::t.test()` in the new test file.
10 (node mean prediction) — `chaid_predict(type='value')`, `node_mean`.
11 (per-node histogram) — `build_chaid_tree_nodes()`, reusing the existing generic `DTreeGenerator.js` renderer.
12 (Prediction Data: Predicted Value + Node ID, optional Residual) — `augment.exploratory_chaid()`'s numeric branch.
13 (existing categorical CHAID unchanged) — `numeric_target` param defaults FALSE on every threaded function; see the regression-guard test.
14 (F statistic matches `aov()`) — the new test's first two cases assert this directly against live `stats::aov()`/`stats::t.test()` output (computed at test time, not hand-derived literals).

# Deferred / explicitly not implemented this pass

- **Partial dependence / FIRM importance for a numeric target.** `partial_dependence.exploratory_chaid()`'s `predict.fun` is hardcoded to `type="prob"`, meaningless for a numeric target; a numeric-target fit sets `model$partial_dependence <- NULL` and always uses (RMSE-based) permutation importance regardless of the `importance_measure` setting.
- **A polished, numeric-specific "Split Evidence" report pivot** (F-statistic-flavored, with its own conditional-formatting bars) — the tam-side report instead reuses the plain, already-generic `chaid_node_summary`/`chaid_split_summary` raw tables. See the tam PR's design doc.
- **CART-numeric-style "Actual vs Predicted"/"Prediction Error Distribution" charts** — no such viz chart blocks exist in `exp_chaid.json`; out of scope for this pass.
- `chaid_tree_data()` (an internal helper used only by this package's own `test_chaid.R`, not by tam) was left unbranched; it degrades gracefully (empty distribution string) for a numeric target rather than reporting Mean/Std. Dev.

# How to Confirm the Fix

`Rscript -e "devtools::test(filter = 'chaid')"` should run both `test_chaid.R` (now includes a POSIXct-rejection regression case + a re-run of an existing categorical merge fixture proving `numeric_target` defaulting to FALSE is unchanged) and the new `test_chaid_numeric.R`.

**No R/Rserve is available in the environment this PR was authored in** (`which R Rscript` returned nothing; no reachable Rserve). The new tests were written to be genuinely self-verifying wherever feasible — the two most load-bearing cases (the ANOVA formula itself, and the 2-group F = t² identity from spec §38) compute their expected values live via `stats::aov()`/`stats::t.test(..., var.equal=TRUE)` inside the test rather than a hand-derived literal — and every other fixture's expected value was hand-traced in code comments. This is **not equivalent to live execution** per this codebase's own "verify R-codegen changes by executing the generated R" convention, and is flagged here explicitly as the main open verification gap. Please run the test suite (and ideally exercise `exp_chaid()` against a real numeric-target data frame) before merging.

# Checklist
- [x] Add test cases for this fix/enhancement (`tests/testthat/test_chaid_numeric.R`, plus a targeted update to `test_chaid.R`)
- [ ] Pass `devtools::check()` — not run (no R available in this environment)
- [ ] Pass `devtools::test()` — not run (no R available in this environment)
- [ ] Test installing from github — not run
- [ ] Tested with Exploratory — not run; paired tam PR needs a real end-to-end pass once R is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eij4X7qXwnjJ3jk4UZ41Dn)_