### PR TITLE
WIP: Analytics: K-Means Clustering: Support for Important Variables (R package)

### DIFF
--- a/R/cluster_variable_importance.R
+++ b/R/cluster_variable_importance.R
@@ -1,0 +1,41 @@
+# Shared per-variable "Characteristic Variables" computation for numeric-only clustering
+# analytics types (K-Medoids, K-Means). tam#38160.
+#
+# Ranks each clustering variable by eta-squared (the proportion of that variable's total
+# variance explained by cluster membership -- a one-way-ANOVA effect size), paired with the
+# ANOVA F statistic and p value for the same one-way model (variable ~ cluster). Larger
+# eta-squared means the variable differs more strongly across clusters, i.e. it is more
+# "characteristic" of the clustering.
+#
+# K-Modes' sibling feature (`.kmodes_variable_importance` in kmodes.R, not shown here) uses a
+# different statistic (Cramer's V from a chi-square test) because K-Modes clusters purely
+# CATEGORICAL variables, where ANOVA/eta-squared does not apply. K-Medoids and K-Means both
+# cluster purely NUMERIC variables (see exp_kmedoids()'s `if (!all(vapply(df[selected_cols],
+# is.numeric, ...)))` guard and kmeans.json's `columnTypes: ["numeric"]`), so they share this
+# ANOVA-based implementation.
+#
+# @param mat a numeric matrix, one column per clustering variable, one row per observation
+#   used in the fit (already NA-filtered by the caller -- see `preprocess_factanal_data_before_sample()`).
+# @param cluster_ids a vector (integer or factor), length == nrow(mat), giving each row's
+#   cluster assignment.
+# @return a tibble with columns: variable, eta_squared, test_statistic (F value), p_value.
+cluster_variable_importance_anova <- function(mat, cluster_ids) {
+  ids <- factor(cluster_ids)
+  purrr::map_dfr(seq_len(ncol(mat)), function(index) {
+    value <- mat[, index]
+    grand_mean <- mean(value, na.rm = TRUE)
+    between <- sum(tapply(value, ids, function(group) {
+      length(group) * (mean(group, na.rm = TRUE) - grand_mean)^2
+    }), na.rm = TRUE)
+    total <- sum((value - grand_mean)^2, na.rm = TRUE)
+    eta_squared <- if (total > 0) between / total else 0
+    fit <- tryCatch(stats::aov(value ~ ids), error = function(e) NULL)
+    fit_table <- if (is.null(fit)) NULL else summary(fit)[[1]]
+    tibble::tibble(
+      variable = colnames(mat)[[index]],
+      eta_squared = eta_squared,
+      test_statistic = if (is.null(fit_table)) NA_real_ else fit_table[['F value']][[1]],
+      p_value = if (is.null(fit_table)) NA_real_ else fit_table[['Pr(>F)']][[1]]
+    )
+  })
+}

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -240,9 +240,13 @@ exp_kmeans <- function(df, ...,
                                               seed = NULL, # Seed is already done. Skip it.
                                               na.rm = FALSE) # NA filtering is already done. Skip it to save time. 
 
-  # This is about how UI-side is done, but it can handle single column case, only if it is single column from the beginnig.
-  # Check that and pass that info to do_prcomp() as allow_single_column.
-  allow_single_column <- length(selected_cols) == 1
+  # do_prcomp() removes constant columns before fitting. Allow a one-column PCA when the
+  # selected input has exactly one non-constant variable, even if constant variables were also
+  # selected; K-Means still retains those variables for the characteristic-variable report.
+  n_non_constant_cols <- sum(vapply(df[selected_cols], function(column) {
+    length(unique(column)) > 1
+  }, logical(1)))
+  allow_single_column <- n_non_constant_cols == 1
   ret <- do_prcomp(df, normalize_data = normalize_data, allow_single_column = allow_single_column, seed = NULL,
                    na.rm = FALSE, # Skip NA filtering since it is already done.
                    with_report_data = FALSE, # PCA report data + sign flip are pure-PCA only; k-means fits must not be altered. (#37019)

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -155,6 +155,19 @@ compute_silhouette_per_row <- function(cluster_ids, mat, d = NULL, sample_idx = 
   na_result
 }
 
+# "Characteristic Variables" for K-Means (tam#38160), reusing the K-Medoids ANOVA/eta-squared
+# machinery (cluster_variable_importance.R) -- K-Means, like K-Medoids, clusters purely numeric
+# variables, so the same one-way-ANOVA-per-variable statistic applies directly. `x` is the
+# prcomp_exploratory fit `exp_kmeans()` attaches `x$kmeans`/`x$df`/`x$selected_cols` to; see
+# tidy.prcomp_exploratory(type = "variable_importance") in prcomp.R for the call site.
+# `x$df` is the same (NA-filtered, sampled) data build_kmeans.cols() fit `x$kmeans` on -- see
+# exp_kmeans()'s single shared `df` feeding both build_kmeans.cols() and do_prcomp() -- so the
+# rows in `x$df[, x$selected_cols]` are row-for-row aligned with `x$kmeans$cluster`.
+.kmeans_variable_importance <- function(x) {
+  mat <- as_numeric_matrix_(x$df, columns = x$selected_cols)
+  cluster_variable_importance_anova(mat, x$kmeans$cluster)
+}
+
 #' analytics function for K-means view
 #' @export
 exp_kmeans <- function(df, ...,

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -387,24 +387,9 @@
 }
 
 .kmedoids_variable_importance <- function(x) {
-  ids <- factor(x$clustering)
-  purrr::map_dfr(seq_len(ncol(x$mat)), function(index) {
-    value <- x$mat[, index]
-    grand_mean <- mean(value, na.rm = TRUE)
-    between <- sum(tapply(value, ids, function(group) {
-      length(group) * (mean(group, na.rm = TRUE) - grand_mean)^2
-    }), na.rm = TRUE)
-    total <- sum((value - grand_mean)^2, na.rm = TRUE)
-    eta_squared <- if (total > 0) between / total else 0
-    fit <- tryCatch(stats::aov(value ~ ids), error = function(e) NULL)
-    fit_table <- if (is.null(fit)) NULL else summary(fit)[[1]]
-    tibble::tibble(
-      variable = colnames(x$mat)[[index]],
-      eta_squared = eta_squared,
-      test_statistic = if (is.null(fit_table)) NA_real_ else fit_table[['F value']][[1]],
-      p_value = if (is.null(fit_table)) NA_real_ else fit_table[['Pr(>F)']][[1]]
-    )
-  })
+  # Shared with K-Means (tam#38160) -- see cluster_variable_importance.R. K-Medoids' `x$mat`
+  # is already the (optionally normalized) numeric fit matrix, so this is a direct pass-through.
+  cluster_variable_importance_anova(x$mat, x$clustering)
 }
 
 .kmedoids_representative_values <- function(x) {

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -581,6 +581,18 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       res <- res %>% tibble::add_row(size=x$excluded_nrow)
     }
   }
+  else if (type == "variable_importance") { # This is only for kmeans case (tam#38160). Same shape as K-Medoids' own type='variable_importance' (kmedoids.R).
+    if (!is.null(x$kmeans) && !is.null(x$df) && !is.null(x$selected_cols) && length(x$selected_cols) > 0) {
+      res <- .kmeans_variable_importance(x)
+    }
+    else {
+      # Pure-PCA fit (no kmeans attached), or an old saved model missing the fields
+      # exp_kmeans() stamps -- return an empty, correctly-typed tibble so the chart no-ops
+      # instead of erroring.
+      res <- tibble::tibble(variable = character(0), eta_squared = numeric(0),
+                            test_statistic = numeric(0), p_value = numeric(0))
+    }
+  }
   else if (type == "screeplot") {
     eigen_res <- eigen(x$correlation, only.values = TRUE) # Cattell's scree plot is eigenvalues of correlation/covariance matrix.
     res <- tibble::tibble(factor=1:length(eigen_res$values), eigenvalue=eigen_res$values)

--- a/R/util.R
+++ b/R/util.R
@@ -587,7 +587,7 @@ str_normalize <- function(text) {
 as_numeric_matrix_ <- function(df, columns) {
   loadNamespace("dplyr")
 
-  orig_mat <- df[,columns] %>%
+  orig_mat <- df[, columns, drop = FALSE] %>%
     as.matrix()
 
   ret <- orig_mat %>%

--- a/tests/testthat/test_kmeans_variable_importance.R
+++ b/tests/testthat/test_kmeans_variable_importance.R
@@ -1,0 +1,139 @@
+context('K-Means Characteristic Variables (tam#38160)')
+
+# K-Means shares its "Characteristic Variables" computation with K-Medoids
+# (cluster_variable_importance_anova() in cluster_variable_importance.R) -- both cluster
+# purely numeric variables, so the same one-way-ANOVA-per-variable eta-squared statistic
+# applies to both. K-Modes uses a DIFFERENT statistic (Cramer's V) because it clusters purely
+# categorical variables -- not covered here.
+
+test_that('tidy(type="variable_importance") returns one row per clustering variable with the expected columns', {
+  set.seed(1)
+  model_df <- mtcars %>% exp_kmeans(mpg, disp, hp, centers = 3, seed = 1)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  expect_true(is.data.frame(vi))
+  expect_equal(nrow(vi), 3)
+  expect_setequal(colnames(vi), c('variable', 'eta_squared', 'test_statistic', 'p_value'))
+  expect_setequal(vi$variable, c('mpg', 'disp', 'hp'))
+  # eta-squared is a proportion of variance explained: must be within [0, 1].
+  expect_true(all(vi$eta_squared >= 0 & vi$eta_squared <= 1))
+  # A real, non-degenerate ANOVA F statistic/p-value should be produced for every variable
+  # here (3 clusters, 32 rows, no zero-variance/constant columns).
+  expect_true(all(!is.na(vi$test_statistic)))
+  expect_true(all(!is.na(vi$p_value)))
+})
+
+test_that('eta_squared/F/p match an independent hand computation against the real fitted cluster assignment', {
+  # Cross-checks the PACKAGE's own R implementation against stats::aov() computed directly
+  # in the test, rather than re-deriving the same formula a second time (which would risk
+  # encoding the same bug twice) -- per testing.md#r-codegen-fix-live-execution-required's
+  # sibling guidance for R-that-inspects-data.
+  set.seed(7)
+  model_df <- iris %>% exp_kmeans(Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+                                  centers = 3, seed = 7)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  cluster_ids <- factor(model$kmeans$cluster)
+  vars <- c('Sepal.Length', 'Sepal.Width', 'Petal.Length', 'Petal.Width')
+  for (v in vars) {
+    value <- model$df[[v]]
+    fit <- stats::aov(value ~ cluster_ids)
+    tab <- summary(fit)[[1]]
+    expected_f <- tab[['F value']][[1]]
+    expected_p <- tab[['Pr(>F)']][[1]]
+    # eta-squared = SS_between / SS_total, independently derived here via the ANOVA table
+    # (SS for "cluster_ids" over SS "Sum Sq" total) instead of the package's own tapply-based
+    # between/total computation, so the two derivations don't share a possible shared bug.
+    expected_eta <- tab[['Sum Sq']][[1]] / sum(tab[['Sum Sq']])
+
+    row <- vi[vi$variable == v, , drop = FALSE]
+    expect_equal(nrow(row), 1)
+    expect_equal(row$test_statistic, expected_f, tolerance = 1e-8)
+    expect_equal(row$p_value, expected_p, tolerance = 1e-8)
+    expect_equal(row$eta_squared, expected_eta, tolerance = 1e-8)
+  }
+})
+
+test_that('a zero-variance (constant) clustering variable gets eta_squared = 0, not NaN/NA', {
+  set.seed(1)
+  data <- tibble::tibble(x = c(1, 2, 3, 10, 11, 12), constant = rep(5, 6))
+  model_df <- data %>% exp_kmeans(x, constant, centers = 2, seed = 1, normalize_data = FALSE)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  constant_row <- vi[vi$variable == 'constant', , drop = FALSE]
+  expect_equal(nrow(constant_row), 1)
+  expect_false(is.nan(constant_row$eta_squared))
+  expect_false(is.na(constant_row$eta_squared))
+  expect_equal(constant_row$eta_squared, 0)
+})
+
+test_that('single-column K-Means (allow_single_column) still returns a one-row variable_importance', {
+  set.seed(1)
+  model_df <- mtcars %>% exp_kmeans(mpg, centers = 2, seed = 1)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  expect_equal(nrow(vi), 1)
+  expect_equal(vi$variable, 'mpg')
+  expect_true(vi$eta_squared >= 0 && vi$eta_squared <= 1)
+})
+
+test_that('variable_importance survives a complex/stress-test column name (tam workflow.md rule 7)', {
+  set.seed(1)
+  weird_name <- "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
+  df <- mtcars
+  colnames(df)[colnames(df) == 'cyl'] <- weird_name
+  model_df <- df %>% exp_kmeans(!!rlang::sym(weird_name), mpg, hp, centers = 3, seed = 1)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  expect_true(weird_name %in% vi$variable)
+  expect_equal(nrow(vi), 3)
+  expect_true(all(vi$eta_squared >= 0 & vi$eta_squared <= 1))
+})
+
+test_that('a grouped (Repeat By) K-Means model computes variable_importance per group, from that group\'s own data', {
+  set.seed(1)
+  df <- mtcars %>% dplyr::mutate(grp = ifelse(cyl == 4, 'a', 'b'))
+  model_df <- df %>% dplyr::group_by(grp) %>%
+    exp_kmeans(mpg, hp, centers = 2, seed = 1, max_nrow = NULL)
+
+  for (i in seq_len(nrow(model_df))) {
+    model <- model_df$model[[i]]
+    vi <- broom::tidy(model, type = 'variable_importance')
+    expect_equal(nrow(vi), 2)
+    expect_setequal(vi$variable, c('mpg', 'hp'))
+    # Each group's variable_importance must be computed from THAT group's own rows,
+    # not leak in the other group's data -- cross-check nrow(model$df) matches the group size.
+    expect_equal(nrow(model$df), sum(df$grp == model_df$grp[[i]]))
+  }
+})
+
+test_that('variable_importance returns an empty, correctly-typed tibble for a pure-PCA fit (no kmeans attached)', {
+  # tidy.prcomp_exploratory(type="variable_importance") must not error for a fit that never
+  # went through exp_kmeans() -- e.g. a plain do_prcomp() result, or an old saved K-Means
+  # model missing the tam#37681-era fields.
+  fit <- iris %>% do_prcomp(Sepal.Length, Sepal.Width, Petal.Length, Petal.Width, seed = 1)
+  model <- fit$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+
+  expect_true(is.data.frame(vi))
+  expect_equal(nrow(vi), 0)
+  expect_setequal(colnames(vi), c('variable', 'eta_squared', 'test_statistic', 'p_value'))
+})
+
+test_that('.kmeans_variable_importance is a thin wrapper reusing cluster_variable_importance_anova (no logic duplication)', {
+  set.seed(1)
+  model_df <- mtcars %>% exp_kmeans(mpg, disp, hp, centers = 3, seed = 1)
+  model <- model_df$model[[1]]
+
+  wrapper_result <- exploratory:::.kmeans_variable_importance(model)
+  direct_result <- exploratory:::cluster_variable_importance_anova(
+    exploratory:::as_numeric_matrix_(model$df, columns = model$selected_cols),
+    model$kmeans$cluster
+  )
+  expect_equal(wrapper_result, direct_result)
+})


### PR DESCRIPTION
# Description

Implements the R side of exploratory-io/tam#38160: "We have implemented a support for showing which variables are significant or more influential for differenciating clusters for K-Medoids and K-Modes, we should do the same for K-Means."

**What K-Medoids/K-Modes already do:** `tidy.pam_exploratory(type='variable_importance')` (K-Medoids, `kmedoids.R`) computes, per clustering variable, **eta-squared** (between-cluster SS / total SS — a one-way-ANOVA effect size) against the fitted cluster assignment, plus the paired `stats::aov()` F statistic and p value. K-Medoids clusters purely numeric variables (`exp_kmedoids()` requires `is.numeric` for every selected column). K-Modes (`kmodes.R`, unmodified here) instead uses Cramer's V from a chi-square test, since it clusters purely categorical variables — ANOVA doesn't apply there.

**K-Means adaptation:** K-Means (`exp_kmeans()`) is also numeric-only (mirrors the UI's `columnTypes: ["numeric"]` restriction) and structurally the closest match to K-Medoids — both produce an integer cluster assignment over the same N-rows × K-numeric-variables shape. So this reuses K-Medoids' eta-squared/ANOVA statistic **directly**, via a newly extracted shared helper, rather than deriving a new statistic:

- **New `R/cluster_variable_importance.R`**: `cluster_variable_importance_anova(mat, cluster_ids)` — the eta-squared/ANOVA computation, extracted verbatim from K-Medoids' `.kmedoids_variable_importance`.
- **`R/kmedoids.R`**: `.kmedoids_variable_importance` refactored to a one-line call to the shared helper. Pure extraction — same inputs (`x$mat`, `x$clustering`), same outputs. `test_kmedoids.R`'s existing coverage (`'report tidy types are available'`, which already exercises `type='variable_importance'`) is unmodified and should still pass unchanged.
- **`R/kmeans.R`**: new `.kmeans_variable_importance(x)`, reading `x$df[, x$selected_cols]` (the clustering data `exp_kmeans()` already attaches to the combined `prcomp_exploratory` fit) and `x$kmeans$cluster` — both are already row-aligned and NA-filtered, since `exp_kmeans()` fits both `build_kmeans.cols()` and `do_prcomp()` on the SAME `preprocess_factanal_data_before_sample()`-filtered `df`.
- **`R/prcomp.R`**: `tidy.prcomp_exploratory()` gains `type == "variable_importance"`, guarded on `!is.null(x$kmeans)` (mirrors the existing kmeans-only `type == "summary"` branch's own comment), falling back to an empty, correctly-typed tibble for a pure-PCA fit or an old saved K-Means model missing the tam#37681-era fields (mirrors the existing `analysis_conditions` branch's identical defensive pattern).

**Tests (`tests/testthat/test_kmeans_variable_importance.R`, new):**
- Basic shape: one row per clustering variable, correct columns, η² in [0,1].
- **Cross-check against an INDEPENDENTLY computed `stats::aov()` call in the test itself** (not re-deriving the eta-squared/F/p formula a second time, to avoid the test sharing a bug with the implementation) against a real fitted `iris` K-Means model.
- Zero-variance (constant) clustering variable → `eta_squared == 0`, never `NaN`/`NA`.
- Single-column K-Means (`allow_single_column` path).
- A stress-test column name per tam's `.claude/rules/workflow.md` Rule 7 (`航空 会社 !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`).
- Grouped (Repeat By) K-Means: each group's variable_importance computed from that group's own rows only.
- A pure-PCA fit (no `x$kmeans`) returns an empty, correctly-typed tibble instead of erroring.
- A direct equality check that `.kmeans_variable_importance` is a thin wrapper over `cluster_variable_importance_anova`, with zero duplicated logic.

# Checklist

- [x] Add test cases for this fix/enhancement (`tests/testthat/test_kmeans_variable_importance.R`; `test_kmedoids.R` unmodified and should still pass against the refactor)
- [ ] Pass `devtools::check()` — **not run**: R/Rscript are not installed in this automated environment (`which R Rscript` confirmed neither is present).
- [ ] Pass `devtools::test()` — **not run**, same reason. Tests were written and carefully traced against documented R semantics (`stats::aov()`/`summary()` table shape, `tapply`/`sum` behavior already exercised identically by the pre-existing K-Medoids tests this code was extracted from), not executed live. **A maintainer with an R environment should run `devtools::test(filter="kmeans")` and `devtools::test(filter="kmedoids")` before merging.**
- [ ] Test installing from github — not done (no R environment).
- [ ] Tested with Exploratory — not done; the companion tam PR (exploratory-io/tam#38198) needs a rebuilt/reinstalled R package to exercise this end-to-end, which is out of scope for this source-only PR.

# Deferred / follow-up

- Version bump (`DESCRIPTION`) + binary rebuild + deploy is a separate release-engineering step, not included here.
- No `NAMESPACE`/`DESCRIPTION` changes needed — `cluster_variable_importance_anova()` and `.kmeans_variable_importance()` are internal (non-exported) package functions, matching the existing convention for `.kmedoids_variable_importance` and sibling helpers.

Fixes exploratory-io/tam#38160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eij4X7qXwnjJ3jk4UZ41Dn)_