### PR TITLE
Bump version to 16.1.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.6
-Date: 2026-08-30
+Version: 16.1.7
+Date: 2026-09-01
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory


### PR DESCRIPTION
## Why

The published `exploratory_16.1.6` binaries (Windows `.zip` + both Mac
`.tgz`) on the server were built from this repo's #1640 branch **~3
hours before it merged to master**. Their actual content is
16.1.2 + CHAID-numeric — 16.1.3 (#1639), 16.1.4 (#1636) and 16.1.5
(#1642) were silently reverted. Version string and md5 both looked
correct; only the package's real content was wrong.

This surfaced as 65 NPM test failures in the 2026-09-01 Windows daily
test (tam#38196 — was 1 failure on 2026-08-31). Full root-cause
writeup: `tam/docs/plans/design/2026-09-01-exploratory-16-1-6-regression-and-package-provenance-guard.md`.

`master` (parent of this commit, `74e1f8e9`) already contains
everything that should be in 16.1.6 — #1636, #1639, #1642, #1640. No
code changes here, **version-number-only bump** so a correct rebuild
from `master` can be published under a number that was never tainted.
`16.1.6` must never be reused.

## What's next

After this merges: tag `v16.1.7` on the resulting master commit,
rebuild Mac (Intel/ARM) + Windows binaries from that commit, run them
through tam's new `tools/verify_exploratory_pkg_content.R` gate before
publishing to download2, then re-pin tam's
`requiredRPackagesReduced.json` to 16.1.7.