### PR TITLE
Support partial dependence for a numeric CHAID target (tam#38345)

### DIFF
--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -248,7 +248,16 @@ exp_chaid <- function(df,
         imp_vars <- chaid_partial_dependence_vars(
           model$importance, c_cols, model$terms_mapping, max_pd_vars_eff
         )
-        model$partial_dependence <- NULL
+        # tam #38345: PD now works for a numeric target too (predict.fun above
+        # switches to type = "value"), so the Analytics Report's
+        # {{variable_effect}} / local_importance_regression chart has data --
+        # the same contract exp_rpart's numeric report already uses. `firm`
+        # importance stays on the RMSE-drop permutation variant regardless,
+        # because calc_firm_from_pd() is written against class probabilities.
+        model$partial_dependence <- partial_dependence.exploratory_chaid(
+          model, clean_target_col, vars = imp_vars, data = df,
+          n = c(pd_grid_resolution, min(nrow(df), pd_sample_size))
+        )
       } else {
         # tam#37466: `firm` derives importance from the partial-dependence curves,
         # so unlike `permutation` it has to see the PD of EVERY predictor before it
@@ -314,7 +323,13 @@ exp_chaid <- function(df,
       }
 
       model$imp_vars <- imp_vars
-      if (isTRUE(pd_with_bin_means) && isTRUE(is_target_logical)) {
+      # tam #38345: a numeric target gets the binned-mean "Actual" overlay too --
+      # calc_partial_binning_data() takes the mean of the target within each
+      # predictor bin, which is exactly the regression reading. Multiclass is
+      # still excluded (handle_partial_dependence()'s partial_binning branch
+      # handles regression and binary only).
+      if (isTRUE(pd_with_bin_means) &&
+          (isTRUE(is_target_logical) || identical(model$target_type, "numeric"))) {
         model$partial_binning <- calc_partial_binning_data(
           df, clean_target_col, imp_vars
         )
@@ -912,10 +927,19 @@ partial_dependence.exploratory_chaid <- function(fit, target,
     return(NULL)
   }
 
+  # tam #38345: a numeric target has no class-probability distribution
+  # (chaid_predict_prepared() returns a zero-column frame for type = "prob"), so
+  # PD predicts the node MEAN instead -- the same numeric-vector contract
+  # partial_dependence.rpart() uses for its own regression case.
+  is.numeric.target <- identical(fit$target_type, "numeric")
+
   # Default S3 predict() returns class labels; PD needs class probabilities with
   # the same column names (TRUE/FALSE or class levels) that handle_partial_dependence
   # expects from rpart/ranger.
   predict.fun <- function(object, newdata) {
+    if (is.numeric.target) {
+      return(as.numeric(predict(object, newdata, type = "value")))
+    }
     prob <- as.data.frame(
       predict(object, newdata, type = "prob"),
       stringsAsFactors = FALSE,
@@ -957,16 +981,26 @@ partial_dependence.exploratory_chaid <- function(fit, target,
       if ("points" %in% names(args)) {
         args$points <- args$points[x]
       }
-      do.call(mmpf::marginalPrediction, args)
+      mp <- do.call(mmpf::marginalPrediction, args)
+      # A vector-returning predict.fun leaves mmpf's own column name on the
+      # prediction; handle_partial_dependence() finds it by attr(pd, "target").
+      if (is.numeric.target) {
+        names(mp)[ncol(mp)] <- target
+      }
+      mp
     }, simplify = FALSE), fill = TRUE)
     data.table::setcolorder(pd, c(vars, colnames(pd)[!colnames(pd) %in% vars]))
   } else {
     pd <- do.call(mmpf::marginalPrediction, args)
+    if (is.numeric.target) {
+      names(pd)[ncol(pd)] <- target
+    }
   }
 
   attr(pd, "class") <- c("pd", "data.frame")
   attr(pd, "interaction") <- isTRUE(interaction)
-  attr(pd, "target") <- if (identical(fit$classification_type, "binary")) {
+  attr(pd, "target") <- if (is.numeric.target ||
+                            identical(fit$classification_type, "binary")) {
     target
   } else {
     fit$class_levels

--- a/tests/testthat/test_chaid_numeric.R
+++ b/tests/testthat/test_chaid_numeric.R
@@ -285,3 +285,102 @@ test_that('existing categorical/logical CHAID behavior is unchanged (regression 
   expect_equal(logical_model$target_type, 'logical')
   expect_true(!is.null(logical_model$class_levels))
 })
+
+# ---------------------------------------------------------------------------
+# tam #38345: partial dependence for a NUMERIC target.
+#
+# #38166 deferred this -- partial_dependence.exploratory_chaid()'s predict.fun
+# hardcoded predict(type = "prob"), which has no meaning for a numeric target
+# (chaid_predict_prepared() returns a zero-column frame), so build_exp_chaid()
+# set model$partial_dependence <- NULL and the Analytics Report's
+# {{variable_effect}} chart had nothing to draw. exp_rpart's numeric report has
+# always had that chart; this closes the gap.
+# ---------------------------------------------------------------------------
+
+chaid_numeric_pd_fixture <- function(n = 240) {
+  set.seed(38345)
+  # Draw the two predictors INDEPENDENTLY. A rep(..., length.out = n) pair
+  # cycles in lockstep, aliasing them completely -- the tree then splits on one
+  # and the other's partial-dependence curve is flat, which looks exactly like
+  # a broken PD implementation.
+  rank <- factor(sample(c('bronze', 'silver', 'gold'), n, replace = TRUE),
+                 levels = c('bronze', 'silver', 'gold'), ordered = TRUE)
+  channel <- sample(c('web', 'app', 'store'), n, replace = TRUE)
+  base <- c(bronze = 100, silver = 200, gold = 300)[as.character(rank)]
+  bump <- c(web = 0, app = 20, store = -20)[channel]
+  data.frame(
+    amount = as.numeric(base + bump + stats::rnorm(n, sd = 5)),
+    rank = rank,
+    channel = channel,
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that('a numeric target gets partial dependence instead of NULL', {
+  skip_if_not_installed('mmpf')
+  df <- chaid_numeric_pd_fixture()
+  model_df <- df %>% exp_chaid(amount, rank, channel, seed = 1)
+  model <- model_df$model[[1]]
+
+  expect_equal(model$target_type, 'numeric')
+  expect_false(is.null(model$partial_dependence))
+  # The prediction column is named after the TARGET, the way
+  # partial_dependence.rpart() names its own regression output --
+  # handle_partial_dependence() finds it through attr(pd, "target").
+  expect_true('amount' %in% colnames(model$partial_dependence))
+  expect_equal(unname(attr(model$partial_dependence, 'target')), 'amount')
+  expect_setequal(attr(model$partial_dependence, 'vars'), c('rank', 'channel'))
+  # Values are node MEANS on the target's own scale, not probabilities in 0..1.
+  pd_values <- model$partial_dependence[['amount']]
+  expect_true(all(is.finite(pd_values)))
+  expect_gt(max(pd_values), 1)
+})
+
+test_that('numeric partial dependence tracks the real group means', {
+  skip_if_not_installed('mmpf')
+  df <- chaid_numeric_pd_fixture()
+  model_df <- df %>% exp_chaid(amount, rank, channel, seed = 1)
+  pd <- model_df$model[[1]]$partial_dependence
+
+  by_rank <- pd[!is.na(pd$rank), c('rank', 'amount')]
+  ordered_pd <- by_rank[order(by_rank$rank), ]
+  # Independent expectation: the fixture's own group means are strictly
+  # increasing bronze < silver < gold, so the PD curve must be too.
+  actual_means <- tapply(df$amount, df$rank, mean)
+  expect_true(all(diff(as.numeric(actual_means)) > 0))
+  expect_true(all(diff(ordered_pd$amount) > 0))
+})
+
+test_that('pd_with_bin_means gives a numeric target the binned Actual overlay too', {
+  skip_if_not_installed('mmpf')
+  df <- chaid_numeric_pd_fixture()
+  model <- (df %>% exp_chaid(amount, rank, channel, seed = 1,
+                             pd_with_bin_means = TRUE))$model[[1]]
+  expect_false(is.null(model$partial_binning))
+
+  # rf_partial_dependence() is what the report chart actually runs; for a
+  # regression model it must emit both series, the same as exp_rpart's.
+  out <- (df %>% exp_chaid(amount, rank, channel, seed = 1,
+                           pd_with_bin_means = TRUE)) %>% rf_partial_dependence()
+  expect_true(nrow(out) > 0)
+  expect_setequal(unique(as.character(out$y_name)), c('Actual', 'Predicted'))
+  expect_true(all(c('conf_low', 'conf_high', 'bin_sample_size') %in% colnames(out)))
+})
+
+test_that('a categorical target keeps its class-probability partial dependence (regression guard)', {
+  skip_if_not_installed('mmpf')
+  set.seed(38345)
+  n <- 240
+  x <- rep(c('a', 'b', 'c'), length.out = n)
+  y <- ifelse(x == 'a', 'yes', ifelse(x == 'b', 'no', 'yes'))
+  df <- data.frame(target = y, x = x, z = rep(c('p', 'q'), length.out = n),
+                   stringsAsFactors = FALSE)
+  model <- (df %>% exp_chaid(target, x, z, seed = 1))$model[[1]]
+
+  expect_true(model$target_type %in% c('character', 'factor'))
+  expect_false(is.null(model$partial_dependence))
+  # Still keyed by CLASS LEVELS, not by the target column name.
+  expect_equal(attr(model$partial_dependence, 'target'), model$class_levels)
+  expect_true(all(model$class_levels %in% colnames(model$partial_dependence)))
+  expect_false('target' %in% colnames(model$partial_dependence))
+})


### PR DESCRIPTION
## Problem

Desktoip shipped numeric-target CHAID with partial dependence **explicitly deferred**. `partial_dependence.exploratory_chaid()`'s `predict.fun` hardcoded `predict(type = "prob")`, which has no meaning for a numeric target — `chaid_predict_prepared()` returns a zero-column frame for `type = "prob"` on a numeric model by design — so `build_exp_chaid()` set `model$partial_dependence <- NULL` with a comment naming the deferral.

Consequence: the Analytics Report's `{{variable_effect}}` chart had no data, and **CHAID was the only tree analytics whose numeric report lacked it** — `exp_rpart` has had `local_importance_regression` all along, gated on `objectiveVariable.type == numeric` and embedded in `exp_rpart_numeric.js`.

This was not a user-visible *error* (the tam-side viz is `condition`-gated, so no tab is created and nothing throws) — it is a missing feature and a CART-parity gap.

## Change

- **`predict.fun`** switches to `predict(object, newdata, type = "value")` for a numeric target, returning the node mean as a numeric vector. That is the same contract `partial_dependence.rpart()` uses for its own regression case, so `handle_partial_dependence()` needs no change at all.
- The prediction column is renamed to the target and `attr(pd, "target")` is set to it — again mirroring the rpart method, whose `handle_partial_dependence()` regression branch looks the column up through that attribute. The categorical branch keeps returning `fit$class_levels`.
- **`build_exp_chaid()`** computes PD for a numeric target instead of NULLing it, and the `pd_with_bin_means` gate is extended to numeric so the chart gets its binned `Actual (Mean)` overlay — the same `is_target_logical_or_numeric` condition `exp_rpart` already uses. (tam already passes `pd_with_bin_means = TRUE` for `exp_chaid`.)
- **`firm` importance deliberately stays** on the RMSE-drop permutation variant for a numeric target: `calc_firm_from_pd()` is written against class probabilities, so this PR does not extend it.

## Verification

Run with `pkgload::load_all` (the internals these tests reach are unexported, so `test_file` + `library()` alone reports "could not find function"):

| Suite | Result |
|---|---|
| `test_chaid_numeric.R` | all green |
| `test_chaid.R` | all green |
| `test_build_chaid.R` | all green |
| `test_chaid_report_format.R` | all green |

New cases in `test_chaid_numeric.R`:

1. **PD contract** — a numeric target gets a non-NULL `partial_dependence`, the prediction column is named after the target, `attr(pd, "target")` is the target, `attr(pd, "vars")` is the predictor set, and the values are node MEANS on the target's own scale rather than probabilities in 0..1.
2. **Curve correctness** — the PD curve over an ordered predictor is strictly increasing, with the *independent* expectation computed from the fixture's own `tapply` group means rather than from this PR's arithmetic.
3. **Binned overlay** — `pd_with_bin_means = TRUE` populates `partial_binning`, and `rf_partial_dependence()` (what the report chart actually runs) emits both `Actual` and `Predicted` plus `conf_low` / `conf_high` / `bin_sample_size`, the same shape `exp_rpart`'s regression chart consumes.
4. **Categorical regression guard** — a character target still keys `attr(pd, "target")` on the class levels, still carries a column per class, and does NOT carry a column named after the target.

Worth noting about the fixture: the first draft built both predictors with `rep(..., length.out = n)`, which cycles them in lockstep and aliases them completely — the tree then splits on one and the other's PD curve is flat, which is indistinguishable from a broken PD implementation. They are drawn independently now, and the reason is recorded in a comment.

Live sanity check on real data (700-row numeric fixture, 23 nodes / 6 splits), before and after:

```
partial_dependence NULL?  FALSE
pd cols: 会員ランク, 利用月数, サポート問い合わせ回数, 利用チャネル, <stress name>, 年間利用金額
pd target attr: 年間利用金額
rf_partial_dependence(): 124 rows, y_name values: Actual / Predicted
```

## tam side

tam `fix/github-issue-38345-bfa92a` adds the numeric-gated `local_importance_regression` viz (copied from `exp_rpart.json`) and the `変数の値と予測値` / `Variable values and predictions` section. Until this PR is released and pinned in `tools/requiredRPackagesReduced.json`, that chart degrades cleanly — `rf_partial_dependence()` returns an empty frame when `model$partial_dependence` is NULL, which renders as no data rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
