### PR TITLE
Bump version to 16.1.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.7
-Date: 2026-09-01
+Version: 16.1.8
+Date: 2026-09-02
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory


### PR DESCRIPTION
Version-bump-only PR, per this repo's own recipe (`_COMMENT_16_1_*` entries in tam's `requiredRPackagesReduced.json`) — the two fixes below already merged to `master` without a version bump, so this is a dedicated PR rather than piggy-backing on either (both are already closed).

## Covers

- #1646 — partial dependence for a numeric CHAID target (tam#38345)
- #1647 — fix LCA class-conditional response probabilities not summing to 100% within a class/variable (`lca_profile_table()` melt order)

`Version: 16.1.7 -> 16.1.8`, `Date` bumped to today.

## Next steps (not in this PR)

Build Mac (Intel+ARM share one `.tgz`, no compiled code) + Windows binaries, upload to `download2.exploratory.io`, tag `v16.1.8`, and wire the new version into tam's `tools/requiredRPackagesReduced.json` — the remaining steps of `/release-exploratory-r-package --version-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
