### PR TITLE
CHAID: order split categories by declared level order, align tree labels to CART (tam#38372)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.9
-Date: 2026-09-02
+Version: 16.1.10
+Date: 2026-09-03
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -1406,6 +1406,20 @@ build_chaid_tree_nodes <- function(x) {
     if (length(edge_row) == 1) {
       cond_column <- map_name(edges$split_variable[edge_row])
       original_categories <- strsplit(edges$original_categories[edge_row], " \\| ")[[1]]
+      # tam #38372: CHAID records a merged group in MERGE order, so a branch on a
+      # declared factor read "30代, 20代, 40代". CART emits its category lists
+      # straight out of `attr(x, "xlevels")`, i.e. always in level order. Re-order
+      # to the predictor's declared order (chaid_group_level_order() falls back to
+      # ordered/binned-numeric levels, then to alphabetical) BEFORE collapsing --
+      # the merges table has done this since tam #37177, so the tree used to
+      # disagree with it on the very same model. Ordering first also gives
+      # chaid_collapse_intervals() the ascending run it needs to fold.
+      # `edges$split_variable` is the CLEAN (fit-time) name that
+      # chaid_group_level_order() expects; `cond_column` is already mapped back.
+      original_categories <- chaid_order_group_parts(
+        original_categories,
+        chaid_group_level_order(x, edges$split_variable[edge_row])
+      )
       # tam #37177: a branch built from a run of contiguous numeric bins reads
       # as the range it covers ("<= 2317.6, (2317.6, 2695.8]" -> "<= 2695.8").
       # cond_value stays the collapsed bin/category labels so DTreeGenerator's
@@ -1415,10 +1429,7 @@ build_chaid_tree_nodes <- function(x) {
       # "給料 = (2695.8, 4228.8]" -> "2695.8 < 給料 <= 4228.8") so the
       # characteristic-groups Condition column and tree chart match CART.
       display_categories <- chaid_collapse_intervals(original_categories)
-      edge_label <- chaid_readable_one_condition(
-        paste0(cond_column, " in {",
-               paste(display_categories, collapse = CHAID_GROUP_SEPARATOR), "}")
-      )
+      edge_label <- chaid_tree_edge_label(cond_column, display_categories)
       cond_value <- as.character(jsonlite::toJSON(as.character(display_categories)))
     } else {
       cond_column <- NA_character_

--- a/R/chaid.R
+++ b/R/chaid.R
@@ -1665,7 +1665,8 @@ chaid_node_summary <- function(model) {
   if (identical(model$target_type, 'numeric')) {
     return(data.frame(
       Node = model$nodes$node_id,
-      Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule, model$terms_mapping)),
+      Rule = chaid_readable_condition(chaid_map_display_names_in_text(
+      chaid_normalize_condition_groups(model$nodes$rule, model), model$terms_mapping)),
       Rows = model$nodes$n,
       `%` = model$nodes$n / root.n * 100,
       Mean = model$nodes$node_mean,
@@ -1686,7 +1687,8 @@ chaid_node_summary <- function(model) {
     # collapsed to one inequality. The root row reads "All".
     # `rule`/`split_variable` are in CLEAN (fit-time) name space -- map back to
     # the column's real name for display (chaid_map_display_name(_in_text)()).
-    Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule, model$terms_mapping)),
+    Rule = chaid_readable_condition(chaid_map_display_names_in_text(
+      chaid_normalize_condition_groups(model$nodes$rule, model), model$terms_mapping)),
     Rows = model$nodes$n,
     `%` = model$nodes$n / root.n * 100,
     `Predicted Class` = model$nodes$predicted_class,
@@ -1714,7 +1716,8 @@ chaid_rule_table <- function(model) {
   if (identical(model$target_type, 'numeric')) {
     return(data.frame(
       Node = model$nodes$node_id[terminal],
-      Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule[terminal], model$terms_mapping)),
+      Rule = chaid_readable_condition(chaid_map_display_names_in_text(
+      chaid_normalize_condition_groups(model$nodes$rule[terminal], model), model$terms_mapping)),
       Prediction = model$nodes$predicted_class[terminal],
       Mean = model$nodes$node_mean[terminal],
       `Std. Dev.` = model$nodes$node_sd[terminal],
@@ -1726,7 +1729,8 @@ chaid_rule_table <- function(model) {
   data.frame(
     Node = model$nodes$node_id[terminal],
     # tam #37177: see chaid_node_summary(). tam#38107: map clean -> original name.
-    Rule = chaid_readable_condition(chaid_map_display_names_in_text(model$nodes$rule[terminal], model$terms_mapping)),
+    Rule = chaid_readable_condition(chaid_map_display_names_in_text(
+      chaid_normalize_condition_groups(model$nodes$rule[terminal], model), model$terms_mapping)),
     Prediction = model$nodes$predicted_class[terminal],
     Probability = vapply(
       model$nodes$class_distribution[terminal],

--- a/R/chaid_report_format.R
+++ b/R/chaid_report_format.R
@@ -233,6 +233,91 @@ chaid_readable_one_condition <- function(condition) {
   paste0(variable, ' in (', paste(collapsed, collapse = CHAID_GROUP_SEPARATOR), ')')
 }
 
+#' Branch label for the interactive tree chart, in CART's form.
+#'
+#' `build_rpart_tree_nodes()` writes a categorical branch as `X = a, b, c`;
+#' CHAID's report convention is `X in (a + b + c)`. Both feed the SAME
+#' Characteristic Groups table (`dtree_report_characteristic_groups()` joins
+#' `edge_label` with `" AND "`), which therefore printed two formats depending
+#' on the algorithm (tam #38372). The tree chart itself already renders
+#' `a, b, c` from `cond_value`, so the CART form is also what the diagram shows.
+#'
+#' A single member (`X = a`) and a collapsed numeric run (`X <= 6`,
+#' `2 < X <= 5`) already come out CART-shaped from
+#' [chaid_readable_one_condition()] and are delegated to it. A multi-member
+#' group that still contains an interval label — a non-contiguous bin run that
+#' would not collapse — also stays with `in (...)`, because `X = <= 2, (2.8, 5]`
+#' is unreadable.
+#'
+#' @param variable Display (original) column name.
+#' @param categories Character vector of category / bin labels, already ordered
+#'   and interval-collapsed.
+#' @return A single label string.
+chaid_tree_edge_label <- function(variable, categories) {
+  categories <- as.character(categories)
+  in_form <- function() {
+    chaid_readable_one_condition(
+      paste0(variable, ' in {',
+             paste(categories, collapse = CHAID_GROUP_SEPARATOR), '}'))
+  }
+  if (length(categories) <= 1) {
+    return(in_form())
+  }
+  has_interval <- any(vapply(categories,
+                             function(one) !is.null(chaid_parse_interval(one)),
+                             logical(1)))
+  if (has_interval) {
+    return(in_form())
+  }
+  paste0(variable, ' = ', paste(categories, collapse = ', '))
+}
+
+#' Reorder every category group inside composite rule strings.
+#'
+#' A rule is a `" & "`-joined list of `<var> in {a + b}` conditions built in
+#' CHAID's MERGE order. This gives each condition's members the predictor's
+#' declared order (see [chaid_group_level_order()] / [chaid_order_group_parts()]),
+#' so the Node Summary / Rules tabs agree with the tree chart and the Category
+#' Merges table (tam #38372). Variable names are left in whatever name space the
+#' caller passed — apply this BEFORE [chaid_map_display_names_in_text()], while
+#' the names are still CLEAN, since the level lookup is keyed on the clean name.
+#'
+#' @param text Character vector of rule strings.
+#' @param model A fitted `exploratory_chaid` model.
+#' @return `text`, with each condition's members reordered.
+chaid_normalize_condition_groups <- function(text, model) {
+  text <- as.character(text)
+  if (length(text) == 0) {
+    return(text)
+  }
+  level_cache <- new.env(parent = emptyenv())
+  levels_for <- function(variable) {
+    key <- paste0('v', variable)   # avoid clashing with env internals
+    if (!exists(key, envir = level_cache, inherits = FALSE)) {
+      assign(key, list(chaid_group_level_order(model, variable)), envir = level_cache)
+    }
+    get(key, envir = level_cache, inherits = FALSE)[[1]]
+  }
+  map_condition <- function(condition) {
+    m <- regmatches(condition, regexec('^(.*) in \\{(.*)\\}$', condition))[[1]]
+    if (length(m) != 3) {
+      return(condition)
+    }
+    variable <- m[2]
+    parts <- strsplit(m[3], CHAID_GROUP_SEPARATOR, fixed = TRUE)[[1]]
+    parts <- chaid_order_group_parts(parts, levels_for(variable))
+    paste0(variable, ' in {', paste(parts, collapse = CHAID_GROUP_SEPARATOR), '}')
+  }
+  vapply(text, function(rule) {
+    if (is.na(rule)) {
+      return(NA_character_)
+    }
+    conditions <- chaid_split_conditions(rule)
+    paste(vapply(conditions, map_condition, character(1)),
+          collapse = CHAID_CONDITION_SEPARATOR)
+  }, character(1), USE.NAMES = FALSE)
+}
+
 #' Rewrite a CHAID node rule in readable form.
 #'
 #' Drops the leading `Root` term, collapses contiguous numeric bin groups into

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -789,3 +789,90 @@ test_that("a comma-containing predictor column name survives report tables uncor
     expect_true(all(intervals$Variable %in% c("price", "気に入った, 理由")))
   }
 })
+
+# tam #38372 -----------------------------------------------------------------
+# A declared factor whose CHAID merge order differs from its level order. The
+# probabilities make {20s, 30s, 40s} merge into one branch and {50s, 60s+} into
+# another; which of the three is merged first (and therefore the order CHAID
+# records) is an artifact of the merge loop, so the tree used to read
+# "40s, 30s, 20s".
+make_declared_level_df <- function(n = 1000, seed = 38372) {
+  set.seed(seed)
+  age_levels <- c("20s", "30s", "40s", "50s", "60s+")
+  job_levels <- c("student", "employee", "homemaker", "specialist", "parttime",
+                  "selfemployed", "unemployed", "officer", "executive", "other")
+  df <- data.frame(
+    age = factor(sample(age_levels, n, TRUE, prob = c(.2, .25, .25, .2, .1)),
+                 levels = age_levels),
+    job = factor(sample(job_levels, n, TRUE), levels = job_levels),
+    stringsAsFactors = FALSE
+  )
+  df$renew <- runif(n) < ifelse(df$age %in% c("20s", "30s", "40s"), 0.66, 0.32)
+  attr(df, "level_order") <- list(age = age_levels, job = job_levels)
+  df
+}
+
+test_that("tree_nodes category branches use the declared level order (tam #38372)", {
+  df <- make_declared_level_df()
+  level_order <- attr(df, "level_order")
+  model_df <- suppressWarnings(exp_chaid(df, renew, age, job,
+                                         min_split = 40, min_bucket = 20))
+  nodes <- model_df %>% tidy_rowwise(model, type = "tree_nodes")
+  branches <- nodes[!is.na(nodes$cond_column), ]
+  expect_gt(nrow(branches), 0)
+
+  values_of <- lapply(branches$cond_value, jsonlite::fromJSON)
+  # Guard the guard: a tree whose every branch holds ONE category would make the
+  # ordering assertion below vacuously true.
+  expect_true(any(vapply(values_of, length, integer(1)) > 1))
+
+  for (i in seq_len(nrow(branches))) {
+    values <- values_of[[i]]
+    declared <- level_order[[branches$cond_column[i]]]
+    # Same contract as CART: the members are the declared levels, in declared
+    # order (build_rpart_tree_nodes reads them out of attr(x, "xlevels")).
+    expect_equal(values, declared[declared %in% values])
+    # ...and the branch label is CART's "col = a, b, c", not "col in (a + b)".
+    expect_equal(branches$edge_label[i],
+                 paste0(branches$cond_column[i], " = ",
+                        paste(values, collapse = ", ")))
+  }
+})
+
+test_that("node_summary / rules category groups match the tree's order (tam #38372)", {
+  df <- make_declared_level_df()
+  level_order <- attr(df, "level_order")
+  model_df <- suppressWarnings(exp_chaid(df, renew, age, job,
+                                         min_split = 40, min_bucket = 20))
+
+  # Every "<var> in (a + b)" group in any rendered rule, from every table that
+  # renders one, must be in the same declared order the tree branch uses.
+  expect_groups_ordered <- function(text) {
+    hits <- regmatches(text, gregexpr("[^ &]+ in \\([^)]*\\)", text))
+    for (rule_hits in hits) {
+      for (hit in rule_hits) {
+        m <- regmatches(hit, regexec("^(.*) in \\((.*)\\)$", hit))[[1]]
+        declared <- level_order[[m[2]]]
+        if (is.null(declared)) next
+        members <- strsplit(m[3], " + ", fixed = TRUE)[[1]]
+        expect_equal(members, declared[declared %in% members])
+      }
+    }
+  }
+  node_summary <- model_df %>% tidy_rowwise(model, type = "node_summary")
+  rules <- model_df %>% tidy_rowwise(model, type = "rules")
+  merges <- model_df %>% tidy_rowwise(model, type = "category_merges")
+  expect_gt(sum(grepl(" in \\(", node_summary$Rule)), 0)
+  expect_groups_ordered(node_summary$Rule)
+  expect_groups_ordered(rules$Rule)
+
+  # The original symptom: the Category Merges table has ordered its members
+  # since tam #37177, so the tree and the rules disagreed with it on the very
+  # same model. Every merged group must now appear in the rules verbatim.
+  merged <- merges[["Merged Category"]]
+  merged <- merged[grepl(" + ", merged, fixed = TRUE)]
+  expect_gt(length(merged), 0)
+  for (group in merged) {
+    expect_true(any(grepl(paste0("(", group, ")"), node_summary$Rule, fixed = TRUE)))
+  }
+})

--- a/tests/testthat/test_chaid_report_format.R
+++ b/tests/testthat/test_chaid_report_format.R
@@ -261,3 +261,63 @@ test_that('chaid_group_level_order resolves a CLEAN variable name through terms_
   # exactly as chaid_numeric_intervals()/chaid_category_merge_table() do).
   expect_equal(chaid_group_level_order(model, '部署.1'), c('営業', '研究開発', '人事'))
 })
+
+# tam #38372 -----------------------------------------------------------------
+# CHAID records a merged group in MERGE order; CART (build_rpart_tree_nodes())
+# emits its category lists straight out of attr(x, "xlevels"), i.e. always in
+# level order. These two helpers bring the tree chart and the rule tables onto
+# CART's convention.
+
+test_that('chaid_tree_edge_label writes a categorical branch in CART form (tam #38372)', {
+  # Multi-member categorical group -> "col = a, b, c" (build_rpart_tree_nodes'
+  # make_edge_and_cond()), NOT CHAID's report-table "col in (a + b + c)".
+  expect_equal(chaid_tree_edge_label('部署', c('営業', '研究開発', '人事')),
+               '部署 = 営業, 研究開発, 人事')
+  # A single member already reads as an equality in both algorithms.
+  expect_equal(chaid_tree_edge_label('部署', '営業'), '部署 = 営業')
+  # A collapsed numeric run keeps the readable inequality form (tam #37177).
+  expect_equal(chaid_tree_edge_label('給料', '<= 2695.8'), '給料 <= 2695.8')
+  expect_equal(chaid_tree_edge_label('給料', '> 4228.8'), '給料 > 4228.8')
+  expect_equal(chaid_tree_edge_label('給料', '(2695.8, 4228.8]'),
+               '2695.8 < 給料 <= 4228.8')
+  # A multi-member run that still contains an interval (a NON-contiguous bin run
+  # that would not collapse) must not read "給料 = <= 2, (2.8, 5]".
+  expect_equal(chaid_tree_edge_label('給料', c('<= 2', '(2.8, 5]')),
+               '給料 in (<= 2 + (2.8, 5])')
+})
+
+test_that('chaid_normalize_condition_groups reorders every group in a rule (tam #38372)', {
+  model <- list(
+    original_factor_levels = list(部署 = c('営業', '研究開発', '人事')),
+    predictor_info = list(
+      部署 = list(ordered = FALSE, levels = c('研究開発', '人事', '営業')),
+      婚姻ステータス = list(ordered = FALSE, levels = c('離婚', '既婚', '独身')),
+      年齢 = list(ordered = TRUE, levels = c('<= 26', '(26, 29]', '> 29'))
+    )
+  )
+  # Declared factor order.
+  expect_equal(chaid_normalize_condition_groups('部署 in {人事 + 営業}', model),
+               '部署 in {営業 + 人事}')
+  # Every condition of a composite rule is normalized independently, and the
+  # "Root" term is passed through untouched for chaid_readable_condition().
+  expect_equal(
+    chaid_normalize_condition_groups(
+      'Root & 部署 in {人事 + 研究開発 + 営業} & 年齢 in {> 29 + (26, 29]}', model),
+    'Root & 部署 in {営業 + 研究開発 + 人事} & 年齢 in {(26, 29] + > 29}')
+  # A character predictor has no declared order -> alphabetical (same rule the
+  # Category Merges table already applies).
+  expect_equal(
+    chaid_normalize_condition_groups('婚姻ステータス in {独身 + 既婚}', model),
+    '婚姻ステータス in {既婚 + 独身}')
+  # A variable with no level information keeps alphabetical order; a fragment
+  # that is not a group condition is left alone; NA passes through.
+  expect_equal(chaid_normalize_condition_groups('存在しない列 in {b + a}', model),
+               '存在しない列 in {a + b}')
+  expect_equal(chaid_normalize_condition_groups('Root', model), 'Root')
+  expect_true(is.na(chaid_normalize_condition_groups(NA_character_, model)))
+  expect_equal(chaid_normalize_condition_groups(character(0), model), character(0))
+  # Vectorized.
+  expect_equal(
+    chaid_normalize_condition_groups(c('部署 in {人事 + 営業}', 'Root'), model),
+    c('部署 in {営業 + 人事}', 'Root'))
+})


### PR DESCRIPTION
## Description

R-side half of tam https://github.com/exploratory-io/tam/issues/38372
(tam PR: https://github.com/exploratory-io/tam/pull/38373).

CHAID recorded a merged category group in **merge order**, so a decision-tree branch on a
declared factor read `30代, 20代, 40代` instead of `20代, 30代, 40代`.
`build_rpart_tree_nodes()` (CART) reads its category lists straight out of
`attr(x, "xlevels")`, so CART is always in declared level order.

The ordering machinery already existed (`chaid_group_level_order()` +
`chaid_order_group_parts()`, tam #37177) and was already applied to the **Category Merges**
table — so one and the same model printed two different orders:

```
Category Merges              : 20代 + 30代 + 40代     <- ordered (correct)
Tree / Node Summary / Rules  : 40代 + 30代 + 20代     <- merge order (bug)
```

## Changes

**`R/build_chaid.R` — `build_chaid_tree_nodes()`**

- Orders each split's members with `chaid_order_group_parts()` +
  `chaid_group_level_order()` before collapsing. `edges$split_variable` is already the
  CLEAN (fit-time) name that `chaid_group_level_order()` expects. Ordering first also gives
  `chaid_collapse_intervals()` the ascending run it needs to fold a contiguous bin sequence.
- Uses the new `chaid_tree_edge_label()` for `edge_label`.

**`R/chaid_report_format.R` — new `chaid_tree_edge_label()`**

A multi-member categorical branch's `edge_label` now reads CART's `col = a, b, c` instead of
CHAID's report-table `col in (a + b + c)`. Both algorithms feed the **same** Characteristic
Groups table (tam's `dtree_report_characteristic_groups()` joins `edge_label` with `" AND "`),
which therefore printed two formats depending on which algorithm produced the tree.
Singletons (`col = a`) and collapsed numeric ranges (`col <= 6`, `2 < col <= 5`) already came
out CART-shaped from `chaid_readable_one_condition()` and are delegated to it unchanged; a
multi-member run that still holds an interval label keeps `in (...)`, because
`col = <= 2, (2.8, 5]` is unreadable.

**`R/chaid_report_format.R` — new `chaid_normalize_condition_groups()`**

Per-condition normalizer for the composite `" & "`-joined node rules. Applied in
`chaid_node_summary()` and `chaid_rule_table()` (both the categorical and the numeric-target
branches) **before** `chaid_map_display_names_in_text()`, while the variable names are still
clean, so the Rule column agrees with the tree and the merges table.

## Scope note

CHAID's own report convention `X in (a + b)` is kept in Node Summary / Rules / Split
Evidence / Numeric Intervals. Only the shared, cross-algorithm surface — the tree's
`edge_label`, which feeds Characteristic Groups — moves to the CART form.

`chaid_normalize_condition_groups()` splits a rule's group on `" + "`, so it inherits the
documented, deliberately-unfixed `mergedCategoryValueSeparatorAmbiguityDefect` (a category
VALUE containing `" + "`, e.g. `Web + App`). Reordering makes the Rules / Node Summary tabs
render such a group exactly the way the Category Merges table already ships it
(`(Missing) + App + Web + Web`) — which is the consistency this change is for. The tree path
is unaffected; it splits `original_categories` on `" | "`.

## Testing

New tests, both of which **fail on `origin/master` and pass with this change**
(sabotage-checked by running the new test files against a clean `origin/master` worktree):

- `tests/testthat/test_build_chaid.R`
  - `tree_nodes category branches use the declared level order (tam #38372)` — asserts each
    branch's `cond_value` equals the declared levels restricted to its members, and that
    `edge_label` is CART's `col = a, b, c`. Guards itself against being vacuous by asserting
    at least one branch has more than one member.
  - `node_summary / rules category groups match the tree's order (tam #38372)` — asserts
    every `<var> in (a + b)` group in Node Summary and Rules is in declared order, and that
    every merged group from the Category Merges table appears verbatim in the rules.
- `tests/testthat/test_chaid_report_format.R`
  - `chaid_tree_edge_label writes a categorical branch in CART form (tam #38372)`
  - `chaid_normalize_condition_groups reorders every group in a rule (tam #38372)`

Local suite results (`pkgload::load_all()` + `testthat::test_file()`):

| File | tests | failed |
|---|---|---|
| `test_build_chaid.R` | 42 | 6 — all pre-existing `importance_measure = 'firm'`, identical on `origin/master` |
| `test_chaid.R` | 22 | 0 |
| `test_chaid_report_format.R` | 21 | 0 |
| `test_chaid_numeric.R` | 17 | 0 |
| `test_chaid_perf.R` | 3 | 0 |

End-to-end: CHAID and CART were fit on one identical 1,000-row frame, their `tree_nodes`
output diffed column by column, and the result rendered through tam's `DTreeGenerator`. The
two trees now read structurally identically:

```
[1] branch="20代, 30代, 40代"   tooltip: 年代 = 20代, 30代, 40代
[3] branch="<= 5"               tooltip: 年代 = 20代, 30代, 40代 & サービス満足度 <= 5
```

## Follow-ups

- Needs an `exploratory` package version bump (3rd digit) + Mac/Windows binary build and
  upload before it reaches Desktop.
- tam's CHAID harness answer CSVs
  (`src/test/analytics-harness/answers/exp_chaid/*/{node_summary,rules,characteristic_groups,feature_groups_top}.csv`)
  must be regenerated once the new package ships. Two of today's approved rows are the
  evidence for this fix: the same `multiclass_default` model prints `... 表 in (A社 + B社)`
  on one node and `in (B社 + A社)` on another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
