### PR TITLE
CHAID: assign node ids in the chart's left-to-right order (tam#38372 follow-up)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.10
+Version: 16.1.11
 Date: 2026-09-03
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/build_chaid.R
+++ b/R/build_chaid.R
@@ -1312,16 +1312,13 @@ build_chaid_tree_nodes <- function(x) {
     if (!is.null(tm) && v %in% names(tm)) unname(tm[v]) else v
   }
 
-  # Positive class first for a 2-class target (SPSS-style ordering).
-  ord <- seq_along(class_levels)
-  if (!is_reg && length(class_levels) == 2) {
-    up <- toupper(class_levels)
-    positive_idx <- if (setequal(up, c("FALSE", "TRUE"))) which(up == "TRUE")
-                    else if (setequal(up, c("NO", "YES"))) which(up == "YES")
-                    else NA_integer_
-    if (!is.na(positive_idx)) {
-      ord <- c(positive_idx, setdiff(seq_along(class_levels), positive_idx))
-    }
+  # Positive class first for a 2-class target (SPSS-style ordering). Shared with
+  # chaid_renumber_nodes_bfs()'s sibling ranking so the class table's order and
+  # the left-to-right node order can never drift apart (tam #38372).
+  ord <- if (is_reg) {
+    seq_along(class_levels)
+  } else {
+    match(chaid_display_class_order(class_levels), class_levels)
   }
 
   # tam #38166: numeric-target-only. A shared-breaks target histogram per

--- a/R/chaid.R
+++ b/R/chaid.R
@@ -191,7 +191,7 @@ chaid_fit <- function(data,
       class_levels = class.levels,
       numeric_target = numeric.target
     )
-    tree <- chaid_renumber_nodes_bfs(tree)
+    tree <- chaid_renumber_nodes_bfs(tree, class_levels = class.levels)
     model$nodes <- tree$nodes
     model$edges <- tree$edges
     model$.node_metadata <- tree$node_metadata
@@ -1249,18 +1249,27 @@ grow_chaid_tree <- function(data, target, predictors, parameters,
 #' ids through chaid_build_split_index.
 #'
 #' @param tree The list returned by grow_chaid_tree.
+#' @param class_levels The fitted target's class levels, or `NULL` for a numeric
+#'   target. Used only to rank siblings by predicted class
+#'   ([chaid_order_children_for_display()]).
 #' @return The same list with node ids renumbered breadth-first.
-chaid_renumber_nodes_bfs <- function(tree) {
+chaid_renumber_nodes_bfs <- function(tree, class_levels = NULL) {
   nodes <- tree$nodes
   if (is.null(nodes) || nrow(nodes) < 2) {
     return(tree)
   }
   edges <- tree$edges
-  # Children in creation order, which is the group order = left to right.
+  # tam #38372: children in the order the CHART draws them, left to right -- NOT
+  # in group-creation order. Creation order is CHAID's category-merge order, so
+  # the ids it produced disagreed with the chart's chip numbers the moment the
+  # chart applied its own TRUE-left / bins-ascending / predicted-class ordering,
+  # desynchronising every report tab's Node column from the diagram.
+  class.order <- if (is.null(class_levels)) NULL else chaid_display_class_order(class_levels)
   children.of <- if (is.null(edges) || nrow(edges) == 0) {
     list()
   } else {
-    split(as.integer(edges$child_id), as.character(edges$parent_id))
+    lapply(split(as.integer(edges$child_id), as.character(edges$parent_id)),
+           function(kids) chaid_order_children_for_display(kids, edges, nodes, class.order))
   }
 
   visit.order <- integer(0)

--- a/R/chaid_report_format.R
+++ b/R/chaid_report_format.R
@@ -233,6 +233,124 @@ chaid_readable_one_condition <- function(condition) {
   paste0(variable, ' in (', paste(collapsed, collapse = CHAID_GROUP_SEPARATOR), ')')
 }
 
+#' Display order of a classification target's class labels.
+#'
+#' For a 2-class logical / Yes-No target the POSITIVE class is listed first, so a
+#' FALSE-predicted node still shows its TRUE proportion at the top (SPSS parity).
+#' Every other target keeps its level order. This is the order the tree chart's
+#' class table uses, so it is also the order sibling nodes are ranked by when
+#' nothing else separates them (tam #38372).
+#'
+#' @param class_levels Character vector of the fitted target's class levels.
+#' @return `class_levels`, reordered for display.
+chaid_display_class_order <- function(class_levels) {
+  class_levels <- as.character(class_levels)
+  k <- length(class_levels)
+  if (k != 2) {
+    return(class_levels)
+  }
+  up <- toupper(class_levels)
+  positive.idx <- if (setequal(up, c('FALSE', 'TRUE'))) {
+    which(up == 'TRUE')
+  } else if (setequal(up, c('NO', 'YES'))) {
+    which(up == 'YES')
+  } else {
+    NA_integer_
+  }
+  if (is.na(positive.idx)) {
+    return(class_levels)
+  }
+  class_levels[c(positive.idx, setdiff(seq_len(k), positive.idx))]
+}
+
+#' Order one node's children the way the tree chart draws them, left to right.
+#'
+#' MUST stay in lockstep with `DTreeGenerator._orderChildrenTrueLeft` (tam
+#' `src/js/viz/DTreeGenerator.js`) and its report-side mirror
+#' `dtree_renumber_tree_nodes_true_left` (tam `public/lib/library.r`). Tie-breaks
+#' are applied in this order and the FIRST one that separates a pair wins:
+#'
+#'   1. TRUE/Yes first, FALSE/No last (tam #37252).
+#'   2. A binned-numeric run's lowest bound, ascending, so a numeric axis reads
+#'      low -> high left -> right. This MUST outrank the class tie-break below --
+#'      a non-monotone predictor/target relationship would otherwise scramble the
+#'      bins.
+#'   3. The predicted class, in the target's own display order
+#'      ([chaid_display_class_order()]).
+#'   4. The child's own id, so the result is always deterministic.
+#'
+#' Before tam #38372 CHAID emitted ids in group-CREATION order and left the
+#' reordering to the chart, which desynchronised every report tab's Node column
+#' from the chart's chip numbers. Ordering here instead makes the chart's own
+#' reorder a no-op and every consumer agree.
+#'
+#' @param kids Integer vector of child node ids.
+#' @param edges The tree's edge frame (`parent_id`, `child_id`, `original_categories`).
+#' @param nodes The tree's node frame (`node_id`, `predicted_class`).
+#' @param class_order Target class labels in display order, or `NULL` for a
+#'   numeric target (no class tie-break).
+#' @return `kids`, reordered left to right.
+chaid_order_children_for_display <- function(kids, edges, nodes, class_order = NULL) {
+  kids <- as.integer(kids)
+  if (length(kids) < 2) {
+    return(kids)
+  }
+  values.of <- function(child) {
+    row <- which(edges$child_id == child)
+    if (length(row) != 1) {
+      return(character(0))
+    }
+    raw <- edges$original_categories[row]
+    if (is.na(raw)) {
+      return(character(0))
+    }
+    trimws(strsplit(as.character(raw), ' | ', fixed = TRUE)[[1]])
+  }
+  side.rank <- function(child) {
+    values <- toupper(values.of(child))
+    true.side <- any(values %in% c('TRUE', 'YES'))
+    false.side <- any(values %in% c('FALSE', 'NO'))
+    if (true.side && !false.side) return(0L)
+    if (false.side && !true.side) return(2L)
+    1L
+  }
+  # Lowest numeric bound of a binned-numeric run; NA for a nominal split. Reuses
+  # chaid_parse_interval() rather than adding another bin-label regex.
+  ordered.key <- function(child) {
+    values <- values.of(child)
+    if (length(values) == 0) return(NA_real_)
+    lo <- NA_real_
+    for (label in values) {
+      parsed <- chaid_parse_interval(label)
+      if (is.null(parsed)) return(NA_real_)
+      v <- parsed$lower_value
+      if (!is.finite(v) && v > 0) return(NA_real_)   # defensive; lower is never +Inf
+      if (is.na(lo) || v < lo) lo <- v
+    }
+    lo
+  }
+  class.rank <- function(child) {
+    if (is.null(class_order) || length(class_order) == 0) return(NA_real_)
+    row <- which(nodes$node_id == child)
+    if (length(row) != 1) return(NA_real_)
+    hit <- match(as.character(nodes$predicted_class[row]), as.character(class_order))
+    if (is.na(hit)) NA_real_ else as.numeric(hit)
+  }
+
+  ranks <- vapply(kids, side.rank, integer(1))
+  keys <- vapply(kids, ordered.key, numeric(1))
+  classes <- vapply(kids, class.rank, numeric(1))
+  # A nominal split has no numeric key on ANY child; only then does class order
+  # get a say (matching the JS, which requires both keys to be absent).
+  if (any(!is.na(keys))) {
+    classes <- rep(NA_real_, length(kids))
+  }
+  kids[order(ranks,
+             ifelse(is.na(keys), 0, keys),
+             ifelse(is.na(classes), 0, classes),
+             kids)]
+}
+
 #' Branch label for the interactive tree chart, in CART's form.
 #'
 #' `build_rpart_tree_nodes()` writes a categorical branch as `X = a, b, c`;

--- a/R/chaid_report_format.R
+++ b/R/chaid_report_format.R
@@ -267,8 +267,11 @@ chaid_display_class_order <- function(class_levels) {
 #'
 #' MUST stay in lockstep with `DTreeGenerator._orderChildrenTrueLeft` (tam
 #' `src/js/viz/DTreeGenerator.js`) and its report-side mirror
-#' `dtree_renumber_tree_nodes_true_left` (tam `public/lib/library.r`). Tie-breaks
-#' are applied in this order and the FIRST one that separates a pair wins:
+#' `dtree_renumber_tree_nodes_true_left` (tam `public/lib/library.r`). For a
+#' logical target (TRUE/FALSE or Yes/No), the child TRUE rate is the primary key,
+#' followed by the condition side rank and child id (tam #38357). For every other
+#' target, tie-breaks are applied in this order and the FIRST one that separates a
+#' pair wins:
 #'
 #'   1. TRUE/Yes first, FALSE/No last (tam #37252).
 #'   2. A binned-numeric run's lowest bound, ascending, so a numeric axis reads
@@ -286,7 +289,8 @@ chaid_display_class_order <- function(class_levels) {
 #'
 #' @param kids Integer vector of child node ids.
 #' @param edges The tree's edge frame (`parent_id`, `child_id`, `original_categories`).
-#' @param nodes The tree's node frame (`node_id`, `predicted_class`).
+#' @param nodes The tree's node frame (`node_id`, `predicted_class`,
+#'   `class_distribution`).
 #' @param class_order Target class labels in display order, or `NULL` for a
 #'   numeric target (no class tie-break).
 #' @return `kids`, reordered left to right.
@@ -336,8 +340,29 @@ chaid_order_children_for_display <- function(kids, edges, nodes, class_order = N
     hit <- match(as.character(nodes$predicted_class[row]), as.character(class_order))
     if (is.na(hit)) NA_real_ else as.numeric(hit)
   }
+  class.labels <- toupper(as.character(class_order))
+  is.logical.target <- length(class.labels) == 2 &&
+    (setequal(class.labels, c('FALSE', 'TRUE')) ||
+       setequal(class.labels, c('NO', 'YES')))
+  true.rate <- function(child) {
+    if (!is.logical.target || !('class_distribution' %in% names(nodes))) return(0)
+    row <- which(nodes$node_id == child)
+    if (length(row) != 1) return(0)
+    distribution <- nodes$class_distribution[[row]]
+    if (is.null(distribution) || length(distribution) == 0) return(0)
+    hit <- which(toupper(names(distribution)) %in% c('TRUE', 'YES'))
+    if (length(hit) == 0) return(0)
+    rate <- suppressWarnings(as.numeric(distribution[hit[1]]))
+    if (is.na(rate) || !is.finite(rate)) 0 else rate
+  }
 
   ranks <- vapply(kids, side.rank, integer(1))
+  if (is.logical.target) {
+    # Match DTreeGenerator._orderChildrenTrueLeft: a logical target's more
+    # TRUE-heavy branch is always leftmost; condition rank only breaks a tie.
+    rates <- -vapply(kids, true.rate, numeric(1))
+    return(kids[order(rates, ranks, kids)])
+  }
   keys <- vapply(kids, ordered.key, numeric(1))
   classes <- vapply(kids, class.rank, numeric(1))
   # A nominal split has no numeric key on ANY child; only then does class order

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -876,3 +876,73 @@ test_that("node_summary / rules category groups match the tree's order (tam #383
     expect_true(any(grepl(paste0("(", group, ")"), node_summary$Rule, fixed = TRUE)))
   }
 })
+
+test_that("node ids are assigned in the chart's left-to-right order (tam #38372)", {
+  # A nominal split whose two branches predict DIFFERENT classes: the chart ranks
+  # them by predicted class, so the ids must too or every report tab's Node
+  # column points at the wrong branch.
+  set.seed(38372); n <- 1200
+  jobs <- c("student", "employee", "homemaker", "specialist", "parttime",
+            "selfemployed", "unemployed", "officer", "executive", "other")
+  job <- sample(jobs, n, TRUE)
+  band <- ifelse(runif(n) < ifelse(job %in% c("homemaker", "employee"), 0.15, 0.80), "50s", "40s")
+  df <- data.frame(job = job, renewed = runif(n) < 0.5,
+                   age_band = factor(band, levels = c("20s", "30s", "40s", "50s", "60s+")),
+                   stringsAsFactors = FALSE)
+  model_df <- suppressWarnings(exp_chaid(df, age_band, job, renewed,
+                                         min_split = 20, min_bucket = 10, max_depth = 3))
+  model <- model_df$model[[1]]
+  nodes <- model_df %>% tidy_rowwise(model, type = "tree_nodes")
+
+  # The tidy is 0-based, the model 1-based; both must be the SAME ordering.
+  expect_equal(model$nodes$node_id, sort(model$nodes$node_id))
+  expect_equal(nodes$node_id, model$nodes$node_id - 1L)
+
+  # Re-derive the chart's own sibling order from the emitted rows and require the
+  # ids to already be in it -- i.e. DTreeGenerator's reorder is a no-op.
+  class_order <- chaid_display_class_order(model$class_levels)
+  by_parent <- split(nodes$node_id[!is.na(nodes$parent_id)],
+                     nodes$parent_id[!is.na(nodes$parent_id)])
+  expect_gt(length(by_parent), 0)
+  for (kids in by_parent) {
+    expect_equal(kids, sort(kids), info = "children ids must ascend left to right")
+    predicted <- vapply(kids, function(k) as.character(nodes$predicted[nodes$node_id == k]),
+                        character(1))
+    ranks <- match(predicted, class_order)
+    # Within one parent, predicted-class ranks are non-decreasing unless a
+    # TRUE/FALSE or numeric-bin rule took precedence. This fixture's splits are
+    # nominal, so the class rule is the one in force.
+    if (all(!is.na(ranks))) {
+      expect_equal(ranks, sort(ranks),
+                   info = "nominal siblings must be ordered by predicted class")
+    }
+  }
+
+  # The reported symptom, stated directly: the FIRST child of the root is the one
+  # predicting the EARLIER class, not the one CHAID happened to merge first.
+  root_kids <- sort(nodes$node_id[!is.na(nodes$parent_id) & nodes$parent_id == 0])
+  expect_gte(length(root_kids), 2)
+  first_pred <- as.character(nodes$predicted[nodes$node_id == root_kids[1]])
+  last_pred <- as.character(nodes$predicted[nodes$node_id == root_kids[length(root_kids)]])
+  expect_lte(match(first_pred, class_order), match(last_pred, class_order))
+})
+
+test_that("a logical predictor's TRUE branch gets the lower node id (tam #38372)", {
+  set.seed(23); n <- 900
+  renewed <- runif(n) < 0.5
+  df <- data.frame(renewed = renewed, tenure = sample(1:60, n, TRUE), stringsAsFactors = FALSE)
+  df$satisfied <- runif(n) < ifelse(renewed, 0.85, 0.15)
+  model_df <- suppressWarnings(exp_chaid(df, satisfied, renewed, tenure,
+                                         min_split = 20, min_bucket = 10, max_depth = 3))
+  nodes <- model_df %>% tidy_rowwise(model, type = "tree_nodes")
+  logical_edges <- nodes[!is.na(nodes$cond_column) & nodes$cond_column == "renewed", ]
+  expect_gte(nrow(logical_edges), 2)
+  value_of <- function(i) jsonlite::fromJSON(logical_edges$cond_value[i])[[1]]
+  true_id <- logical_edges$node_id[vapply(seq_len(nrow(logical_edges)),
+                                          function(i) identical(value_of(i), "TRUE"), logical(1))]
+  false_id <- logical_edges$node_id[vapply(seq_len(nrow(logical_edges)),
+                                           function(i) identical(value_of(i), "FALSE"), logical(1))]
+  expect_length(true_id, 1)
+  expect_length(false_id, 1)
+  expect_lt(true_id, false_id)
+})

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -946,3 +946,26 @@ test_that("a logical predictor's TRUE branch gets the lower node id (tam #38372)
   expect_length(false_id, 1)
   expect_lt(true_id, false_id)
 })
+
+test_that("a logical target's TRUE-heavy branch gets the lower node id (tam #38357)", {
+  # The low numeric range has the lowest condition bound, but the high range has
+  # the much higher TRUE rate. The chart puts TRUE-heavy children on the left,
+  # so CHAID must assign ids in that order before emitting tree_nodes.
+  set.seed(1); n <- 1000
+  x <- rnorm(n)
+  y <- runif(n) < ifelse(x > 0, 0.9, 0.1)
+  model_df <- suppressWarnings(exp_chaid(data.frame(x = x, y = y), y, x,
+                                         min_split = 20, min_bucket = 10, max_depth = 1,
+                                         max_pd_vars = 0, seed = 1))
+  nodes <- model_df %>% tidy_rowwise(model, type = "tree_nodes")
+  root_kids <- nodes$node_id[!is.na(nodes$parent_id) & nodes$parent_id == 0]
+  expect_gte(length(root_kids), 2)
+  true_rate <- function(id) {
+    classes <- jsonlite::fromJSON(nodes$class_json[nodes$node_id == id])
+    hit <- classes$pct[toupper(as.character(classes$label)) %in% c('TRUE', 'YES')]
+    if (length(hit) == 0) 0 else as.numeric(hit[1])
+  }
+  rates <- vapply(root_kids, true_rate, numeric(1))
+  expect_gt(max(rates) - min(rates), 0.5)
+  expect_equal(rates, sort(rates, decreasing = TRUE))
+})

--- a/tests/testthat/test_chaid_report_format.R
+++ b/tests/testthat/test_chaid_report_format.R
@@ -378,6 +378,23 @@ test_that('chaid_order_children_for_display ranks nominal children by predicted 
   expect_equal(chaid_order_children_for_display(c(2L, 3L), edges, nodes, NULL), c(2L, 3L))
 })
 
+test_that('chaid_order_children_for_display ranks a logical target by TRUE rate first', {
+  edges <- data.frame(parent_id = c(1L, 1L), child_id = c(2L, 3L),
+                      original_categories = c('<= 0', '> 0'), stringsAsFactors = FALSE)
+  nodes <- data.frame(node_id = c(1L, 2L, 3L), predicted_class = c('TRUE', 'FALSE', 'TRUE'),
+                      stringsAsFactors = FALSE)
+  nodes$class_distribution <- list(
+    c('TRUE' = 0.5, 'FALSE' = 0.5),
+    c('TRUE' = 0.1, 'FALSE' = 0.9),
+    c('TRUE' = 0.9, 'FALSE' = 0.1)
+  )
+  # The numeric condition would put <= 0 first, but tam's logical-tree chart
+  # puts the more TRUE-heavy > 0 child on the left.
+  expect_equal(
+    chaid_order_children_for_display(c(2L, 3L), edges, nodes, c('TRUE', 'FALSE')),
+    c(3L, 2L))
+})
+
 test_that('chaid_order_children_for_display is a no-op for fewer than two children', {
   edges <- data.frame(parent_id = 1L, child_id = 2L, original_categories = 'A',
                       stringsAsFactors = FALSE)

--- a/tests/testthat/test_chaid_report_format.R
+++ b/tests/testthat/test_chaid_report_format.R
@@ -321,3 +321,67 @@ test_that('chaid_normalize_condition_groups reorders every group in a rule (tam 
     chaid_normalize_condition_groups(c('部署 in {人事 + 営業}', 'Root'), model),
     c('部署 in {営業 + 人事}', 'Root'))
 })
+
+# tam #38372 (follow-up) ------------------------------------------------------
+# CHAID used to assign node ids in group-CREATION order and leave the
+# left-to-right reordering to the chart, so every report tab's Node column
+# disagreed with the chart's chip numbers. The ordering now happens where the
+# ids are assigned.
+
+test_that('chaid_display_class_order puts the positive class first for a binary target', {
+  expect_equal(chaid_display_class_order(c('FALSE', 'TRUE')), c('TRUE', 'FALSE'))
+  expect_equal(chaid_display_class_order(c('TRUE', 'FALSE')), c('TRUE', 'FALSE'))
+  expect_equal(chaid_display_class_order(c('No', 'Yes')), c('Yes', 'No'))
+  # A 2-class target that is neither logical nor Yes/No keeps its level order.
+  expect_equal(chaid_display_class_order(c('B', 'A')), c('B', 'A'))
+  # 3+ classes always keep their level order.
+  expect_equal(chaid_display_class_order(c('20代', '30代', '40代')), c('20代', '30代', '40代'))
+  expect_equal(chaid_display_class_order(character(0)), character(0))
+})
+
+test_that('chaid_order_children_for_display ranks TRUE first and FALSE last', {
+  edges <- data.frame(parent_id = c(1L, 1L), child_id = c(2L, 3L),
+                      original_categories = c('FALSE', 'TRUE'), stringsAsFactors = FALSE)
+  nodes <- data.frame(node_id = c(1L, 2L, 3L), predicted_class = c('X', 'X', 'X'),
+                      stringsAsFactors = FALSE)
+  # R created the FALSE child first (id 2); TRUE must still come out on the left.
+  expect_equal(chaid_order_children_for_display(c(2L, 3L), edges, nodes, c('X')), c(3L, 2L))
+})
+
+test_that('chaid_order_children_for_display keeps binned-numeric children ascending', {
+  edges <- data.frame(parent_id = rep(1L, 3), child_id = c(2L, 3L, 4L),
+                      original_categories = c('(30, 40]', '> 40', '<= 30'),
+                      stringsAsFactors = FALSE)
+  # Deliberately non-monotone predicted classes: the numeric order must win, or a
+  # numeric axis stops reading low -> high left -> right.
+  nodes <- data.frame(node_id = c(1L, 2L, 3L, 4L),
+                      predicted_class = c('40代', '50代', '20代', '40代'),
+                      stringsAsFactors = FALSE)
+  expect_equal(
+    chaid_order_children_for_display(c(2L, 3L, 4L), edges, nodes,
+                                     c('20代', '30代', '40代', '50代')),
+    c(4L, 2L, 3L))
+})
+
+test_that('chaid_order_children_for_display ranks nominal children by predicted class', {
+  edges <- data.frame(parent_id = c(1L, 1L), child_id = c(2L, 3L),
+                      original_categories = c('その他 | 公務員', '会社員'),
+                      stringsAsFactors = FALSE)
+  nodes <- data.frame(node_id = c(1L, 2L, 3L), predicted_class = c('50代', '50代', '40代'),
+                      stringsAsFactors = FALSE)
+  # The 40代 child was created second (id 3) but must render on the left.
+  expect_equal(
+    chaid_order_children_for_display(c(2L, 3L), edges, nodes,
+                                     c('20代', '30代', '40代', '50代')),
+    c(3L, 2L))
+  # With no class information (numeric target) it falls back to a stable id order.
+  expect_equal(chaid_order_children_for_display(c(2L, 3L), edges, nodes, NULL), c(2L, 3L))
+})
+
+test_that('chaid_order_children_for_display is a no-op for fewer than two children', {
+  edges <- data.frame(parent_id = 1L, child_id = 2L, original_categories = 'A',
+                      stringsAsFactors = FALSE)
+  nodes <- data.frame(node_id = c(1L, 2L), predicted_class = c('A', 'A'), stringsAsFactors = FALSE)
+  expect_equal(chaid_order_children_for_display(2L, edges, nodes, c('A')), 2L)
+  expect_equal(chaid_order_children_for_display(integer(0), edges, nodes, c('A')), integer(0))
+})


### PR DESCRIPTION
## Description

Follow-up to #1650 / tam https://github.com/exploratory-io/tam/issues/38372.
Found while adding a render harness for the tree diagram (tam PR
https://github.com/exploratory-io/tam/pull/38373); pre-existing, not a
regression from #1650.

CHAID's report tabs and the interactive Tree chart disagreed on node numbering,
so "Node 1" in a table pointed at a different branch than chip 1 in the chart.

Measured on a 5-class-target reproduction tree: chip 1 was the 40代 branch while
`Node 1` in Node Summary / Rules / Split Evidence / Characteristic Groups was
the 50代 branch.

## Root cause

`chaid_renumber_nodes_bfs()`'s own docstring already promised what it did not
deliver:

```
#' Every structure keyed by node id is remapped together: a partial remap would
#' desynchronise the report tables from the chart
...
  # Children in creation order, which is the group order = left to right.
```

Creation order is CHAID's category-**merge** order, not the chart's left-to-right
order. The chart applies its own ordering on top — TRUE/Yes left, `<` left,
binned-numeric bins ascending, and (since tam#38372) nominal siblings by
predicted class — and assigns chip numbers from *that* order. So the moment any
of those rules moved a node, the ids and the chips diverged.

Renumbering just one tab (e.g. only Characteristic Groups, the way tam's
`dtree_renumber_tree_nodes_true_left` does for rpart) would have made that tab
disagree with Node Summary and Rules instead. The ids themselves had to move.

## Changes

**`R/chaid_report_format.R`**

- New `chaid_order_children_for_display()` — the chart's tie-break chain, first
  separator wins:
  1. TRUE/Yes first, FALSE/No last (tam#37252)
  2. a binned-numeric run's lowest bound, ascending
  3. the predicted class, in the target's display order
  4. the child's own id (deterministic)

  Reuses `chaid_parse_interval()` rather than adding a fourth bin-label regex.
  (2) deliberately outranks (3): a non-monotone predictor/target relationship
  would otherwise scramble the bins and a numeric axis would stop reading
  low→high left→right.

- New `chaid_display_class_order()` — the positive-class-first rule for a binary
  target, **extracted from** `build_chaid_tree_nodes()` so the class table's
  order and the sibling ranking cannot drift apart. This removes an existing
  duplication rather than adding one.

**`R/chaid.R`** — `chaid_renumber_nodes_bfs()` takes `class_levels` and orders
children through that helper; `exp_chaid()` passes `class.levels`.

**`R/build_chaid.R`** — its inline positive-class-first block now calls the
shared helper.

## Verification

The tidy's `node_id`, the model's `node_id`, and every report tab's `Node`
column now agree — and `DTreeGenerator`'s own reorder became a complete no-op:

```
extractorId=0  chip=0  ==  pred=50代
extractorId=1  chip=1  ==  pred=40代     <- was chip 2 before
extractorId=2  chip=2  ==  pred=50代     <- was chip 1 before
extractorId=3  chip=3  ==  pred=40代     <- TRUE branch
extractorId=4  chip=4  ==  pred=40代     <- FALSE branch
NO-OP: every chip equals the R-assigned node_id
```

`node_summary` on the same model:

```
Node 0   All
Node 1   職業 in (主婦・主夫 + 会社員)                       <- the 40代 branch
Node 2   職業 in (その他 + パート・アルバイト + ...)          <- the 50代 branch
Node 3   ... & 継続意向 = TRUE
Node 4   ... & 継続意向 = FALSE
```

## Testing

7 new tests, **all confirmed failing against `origin/master` and passing here**
(sabotage-checked by copying the test files into a clean master worktree):

- `tests/testthat/test_chaid_report_format.R` — 5 unit tests for the two new
  helpers, incl. the non-monotone binned-numeric case and the numeric-target
  (no class order) fallback.
- `tests/testthat/test_build_chaid.R` — 2 integration tests: node ids are
  already in the chart's sibling order (re-derived from the emitted rows, so
  DTreeGenerator's reorder must be a no-op), and a logical predictor's TRUE
  branch gets the lower id.

Local suite:

| File | tests | failed |
|---|---|---|
| `test_build_chaid.R` | 44 | 6 — all pre-existing `importance_measure = 'firm'`, identical on `origin/master` (local `mmpf` is not installed, so `firm` silently falls back to permutation) |
| `test_chaid.R` | 22 | 0 |
| `test_chaid_report_format.R` | 26 | 0 |
| `test_chaid_numeric.R` | 17 | 0 |
| `test_chaid_perf.R` | 3 | 0 |

## Downstream impact — needs a version bump and answer regeneration

Node ids change for any CHAID tree where the display order differed from
creation order, so this is a **visible change to the Node column** of Node
Summary, Rules, Split Evidence, Category Merges, Numeric Intervals,
Characteristic Groups, Characteristic Group per Category, Feature Groups and
Branch Category Composition — all of them now matching the chart.

Requires:
- a version bump + per-platform binary publish;
- regenerating tam's CHAID harness answer CSVs
  (`src/test/analytics-harness/answers/exp_chaid/*/`) and the new render-harness
  fixtures/answers (`src/test/dtree-render-harness/`), which carry node ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
