### PR TITLE
feat(lca): report normalized entropy per candidate class count (tam#38383)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.11
+Version: 16.1.12
 Date: 2026-09-03
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/lca.R
+++ b/R/lca.R
@@ -208,6 +208,7 @@ lca_class_selection_table <- function(candidates) {
     if (is.null(candidate$fit)) {
       return(tibble::tibble(
         number_of_classes = candidate$nclass, log_likelihood = NA_real_, aic = NA_real_, bic = NA_real_,
+        entropy = NA_real_,
         minimum_class_share = NA_real_, mean_maximum_membership_probability = NA_real_,
         pct_low_confidence = NA_real_, converged = FALSE, error = candidate$error
       ))
@@ -220,6 +221,7 @@ lca_class_selection_table <- function(candidates) {
       log_likelihood = fit$llik,
       aic = fit$aic,
       bic = fit$bic,
+      entropy = lca_entropy(fit),
       minimum_class_share = min(fit$P),
       mean_maximum_membership_probability = mean(max_posterior),
       pct_low_confidence = mean(max_posterior < 0.6),
@@ -233,6 +235,34 @@ lca_class_selection_table <- function(candidates) {
       error = if (converged) NA_character_ else lca_stop_reason(fit)
     )
   }))
+}
+
+# tam#38383: normalized entropy (the "entropy R-squared" / relative entropy
+# criterion, Ramaswamy et al. 1993) -- how cleanly the posterior assigns rows
+# to classes, on 0..1 where 1 means every row belongs to exactly one class.
+#
+#   E = 1 - ( -sum_i sum_k p_ik * log(p_ik) ) / (n * log(K))
+#
+# It is a SEPARATION measure, not a fit criterion: it says nothing about
+# whether K classes are warranted, so it must never be used on its own to pick
+# the class count (the report's own explanation says the same).
+#
+# Two guards on the arithmetic:
+#  - 0 * log(0) is 0 in the limit but NaN in floating point, so the zero
+#    posteriors are dropped rather than multiplied.
+#  - log(K) is 0 for the 1-class baseline, which would divide by zero. Entropy
+#    is undefined for a single class (there is nothing to separate), so that
+#    row reports NA rather than a garbage value or a spurious 1.
+lca_entropy <- function(fit) {
+  posterior <- fit$posterior
+  if (is.null(posterior) || length(posterior) == 0) return(NA_real_)
+  posterior <- as.matrix(posterior)
+  nclass <- ncol(posterior)
+  nobs <- nrow(posterior)
+  if (is.na(nclass) || nclass < 2L || nobs < 1L) return(NA_real_)
+  p <- posterior[is.finite(posterior) & posterior > 0]
+  if (length(p) == 0) return(NA_real_)
+  1 - (-sum(p * log(p))) / (nobs * log(nclass))
 }
 
 lca_fit_converged <- function(fit) {

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -199,13 +199,13 @@ test_that("lca_entropy returns 1 for a perfectly separating posterior", {
   # exercises the 0*log(0) guard: half the matrix is zeros, which is NaN if the
   # zeros are multiplied instead of dropped.
   perfect <- matrix(c(1, 0, 0, 1, 1, 0, 0, 1), ncol = 2, byrow = TRUE)
-  expect_equal(lca_entropy(list(posterior = perfect)), 1)
+  expect_equal(exploratory:::lca_entropy(list(posterior = perfect)), 1)
 
   # Maximum ambiguity: every row equally likely in either class -> entropy 0.
   ambiguous <- matrix(0.5, nrow = 8, ncol = 2)
-  expect_equal(lca_entropy(list(posterior = ambiguous)), 0)
+  expect_equal(exploratory:::lca_entropy(list(posterior = ambiguous)), 0)
 
   # Degenerate shapes report NA rather than erroring or dividing by zero.
-  expect_true(is.na(lca_entropy(list(posterior = matrix(1, nrow = 4, ncol = 1)))))
-  expect_true(is.na(lca_entropy(list(posterior = NULL))))
+  expect_true(is.na(exploratory:::lca_entropy(list(posterior = matrix(1, nrow = 4, ncol = 1)))))
+  expect_true(is.na(exploratory:::lca_entropy(list(posterior = NULL))))
 })

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -153,3 +153,59 @@ test_that("exp_lca rejects non-categorical, insufficient, and invalid class sele
   expect_error(exp_lca(df, a, b, min_nclass = 4, max_nclass = 2), "Class counts")
   expect_error(exp_lca(df, a, b, relationship_column = a), "must be different")
 })
+
+test_that("exp_lca reports normalized entropy per candidate class count", {
+  set.seed(11)
+  n <- 400
+  cls <- sample(1:2, n, replace = TRUE)
+  df <- data.frame(
+    a = ifelse(cls == 1, sample(c("x", "y"), n, TRUE, c(.9, .1)), sample(c("x", "y"), n, TRUE, c(.15, .85))),
+    b = ifelse(cls == 1, sample(c("m", "n"), n, TRUE, c(.85, .15)), sample(c("m", "n"), n, TRUE, c(.2, .8))),
+    c = ifelse(cls == 1, sample(c("lo", "hi"), n, TRUE, c(.8, .2)), sample(c("lo", "hi"), n, TRUE, c(.25, .75))),
+    stringsAsFactors = FALSE
+  )
+  model <- exp_lca(df, a, b, c, min_nclass = 2, max_nclass = 3,
+                   nrep = 3, maxiter = 500, seed = 1)$model[[1]]
+  selection <- tidy(model, type = "class_selection")
+
+  expect_true("entropy" %in% names(selection))
+  # tam#38383: entropy is undefined for the always-added 1-class baseline --
+  # log(K) is 0 there, and there is nothing to separate. It must be NA rather
+  # than a divide-by-zero artifact or a spurious 1.
+  expect_true(is.na(selection$entropy[selection$number_of_classes == 1]))
+
+  multi <- selection[selection$number_of_classes >= 2, , drop = FALSE]
+  expect_false(any(is.na(multi$entropy)))
+  expect_true(all(multi$entropy >= 0 & multi$entropy <= 1))
+
+  # Independent recomputation straight from the candidate posteriors, so this
+  # pins the FORMULA, not just the column's presence.
+  for (candidate in model$candidates) {
+    if (is.null(candidate$fit) || candidate$nclass < 2) next
+    p <- as.matrix(candidate$fit$posterior)
+    nz <- p[p > 0]
+    expected <- 1 - (-sum(nz * log(nz))) / (nrow(p) * log(ncol(p)))
+    expect_equal(selection$entropy[selection$number_of_classes == candidate$nclass],
+                 expected, tolerance = 1e-10)
+  }
+
+  # A well-separated 2-class fixture must not look like noise.
+  expect_gt(selection$entropy[selection$number_of_classes == 2], 0.5)
+})
+
+test_that("lca_entropy returns 1 for a perfectly separating posterior", {
+  # Hard 0/1 assignments carry no uncertainty, so the entropy term is 0 and the
+  # normalized value is exactly 1 -- the definitional upper bound. This also
+  # exercises the 0*log(0) guard: half the matrix is zeros, which is NaN if the
+  # zeros are multiplied instead of dropped.
+  perfect <- matrix(c(1, 0, 0, 1, 1, 0, 0, 1), ncol = 2, byrow = TRUE)
+  expect_equal(lca_entropy(list(posterior = perfect)), 1)
+
+  # Maximum ambiguity: every row equally likely in either class -> entropy 0.
+  ambiguous <- matrix(0.5, nrow = 8, ncol = 2)
+  expect_equal(lca_entropy(list(posterior = ambiguous)), 0)
+
+  # Degenerate shapes report NA rather than erroring or dividing by zero.
+  expect_true(is.na(lca_entropy(list(posterior = matrix(1, nrow = 4, ncol = 1)))))
+  expect_true(is.na(lca_entropy(list(posterior = NULL))))
+})


### PR DESCRIPTION
R-side half of tam#38383 (Analytics: LCA: Add Entropy). Paired tam PR: exploratory-io/tam#38359.

## What

Adds an `entropy` column to `exp_lca`'s `class_selection` tidier — the "entropy R-squared" / relative entropy criterion (Ramaswamy et al. 1993):

```
E = 1 - ( -sum_i sum_k p_ik * log(p_ik) ) / (n * log(K))
```

on 0..1, where 1 means every row's posterior places it in exactly one class. It measures **separation, not fit**, so it must never select the class count on its own — the tam-side report's explanation text says so explicitly.

## Why here and not in tam's preprocessor

The `analytics-spec-loop` rule is to derive a report metric tam-side when possible and avoid the release chain. That does not work here: entropy needs each candidate's **full posterior matrix**. It *is* reachable from tam as `model[[1]]$candidates[[k]]$fit$posterior` — but `exp_lca` supports **grouped data frames** (one model per group; verified: 2 groups → 2 models → per-group `class_selection` rows). A preprocessor written that way would compute group 1's entropy and silently apply it to every other group.

The per-model loop that already derives `mean_maximum_membership_probability` and `pct_low_confidence` from the same posterior is the correct home.

## Arithmetic guards (both tested)

- `0 * log(0)` is 0 in the limit but `NaN` in floating point → zero posteriors are dropped, not multiplied.
- `log(K)` is 0 for the always-added 1-class baseline (tam#38352) → would divide by zero. Entropy is undefined for a single class, so that row reports `NA` rather than a garbage value or a spurious `1`.

## Testing

The tests pin the **formula**, not just the column's presence:
- values recomputed independently from each candidate's posterior;
- closed-form cases — perfectly separating posterior → exactly `1`, uniform `0.5` posterior → exactly `0`, degenerate shapes → `NA`;
- the 1-class baseline row asserted `NA`.

Verified by sabotage: removing the `log(K)` normalization fails 3 assertions across both tests. Full `test_lca.R` passes (49 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)