### PR TITLE
WIP: Analytics: LCA: Sample Data to show for Output table

### DIFF
--- a/R/lca.R
+++ b/R/lca.R
@@ -15,6 +15,11 @@
 #'   composition. It is not used as an indicator.
 #' @param feature_top_n Number of top characteristic categories retained per
 #'   class for the report.
+#' @param max_nrow Optional cap on the number of rows used to fit the model. When
+#'   set and the (group's) data has more rows, a random sample of this size is
+#'   used for fitting AND for the row-level Output Data table (tam#38399), the
+#'   same "Sample Data" behavior K-Means/K-Modes/K-Medoids already have. NULL
+#'   means use every row.
 #' @export
 exp_lca <- function(df, ...,
                     min_nclass = 2,
@@ -23,7 +28,8 @@ exp_lca <- function(df, ...,
                     maxiter = 5000,
                     seed = 1,
                     relationship_column = NULL,
-                    feature_top_n = 10) {
+                    feature_top_n = 10,
+                    max_nrow = NULL) {
   if (!requireNamespace("poLCA", quietly = TRUE)) {
     stop("Latent Class Analysis requires the poLCA package.")
   }
@@ -74,6 +80,16 @@ exp_lca <- function(df, ...,
 
   each_func <- function(group_df) {
     group_df <- dplyr::ungroup(group_df)
+    # tam#38399: cap the data BEFORE fitting, same "Sample Data" behavior as
+    # exp_kmeans/exp_kmodes/exp_kmedoids -- the Output Data table (tidy(..., type="data"))
+    # is built from this same (possibly sampled) data, so max_nrow is exactly what
+    # caps how much data that table shows.
+    if (!is.null(seed)) set.seed(seed)
+    sampled_nrow <- NULL
+    if (!is.null(max_nrow) && nrow(group_df) > max_nrow) {
+      sampled_nrow <- max_nrow
+      group_df <- group_df %>% sample_rows(max_nrow)
+    }
     original <- group_df %>% dplyr::mutate(.lca_row_id = dplyr::row_number())
     indicators <- lca_encode_indicators(original, selected_cols)
     complete_rows <- stats::complete.cases(indicators)
@@ -165,6 +181,7 @@ exp_lca <- function(df, ...,
       discrimination = discrimination,
       row_assignments = row_assignments,
       relationship = relationship,
+      sampled_nrow = sampled_nrow,
       grouped_cols = grouped_cols
     )
     class(model) <- c("lca_exploratory", class(model))

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -358,3 +358,45 @@ test_that("exp_lca reports factor categories in their declared order", {
                                                                   as.integer(tenure_rows$category))]))
   expect_equal(observed_order[seq_along(lv)], lv)
 })
+
+test_that("exp_lca's max_nrow (tam#38399) caps fitting and the Output Data row count, sampled_nrow set only when it actually samples", {
+  set.seed(38399)
+  n <- 80
+  df <- data.frame(
+    a = sample(c("x", "y", "z"), n, replace = TRUE),
+    b = sample(c("m", "n", "o"), n, replace = TRUE)
+  )
+
+  not_sampled <- exp_lca(df, a, b, min_nclass = 2, max_nclass = 2,
+                         nrep = 1, maxiter = 50, seed = 1, max_nrow = 1000)$model[[1]]
+  expect_null(not_sampled$sampled_nrow)
+  expect_equal(nrow(tidy(not_sampled, type = "data")), n)
+
+  sampled <- exp_lca(df, a, b, min_nclass = 2, max_nclass = 2,
+                     nrep = 1, maxiter = 50, seed = 1, max_nrow = 20)$model[[1]]
+  expect_equal(sampled$sampled_nrow, 20)
+  # tam#38399: the Output Data table (tidy(..., type="data")) is built from the SAME
+  # sampled data used to fit -- capping max_nrow must cap what that table shows too,
+  # not just what the model was trained on.
+  expect_equal(nrow(tidy(sampled, type = "data")), 20)
+})
+
+test_that("exp_lca's max_nrow sampling works with a column name using every stress-test character", {
+  # Repo convention (workflow.md #7): verify complex user-supplied identifiers,
+  # not just plain ASCII names -- even though sample_rows() itself never touches
+  # column names, the whole pipeline (encode/quote/select) runs on the sampled data.
+  set.seed(38399)
+  n <- 60
+  stress_name <- "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
+  df <- data.frame(check.names = FALSE, stringsAsFactors = FALSE)
+  df[[stress_name]] <- sample(c("x", "y", "z"), n, replace = TRUE)
+  df[["b"]] <- sample(c("m", "n"), n, replace = TRUE)
+
+  model <- exp_lca(df, `航空 会社 !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`, b,
+                   min_nclass = 2, max_nclass = 2,
+                   nrep = 1, maxiter = 50, seed = 1, max_nrow = 15)$model[[1]]
+  expect_equal(model$sampled_nrow, 15)
+  assignments <- tidy(model, type = "data")
+  expect_equal(nrow(assignments), 15)
+  expect_true(stress_name %in% names(assignments))
+})


### PR DESCRIPTION
# Description

Companion R-package PR for exploratory-io/tam#38415, addressing tam issue
exploratory-io/tam#38399 ("Analytics: LCA: Sample Data to show for Output table").

**That issue's body is a screenshot image only, and the screenshot could not be fetched in
this environment** (`github.com/user-attachments/...` returns an auth error through the
sandbox proxy). This PR's scope is inferred from the title plus codebase investigation —
see exploratory-io/tam#38415's description and `docs/plans/design/38399_design.md` in tam
for the full write-up — and needs visual confirmation against the actual screenshot before
merge.

## What / Why

`exp_lca()` had no way to cap a large input data frame before fitting. Every row reached
`poLCA::poLCA()`, and from there the row-level "Output Data" table
(`tidy(model, type="data")`), unlike its clustering siblings:

- `exp_kmeans`, `exp_kmodes`, `exp_kmedoids`, `exp_factanal`, `exp_cronbach_alpha`, and
  `do_prcomp` all already accept a `max_nrow` parameter and subsample the input (via the
  shared `sample_rows()` util) before fitting, so their own row-level "Data" output tables
  never grow past the cap.
- `exp_lca()` had no equivalent — this PR adds one.

## Fix

- New `max_nrow = NULL` formal on `exp_lca()`.
- In `each_func`, the (per Repeat-By group) input is sampled down to `max_nrow` rows
  (`sample_rows()`, seeded once per group) **before** `.lca_row_id` is assigned, so the
  Output Data table (built by joining back onto that same id) reflects only the sampled
  rows — matching the sibling functions' behavior exactly, not just capping what the model
  is fit on.
- `sampled_nrow` is stored on the model, mirroring `kmeans`/`kmodes`/`kmedoids`/`factanal`.

## Tests (`tests/testthat/test_lca.R`)

- `sampled_nrow` is `NULL` when `max_nrow` doesn't actually trim anything, and set to the
  cap when it does; the Output Data (`tidy(..., type="data")`) row count matches the cap
  exactly in both cases.
- A second test repeats the same assertion using the repo's canonical
  stress-test column name (spaces, multibyte characters, and symbols per
  `.claude/rules/workflow.md` #2 / `r-coding-best-practices`) as one of the two indicator
  columns, to confirm the sampling path doesn't interact badly with a complex user column
  name — `sample_rows()` itself never touches column names, but the rest of the pipeline
  (encode/quote/select) runs on the sampled data, so it's worth pinning explicitly.

# Checklist

- [x] Add test cases for this fix/enhancement
- [ ] Pass `devtools::check()` — **not run**: no R/Rscript available in this sandbox.
- [ ] Pass `devtools::test()` — **not run**, same reason. Please run
  `testthat::test_file("tests/testthat/test_lca.R")` before merge.
- [ ] Test installing from github — not performed.
- [ ] Tested with Exploratory — not performed; the paired tam PR
  (exploratory-io/tam#38415) needs this package version bumped/rebuilt/published before it
  can safely merge (its own PR body flags the `.../tidyselect` risk of shipping the tam side
  ahead of this R-side formal).

Relates to exploratory-io/tam#38399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSeePneDjLeDHsoDZViQXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSeePneDjLeDHsoDZViQXY)_