### PR TITLE
feat(ancova): Phase 2 diagnostics for ANCOVA V2 (tam#38389)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.16
+Version: 16.1.17
 Date: 2026-09-05
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/ancova_v2.R
+++ b/R/ancova_v2.R
@@ -803,8 +803,10 @@ assemble_ancova_result <- function(prep, covariate_summary, homogeneity,
 #'   `predict()` / `rstandard()` off the SAME fits the reported statistics
 #'   came from instead of refitting a second, possibly divergent model.
 #' @return A nested R list mirroring the "ancova_result" shape from the
-#'   tam#38385 spec. On failure, a short list with
-#'   `analysis_status = "error"` and an `error_code`.
+#'   tam#38385 spec, plus the `diagnostics` sub-list of tam#38389 Phase 2
+#'   (relationship and residual chart data, derived from these same fits). On
+#'   failure, a short list with `analysis_status = "error"` and an
+#'   `error_code` -- and no `diagnostics` key, which consumers must tolerate.
 #' @export
 run_ancova_v2 <- function(data, outcome, factor, covariates, alpha = 0.05,
                           keep_internals = FALSE) {
@@ -885,6 +887,15 @@ run_ancova_v2 <- function(data, outcome, factor, covariates, alpha = 0.05,
       prep, centered$covariate_summary, homogeneity, covariate_tests, selection,
       ancova_table, adjusted_means, pairwise_comparisons, conditional_means,
       conditional_pairwise, interaction_details, raw_statistics, alpha, warnings_list)
+
+    # Phase 2 (tam#38389). A presentation layer over the fits above -- it adds
+    # no statistic and re-decides nothing. Wrapped because a diagnostic that
+    # cannot be produced must never cost the ANCOVA result itself.
+    result$diagnostics <- tryCatch(
+      compute_ancova_diagnostics(models, final_model, centered$analysis_data, prep,
+                                 centered, selection, homogeneity, covariate_tests, alpha),
+      error = function(e) list(diagnostics_version = 1, diagnostics_available = FALSE,
+                               reason = conditionMessage(e)))
 
     if (isTRUE(keep_internals)) {
       # NOT part of the serializable contract -- see the @param note. Everything

--- a/R/ancova_v2_diagnostics.R
+++ b/R/ancova_v2_diagnostics.R
@@ -1,0 +1,491 @@
+# ANCOVA Calculation V2 -- Phase 2 diagnostics (tam#38389).
+#
+# Phase 1 (R/ancova_v2.R) decides everything: which rows are in the analysis,
+# which model is final, what the slope-homogeneity test concluded. This file
+# adds NOTHING to that. It is a presentation layer that turns the fits Phase 1
+# already produced into the data three diagnostic charts need, and it obeys two
+# rules the spec states outright:
+#
+#   Relationship chart -> ALWAYS the full-interaction model. The chart exists to
+#   let a reader judge whether the slopes really are parallel; drawing it from
+#   the additive model, which forces them parallel by construction, would be a
+#   circular diagnostic (spec sections 15 and 82).
+#
+#   Residual diagnostics -> ALWAYS the FINAL model, whichever that is. These ask
+#   whether the model being reported describes the data (sections 34, 82).
+#
+# Nothing here refits: every fit comes from run_ancova_v2's own `internals`, so
+# a diagnostic cannot drift from the numbers the report shows. predict() and
+# rstandard() on those fits are the only model calls (section 65).
+#
+# Serialization contract, inherited from R/ancova_v2.R's header: every leaf is a
+# tibble, a length-1 scalar, or a plain list. No model objects, no emmGrid.
+
+# ------------------------------------------------------------
+# Constants (spec sections 19, 48, 49, 50, 51)
+# ------------------------------------------------------------
+
+#' Prediction-grid resolution per factor level for a regression line.
+ANCOVA_RELATIONSHIP_GRID_SIZE <- 100L
+
+#' Scatter points a single chart may carry.
+ANCOVA_MAX_POINTS_PER_CHART <- 5000L
+
+#' Total scatter points the relationship charts may carry ACROSS every
+#' covariate. With many covariates a per-chart cap alone would multiply into a
+#' payload nothing can render; this bounds the whole set.
+ANCOVA_DIAGNOSTIC_POINT_BUDGET <- 50000L
+
+#' Floor for the per-covariate share of that budget. Below this a scatter stops
+#' conveying a distribution at all, so a very wide covariate list gets fewer
+#' USABLE charts rather than many useless ones.
+ANCOVA_MIN_POINTS_PER_COVARIATE <- 500L
+
+#' Q-Q points. Sampled as evenly spaced order statistics, never at random --
+#' random sampling drops exactly the tails a Q-Q plot is read for (section 51).
+ANCOVA_QQ_MAX_POINTS <- 2000L
+
+#' Factor levels beyond which the relationship chart's points are omitted by
+#' default and only the regression lines are drawn (section 63).
+ANCOVA_MAX_LEVELS_WITH_POINTS <- 12L
+
+# ------------------------------------------------------------
+# Sampling helpers
+# ------------------------------------------------------------
+
+#' Factor-stratified sample of row indices.
+#'
+#' Plain random sampling can erase a small group entirely, which is the one
+#' thing a group-comparison chart must not do. Each level keeps at least its
+#' proportional share, and a level smaller than that share is kept whole
+#' (section 48).
+#' @noRd
+sample_ancova_scatter_points <- function(factor_values, max_points) {
+  n <- length(factor_values)
+  if (n <= max_points) {
+    return(seq_len(n))
+  }
+  idx_by_level <- split(seq_len(n), factor_values)
+  idx_by_level <- idx_by_level[vapply(idx_by_level, length, integer(1)) > 0]
+  sizes <- vapply(idx_by_level, length, integer(1))
+
+  # Largest-remainder allocation, so the kept total is exactly max_points
+  # instead of drifting with rounding across many levels.
+  exact <- sizes / n * max_points
+  keep <- pmin(sizes, floor(exact))
+  remainder <- max_points - sum(keep)
+  if (remainder > 0) {
+    room <- sizes - keep
+    order_by_frac <- order(exact - floor(exact), decreasing = TRUE)
+    for (i in order_by_frac) {
+      if (remainder <= 0) break
+      take <- min(room[[i]], remainder)
+      keep[[i]] <- keep[[i]] + take
+      remainder <- remainder - take
+    }
+  }
+
+  picked <- unlist(lapply(seq_along(idx_by_level), function(i) {
+    ids <- idx_by_level[[i]]
+    if (keep[[i]] >= length(ids)) ids else sort(sample(ids, keep[[i]]))
+  }), use.names = FALSE)
+  sort(picked)
+}
+
+#' Per-covariate point allocation under the shared budget (section 49).
+#' @noRd
+ancova_points_per_covariate <- function(n_covariates) {
+  if (n_covariates <= 0) return(ANCOVA_MAX_POINTS_PER_CHART)
+  share <- floor(ANCOVA_DIAGNOSTIC_POINT_BUDGET / n_covariates)
+  max(ANCOVA_MIN_POINTS_PER_COVARIATE, min(ANCOVA_MAX_POINTS_PER_CHART, share))
+}
+
+# ------------------------------------------------------------
+# Relationship chart (sections 11-32)
+# ------------------------------------------------------------
+
+#' Regression lines for one covariate, from the INTERACTION model.
+#'
+#' One line per factor level, spanning only that level's own observed range of
+#' the covariate -- a line drawn past where a group has data invites reading a
+#' comparison the data cannot support (section 18). Every other covariate is
+#' held at its grand mean, which in centered space is 0 (section 16).
+#' @noRd
+compute_ancova_relationship_lines <- function(model_interaction, analysis_data, safe_factor,
+                                              safe_xc_target, safe_xc_all, factor_levels,
+                                              covariate_mean, alpha) {
+  conf_level <- 1 - alpha
+  purrr::map_dfr(factor_levels, function(lv) {
+    in_level <- analysis_data[[safe_factor]] == lv
+    xs <- analysis_data[[safe_xc_target]][in_level]
+    xs <- xs[is.finite(xs)]
+    if (length(xs) < 2 || length(unique(xs)) < 2) {
+      # A group with no spread has no line to draw; the other groups still do.
+      return(tibble::tibble())
+    }
+    grid <- seq(min(xs), max(xs), length.out = ANCOVA_RELATIONSHIP_GRID_SIZE)
+    newdata <- as.data.frame(stats::setNames(
+      lapply(safe_xc_all, function(nm) if (identical(nm, safe_xc_target)) grid else rep(0, length(grid))),
+      safe_xc_all), stringsAsFactors = FALSE)
+    newdata[[safe_factor]] <- factor(lv, levels = factor_levels)
+
+    pred <- stats::predict(model_interaction, newdata = newdata, se.fit = TRUE)
+    tcrit <- stats::qt(1 - alpha / 2, df = pred$df)
+    tibble::tibble(
+      factor_level = as.character(lv),
+      # Reported on the covariate's own raw scale -- the chart's x axis is the
+      # column the user picked, not a centered internal.
+      x = grid + covariate_mean,
+      predicted_y = as.numeric(pred$fit),
+      standard_error = as.numeric(pred$se.fit),
+      ci_lower = as.numeric(pred$fit) - tcrit * as.numeric(pred$se.fit),
+      ci_upper = as.numeric(pred$fit) + tcrit * as.numeric(pred$se.fit),
+      confidence_level = conf_level
+    )
+  })
+}
+
+#' Observation points for one covariate, adjusted for the other covariates.
+#'
+#' Plotting the raw outcome against one covariate while the LINE holds the
+#' others at their means shows a cloud and a line that answer different
+#' questions; the scatter looks far noisier than the model it is drawn beside.
+#' So each point is moved to where it would sit if that row's other covariates
+#' were at their means, keeping its own residual (sections 22-25):
+#'
+#'   adjusted_y = predict(interaction, row with other covariates centered at 0)
+#'                + (y - predict(interaction, row as observed))
+#'
+#' With a single covariate the reference row IS the observed row, so
+#' adjusted_y == raw_y exactly and no special case is needed (section 26).
+#' @noRd
+compute_ancova_relationship_points <- function(model_interaction, analysis_data, safe_y, safe_factor,
+                                               safe_xc_target, safe_xc_all, factor_levels,
+                                               covariate_mean, low_cardinality, max_points) {
+  n <- nrow(analysis_data)
+  fitted_observed <- as.numeric(stats::predict(model_interaction, newdata = analysis_data))
+  residual <- analysis_data[[safe_y]] - fitted_observed
+
+  reference_data <- analysis_data
+  for (nm in safe_xc_all) {
+    if (!identical(nm, safe_xc_target)) reference_data[[nm]] <- 0
+  }
+  fitted_reference <- as.numeric(stats::predict(model_interaction, newdata = reference_data))
+  adjusted_y <- fitted_reference + residual
+
+  raw_x <- analysis_data[[safe_xc_target]] + covariate_mean
+
+  # Jitter is a DISPLAY concession for a covariate with a handful of distinct
+  # values, where every point would otherwise land on the same few verticals.
+  # It never touches the model, the prediction, or the reported value: display_x
+  # is a separate column and raw x is what a tooltip reads (sections 31-32).
+  display_x <- raw_x
+  if (isTRUE(low_cardinality)) {
+    spread <- diff(range(raw_x, na.rm = TRUE))
+    width <- if (is.finite(spread) && spread > 0) spread / 60 else 0.05
+    display_x <- raw_x + stats::runif(n, -width, width)
+  }
+
+  keep <- sample_ancova_scatter_points(analysis_data[[safe_factor]], max_points)
+  list(
+    points = tibble::tibble(
+      row_id = keep,
+      factor_level = as.character(analysis_data[[safe_factor]])[keep],
+      x = raw_x[keep],
+      display_x = display_x[keep],
+      raw_y = analysis_data[[safe_y]][keep],
+      adjusted_y = adjusted_y[keep]
+    ),
+    n_total = n,
+    n_displayed = length(keep),
+    sampled = length(keep) < n
+  )
+}
+
+#' Everything the relationship chart needs, one entry per covariate.
+#' @noRd
+compute_ancova_relationships <- function(model_interaction, analysis_data, prep, centered,
+                                         covariate_tests, interaction_estimable, alpha) {
+  covariate_names <- prep$covariate_names
+  n_cov <- length(covariate_names)
+  max_points <- ancova_points_per_covariate(n_cov)
+  factor_levels <- prep$factor_levels
+  slopes_by_covariate <- NULL
+
+  purrr::map(seq_len(n_cov), function(j) {
+    cov_name <- covariate_names[[j]]
+    base <- list(
+      covariate = cov_name,
+      reference_value = unname(centered$covariate_means[[cov_name]]),
+      interaction_test = ancova_covariate_test_row(covariate_tests, cov_name)
+    )
+
+    if (!isTRUE(interaction_estimable)) {
+      # Better to say the chart cannot be drawn than to draw the additive
+      # model's parallel lines and let them be read as evidence of parallelism.
+      return(c(base, list(
+        available = FALSE,
+        reason = "interaction_model_not_estimable",
+        points = tibble::tibble(), lines = tibble::tibble(), slopes = tibble::tibble(),
+        metadata = list(source_model = "interaction", n_total = nrow(analysis_data),
+                        n_displayed = 0L, sampled = FALSE)
+      )))
+    }
+
+    safe_xc_target <- centered$safe_xc[[j]]
+    if (length(unique(analysis_data[[safe_xc_target]])) < 2) {
+      return(c(base, list(
+        available = FALSE, reason = "insufficient_unique_x",
+        points = tibble::tibble(), lines = tibble::tibble(), slopes = tibble::tibble(),
+        metadata = list(source_model = "interaction", n_total = nrow(analysis_data),
+                        n_displayed = 0L, sampled = FALSE)
+      )))
+    }
+
+    lines <- compute_ancova_relationship_lines(
+      model_interaction, analysis_data, prep$safe_factor, safe_xc_target,
+      centered$safe_xc, factor_levels, base$reference_value, alpha)
+
+    if (nrow(lines) == 0 || any(!is.finite(lines$predicted_y))) {
+      return(c(base, list(
+        available = FALSE, reason = "non_finite_predictions",
+        points = tibble::tibble(), lines = tibble::tibble(), slopes = tibble::tibble(),
+        metadata = list(source_model = "interaction", n_total = nrow(analysis_data),
+                        n_displayed = 0L, sampled = FALSE)
+      )))
+    }
+
+    show_points <- length(factor_levels) <= ANCOVA_MAX_LEVELS_WITH_POINTS
+    pts <- if (show_points) {
+      compute_ancova_relationship_points(
+        model_interaction, analysis_data, prep$safe_y, prep$safe_factor,
+        safe_xc_target, centered$safe_xc, factor_levels, base$reference_value,
+        centered$covariate_summary$low_cardinality[[j]], max_points)
+    } else {
+      list(points = tibble::tibble(), n_total = nrow(analysis_data),
+           n_displayed = 0L, sampled = FALSE)
+    }
+
+    if (is.null(slopes_by_covariate)) {
+      # emtrends once for every covariate, not once per covariate.
+      slopes_by_covariate <<- tryCatch(
+        compute_ancova_slopes(model_interaction, prep$safe_factor, centered$safe_xc,
+                              covariate_names, factor_levels, 1 - alpha),
+        error = function(e) list())
+    }
+    slopes <- ancova_slopes_for_covariate(slopes_by_covariate, cov_name)
+
+    c(base, list(
+      available = TRUE,
+      reason = NA_character_,
+      points = pts$points,
+      lines = lines,
+      slopes = slopes,
+      metadata = list(
+        source_model = "interaction",
+        other_covariates_reference = if (n_cov > 1) "grand_mean" else "not_applicable",
+        points_shown_by_default = show_points,
+        low_cardinality_jitter = isTRUE(centered$covariate_summary$low_cardinality[[j]]),
+        n_total = pts$n_total,
+        n_displayed = pts$n_displayed,
+        sampled = pts$sampled
+      )
+    ))
+  })
+}
+
+#' @noRd
+ancova_covariate_test_row <- function(covariate_tests, cov_name) {
+  if (is.null(covariate_tests) || nrow(covariate_tests) == 0) return(list())
+  row <- covariate_tests[covariate_tests$covariate == cov_name, , drop = FALSE]
+  if (nrow(row) == 0) return(list())
+  as.list(row[1, , drop = TRUE])
+}
+
+#' @noRd
+ancova_slopes_for_covariate <- function(interaction_details, cov_name) {
+  if (length(interaction_details) == 0) return(tibble::tibble())
+  for (entry in interaction_details) {
+    if (identical(entry$covariate, cov_name)) return(entry$slopes)
+  }
+  tibble::tibble()
+}
+
+# ------------------------------------------------------------
+# Residual diagnostics (sections 33-45)
+# ------------------------------------------------------------
+
+#' @noRd
+compute_residual_fitted_data <- function(final_model, analysis_data, safe_factor, max_points) {
+  std_resid <- stats::rstandard(final_model)
+  fitted <- stats::fitted(final_model)
+  raw_resid <- stats::residuals(final_model)
+  n <- length(std_resid)
+  keep <- sample_ancova_scatter_points(analysis_data[[safe_factor]][seq_len(n)], max_points)
+  list(
+    points = tibble::tibble(
+      fitted = as.numeric(fitted)[keep],
+      residual = as.numeric(raw_resid)[keep],
+      standardized_residual = as.numeric(std_resid)[keep],
+      factor_level = as.character(analysis_data[[safe_factor]])[keep]
+    ),
+    n_total = n,
+    n_displayed = length(keep),
+    sampled = length(keep) < n,
+    full_fitted = as.numeric(fitted),
+    full_std_resid = as.numeric(std_resid)
+  )
+}
+
+#' Lowess smoother over the FULL data, not the sampled points.
+#'
+#' The smoother is what a reader actually judges the residual pattern from, so
+#' it must describe every row -- computing it from the scatter sample would let
+#' the picture change with the sampling (section 50).
+#' @noRd
+compute_residual_smoother <- function(fitted, standardized_residual) {
+  ok <- is.finite(fitted) & is.finite(standardized_residual)
+  if (sum(ok) < 3) return(tibble::tibble())
+  sm <- stats::lowess(fitted[ok], standardized_residual[ok], f = 2 / 3, iter = 3)
+  tibble::tibble(fitted = sm$x, smoothed_residual = sm$y)
+}
+
+#' Q-Q data, thinned by evenly spaced ORDER STATISTICS.
+#'
+#' Sorting first and then taking every k-th value keeps both tails, which is
+#' the part of a Q-Q plot that carries the information; a random subsample
+#' would preferentially drop them (section 51).
+#' @noRd
+compute_qq_data <- function(standardized_residual) {
+  z <- sort(standardized_residual[is.finite(standardized_residual)])
+  n <- length(z)
+  if (n < 3) {
+    return(list(points = tibble::tibble(), reference_line = list(intercept = NA_real_, slope = NA_real_),
+                n_total = n, n_displayed = 0L, sampled = FALSE))
+  }
+  theoretical <- stats::qnorm(stats::ppoints(n))
+
+  idx <- seq_len(n)
+  if (n > ANCOVA_QQ_MAX_POINTS) {
+    idx <- unique(round(seq(1, n, length.out = ANCOVA_QQ_MAX_POINTS)))
+  }
+
+  # Reference line through the first and third quartiles -- the conventional
+  # Q-Q line, computed from ALL residuals even when the points are thinned.
+  xq <- stats::qnorm(c(0.25, 0.75))
+  yq <- stats::quantile(z, c(0.25, 0.75), names = FALSE)
+  slope <- diff(yq) / diff(xq)
+  intercept <- yq[[1]] - slope * xq[[1]]
+
+  list(
+    points = tibble::tibble(theoretical = theoretical[idx], observed = z[idx]),
+    reference_line = list(intercept = intercept, slope = slope),
+    n_total = n,
+    n_displayed = length(idx),
+    sampled = length(idx) < n
+  )
+}
+
+#' @noRd
+compute_ancova_residual_diagnostics <- function(final_model, analysis_data, safe_factor,
+                                                final_model_type) {
+  rf <- compute_residual_fitted_data(final_model, analysis_data, safe_factor,
+                                     ANCOVA_MAX_POINTS_PER_CHART)
+  smoother <- compute_residual_smoother(rf$full_fitted, rf$full_std_resid)
+  qq <- compute_qq_data(rf$full_std_resid)
+
+  list(
+    available = TRUE,
+    source_model = final_model_type,
+    model_type = final_model_type,
+    n = rf$n_total,
+    residual_vs_fitted = list(
+      points = rf$points,
+      smoother = smoother,
+      reference_y = 0,
+      n_total = rf$n_total,
+      n_displayed = rf$n_displayed,
+      sampled = rf$sampled
+    ),
+    qq = list(
+      points = qq$points,
+      reference_line = qq$reference_line,
+      n_total = qq$n_total,
+      n_displayed = qq$n_displayed,
+      sampled = qq$sampled
+    )
+  )
+}
+
+# ------------------------------------------------------------
+# Assembly (sections 52, 56, 57, 77, 79)
+# ------------------------------------------------------------
+
+#' @noRd
+assemble_ancova_diagnostics <- function(relationships, residuals, selection, homogeneity,
+                                        covariate_tests, alpha) {
+  detected <- character(0)
+  if (!is.null(covariate_tests) && nrow(covariate_tests) > 0) {
+    detected <- as.character(covariate_tests$covariate[isTRUE_vec(covariate_tests$significant_adjusted)])
+  }
+  list(
+    diagnostics_version = 1,
+    relationships = relationships,
+    residuals = residuals,
+    # Phase 3 reads these rather than re-deriving them from the tables
+    # (section 79).
+    homogeneity_status = selection$status,
+    standard_ancova_valid = selection$standard_ancova_valid,
+    interaction_detected_covariates = as.list(detected),
+    diagnostic_model_type = selection$final_model_type,
+    diagnostics_available = isTRUE(residuals$available) ||
+      any(vapply(relationships, function(r) isTRUE(r$available), logical(1))),
+    metadata = list(
+      relationship_model = "full_interaction",
+      residual_model = "final_model",
+      relationship_reference = "other_covariates_at_grand_mean",
+      relationship_points = "partial_adjusted_observations",
+      residual_type = "standardized",
+      qq_distribution = "normal",
+      scatter_sampling = "factor_stratified",
+      # Not testable from the data alone, so it is stated rather than judged
+      # (section 4).
+      independence_tested = FALSE,
+      alpha = alpha,
+      grid_size = ANCOVA_RELATIONSHIP_GRID_SIZE,
+      max_points_per_chart = ANCOVA_MAX_POINTS_PER_CHART,
+      diagnostic_point_budget = ANCOVA_DIAGNOSTIC_POINT_BUDGET,
+      qq_max_points = ANCOVA_QQ_MAX_POINTS
+    )
+  )
+}
+
+#' @noRd
+isTRUE_vec <- function(x) {
+  if (is.null(x)) return(logical(0))
+  !is.na(x) & x
+}
+
+#' Top-level Phase 2 entry point, called from within run_ancova_v2().
+#'
+#' Guarded per chart family: one diagnostic that cannot be produced must not
+#' cost the report the rest of them, or the ANCOVA result itself (section 64).
+#' @noRd
+compute_ancova_diagnostics <- function(models, final_model, analysis_data, prep, centered,
+                                       selection, homogeneity, covariate_tests, alpha) {
+  interaction_estimable <- isTRUE(homogeneity$estimable) && inherits(models$interaction, "lm")
+
+  relationships <- tryCatch(
+    compute_ancova_relationships(models$interaction, analysis_data, prep, centered,
+                                 covariate_tests, interaction_estimable, alpha),
+    error = function(e) list())
+
+  residuals <- tryCatch(
+    compute_ancova_residual_diagnostics(final_model, analysis_data, prep$safe_factor,
+                                        selection$final_model_type),
+    error = function(e) list(available = FALSE, reason = "residuals_not_available",
+                             source_model = selection$final_model_type))
+
+  assemble_ancova_diagnostics(relationships, residuals, selection, homogeneity,
+                              covariate_tests, alpha)
+}

--- a/R/ancova_v2_wrapper.R
+++ b/R/ancova_v2_wrapper.R
@@ -450,12 +450,145 @@ ancova_v2_shapiro_table <- function(x, shapiro_seed) {
                                           "Normality assumption is valid."))
 }
 
+# ------------------------------------------------------------
+# Phase 2 diagnostic surfaces (tam#38389)
+# ------------------------------------------------------------
+
+#' Relationship data for one chart, long-form.
+#'
+#' Points and lines share a table because they share a chart: one row kind
+#' carries the observations, the other the fitted line and its band, and the
+#' renderer separates them on `Row Kind`. Emitting two tables instead would
+#' need two charts that cannot be overlaid.
+#' @noRd
+ancova_v2_relationship_table <- function(x, covariate = NULL) {
+  rels <- x$result$diagnostics$relationships
+  if (is.null(rels) || length(rels) == 0) return(tibble::tibble())
+  if (!is.null(covariate) && nzchar(covariate)) {
+    rels <- Filter(function(r) identical(r$covariate, covariate), rels)
+  }
+  purrr::map_dfr(rels, function(r) {
+    if (!isTRUE(r$available)) return(tibble::tibble())
+    slope_by_level <- stats::setNames(
+      if (nrow(r$slopes) > 0) r$slopes$slope else numeric(0),
+      if (nrow(r$slopes) > 0) as.character(r$slopes$group) else character(0))
+
+    pts <- if (nrow(r$points) > 0) tibble::tibble(
+      `Covariate` = r$covariate,
+      `Group` = r$points$factor_level,
+      `Row Kind` = "point",
+      `X` = r$points$display_x,
+      `Covariate Value` = r$points$x,
+      `Observed` = r$points$adjusted_y,
+      `Raw Outcome` = r$points$raw_y,
+      `Predicted` = NA_real_,
+      `Conf Low` = NA_real_,
+      `Conf High` = NA_real_,
+      `Slope` = unname(slope_by_level[r$points$factor_level]),
+      `Reference Value` = r$reference_value
+    ) else tibble::tibble()
+
+    lns <- tibble::tibble(
+      `Covariate` = r$covariate,
+      `Group` = r$lines$factor_level,
+      `Row Kind` = "line",
+      `X` = r$lines$x,
+      `Covariate Value` = r$lines$x,
+      `Observed` = NA_real_,
+      `Raw Outcome` = NA_real_,
+      `Predicted` = r$lines$predicted_y,
+      `Conf Low` = r$lines$ci_lower,
+      `Conf High` = r$lines$ci_upper,
+      `Slope` = unname(slope_by_level[r$lines$factor_level]),
+      `Reference Value` = r$reference_value
+    )
+    dplyr::bind_rows(pts, lns)
+  })
+}
+
+#' @noRd
+ancova_v2_residual_fitted_table <- function(x) {
+  d <- x$result$diagnostics$residuals
+  if (is.null(d) || !isTRUE(d$available)) return(tibble::tibble())
+  rvf <- d$residual_vs_fitted
+  pts <- tibble::tibble(
+    `Row Kind` = "point",
+    `Fitted Value` = rvf$points$fitted,
+    `Standardized Residual` = rvf$points$standardized_residual,
+    `Residual` = rvf$points$residual,
+    `Group` = rvf$points$factor_level
+  )
+  sm <- if (nrow(rvf$smoother) > 0) tibble::tibble(
+    `Row Kind` = "smoother",
+    `Fitted Value` = rvf$smoother$fitted,
+    `Standardized Residual` = rvf$smoother$smoothed_residual,
+    `Residual` = NA_real_,
+    `Group` = NA_character_
+  ) else tibble::tibble()
+  dplyr::bind_rows(pts, sm)
+}
+
+#' @noRd
+ancova_v2_qq_table <- function(x) {
+  d <- x$result$diagnostics$residuals
+  if (is.null(d) || !isTRUE(d$available)) return(tibble::tibble())
+  qq <- d$qq
+  if (nrow(qq$points) == 0) return(tibble::tibble())
+  ref <- qq$reference_line
+  tibble::tibble(
+    `Theoretical Quantile` = qq$points$theoretical,
+    `Standardized Residual` = qq$points$observed,
+    # The reference line as a per-row column, so the chart can draw it as a
+    # second series without a second query.
+    `Reference` = ref$intercept + ref$slope * qq$points$theoretical
+  )
+}
+
+#' Global slope-homogeneity test, one row (sections 5-7).
+#' @noRd
+ancova_v2_slope_homogeneity_table <- function(x) {
+  sh <- x$result$slope_homogeneity
+  if (is.null(sh)) return(tibble::tibble())
+  g <- sh$global_test
+  tibble::tibble(
+    `DF 1` = g$df1,
+    `DF 2` = g$df2,
+    `F Value` = g$F,
+    `P Value` = g$p_value,
+    `Status` = sh$status
+  )
+}
+
+#' Per-covariate interaction tests. Deliberately EMPTY with one covariate:
+#' the global test and the single covariate's test are the same hypothesis, so
+#' a one-row table restating it would be noise (section 10). A zero-row table
+#' renders as nothing at all, which is the intended "hidden".
+#' @noRd
+ancova_v2_slope_covariate_tests_table <- function(x) {
+  sh <- x$result$slope_homogeneity
+  if (is.null(sh) || is.null(sh$covariate_tests) || nrow(sh$covariate_tests) == 0) {
+    return(tibble::tibble())
+  }
+  if (length(x$covariates) < 2) return(tibble::tibble())
+  ct <- sh$covariate_tests
+  tibble::tibble(
+    `Covariate` = ct$covariate,
+    `DF 1` = ct$df1,
+    `DF 2` = ct$df2,
+    `F Value` = ct$F,
+    `P Value` = ct$p_raw,
+    `Adjusted P Value` = ct$p_holm
+  )
+}
+
 #' Tidy an ANCOVA V2 model for the Analytics View.
 #'
 #' Supported types: "model" (ANCOVA table), "emmeans" (adjusted + unadjusted
 #' means), "pairs", "prob_dist", "levene", "shapiro", and "data" (the analysis
-#' rows). Any unrecognized type returns the data, matching
-#' tidy.anova_exploratory()'s own catch-all.
+#' rows), plus the Phase 2 diagnostics (tam#38389): "slope_homogeneity",
+#' "slope_covariate_tests", "relationship", "residual_fitted" and "qq". Any
+#' unrecognized type returns the data, matching tidy.anova_exploratory()'s own
+#' catch-all.
 #'
 #' @param x An `ancova_v2_exploratory` model.
 #' @param type Which report surface to return.
@@ -465,12 +598,16 @@ ancova_v2_shapiro_table <- function(x, shapiro_seed) {
 #' @param levene_test_center "mean" or "median".
 #' @param shapiro_seed Seed used when residuals are subsampled to 5000.
 #' @param sort_factor_levels Order group levels by descending unadjusted mean.
+#' @param covariate For `type="relationship"`, limit the result to one
+#'   covariate. NULL returns every covariate, which is what a Repeat By facet
+#'   needs.
 #' @export
 tidy.ancova_v2_exploratory <- function(x, type = "model", conf_level = 0.95,
                                        pairs_adjust = "none",
                                        levene_test_center = "median",
                                        shapiro_seed = 1,
-                                       sort_factor_levels = FALSE) {
+                                       sort_factor_levels = FALSE,
+                                       covariate = NULL) {
   if ("error" %in% class(x)) {
     message <- if (is.null(x$message) || x$message == "") as.character(x) else x$message
     if (type %in% c("model", "between", "within")) {
@@ -496,6 +633,21 @@ tidy.ancova_v2_exploratory <- function(x, type = "model", conf_level = 0.95,
   }
   else if (type == "shapiro") {
     ancova_v2_shapiro_table(x, shapiro_seed)
+  }
+  else if (type == "slope_homogeneity") {
+    ancova_v2_slope_homogeneity_table(x)
+  }
+  else if (type == "slope_covariate_tests") {
+    ancova_v2_slope_covariate_tests_table(x)
+  }
+  else if (type == "relationship") {
+    ancova_v2_relationship_table(x, covariate)
+  }
+  else if (type == "residual_fitted") {
+    ancova_v2_residual_fitted_table(x)
+  }
+  else if (type == "qq") {
+    ancova_v2_qq_table(x)
   }
   else { # type == "data"
     ret <- x$dataframe

--- a/tests/testthat/test_ancova_v2_diagnostics.R
+++ b/tests/testthat/test_ancova_v2_diagnostics.R
@@ -1,0 +1,395 @@
+# ANCOVA Calculation V2 Phase 2 diagnostics (tam#38389).
+# how to run this test: devtools::test(filter="ancova_v2_diagnostics")
+#
+# The numbered cases below are the spec's own regression tests (sections
+# 66-76). Each asserts the PROPERTY the spec states, not the shape of the
+# output -- a diagnostic layer that returns well-formed tables describing the
+# wrong model would pass a shape check.
+context("ANCOVA V2 diagnostics (Phase 2), tam#38389")
+
+make_diag_data <- function(n_per_group = 60, seed = 5,
+                           group_levels = c("A", "B", "C"),
+                           slope_offsets = NULL, x1_slope = 2, x2_slope = 0.5,
+                           noise_sd = 3, low_card_x1 = FALSE) {
+  set.seed(seed)
+  k <- length(group_levels)
+  n <- n_per_group * k
+  group <- factor(rep(group_levels, each = n_per_group), levels = group_levels)
+  x1 <- if (low_card_x1) sample(1:5, n, replace = TRUE) else runif(n, 0, 10)
+  x2 <- rnorm(n, 50, 8)
+  intercepts <- stats::setNames(seq(0, by = 5, length.out = k), group_levels)
+  extra <- if (is.null(slope_offsets)) rep(0, n) else
+    unname(slope_offsets[as.character(group)]) * x1
+  y <- intercepts[as.character(group)] + x1_slope * x1 + x2_slope * x2 + extra +
+    rnorm(n, 0, noise_sd)
+  data.frame(y = as.numeric(y), group = group, X1 = as.numeric(x1), X2 = x2,
+             stringsAsFactors = FALSE)
+}
+
+rel_for <- function(res, covariate) {
+  for (r in res$diagnostics$relationships) if (identical(r$covariate, covariate)) return(r)
+  NULL
+}
+
+# ------------------------------------------------------------
+# Test 1 (section 66): one covariate, no interaction detected
+# ------------------------------------------------------------
+test_that("Test 1: single covariate, homogeneous slopes -- additive final model, interaction-based chart", {
+  df <- make_diag_data()
+  res <- run_ancova_v2(df, "y", "group", "X1")
+
+  expect_equal(res$slope_homogeneity$status, "not_detected")
+  expect_equal(res$model_selection$final_model_type, "additive")
+  # The two models are deliberately different: the chart is drawn from the
+  # interaction fit even though the additive one was selected (section 15).
+  expect_equal(res$diagnostics$residuals$source_model, "additive")
+  rel <- rel_for(res, "X1")
+  expect_true(rel$available)
+  expect_equal(rel$metadata$source_model, "interaction")
+  # A single covariate has nothing to adjust FOR, so the adjustment is the
+  # identity -- and it must fall out of the same code path, not a special case
+  # (section 26).
+  expect_equal(rel$points$adjusted_y, rel$points$raw_y, tolerance = 1e-10)
+  expect_equal(rel$metadata$other_covariates_reference, "not_applicable")
+})
+
+test_that("the relationship lines are NOT parallel even when the additive model was selected", {
+  # The load-bearing rule of the whole diagnostics layer (sections 15, 82): the
+  # chart a reader uses to judge whether the slopes are parallel must come from
+  # the model that let them differ. Drawn from the additive model the lines are
+  # parallel BY CONSTRUCTION, so the chart would answer its own question yes no
+  # matter what the data said -- and it would look completely normal.
+  df <- make_diag_data(seed = 13)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2"))
+  expect_equal(res$model_selection$final_model_type, "additive")
+
+  lines <- rel_for(res, "X1")$lines
+  slope_of <- function(lv) {
+    g <- lines[lines$factor_level == lv, ]
+    (g$predicted_y[[nrow(g)]] - g$predicted_y[[1]]) / (g$x[[nrow(g)]] - g$x[[1]])
+  }
+  slopes <- vapply(unique(lines$factor_level), slope_of, numeric(1))
+  # Additive lines would agree to floating-point noise; interaction lines carry
+  # each group's own estimate, which differs even when the difference is not
+  # significant.
+  expect_gt(diff(range(slopes)), 1e-6)
+
+  # ... and they agree with what emtrends reported for those same groups.
+  emtrend_slopes <- rel_for(res, "X1")$slopes
+  for (lv in names(slopes)) {
+    expect_equal(slopes[[lv]],
+                 emtrend_slopes$slope[as.character(emtrend_slopes$group) == lv][[1]],
+                 tolerance = 1e-6)
+  }
+})
+
+# ------------------------------------------------------------
+# Test 2 (section 67): three covariates, no interaction detected
+# ------------------------------------------------------------
+test_that("Test 2: three covariates produce three relationship sets, each holding the others at the mean", {
+  df <- make_diag_data()
+  df$X3 <- rnorm(nrow(df), 20, 4)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2", "X3"))
+
+  expect_equal(length(res$diagnostics$relationships), 3)
+  expect_equal(vapply(res$diagnostics$relationships, function(r) r$covariate, character(1)),
+               c("X1", "X2", "X3"))
+  for (r in res$diagnostics$relationships) {
+    expect_true(r$available)
+    expect_equal(r$metadata$source_model, "interaction")
+    expect_equal(r$metadata$other_covariates_reference, "grand_mean")
+    # The reference value is the covariate's own raw grand mean.
+    expect_equal(r$reference_value, mean(df[[r$covariate]]), tolerance = 1e-10)
+  }
+  expect_equal(res$diagnostics$residuals$source_model, "additive")
+})
+
+# ------------------------------------------------------------
+# Test 3 (section 68): one covariate interacts strongly
+# ------------------------------------------------------------
+test_that("Test 3: a strong interaction in ONE covariate keeps every covariate's chart available", {
+  df <- make_diag_data(seed = 9, slope_offsets = c(A = 0, B = 6, C = -6))
+  df$X3 <- rnorm(nrow(df), 20, 4)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2", "X3"))
+
+  expect_equal(res$slope_homogeneity$status, "detected")
+  expect_equal(res$model_selection$final_model_type, "interaction")
+  # No term is dropped just because its own test was not significant
+  # (section 68) -- all three charts stay available.
+  expect_equal(length(res$diagnostics$relationships), 3)
+  for (r in res$diagnostics$relationships) expect_true(r$available)
+  expect_equal(res$diagnostics$residuals$source_model, "interaction")
+  # X1 is the one built to interact, so its per-group slopes must differ.
+  slopes <- rel_for(res, "X1")$slopes
+  expect_equal(nrow(slopes), 3)
+  expect_gt(diff(range(slopes$slope)), 5)
+})
+
+# ------------------------------------------------------------
+# Test 4 (section 69): the adjustment removes the other covariate's variation
+# ------------------------------------------------------------
+test_that("Test 4: adjusted points strip the variation a second, dominant covariate contributes", {
+  set.seed(21)
+  n <- 150
+  group <- factor(rep(c("A", "B", "C"), each = 50))
+  x1 <- runif(n, 0, 10)
+  x2 <- rnorm(n, 0, 1)
+  # X2's contribution dwarfs X1's, so raw points scatter enormously around the
+  # X1 relationship while adjusted points should not.
+  df <- data.frame(y = x1 + 100 * x2 + rnorm(n, 0, 0.5), group = group, X1 = x1, X2 = x2)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2"))
+
+  rel <- rel_for(res, "X1")
+  expect_true(rel$available)
+  expect_lt(stats::sd(rel$points$adjusted_y), stats::sd(rel$points$raw_y) / 10)
+})
+
+# ------------------------------------------------------------
+# Test 5 (section 70): the adjusted-point identity, to 1e-8
+# ------------------------------------------------------------
+test_that("Test 5: adjusted_y equals the reference prediction plus the observed residual", {
+  df <- make_diag_data(seed = 12)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2"), keep_internals = TRUE)
+  rel <- rel_for(res, "X1")
+  internals <- res$internals
+  ad <- internals$analysis_data
+
+  fitted_observed <- as.numeric(stats::predict(internals$model_interaction, newdata = ad))
+  residual <- ad[[internals$safe_y]] - fitted_observed
+  reference <- ad
+  reference[[internals$safe_xc[[2]]]] <- 0
+  fitted_reference <- as.numeric(stats::predict(internals$model_interaction, newdata = reference))
+  expected <- (fitted_reference + residual)[rel$points$row_id]
+
+  expect_equal(rel$points$adjusted_y, expected, tolerance = 1e-8)
+})
+
+# ------------------------------------------------------------
+# Test 6 (section 71): low-cardinality jitter is display-only
+# ------------------------------------------------------------
+test_that("Test 6: a 1-5 covariate is jittered for display only", {
+  df <- make_diag_data(seed = 15, low_card_x1 = TRUE)
+  res <- run_ancova_v2(df, "y", "group", "X1")
+  rel <- rel_for(res, "X1")
+
+  expect_true(res$covariate_summary$low_cardinality[[1]])
+  expect_true(rel$metadata$low_cardinality_jitter)
+  # x is the real value a tooltip shows; display_x is the nudged one.
+  expect_true(all(rel$points$x %in% 1:5))
+  expect_false(all(rel$points$display_x %in% 1:5))
+  expect_lt(max(abs(rel$points$display_x - rel$points$x)), 1)
+  # The lines are never jittered -- they are model output, not display.
+  expect_true(all(rel$lines$x >= 1 & rel$lines$x <= 5))
+})
+
+test_that("a covariate with many distinct values is NOT jittered", {
+  df <- make_diag_data(seed = 15)
+  rel <- rel_for(run_ancova_v2(df, "y", "group", "X1"), "X1")
+  expect_false(rel$metadata$low_cardinality_jitter)
+  expect_equal(rel$points$display_x, rel$points$x)
+})
+
+# ------------------------------------------------------------
+# Test 7 (section 72): lines stop at each group's own range
+# ------------------------------------------------------------
+test_that("Test 7: each group's regression line spans only that group's observed covariate range", {
+  set.seed(31)
+  a <- data.frame(group = "A", X1 = runif(60, 0, 10))
+  b <- data.frame(group = "B", X1 = runif(60, 5, 20))
+  df <- rbind(a, b)
+  df$group <- factor(df$group)
+  df$y <- ifelse(df$group == "A", 0, 5) + 2 * df$X1 + rnorm(nrow(df), 0, 2)
+  res <- run_ancova_v2(df, "y", "group", "X1")
+  lines <- rel_for(res, "X1")$lines
+
+  for (lv in c("A", "B")) {
+    own <- df$X1[df$group == lv]
+    drawn <- lines$x[lines$factor_level == lv]
+    expect_equal(min(drawn), min(own), tolerance = 1e-8)
+    expect_equal(max(drawn), max(own), tolerance = 1e-8)
+    expect_equal(length(drawn), ANCOVA_RELATIONSHIP_GRID_SIZE)
+  }
+  # No extrapolation: B starts where B's data starts, not where A's does.
+  expect_gt(min(lines$x[lines$factor_level == "B"]), min(lines$x[lines$factor_level == "A"]))
+})
+
+# ------------------------------------------------------------
+# Test 8 (section 73): the residual model follows the global test
+# ------------------------------------------------------------
+test_that("Test 8: residual diagnostics always come from the FINAL model", {
+  homogeneous <- run_ancova_v2(make_diag_data(seed = 4), "y", "group", "X1")
+  expect_equal(homogeneous$slope_homogeneity$status, "not_detected")
+  expect_equal(homogeneous$diagnostics$residuals$source_model, "additive")
+
+  heterogeneous <- run_ancova_v2(
+    make_diag_data(seed = 4, slope_offsets = c(A = 0, B = 7, C = -7)), "y", "group", "X1")
+  expect_equal(heterogeneous$slope_homogeneity$status, "detected")
+  expect_equal(heterogeneous$diagnostics$residuals$source_model, "interaction")
+
+  # ... and the relationship chart is the interaction model in BOTH cases.
+  expect_equal(rel_for(homogeneous, "X1")$metadata$source_model, "interaction")
+  expect_equal(rel_for(heterogeneous, "X1")$metadata$source_model, "interaction")
+})
+
+test_that("residual diagnostics describe the final model's own residuals", {
+  df <- make_diag_data(seed = 6)
+  res <- run_ancova_v2(df, "y", "group", c("X1", "X2"), keep_internals = TRUE)
+  expected <- as.numeric(stats::rstandard(res$internals$final_model))
+  got <- res$diagnostics$residuals$residual_vs_fitted$points$standardized_residual
+  expect_equal(sort(got), sort(expected), tolerance = 1e-10)
+  expect_equal(res$diagnostics$residuals$residual_vs_fitted$reference_y, 0)
+  expect_gt(nrow(res$diagnostics$residuals$residual_vs_fitted$smoother), 0)
+})
+
+# ------------------------------------------------------------
+# Test 9 (section 74): Q-Q behaviour, with no normality verdict
+# ------------------------------------------------------------
+test_that("Test 9: near-normal residuals hug the Q-Q reference line and heavy tails leave it", {
+  normal_res <- run_ancova_v2(make_diag_data(n_per_group = 200, seed = 8), "y", "group", "X1")
+  qq <- normal_res$diagnostics$qq
+  qq <- normal_res$diagnostics$residuals$qq
+  fitted_line <- qq$reference_line$intercept + qq$reference_line$slope * qq$points$theoretical
+  normal_gap <- max(abs(qq$points$observed - fitted_line))
+
+  heavy <- make_diag_data(n_per_group = 200, seed = 8)
+  set.seed(99)
+  heavy$y <- heavy$y + stats::rt(nrow(heavy), df = 2) * 12
+  heavy_qq <- run_ancova_v2(heavy, "y", "group", "X1")$diagnostics$residuals$qq
+  heavy_line <- heavy_qq$reference_line$intercept +
+    heavy_qq$reference_line$slope * heavy_qq$points$theoretical
+  heavy_gap <- max(abs(heavy_qq$points$observed - heavy_line))
+
+  expect_lt(normal_gap, 1)
+  expect_gt(heavy_gap, normal_gap * 2)
+  # No verdict either way -- the spec forbids one (section 44).
+  expect_null(normal_res$diagnostics$residuals$normal)
+  expect_null(normal_res$diagnostics$residuals$normality_status)
+})
+
+# ------------------------------------------------------------
+# Test 10 (section 75): statistics on all rows, charts on a sample
+# ------------------------------------------------------------
+test_that("Test 10: a large N is fitted in full and only the scatter points are sampled", {
+  set.seed(77)
+  n <- 60000
+  group <- factor(sample(c("A", "B", "C"), n, replace = TRUE, prob = c(0.02, 0.49, 0.49)))
+  x1 <- runif(n, 0, 10)
+  df <- data.frame(y = as.numeric(group) * 2 + 2 * x1 + rnorm(n, 0, 3), group = group, X1 = x1)
+  res <- run_ancova_v2(df, "y", "group", "X1")
+
+  expect_equal(res$analysis_sample$n_used, n)
+  rel <- rel_for(res, "X1")
+  expect_equal(rel$metadata$n_total, n)
+  expect_true(rel$metadata$sampled)
+  expect_lte(rel$metadata$n_displayed, ANCOVA_MAX_POINTS_PER_CHART)
+  expect_equal(nrow(rel$points), rel$metadata$n_displayed)
+  # The rare group survives the sample -- the reason the sampling is stratified.
+  expect_true("A" %in% rel$points$factor_level)
+
+  rvf <- res$diagnostics$residuals$residual_vs_fitted
+  expect_true(rvf$sampled)
+  expect_lte(nrow(rvf$points), ANCOVA_MAX_POINTS_PER_CHART)
+  # The smoother is computed from every row, so it is longer than the sample.
+  expect_gt(nrow(rvf$smoother), 0)
+
+  qq <- res$diagnostics$residuals$qq
+  expect_equal(qq$n_total, n)
+  expect_lte(nrow(qq$points), ANCOVA_QQ_MAX_POINTS)
+  # Order statistics, not a random draw: the extremes are still present.
+  expect_equal(min(qq$points$observed), min(stats::rstandard(stats::lm(
+    y ~ group + I(X1 - mean(X1)), data = df))), tolerance = 1e-8)
+})
+
+# ------------------------------------------------------------
+# Sampling helper, in isolation
+# ------------------------------------------------------------
+test_that("factor-stratified sampling keeps every level and hits the target size", {
+  f <- factor(c(rep("big", 9800), rep("small", 200)))
+  idx <- sample_ancova_scatter_points(f, 1000)
+  expect_equal(length(idx), 1000)
+  kept <- table(f[idx])
+  expect_gt(kept[["small"]], 0)
+  # Proportional, so the rare level is represented rather than swamped.
+  expect_gte(kept[["small"]], 15)
+  expect_true(!is.unsorted(idx))
+})
+
+test_that("sampling is a no-op below the cap", {
+  f <- factor(rep(c("a", "b"), each = 10))
+  expect_equal(sample_ancova_scatter_points(f, 5000), seq_len(20))
+})
+
+test_that("the per-covariate budget splits, floors and caps", {
+  expect_equal(ancova_points_per_covariate(1), ANCOVA_MAX_POINTS_PER_CHART)
+  expect_equal(ancova_points_per_covariate(20),
+               floor(ANCOVA_DIAGNOSTIC_POINT_BUDGET / 20))
+  # A very wide covariate list would otherwise allocate a handful of points per
+  # chart; the floor keeps each chart readable instead.
+  expect_equal(ancova_points_per_covariate(500), ANCOVA_MIN_POINTS_PER_COVARIATE)
+})
+
+# ------------------------------------------------------------
+# Availability and metadata (sections 57, 60, 64, 77, 79)
+# ------------------------------------------------------------
+test_that("an unestimable interaction model reports the chart as unavailable, never a parallel-line stand-in", {
+  set.seed(41)
+  df <- make_diag_data(seed = 41)
+  # Constant within one group -> the interaction model is rank-deficient.
+  df$X1[df$group == "B"] <- 5
+  res <- run_ancova_v2(df, "y", "group", "X1")
+
+  expect_equal(res$slope_homogeneity$status, "not_estimable")
+  rel <- rel_for(res, "X1")
+  expect_false(rel$available)
+  expect_equal(rel$reason, "interaction_model_not_estimable")
+  expect_equal(nrow(rel$lines), 0)
+  # Residual diagnostics still work -- one dead chart must not cost the rest
+  # (section 64).
+  expect_true(res$diagnostics$residuals$available)
+})
+
+test_that("the Phase 3 handoff fields and metadata are present and consistent", {
+  res <- run_ancova_v2(make_diag_data(seed = 17), "y", "group", c("X1", "X2"))
+  d <- res$diagnostics
+
+  expect_equal(d$diagnostics_version, 1)
+  expect_equal(d$homogeneity_status, res$slope_homogeneity$status)
+  expect_equal(d$standard_ancova_valid, res$model_selection$standard_ancova_valid)
+  expect_equal(d$diagnostic_model_type, res$model_selection$final_model_type)
+  expect_true(d$diagnostics_available)
+  expect_true(is.list(d$interaction_detected_covariates))
+
+  expect_equal(d$metadata$relationship_model, "full_interaction")
+  expect_equal(d$metadata$residual_model, "final_model")
+  expect_equal(d$metadata$relationship_reference, "other_covariates_at_grand_mean")
+  expect_equal(d$metadata$relationship_points, "partial_adjusted_observations")
+  expect_equal(d$metadata$residual_type, "standardized")
+  expect_equal(d$metadata$qq_distribution, "normal")
+  expect_equal(d$metadata$scatter_sampling, "factor_stratified")
+  # Independence cannot be judged from the data alone, so it is recorded as
+  # untested rather than reported as satisfied (section 4).
+  expect_false(d$metadata$independence_tested)
+})
+
+test_that("confidence bands use 1 - alpha and are a mean-response interval", {
+  df <- make_diag_data(seed = 23)
+  wide <- run_ancova_v2(df, "y", "group", "X1", alpha = 0.01)
+  narrow <- run_ancova_v2(df, "y", "group", "X1", alpha = 0.10)
+
+  wl <- rel_for(wide, "X1")$lines
+  nl <- rel_for(narrow, "X1")$lines
+  expect_equal(unique(wl$confidence_level), 0.99)
+  expect_equal(unique(nl$confidence_level), 0.90)
+  expect_equal(wl$predicted_y, nl$predicted_y, tolerance = 1e-10)
+  # A smaller alpha widens the band; the fitted line itself does not move.
+  expect_true(all((wl$ci_upper - wl$ci_lower) > (nl$ci_upper - nl$ci_lower)))
+  # Mean-response, not prediction: the band is far narrower than the residual
+  # spread it would have to cover to hold individual observations.
+  expect_lt(mean(wl$ci_upper - wl$ci_lower), 4 * stats::sd(df$y))
+})
+
+test_that("the diagnostics never appear on the error path", {
+  bad <- run_ancova_v2(data.frame(y = 1:5, group = "A", X1 = 1:5), "y", "group", "X1")
+  expect_equal(bad$analysis_status, "error")
+  expect_null(bad$diagnostics)
+})

--- a/tests/testthat/test_ancova_v2_wrapper.R
+++ b/tests/testthat/test_ancova_v2_wrapper.R
@@ -311,3 +311,111 @@ test_that("the V1 error strings tam's formatter matches are preserved", {
   expect_error(exp_ancova(all_na, "y", "group", covariates = c("X1", "X2")),
                "There is no data left after removing NA.")
 })
+
+# ------------------------------------------------------------
+# Phase 2 diagnostic surfaces (tam#38389)
+# ------------------------------------------------------------
+
+test_that("type='slope_homogeneity' reports the global test the model selection used", {
+  df <- make_wrapper_data()
+  ret <- fit_v2(df)
+  tbl <- tidy_rowwise(ret, model, type = "slope_homogeneity")
+
+  expect_equal(colnames(tbl), c("DF 1", "DF 2", "F Value", "P Value", "Status"))
+  expect_equal(nrow(tbl), 1)
+  res <- ret$model[[1]]$result
+  expect_equal(tbl$`P Value`[[1]], res$slope_homogeneity$global_test$p_value)
+  expect_equal(tbl$Status[[1]], res$slope_homogeneity$status)
+  # Not recomputed anywhere -- the chart shows the number the model selection
+  # was actually made on.
+  expect_equal(tbl$`F Value`[[1]], res$slope_homogeneity$global_test$F)
+})
+
+test_that("type='slope_covariate_tests' is empty with one covariate and populated with more", {
+  df <- make_wrapper_data()
+  single <- tidy_rowwise(fit_v2(df, covariates = "X1"), model, type = "slope_covariate_tests")
+  # With one covariate this restates the global test, so it is deliberately
+  # empty -- a zero-row table renders as nothing.
+  expect_equal(nrow(single), 0)
+
+  two <- tidy_rowwise(fit_v2(df), model, type = "slope_covariate_tests")
+  expect_equal(nrow(two), 2)
+  expect_equal(colnames(two),
+               c("Covariate", "DF 1", "DF 2", "F Value", "P Value", "Adjusted P Value"))
+  expect_equal(two$Covariate, c("X1", "X2"))
+  # Holm-adjusted P is never smaller than the raw one.
+  expect_true(all(two$`Adjusted P Value` >= two$`P Value` - 1e-12))
+})
+
+test_that("type='relationship' carries points and lines for every covariate in one table", {
+  df <- make_wrapper_data()
+  tbl <- tidy_rowwise(fit_v2(df), model, type = "relationship")
+
+  expect_true(all(c("Covariate", "Group", "Row Kind", "X", "Covariate Value", "Observed",
+                    "Raw Outcome", "Predicted", "Conf Low", "Conf High", "Slope",
+                    "Reference Value") %in% colnames(tbl)))
+  expect_setequal(unique(tbl$Covariate), c("X1", "X2"))
+  expect_setequal(unique(tbl$`Row Kind`), c("point", "line"))
+
+  lines <- tbl[tbl$`Row Kind` == "line" & tbl$Covariate == "X1", ]
+  # 3 groups x the grid size.
+  expect_equal(nrow(lines), 3 * 100)
+  expect_true(all(is.na(lines$Observed)))
+  expect_true(all(lines$`Conf Low` < lines$Predicted))
+  expect_true(all(lines$`Conf High` > lines$Predicted))
+
+  points <- tbl[tbl$`Row Kind` == "point" & tbl$Covariate == "X1", ]
+  expect_equal(nrow(points), nrow(df))
+  expect_true(all(is.na(points$Predicted)))
+  # Every point knows its group's slope, so a tooltip can show it.
+  expect_true(all(is.finite(points$Slope)))
+  # The reference value is the covariate's raw grand mean, for the vertical line.
+  expect_equal(unique(points$`Reference Value`), mean(df$X1), tolerance = 1e-10)
+})
+
+test_that("type='relationship' can be narrowed to one covariate", {
+  df <- make_wrapper_data()
+  one <- tidy_rowwise(fit_v2(df), model, type = "relationship", covariate = "X2")
+  expect_equal(unique(one$Covariate), "X2")
+  expect_gt(nrow(one), 0)
+})
+
+test_that("type='residual_fitted' carries the points and the smoother as separate row kinds", {
+  df <- make_wrapper_data()
+  tbl <- tidy_rowwise(fit_v2(df), model, type = "residual_fitted")
+
+  expect_equal(colnames(tbl),
+               c("Row Kind", "Fitted Value", "Standardized Residual", "Residual", "Group"))
+  expect_setequal(unique(tbl$`Row Kind`), c("point", "smoother"))
+  pts <- tbl[tbl$`Row Kind` == "point", ]
+  expect_equal(nrow(pts), nrow(df))
+  expect_true(all(!is.na(pts$Group)))
+  expect_gt(nrow(tbl[tbl$`Row Kind` == "smoother", ]), 0)
+})
+
+test_that("type='qq' carries the reference line as a per-row column", {
+  df <- make_wrapper_data()
+  tbl <- tidy_rowwise(fit_v2(df), model, type = "qq")
+
+  expect_equal(colnames(tbl),
+               c("Theoretical Quantile", "Standardized Residual", "Reference"))
+  expect_equal(nrow(tbl), nrow(df))
+  # A straight line in the theoretical quantile: equal spacing in x gives
+  # equal spacing in Reference.
+  slopes <- diff(tbl$Reference) / diff(tbl$`Theoretical Quantile`)
+  expect_lt(diff(range(slopes)), 1e-8)
+})
+
+test_that("the diagnostic surfaces degrade to empty rather than erroring when a fit is unavailable", {
+  df <- make_wrapper_data()
+  # Constant within one group -> the interaction model cannot be estimated.
+  df$X1[df$group == "B"] <- 5
+  ret <- fit_v2(df, covariates = "X1")
+
+  expect_equal(ret$model[[1]]$result$slope_homogeneity$status, "not_estimable")
+  expect_equal(nrow(tidy_rowwise(ret, model, type = "relationship")), 0)
+  # Residual diagnostics come from the final model, which WAS fitted, so they
+  # survive -- one dead chart does not take the others with it.
+  expect_gt(nrow(tidy_rowwise(ret, model, type = "residual_fitted")), 0)
+  expect_gt(nrow(tidy_rowwise(ret, model, type = "qq")), 0)
+})


### PR DESCRIPTION
Phase 2 of the ANCOVA V2 work (tam#38389). Phase 1 (#1654) computed the ANCOVA; Phase 1.5 (#1658) made the Analytics View able to reach it. This adds the data behind the report's new "ANCOVA Assumptions" section: the covariate-vs-outcome relationship chart, residuals vs fitted values, and a Q-Q plot of the residuals.

## It decides nothing

Every fit comes from `run_ancova_v2`'s own `internals`, so a chart cannot drift from the numbers printed beside it. `predict()` and `rstandard()` on those fits are the only model calls — no refit, no re-test, no second model selection.

## The two rules that make the charts meaningful

**The relationship chart always uses the full-interaction model**, even when the additive one was selected. Its entire purpose is to let a reader judge whether the slopes really are parallel. Drawn from the additive model they are parallel *by construction* — the chart would answer its own question yes regardless of the data, and would look completely normal doing it. That circularity is the reason the spec fixes the model per chart rather than per analysis.

Pinned directly: on a fixture where the additive model **was** selected, the per-group lines must still differ in slope, cross-checked against `emtrends`. Sabotage-checked — pointing the chart at the final model fails that test and the adjusted-point identity.

**Residual diagnostics always use the final model**, whichever it is, because they ask a different question: does the model being reported describe the data.

## Adjusted observations

Plotting the raw outcome against one covariate while the line holds the others at their means shows a cloud and a line answering different questions — the scatter looks far noisier than the model drawn through it. Each point is moved to where it would sit with the other covariates at their means, keeping its own residual:

```
adjusted_y = predict(interaction, row with other covariates at 0) + (y - predict(interaction, row as observed))
```

With one covariate the reference row **is** the observed row, so `adjusted == raw` falls out of the same code path rather than needing a special case.

## Sampling

Statistics, lines, tests and residuals always use every row; only scatter points are sampled. Stratified by factor level, because plain random sampling can erase a small group entirely — the one thing a group-comparison chart must not do. Q-Q points are evenly spaced **order statistics**, never a random draw, which would preferentially drop the tails the plot is read for. Grid size, per-chart cap, cross-covariate budget and its floor are named constants.

## Failure is per chart

An unestimable interaction model reports `available = FALSE` with a reason instead of substituting the additive model's parallel lines, and residual diagnostics still work. A diagnostic that cannot be produced never costs the ANCOVA result — on the error path there is no `diagnostics` key at all, which consumers must tolerate.

## Reaching it from tam

Five tidy types: `slope_homogeneity`, `slope_covariate_tests` (deliberately empty with one covariate, where it would only restate the global test — a zero-row table renders as nothing, which is the intended "hidden"), `relationship`, `residual_fitted`, `qq`. The relationship table carries points and lines as row kinds in one table because they share one chart.

## Verification

The tests are the spec's own regression cases (sections 66–76): the adjusted-point identity to 1e-8, the single-covariate identity, a dominant second covariate whose variation the adjustment removes, low-cardinality jitter being display-only, per-group line ranges that do not extrapolate, the residual model following the global test, Q-Q behaviour under normal and heavy-tailed residuals with no normality verdict, and N=60000 fitted in full while the charts sample (the rare 2% group surviving the stratified sample).

113 assertions, 0 failures. The Phase 1 and wrapper suites are unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
