### PR TITLE
test(ancova): run Tests K and L instead of skipping them on every platform

### DIFF
--- a/tests/testthat/test_ancova_v2.R
+++ b/tests/testthat/test_ancova_v2.R
@@ -371,10 +371,16 @@ test_that("Test J: different NA patterns per covariate all resolve to the same c
 # ------------------------------------------------------------
 
 test_that("Test K: adjusted means equal a direct prediction at the covariates' raw-scale means", {
-  df <- make_ancova_data(n_per_group = 60, seed = 61, covariate_names = c("X1", "X2"))
+  df <- make_ancova_data(n_per_group = 60, seed = 2026, covariate_names = c("X1", "X2"))
   res <- run_ancova_v2(df, outcome = "y", factor = "group", covariates = c("X1", "X2"), alpha = 0.05)
-  skip_if(res$model_selection$final_model_type != "additive",
-          "final model was interaction for this seed; Test K only applies to the additive case")
+  # make_ancova_data() is called without group_slope_offsets, so the true data
+  # generating process has parallel slopes and selection must land on the
+  # additive model -- which is also the only case the additive lm() oracle below
+  # can check. Assert it rather than skip on it: the seed is fixed, so this is
+  # deterministic, and the previous `skip_if` silently disabled Test K and
+  # Test L on EVERY platform because seed 61 happened to draw a Type I error on
+  # the homogeneity-of-slopes test.
+  expect_identical(res$model_selection$final_model_type, "additive")
 
   direct_model <- stats::lm(y ~ group + X1 + X2, data = df)
   ref <- data.frame(group = factor(levels(df$group), levels = levels(df$group)),
@@ -393,10 +399,10 @@ test_that("Test K: adjusted means equal a direct prediction at the covariates' r
 # ------------------------------------------------------------
 
 test_that("Test L: pairwise adjusted_difference matches the EMM difference within 1e-8", {
-  df <- make_ancova_data(n_per_group = 60, seed = 61, covariate_names = c("X1", "X2"))
+  df <- make_ancova_data(n_per_group = 60, seed = 2026, covariate_names = c("X1", "X2"))
   res <- run_ancova_v2(df, outcome = "y", factor = "group", covariates = c("X1", "X2"), alpha = 0.05)
-  skip_if(res$model_selection$final_model_type != "additive",
-          "final model was interaction for this seed")
+  # Asserted, not skipped -- see the note in Test K.
+  expect_identical(res$model_selection$final_model_type, "additive")
 
   means <- res$adjusted_means$means
   emm_by_group <- stats::setNames(means$estimate, means$group)


### PR DESCRIPTION
## Problem

The [2026-09-05 Windows daily](https://exploratory-devbuild.s3.us-east-1.amazonaws.com/test_results/test_all_result-win-20260905-063957.md) reported **2 skipped R tests**, both in `tests/testthat/test_ancova_v2.R`:

| Test |
|---|
| Test K: adjusted means equal a direct prediction at the covariates' raw-scale means |
| Test L: pairwise adjusted_difference matches the EMM difference within 1e-8 |

## Root cause — not a Windows or dependency issue

Both guard on:

```r
skip_if(res$model_selection$final_model_type != "additive", ...)
```

against a fixture built with a hardcoded `seed = 61`.

`make_ancova_data()` is called **without** `group_slope_offsets`, so the true data-generating process has parallel slopes — but at α = 0.05, seed 61 happens to draw a **Type I error** on the homogeneity-of-slopes test, and selection lands on the interaction model.

R's RNG is deterministic across platforms, so **these two tests have been skipped on every platform since they merged** in `755725e8` ("WIP: Analytics: Update R layer for ANCOVA (#1654)"). Confirmed on macOS:

```
final_model_type : interaction   ->  SKIPS? TRUE
```

There is no `skip_on_os` / `skip_if_not_installed` anywhere in the file. The file's own header is explicit that these were written blind:

> "these tests were written and statically reviewed **WITHOUT access to a working R/Rscript** ... they have **never actually been executed** ... this has **NOT been empirically confirmed** by running the suite."

It was not. Nothing needs installing on the Windows box.

## Change

1. **`seed = 61` → `seed = 2026`**, matching the golden tests elsewhere in the file. A scan of seeds 1–40 selected the additive model **40/40**, so seed 61 is the unlucky outlier rather than the rule.

2. **`skip_if` → `expect_identical(..., "additive")`.** The additive case is not an accident of the seed — it is what the fixture is built to produce, and the Test K oracle is itself an additive `lm()`, so the test is only meaningful there. With a fixed seed the outcome is deterministic, so this should assert.

   As written, a genuine bug in `select_ancova_model()` that wrongly returned `"interaction"` would have presented as a **skip rather than a failure** — fail-open, exactly the pattern `learned.md` warns about.

## Verification

```
failed=0 skipped=0 passed=123      (was 121 passed + 2 skipped)
Test K -> 4 assertions, 0 failed, skipped FALSE
Test L -> 4 assertions, 0 failed, skipped FALSE
```

**Sabotage-checked**, since these assertions had previously run zero times: perturbing the oracle (`X1 = mean(df$X1) + 1`) makes Test K fail 3 assertions. So they bite.

Test-only change; no package code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)