### PR TITLE
K-Medoids: order the Cluster Profile axis before profile_top_n narrows the frame (tam#38492)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.18
-Date: 2026-09-05
+Version: 16.1.19
+Date: 2026-09-06
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -269,8 +269,9 @@
 #' The radar groups variables by the cluster that peaks on them, so that each
 #' cluster's characteristic variables form one contiguous arc: variables whose
 #' peak is cluster 1 come first, then cluster 2's, and so on, ordered within a
-#' group by descending peak value. (`max(value) - 10 * peak_index` -- the fixed
-#' 10 * index term dominates because `standardized_mean` is a z-score.)
+#' group by descending peak value. The peak cluster is an explicit primary sort
+#' key; using a fixed numeric penalty would be incorrect because a z-score is
+#' not bounded by 10.
 #'
 #' This MUST be computed over every (variable, cluster) pair, before
 #' `profile_top_n` narrows the frame to each cluster's most characteristic
@@ -288,10 +289,12 @@
     dplyr::summarize(value = mean(standardized_mean, na.rm = TRUE), .groups = 'drop_last') %>%
     dplyr::arrange(cluster, .by_group = TRUE) %>%
     dplyr::summarize(
-      score = max(value) - 10 * which.max(value),
+      peak_cluster = cluster[which.max(value)],
+      peak_value = max(value),
       .groups = 'drop'
-    )
-  scores$order <- rank(-scores$score, ties.method = 'first')
+    ) %>%
+    dplyr::arrange(peak_cluster, dplyr::desc(peak_value), variable)
+  scores$order <- seq_len(nrow(scores))
   scores[, c('variable', 'order')]
 }
 

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -264,6 +264,37 @@
   result
 }
 
+#' Position of each variable in the Cluster Profile radar's category axis.
+#'
+#' The radar groups variables by the cluster that peaks on them, so that each
+#' cluster's characteristic variables form one contiguous arc: variables whose
+#' peak is cluster 1 come first, then cluster 2's, and so on, ordered within a
+#' group by descending peak value. (`max(value) - 10 * peak_index` -- the fixed
+#' 10 * index term dominates because `standardized_mean` is a z-score.)
+#'
+#' This MUST be computed over every (variable, cluster) pair, before
+#' `profile_top_n` narrows the frame to each cluster's most characteristic
+#' variables (tam#38492). Computed afterwards, a variable that survived in only
+#' some clusters has its peak decided from that partial set -- on a 16-variable,
+#' 4-cluster survey, 9 of 16 variables kept only 2 of their 4 clusters, and one
+#' cluster's variables were split into two arcs on opposite sides of the wheel.
+#'
+#' Returned as a rank column rather than by reordering `variable` itself, so the
+#' column keeps its character class for every other consumer; the chart's
+#' preprocessor turns it into the factor order.
+.kmedoids_profile_variable_order <- function(rows) {
+  scores <- rows %>%
+    dplyr::group_by(variable, cluster) %>%
+    dplyr::summarize(value = mean(standardized_mean, na.rm = TRUE), .groups = 'drop_last') %>%
+    dplyr::arrange(cluster, .by_group = TRUE) %>%
+    dplyr::summarize(
+      score = max(value) - 10 * which.max(value),
+      .groups = 'drop'
+    )
+  scores$order <- rank(-scores$score, ties.method = 'first')
+  scores[, c('variable', 'order')]
+}
+
 .kmedoids_profile <- function(x) {
   mat <- x$mat
   original_mat <- .kmedoids_original_fit_mat(x)
@@ -295,10 +326,13 @@
       overall_mean = as.numeric(original_overall_mean)
     )
   })
+  variable_order <- .kmedoids_profile_variable_order(rows)
   rows %>%
     dplyr::group_by(cluster) %>%
     dplyr::mutate(rank = rank(-effect_size, ties.method = 'first')) %>%
     dplyr::ungroup() %>%
+    dplyr::left_join(variable_order, by = 'variable') %>%
+    dplyr::rename(variable_order = order) %>%
     {
       result <- .
       if (!isTRUE(x$profile_show_all)) {

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -621,3 +621,16 @@ test_that('profile variable_order groups variables by peak cluster, regardless o
   expect_equal(order_of(narrowed), order_of(full))
   expect_equal(runs_around_axis(order_of(narrowed)), dplyr::n_distinct(peak$cluster))
 })
+
+test_that('profile variable_order keeps the peak cluster primary when a z-score exceeds 10', {
+  rows <- tibble::tibble(
+    variable = rep(c('early_peak', 'late_peak'), each = 2),
+    cluster = rep(1:2, 2),
+    standardized_mean = c(0.1, 0, 0, 100)
+  )
+
+  ordered <- exploratory:::.kmedoids_profile_variable_order(rows)
+
+  expect_equal(ordered$variable, c('early_peak', 'late_peak'))
+  expect_equal(ordered$order, c(1, 2))
+})

--- a/tests/testthat/test_kmedoids.R
+++ b/tests/testthat/test_kmedoids.R
@@ -570,3 +570,54 @@ test_that('silhouette_sample_size is only validated when a silhouette is compute
                                silhouette_sample_size = 2, seed = 1),
     'silhouette_sample_size must be greater than the number of clusters')
 })
+
+test_that('profile variable_order groups variables by peak cluster, regardless of profile_top_n (tam#38492)', {
+  # The Cluster Profile radar orders its category axis by variable_order so that each
+  # cluster's characteristic variables form one contiguous arc. profile_top_n keeps only
+  # each cluster's most characteristic variables, so a variable can survive for some
+  # clusters and not others -- the order must therefore be decided BEFORE that filter,
+  # or the peak cluster is read off a partial set and the arc breaks apart.
+  set.seed(11)
+  n <- 400
+  n_var <- 12
+  n_cluster <- 3
+  group <- sample(seq_len(n_cluster), n, replace = TRUE)
+  values <- matrix(3, n, n_var)
+  for (i in seq_len(n)) {
+    block <- ((group[i] - 1) * 4 + 1):((group[i] - 1) * 4 + 4)
+    values[i, block] <- values[i, block] + 1.2
+  }
+  noisy <- values + matrix(stats::rnorm(n * n_var, 0, 0.8), n, n_var)
+  df <- as.data.frame(matrix(round(pmin(5, pmax(1, as.vector(noisy)))), n, n_var))
+  names(df) <- paste0('V', sprintf('%02d', seq_len(n_var)))
+
+  fit <- function(show_all, top_n) {
+    result <- df %>% exploratory:::exp_kmedoids(
+      !!!rlang::syms(names(df)),
+      centers = n_cluster, seed = 1,
+      profile_show_all = show_all, profile_top_n = top_n
+    )
+    broom::tidy(result$model[[1]], type = 'profile')
+  }
+  order_of <- function(profile) {
+    unique(profile[order(profile$variable_order), ][['variable']])
+  }
+  # Independent oracle: the cluster whose standardized mean is highest for that variable,
+  # taken from every (variable, cluster) pair -- never from the filtered frame.
+  full <- fit(TRUE, 12)
+  peak <- full %>%
+    dplyr::group_by(variable) %>%
+    dplyr::slice_max(standardized_mean, n = 1, with_ties = FALSE) %>%
+    dplyr::ungroup()
+  runs_around_axis <- function(variables) {
+    clusters <- peak$cluster[match(variables, peak$variable)]
+    sum(clusters != c(clusters[-1], clusters[1]))
+  }
+
+  narrowed <- fit(FALSE, 4)
+  expect_lt(nrow(narrowed), nrow(full))            # the filter really did narrow the frame
+  expect_true(any(table(narrowed$variable) < n_cluster))  # ... per (variable, cluster), not per variable
+
+  expect_equal(order_of(narrowed), order_of(full))
+  expect_equal(runs_around_axis(order_of(narrowed)), dplyr::n_distinct(peak$cluster))
+})


### PR DESCRIPTION
Ordering fix for the K-Medoids **Cluster Profile** radar, driven by exploratory-io/tam#38492.

## Problem

`.kmedoids_profile()` applies `filter(rank <= profile_top_n)` itself when `profile_show_all` is FALSE — **the default** — so the chart's preprocessor in tam never sees the full frame. It was computing each variable's peak cluster (the thing that groups the radar axis into one arc per cluster) from whatever clusters happened to survive that filter.

On the reporting customer's data (1,500 rows, 16 Likert variables, `centers = 4`, `normalize_data = TRUE`) the tidier returned 40 of the 64 `(variable, cluster)` pairs:

| clusters still present for a variable | 1 | 2 | 3 | 4 |
| --- | --- | --- | --- | --- |
| variables | 1 | **9** | 3 | 3 |

`which.max()` then read the peak off a partial set and cluster 2's variables were split into two arcs on opposite sides of the wheel.

This cannot be fixed on the tam side: the narrowing happens here, before the preprocessor runs, and a preprocessor cannot call `tidy_rowwise(model, ...)` a second time to fetch the unfiltered frame.

## Change

- New `.kmedoids_profile_variable_order()` computes the peak-cluster score over **every** `(variable, cluster)` pair, before the top-N filter.
- `.kmedoids_profile()` returns it as a `variable_order` rank column.

Returned as a column rather than by reordering `variable` into a factor here, so `variable` keeps its character class for every other consumer, and the chart's own ordering stays visible in its template (which is what tam's `AnalyticsCategoryAxisOrdering` guard test checks for).

## Verification

Measured on the customer's own data — peak-cluster changes around the axis, 3 is optimal there (cluster 1 peaks on no variable, so it owns no arc):

| chart | before | after |
| --- | --- | --- |
| Cluster Profile (`radar`) | 5 | **3**, level-for-level identical to the Medoid Values radar |

With `profile_show_all = TRUE` the order is unchanged (already 3) — the R-side order is now identical either way, which is what the new test pins.

`test_kmedoids.R` passes in full. The new test was sabotage-checked: computing `variable_order` after the filter instead of before makes it fail.

## Paired change

exploratory-io/tam#38494 switches the `radar` preprocessor to `forcats::fct_reorder(variable, variable_order)`. It needs the package version that includes this column, so `requiredRPackagesReduced.json` has to pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
