### PR TITLE
LCA: derive the answer-category class composition from the model (tam#38502)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.19
-Date: 2026-09-06
+Version: 16.1.20
+Date: 2026-09-07
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/lca.R
+++ b/R/lca.R
@@ -26,7 +26,7 @@ exp_lca <- function(df, ...,
                     max_nclass = 6,
                     nrep = 20,
                     max_nrep = 50,
-                    maxiter = 5000,
+                    maxiter = 1000,
                     seed = 1,
                     relationship_column = NULL,
                     feature_top_n = 10,
@@ -168,10 +168,6 @@ exp_lca <- function(df, ...,
 
     class_selection <- lca_class_selection_table(candidates)
     profiles <- lca_profile_table(selected, original[complete_rows, selected_cols, drop = FALSE], selected_cols)
-    discrimination <- profiles %>%
-      dplyr::group_by(variable, category) %>%
-      dplyr::summarise(max_minus_min_probability = max(probability) - min(probability), .groups = "drop") %>%
-      dplyr::arrange(dplyr::desc(max_minus_min_probability), variable, category)
     characteristics <- profiles %>%
       dplyr::group_by(class) %>%
       dplyr::arrange(dplyr::desc(abs_difference), variable, category, .by_group = TRUE) %>%
@@ -179,8 +175,8 @@ exp_lca <- function(df, ...,
       dplyr::filter(rank <= feature_top_n) %>%
       dplyr::ungroup()
     row_assignments <- lca_assignment_table(original, used_row_ids, selected)
-    class_distribution <- lca_class_distribution_table(original, selected_cols, used_row_ids,
-                                                       selected$predclass, length(selected$P))
+    class_distribution <- lca_class_composition_table(selected, original[complete_rows, selected_cols, drop = FALSE],
+                                                      selected_cols)
     variable_discrimination <- calculate_lca_variable_discrimination(profiles)
     relationship <- lca_relationship_table(original, used_row_ids, selected$predclass, relationship_col)
 
@@ -204,7 +200,6 @@ exp_lca <- function(df, ...,
       class_selection = class_selection,
       profiles = profiles,
       characteristics = characteristics,
-      discrimination = discrimination,
       variable_discrimination = variable_discrimination,
       class_distribution = class_distribution,
       row_assignments = row_assignments,
@@ -747,36 +742,40 @@ lca_assignment_table <- function(original, used_row_ids, fit) {
     dplyr::select(-.lca_row_id)
 }
 
-# tam#38419: how the assigned classes are distributed WITHIN each answer category, for
-# every indicator variable at once. The report renders it as a 100% stacked bar faceted by
-# variable, so what matters here is the count per (variable, category, class) cell -- the
-# ratio is a chart-side window function, not something to precompute (see the spec loop's
-# "Ratio + Total: window function, never a static R column" rule).
+# tam#38502: the class composition of an answer category is a property of the MODEL, not of
+# the hard assignments, so it is derived straight from the fit:
 #
-# Rows EXCLUDED from the estimation are kept, with class NA. They are a real part of the
-# picture: an answer category answered only by rows that were dropped for missingness
-# elsewhere shows up as a full-height (NA) band rather than silently disappearing, which
-# is what the spec's reference chart shows.
+#   P(C = c | Y_j = r) = P(C = c) P(Y_j = r | C = c) / sum_c' P(C = c') P(Y_j = r | C = c')
 #
-# tidyr::complete() fills unobserved (category, class) combinations with 0 so a missing
-# cell is drawn as absent rather than collapsing the stack.
-lca_class_distribution_table <- function(original, cols, used_row_ids, predclass, nclass) {
-  class_levels <- paste("Class", seq_len(nclass))
-  assigned <- tibble::tibble(.lca_row_id = used_row_ids, class = paste("Class", predclass))
-  base <- original %>%
-    dplyr::select(dplyr::all_of(c(".lca_row_id", cols))) %>%
-    dplyr::left_join(assigned, by = ".lca_row_id")
+# Both factors are already estimated -- fit$P (class shares) and fit$probs[[col]] (class x
+# category conditional response probabilities) -- so no pass over the rows is needed at all.
+# tam#38419's predecessor counted argmax-assigned rows instead, which is why it had to carry
+# an (NA) class band for rows excluded from estimation and an (NA) category bar for rows that
+# skipped that one question. Neither is a quantity the model asserts, and the spec asks for a
+# chart whose every category bar is a clean 100%; both disappear by construction here.
+#
+# The denominator is exactly lca_profile_table()'s model_overall_probability, so the two
+# tables reconcile: class_composition * model_overall_probability == P(C=c) * probability.
+lca_class_composition_table <- function(fit, observed, cols) {
+  class_shares <- fit$P
+  class_levels <- paste("Class", seq_along(class_shares))
   dplyr::bind_rows(lapply(cols, function(col) {
-    levels <- lca_indicator_levels(original[[col]])
-    counted <- base %>%
-      dplyr::transmute(
-        category = factor(as.character(.data[[col]]), levels = levels),
-        class = factor(class, levels = class_levels)
-      ) %>%
-      dplyr::count(category, class, name = "rows")
-    tidyr::complete(counted, category, class, fill = list(rows = 0L)) %>%
-      dplyr::mutate(variable = col) %>%
-      dplyr::select(variable, category, class, rows)
+    levels <- lca_indicator_levels(observed[[col]])
+    probabilities <- fit$probs[[col]]
+    # probabilities is class x category, so multiplying by the class-share vector recycles
+    # down the ROWS -- one share per class -- giving the joint P(C=c, Y=r) cell by cell.
+    joint <- probabilities * class_shares
+    overall <- colSums(joint)
+    # A category the model gives zero marginal probability to has no composition to report.
+    # poLCA does not produce an all-zero column for a category that occurs in the data, but
+    # dividing by it would silently emit NaN rather than a value a reader could question.
+    composition <- sweep(joint, 2, ifelse(overall > 0, overall, NA_real_), "/")
+    tibble::tibble(
+      variable = col,
+      category = factor(rep(levels, each = nrow(composition)), levels = levels),
+      class = factor(rep(class_levels, times = length(levels)), levels = class_levels),
+      class_composition = as.vector(composition)
+    )
   }))
 }
 
@@ -852,10 +851,9 @@ tidy.lca_exploratory <- function(x, type = "summary", ...) {
   }
   if (type == "profiles") return(x$profiles)
   if (type == "characteristics") return(x$characteristics)
-  if (type == "discrimination") return(x$discrimination)
-  # tam#38418: per-VARIABLE discrimination (mean pairwise TVD). Distinct from the
-  # "discrimination" type above, which is per variable AND category (max - min response
-  # probability) and feeds the "Class-Characterizing Categories" chart.
+  # tam#38418: per-VARIABLE discrimination (mean pairwise TVD). tam#38502 removed the
+  # sibling per-variable-AND-category "discrimination" type together with the
+  # "Class-Characterizing Categories" chart it existed for.
   if (type == "variable_discrimination") return(x$variable_discrimination)
   if (type == "variable_discrimination_pairs") {
     pairs <- attr(x$variable_discrimination, "pairwise")

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -44,7 +44,9 @@ test_that("exp_lca selects a BIC-minimum categorical model and exposes its repor
   profile_sums <- as.numeric(tapply(profiles$probability, interaction(profiles$variable, profiles$class, drop = TRUE), sum))
   expect_equal(profile_sums, rep(1, length(profile_sums)), tolerance = 1e-8)
   expect_equal(nrow(tidy(model, type = "characteristics")), glance(model)$selected_classes * 2)
-  expect_true(all(tidy(model, type = "discrimination")$max_minus_min_probability >= 0))
+  # tam#38502 deleted the per-variable-AND-category "discrimination" type along with the
+  # "Class-Characterizing Categories" chart that was its only consumer.
+  expect_error(tidy(model, type = "discrimination"), "Unknown tidy type")
 
   assignments <- tidy(model, type = "data")
   expect_equal(nrow(assignments), nrow(df))
@@ -796,13 +798,29 @@ test_that("exp_lca exposes per-variable discrimination and a class distribution 
   nclass <- length(model$selected_fit$P)
   expect_equal(nrow(pairs), 3 * choose(nclass, 2))
 
+  # tam#38502: the composition comes from the MODEL, not from the argmax assignments, so it
+  # is a probability per (variable, category, class) that sums to 1 within each answer
+  # category -- and it carries no NA class and no NA category, because neither the excluded
+  # rows nor a missing answer is something the model asserts a composition for.
   distribution <- tidy(model, type = "class_distribution")
-  expect_equal(names(distribution), c("variable", "category", "class", "rows"))
-  # Every (variable, category, class) cell exists, including the NA class carrying the
-  # rows excluded from the estimation, and every original row is accounted for exactly
-  # once per variable.
-  expect_true(any(is.na(distribution$class)))
-  per_variable <- distribution %>% dplyr::group_by(variable) %>%
-    dplyr::summarise(total = sum(rows), .groups = "drop")
-  expect_true(all(per_variable$total == nrow(df)))
+  expect_equal(names(distribution), c("variable", "category", "class", "class_composition"))
+  expect_false(any(is.na(distribution$class)))
+  expect_false(any(is.na(distribution$category)))
+  expect_true(all(distribution$class_composition >= 0 & distribution$class_composition <= 1))
+  composition_sums <- as.numeric(tapply(distribution$class_composition,
+                                        interaction(distribution$variable, distribution$category, drop = TRUE), sum))
+  expect_equal(composition_sums, rep(1, length(composition_sums)), tolerance = 1e-8)
+
+  # It reconciles with the profile table it shares a denominator with:
+  #   class_composition * P(Y = r) == P(C = c) * P(Y = r | C = c)
+  profiles <- tidy(model, type = "profiles")
+  shares <- tidy(model, type = "summary")
+  joined <- distribution %>%
+    dplyr::mutate(class = as.character(class), category = as.character(category)) %>%
+    dplyr::inner_join(profiles %>% dplyr::mutate(class = as.character(class), category = as.character(category)),
+                      by = c("variable", "category", "class")) %>%
+    dplyr::inner_join(shares %>% dplyr::transmute(class = as.character(class), class_share = share), by = "class")
+  expect_equal(nrow(joined), nrow(distribution))
+  expect_equal(joined$class_composition * joined$model_overall_probability,
+               joined$class_share * joined$probability, tolerance = 1e-8)
 })


### PR DESCRIPTION
Paired with tam#38502 (LCA Analytics Report Part 3). tam PR follows.

## What changes

### 1. `class_distribution` becomes a model-derived composition

`lca_class_distribution_table()` counted argmax-assigned rows per
`(variable, category, class)`. It is replaced by `lca_class_composition_table()`,
which derives

```
P(C = c | Y_j = r) = P(C = c) P(Y_j = r | C = c) / sum_c' P(C = c') P(Y_j = r | C = c')
```

directly from `fit$P` and `fit$probs[[col]]`. Both factors are already estimated, so
there is no pass over the rows at all.

Two consequences the report reader sees directly:

- **no `(NA)` class band** — those were rows the estimation excluded, and the model
  asserts no composition for a row it never saw;
- **no `(NA)` answer category** — same reason.

Neither is filtered away; neither exists. `tidy(type = "class_distribution")` keeps its
name but returns `variable / category / class / class_composition` (the `rows` column is
gone).

The denominator is exactly `lca_profile_table()`'s `model_overall_probability`, so the two
tables reconcile:

```
class_composition * model_overall_probability == P(C=c) * probability
```

That identity is the test that matters. A per-category "sums to 1" check passes even when
the class order is reversed (a transposed matrix keeps every column sum) — which is the
exact shape of the melt bug #1647 hit on the sibling table. Sabotage-checked: reversing the
class order in the melt fails the reconciliation assertion (14/27 mismatches) while the
sum-to-1 assertion still passes.

### 2. The per-category `discrimination` table is deleted

tam#38502 deletes the Class-Characterizing Categories chart, the only consumer of
`x$discrimination` / `tidy(type = "discrimination")`. The spec also asked whether removing
it improves performance, so it was measured rather than asserted — `exp_lca()`, 3 runs per
fixture, same machine and seed, master vs this branch:

| fixture | before (median) | after (median) |
|---|---|---|
| `segmented_survey.csv`, 5 vars | 4.35s | 4.28s |
| `lca_japanese_survey_600.csv`, 6 vars | 2.33s | 2.45s |

**No measurable improvement** — the difference is inside run-to-run noise. The deleted
block was one `group_by`/`summarise` over a few hundred profile rows; essentially all the
time is poLCA EM fitting. This is a scope change, not a performance fix.

### 3. `maxiter` default 5000 -> 1000

Per the spec, kept in sync with the tam JSON default, the codegen default and
`tools/analytics_r_formals.json`.

## Tests

`tests/testthat/test_lca.R` — 182 assertions passing. New/changed coverage: the column
contract, the per-category sum-to-1, the profile reconciliation above, absence of NA class
and NA category, and `expect_error(tidy(type = "discrimination"), "Unknown tidy type")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)