### PR TITLE
Ship the eta-squared variable ranking with the cluster per-observation frames (tam#38491)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.20
+Version: 16.1.21
 Date: 2026-09-07
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/cluster_variable_importance.R
+++ b/R/cluster_variable_importance.R
@@ -39,3 +39,39 @@ cluster_variable_importance_anova <- function(mat, cluster_ids) {
     )
   })
 }
+
+# Rank of each clustering variable by "characteristic-ness", as an integer order column.
+# tam#38491.
+#
+# The eta-squared ranking is what the "Characteristic Variables" bar chart shows, but the
+# sibling charts drawn from OTHER tidiers (the per-observation boxplot's colour legend, the
+# per-variable detail table) had no way to reach it: a chart preprocessor cannot call
+# `tidy_rowwise(model, ...)` twice, so the ranking cannot be joined in on the tam side. It
+# therefore has to travel WITH the frame that needs it, the same way #38492 shipped the
+# Cluster Profile axis order as a `variable_order` column.
+#
+# Returned as a rank column rather than by reordering `variable` itself, so `variable` keeps
+# its character class for every other consumer; the chart preprocessor turns the rank into
+# the factor order with `forcats::fct_reorder()`.
+#
+# @param mat a numeric matrix, one column per clustering variable (same argument as
+#   `cluster_variable_importance_anova()`).
+# @param cluster_ids a vector giving each row's cluster assignment.
+# @param variables optional character vector of variable names the caller needs an order for.
+#   Names not present in `mat` (so not rankable by eta-squared) are appended after the ranked
+#   ones in name order, so the returned map always covers every requested name and a
+#   downstream `fct_reorder()` never sees an NA rank.
+# @return a tibble with columns: variable, importance_order (1 = most characteristic).
+cluster_variable_importance_order <- function(mat, cluster_ids, variables = NULL) {
+  ranked <- cluster_variable_importance_anova(mat, cluster_ids) %>%
+    dplyr::arrange(dplyr::desc(eta_squared), variable)
+  names_in_order <- ranked$variable
+  if (!is.null(variables)) {
+    extra <- sort(setdiff(as.character(variables), names_in_order))
+    names_in_order <- c(names_in_order, extra)
+  }
+  tibble::tibble(
+    variable = names_in_order,
+    importance_order = seq_along(names_in_order)
+  )
+}

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -432,6 +432,9 @@
 .kmedoids_representative_values <- function(x) {
   ids <- x$clustering
   original_mat <- .kmedoids_original_fit_mat(x)
+  # tam#38491: same rank the Characteristic Variables bar sorts by, so the table can list
+  # each cluster's variables in that order instead of the fitted-column order.
+  importance_order <- cluster_variable_importance_order(x$mat, x$clustering, colnames(original_mat))
   purrr::map_dfr(sort(unique(ids)), function(cluster_id) {
     index <- which(ids == cluster_id)
     medoid_index <- x$medoid_indices[[cluster_id]]
@@ -444,7 +447,8 @@
       overall_median = apply(original_mat, 2, stats::median, na.rm = TRUE),
       overall_mean = colMeans(original_mat, na.rm = TRUE)
     )
-  })
+  }) %>%
+    dplyr::left_join(importance_order, by = 'variable')
 }
 
 #' Per-row, per-variable distribution rows (tam#37938: クラスター内のばらつき boxplot,

--- a/R/kmedoids.R
+++ b/R/kmedoids.R
@@ -478,13 +478,24 @@
   standardized_mat <- x$mat
   n <- nrow(original_mat)
   p <- ncol(original_mat)
-  tibble::tibble(
+  rows <- tibble::tibble(
     cluster = rep(as.integer(ids), each = p),
     variable = rep(colnames(original_mat), times = n),
     value = as.numeric(t(original_mat)),
     standardized_value = as.numeric(t(standardized_mat)),
     is_medoid = rep(seq_len(n) %in% medoid_indices, each = p)
   )
+  # tam#38491: the boxplot's colour legend is one entry per variable and had no order of its
+  # own, so it fell back to the character collation order while the "Characteristic Variables"
+  # bar right above it was sorted by eta-squared. Ship the eta-squared rank alongside the rows
+  # so the chart preprocessor can turn `variable` into a factor in that same order. Same
+  # `x$mat` / `x$clustering` the type='variable_importance' tidier ranks, so the two charts
+  # cannot disagree.
+  rows %>%
+    dplyr::left_join(
+      cluster_variable_importance_order(x$mat, x$clustering, colnames(original_mat)),
+      by = 'variable'
+    )
 }
 
 .kmedoids_cohesion <- function(x) {

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -1132,6 +1132,20 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
           x$kmeans$cluster,
           column_names
         ) %>% dplyr::rename(key = variable)
+
+        # `res` intentionally keeps non-clustering columns so the parallel-coordinate
+        # chart can use a subject column. If one of those columns is already named
+        # `importance_order`, dplyr would suffix the joined rank to `.y` and leave the
+        # user's column as `.x`, violating the tidier contract that the chart rank is
+        # available as `importance_order`. Preserve the input column under a unique name
+        # before adding the generated rank.
+        if ("importance_order" %in% colnames(res)) {
+          preserved_name <- "input_importance_order"
+          while (preserved_name %in% colnames(res)) {
+            preserved_name <- paste0(".", preserved_name)
+          }
+          names(res)[names(res) == "importance_order"] <- preserved_name
+        }
         res <- res %>% dplyr::left_join(importance_order, by = "key")
       }
     }

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -1118,6 +1118,22 @@ tidy.prcomp_exploratory <- function(x, type="variances", n_sample=NULL, pretty.n
       # res <- res %>% dplyr::select(!!c(column_names,"cluster"))
       res <- res %>% dplyr::mutate(row_id=seq(n())) # row_id for line representation.
       res <- res %>% tidyr::gather(key="key",value="value",!!column_names)
+      # tam#38491: carry the eta-squared rank of each clustering variable (the order the
+      # "Characteristic Variables" bar shows) so the charts built from this frame -- the
+      # BoxPlot's colour legend above all -- can order their variable axis the same way
+      # instead of falling back to character collation. A chart preprocessor cannot call
+      # tidy_rowwise(model, ...) a second time, so the rank has to travel with the rows.
+      # Only computable when a k-means fit is attached; a pure-PCA gather leaves the column
+      # out entirely rather than emitting a meaningless order.
+      if (!is.null(x$kmeans) && !is.null(x$df) && !is.null(x$selected_cols) &&
+          length(x$selected_cols) > 0) {
+        importance_order <- cluster_variable_importance_order(
+          as_numeric_matrix_(x$df, columns = x$selected_cols),
+          x$kmeans$cluster,
+          column_names
+        ) %>% dplyr::rename(key = variable)
+        res <- res %>% dplyr::left_join(importance_order, by = "key")
+      }
     }
   }
   res

--- a/tests/testthat/test_kmeans_1.R
+++ b/tests/testthat/test_kmeans_1.R
@@ -18,7 +18,7 @@ test_that("exp_kmeans", {
   res <- model_df %>% tidy_rowwise(model, type="gathered_data", normalize_data=TRUE, n_sample=20)
   expect_equal(colnames(res),
                c("disp","drat","wt","qsec","vs","am","gear","carb","new_col","cluster","PC1","PC2","PC3","row_id","key",
-                 "value"))
+                 "value","importance_order")) # importance_order: eta-squared rank of `key`, tam#38491
 })
 
 test_that("exp_kmeans with strange column name", {
@@ -45,7 +45,7 @@ test_that("exp_kmeans with strange column name", {
   res <- model_df %>% tidy_rowwise(model, type="gathered_data", normalize_data=TRUE, n_sample=100) # testing n_sample more than nrow()
   expect_equal(colnames(res),
                c("disp","drat","wt","qsec","vs","am","gear","carb","new_col","cluster","PC1","PC2","PC3","row_id","key",
-                 "value"))
+                 "value","importance_order")) # importance_order: eta-squared rank of `key`, tam#38491
 })
 
 test_that("exp_kmeans with single column name", {
@@ -57,7 +57,8 @@ test_that("exp_kmeans with single column name", {
   model_df %>% tidy_rowwise(model, type="gathered_data")
   res <- model_df %>% tidy_rowwise(model, type="gathered_data", normalize_data=TRUE, n_sample=100) # testing n_sample more than nrow()
   expect_equal(colnames(res),
-               c("cyl","disp","hp","drat","wt","qsec","vs","am","gear","carb","cluster","PC1","row_id","key","value"))
+               c("cyl","disp","hp","drat","wt","qsec","vs","am","gear","carb","cluster","PC1","row_id","key","value",
+                 "importance_order")) # importance_order: eta-squared rank of `key`, tam#38491
 })
 
 test_that("exp_kmeans elbow method mode", {

--- a/tests/testthat/test_kmeans_variable_importance.R
+++ b/tests/testthat/test_kmeans_variable_importance.R
@@ -137,3 +137,68 @@ test_that('.kmeans_variable_importance is a thin wrapper reusing cluster_variabl
   )
   expect_equal(wrapper_result, direct_result)
 })
+
+# tam#38491: the same eta-squared ranking has to reach the charts that are NOT built from
+# type='variable_importance' -- the K-Means BoxPlot and the K-Medoids Distributions boxplot,
+# whose colour legend is one entry per variable. A chart preprocessor cannot call
+# tidy_rowwise(model, ...) twice, so the ranking rides along as an `importance_order` column
+# on the per-observation frames. These tests pin that the two frames agree with the ranking
+# chart, not merely that the column exists.
+
+test_that('gathered_data carries importance_order matching the variable_importance ranking (tam#38491)', {
+  set.seed(1)
+  model_df <- iris %>% exp_kmeans(Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+                                  centers = 3, seed = 1)
+  model <- model_df$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+  gathered <- broom::tidy(model, type = 'gathered_data', normalize_data = TRUE)
+
+  expect_true('importance_order' %in% colnames(gathered))
+  # One order per variable, and no variable left without one.
+  per_variable <- gathered %>%
+    dplyr::distinct(key, importance_order) %>%
+    dplyr::arrange(importance_order)
+  expect_equal(nrow(per_variable), dplyr::n_distinct(gathered$key))
+  expect_false(any(is.na(per_variable$importance_order)))
+  expect_equal(per_variable$importance_order, seq_len(nrow(per_variable)))
+  # The order IS the eta-squared ranking the Characteristic Variables bar shows.
+  expected <- vi %>% dplyr::arrange(dplyr::desc(eta_squared), variable)
+  expect_equal(per_variable$key, expected$variable)
+})
+
+test_that('K-Medoids distribution carries the same importance_order contract (tam#38491)', {
+  set.seed(1)
+  result <- iris %>% exploratory:::exp_kmedoids(
+    Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+    centers = 3, distance = 'euclidean', normalize_data = TRUE, seed = 1
+  )
+  model <- result$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+  distribution <- broom::tidy(model, type = 'distribution')
+
+  expect_true('importance_order' %in% colnames(distribution))
+  per_variable <- distribution %>%
+    dplyr::distinct(variable, importance_order) %>%
+    dplyr::arrange(importance_order)
+  expect_equal(nrow(per_variable), dplyr::n_distinct(distribution$variable))
+  expect_false(any(is.na(per_variable$importance_order)))
+  expected <- vi %>% dplyr::arrange(dplyr::desc(eta_squared), variable)
+  expect_equal(per_variable$variable, expected$variable)
+  # Adding the column must not change the rows the boxplot plots.
+  expect_equal(nrow(distribution), nrow(iris) * 4)
+})
+
+test_that('cluster_variable_importance_order covers names absent from the fitted matrix (tam#38491)', {
+  set.seed(3)
+  mat <- as.matrix(iris[, c('Sepal.Length', 'Sepal.Width')])
+  ids <- rep(1:3, length.out = nrow(mat))
+  ordered <- exploratory:::cluster_variable_importance_order(
+    mat, ids, c('Sepal.Length', 'Sepal.Width', 'Not.Fitted')
+  )
+
+  expect_equal(ordered$importance_order, 1:3)
+  expect_setequal(ordered$variable, c('Sepal.Length', 'Sepal.Width', 'Not.Fitted'))
+  # An unrankable name goes last, never NA -- a downstream forcats::fct_reorder() on an NA
+  # rank would silently scatter that level.
+  expect_equal(ordered$variable[[3]], 'Not.Fitted')
+})

--- a/tests/testthat/test_kmeans_variable_importance.R
+++ b/tests/testthat/test_kmeans_variable_importance.R
@@ -166,6 +166,27 @@ test_that('gathered_data carries importance_order matching the variable_importan
   expect_equal(per_variable$key, expected$variable)
 })
 
+test_that('gathered_data preserves a colliding input importance_order column', {
+  set.seed(1)
+  df <- iris %>% dplyr::mutate(
+    importance_order = paste0('subject-', dplyr::row_number())
+  )
+  model <- df %>% exp_kmeans(Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+                             centers = 3, seed = 1) %>%
+    dplyr::pull(model) %>%
+    purrr::pluck(1)
+
+  gathered <- broom::tidy(model, type = 'gathered_data')
+
+  # The generated rank keeps its contract name, while the original subject column is
+  # retained under a deterministic non-conflicting name.
+  expect_true('importance_order' %in% colnames(gathered))
+  expect_true('input_importance_order' %in% colnames(gathered))
+  expect_true(is.numeric(gathered$importance_order))
+  expect_false(any(is.na(gathered$importance_order)))
+  expect_true(all(grepl('^subject-', gathered$input_importance_order)))
+})
+
 test_that('K-Medoids distribution carries the same importance_order contract (tam#38491)', {
   set.seed(1)
   result <- iris %>% exploratory:::exp_kmedoids(

--- a/tests/testthat/test_kmeans_variable_importance.R
+++ b/tests/testthat/test_kmeans_variable_importance.R
@@ -202,3 +202,23 @@ test_that('cluster_variable_importance_order covers names absent from the fitted
   # rank would silently scatter that level.
   expect_equal(ordered$variable[[3]], 'Not.Fitted')
 })
+
+test_that('K-Medoids representative_values carries importance_order too (tam#38491)', {
+  set.seed(1)
+  result <- iris %>% exploratory:::exp_kmedoids(
+    Sepal.Length, Sepal.Width, Petal.Length, Petal.Width,
+    centers = 3, distance = 'euclidean', normalize_data = TRUE, seed = 1
+  )
+  model <- result$model[[1]]
+  vi <- broom::tidy(model, type = 'variable_importance')
+  rep_values <- broom::tidy(model, type = 'representative_values')
+
+  expect_true('importance_order' %in% colnames(rep_values))
+  per_variable <- rep_values %>%
+    dplyr::distinct(variable, importance_order) %>%
+    dplyr::arrange(importance_order)
+  expected <- vi %>% dplyr::arrange(dplyr::desc(eta_squared), variable)
+  expect_equal(per_variable$variable, expected$variable)
+  # One row per (cluster, variable) still -- the join must not duplicate rows.
+  expect_equal(nrow(rep_values), 3 * 4)
+})


### PR DESCRIPTION
## Why

tam#38491. Inside one K-Medoids report the same set of variables was shown in three different orders:

- 「クラスターの違いを特徴づける変数」 (bar) — eta-squared descending (the viz sorts by the plotted value)
- 「変数の詳細」 (table) — the fitted-column order (a table keeps the tibble row order; there is no sort option)
- 「クラスター内のばらつき」 (boxplot) — the colour legend fell back to character collation order

The ranking exists (`tidy(type='variable_importance')`), but the charts that need it are built from
*other* tidiers, and a tam chart preprocessor cannot call `tidy_rowwise(model, ...)` a second time —
so it cannot be joined in on the tam side. Same situation #38492 hit with the Cluster Profile axis,
and the same fix shape: the rank rides along with the frame that needs it.

## What

- `cluster_variable_importance_order()` — new shared helper next to the shared ANOVA one
  (`cluster_variable_importance_anova()`), so K-Means and K-Medoids cannot drift apart.
  Returns `variable` + `importance_order` (1 = most characteristic; eta-squared desc, ties by name).
  Names not present in the fitted matrix are appended in name order rather than left NA — an NA rank
  would scatter that level in a downstream `forcats::fct_reorder()`.
- `.kmedoids_distribution()` — joins the rank (computed from the same `x$mat` / `x$clustering` the
  `type='variable_importance'` tidier ranks, so the two charts cannot disagree).
- `.kmedoids_representative_values()` — same rank, so the per-cluster table can list variables in
  report order instead of fitted-column order.
- `tidy.prcomp_exploratory(type="gathered_data")` — same `importance_order` column, only when a
  k-means fit is attached (a pure-PCA gather leaves it out rather than emitting a meaningless order).

`Version: 16.1.21`.

## Tests

`tests/testthat/test_kmeans_variable_importance.R`:

- `gathered_data` and `distribution` and `representative_values` each carry `importance_order`,
  it is complete (no NA), one value per variable, and it reproduces
  `tidy(type='variable_importance') %>% arrange(desc(eta_squared), variable)` exactly.
- the join must not duplicate rows (`nrow` pinned).
- `cluster_variable_importance_order()` appends an unrankable name last, never NA.

Sabotage-checked: removing either `left_join` makes the new tests fail (4 failures), and the
existing `test_kmeans_1.R` column-set assertions were updated for the new `gathered_data` column.

Ran green: `test_kmeans_variable_importance.R`, `test_kmeans_1.R`, `test_kmeans_3.R`,
`test_kmedoids.R`, `test_prcomp.R`. (`test_kmeans_2.R` fails on this machine before the change too —
it downloads a Dropbox CSV and `digest` is missing locally.)

## Consumer

tam PR https://github.com/exploratory-io/tam/pull/38493 uses the column; it must not merge before
this package version is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)