### PR TITLE
fix: treat empty-string target value as missing in calc_feature_imp (#38309)

### DIFF
--- a/R/randomForest_tidiers.R
+++ b/R/randomForest_tidiers.R
@@ -2127,9 +2127,20 @@ cleanup_df <- function(df, target_col, selected_cols, grouped_cols, target_n, pr
   clean_cols <- name_map[cols]
 
   if (!is.numeric(clean_df[[clean_target_col]]) && !is.logical(clean_df[[clean_target_col]])) {
+    # Treat an empty-string target value as missing, same as NA. Without this, "" survives as its
+    # own factor level here and is only filtered out later if it happens to be NA -- and
+    # ranger::ranger()'s OOB-error post-processing crashes with "subscript out of bounds" when the
+    # target factor has a "" level: R's matrix `[` can never select a column literally named ""
+    # by name, even though `colnames(result$predictions) <- unique(y)` did create one (tam #38309).
+    target_col_data <- clean_df[[clean_target_col]]
+    if (is.factor(target_col_data)) {
+      levels(target_col_data)[levels(target_col_data) == ""] <- NA
+    } else if (is.character(target_col_data)) {
+      target_col_data[target_col_data == ""] <- NA_character_
+    }
     # limit the number of levels in factor by fct_lump
     clean_df[[clean_target_col]] <- forcats::fct_lump(
-      as.factor(clean_df[[clean_target_col]]), n = target_n, ties.method="first"
+      as.factor(target_col_data), n = target_n, ties.method="first"
     )
   }
 

--- a/tests/testthat/test_randomForest_tidiers_1.R
+++ b/tests/testthat/test_randomForest_tidiers_1.R
@@ -602,6 +602,39 @@ test_that("calc_feature_imp defaults leave mtry/max.depth as ranger auto-default
   expect_equal(result$model[[1]]$max.depth, 0)
 })
 
+test_that("calc_feature_imp does not crash with 'subscript out of bounds' when the character target contains empty strings (tam #38309)", {
+  # ranger::ranger()'s own OOB-error post-processing crashes trying to select a column literally
+  # named "" from its predictions matrix by name -- R's matrix `[` never matches an empty-string
+  # name even when such a column exists. calc_feature_imp() must treat "" in the target the same
+  # as NA (dropping those rows) so this level never reaches ranger.
+  set.seed(1)
+  nrow <- 200
+  test_data <- data.frame(
+    target = sample(c("A", "B", "C", ""), nrow, replace = TRUE, prob = c(0.4, 0.3, 0.25, 0.05)),
+    x1 = rnorm(nrow),
+    x2 = sample(letters[1:5], nrow, replace = TRUE),
+    x3 = rnorm(nrow)
+  )
+  n_blank <- sum(test_data$target == "")
+  expect_true(n_blank > 0) # sanity check on the fixture itself
+
+  result <- test_data %>% calc_feature_imp(target, x1, x2, x3, with_boruta = FALSE, smote = FALSE)
+  model <- result$model[[1]]
+  expect_false("error" %in% class(model))
+  # Rows whose target was "" should be dropped, just like target NA rows already are.
+  expect_equal(model$num.samples, nrow - n_blank)
+  expect_false("" %in% levels(model$y))
+  expect_false("" %in% model$imp_df$variable)
+
+  # Same fixture, but with the target already stored as a Factor with a literal "" level.
+  factor_test_data <- test_data %>% dplyr::mutate(target = factor(target))
+  result_factor <- factor_test_data %>% calc_feature_imp(target, x1, x2, x3, with_boruta = FALSE, smote = FALSE)
+  model_factor <- result_factor$model[[1]]
+  expect_false("error" %in% class(model_factor))
+  expect_equal(model_factor$num.samples, nrow - n_blank)
+  expect_false("" %in% levels(model_factor$y))
+})
+
 test_that("calc_feature_imp errors clearly when mtry exceeds the number of predictors", {
   set.seed(1)
   test_data <- data.frame(


### PR DESCRIPTION
## Summary

Fixes the issue — Random Forest "Variable Importance" (`calc_feature_imp()`) crashed with a raw `subscript out of bounds` error whenever the target column contained an empty-string (`""`) value.

## Root cause

`calc_feature_imp()` only filters `NA` target rows; `""` is not `NA`, so it survived as a genuine factor level (e.g. `levels(y) == c("A","B","C","")`).

`ranger::ranger()` is trained with `probability = TRUE, keep.inbag = TRUE` (OOB error stays on by default). Its own OOB-error post-processing (not our code) does:

```r
colnames(result$predictions) <- unique(y)
if (is.factor(y)) {
  result$predictions <- result$predictions[, levels(droplevels(y)), drop = FALSE]
}
```

This crashes with `subscript out of bounds` whenever the target factor has a `""` level — a documented R quirk: a matrix's `[` can never select a column by an empty-string name, even when a column literally named `""` exists:

```r
m <- matrix(1:8, nrow = 2, dimnames = list(NULL, c("A","B","C","")))
m[, ""]  # Error: subscript out of bounds
```

Confirmed by reproducing against `origin/master` with `pkgload::load_all()` + a live `ranger` training run, and by capturing the real call stack via `withCallingHandlers`/`sys.calls()` (the crash's own `tryCatch` re-throws with `stop(e)`, which erases the original stack from a plain `traceback()`).

## Fix

`cleanup_df()` (`R/randomForest_tidiers.R`) — shared by `calc_feature_imp`, `exp_chaid`, `build_xgboost`, `build_lightgbm`, `build_catboost` — now normalizes an empty-string target value to `NA` before building the training factor, for both `character` and `factor`-typed target columns. This routes blank target rows through the existing, already-tested "drop NA target rows" path (`preprocess_regression_data_before_sample`) instead of letting `""` reach `ranger`.

This mirrors the exact same idiom already used elsewhere in this codebase for the identical class of R quirk (`util.R`'s `pivot_wider()`: "Convert empty strings to NA ... prevents ... 'Subscript can't contain the empty string'").

## Testing

- Added a regression test to `test_randomForest_tidiers_1.R` covering both a plain-character target with blanks and a target already stored as a `factor` with a literal `""` level.
- Verified the new test fails on the pre-fix code (`subscript out of bounds`) and passes with the fix.
- Ran the full `randomForest_tidiers_1..6`, `smote_*`, `sampling`, `partial_dependence`, `model_target_col_name_cleaning`, `conf_mat_threshold_test_mode`, `report_metrics_ml_models`, `mean_error_metric`, `xgboost`, `lightgbm`, `catboost`, `chaid` suites — all green (remaining skips are pre-existing, from optional packages not installed locally: `Boruta`/`unbalanced`; two unrelated `test_partial_dependence.R` survival-forest failures from a missing `matrixStats` package reproduce identically against `origin/master`, confirming they predate this change).

Design doc: `docs/plans/design/38309_issue_design.md` in the `tam` repo (this bug's root cause is entirely in `exploratory_func`; no `tam` code changes are needed for the fix itself — a subsequent `requiredRPackagesReduced.json` version bump in `tam` is needed once this is merged and released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)