### PR TITLE
ANCOVA: add a 95% Q-Q envelope and make the reference line the identity (tam#38520)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.21
+Version: 16.1.22
 Date: 2026-09-07
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/ancova_v2_diagnostics.R
+++ b/R/ancova_v2_diagnostics.R
@@ -353,10 +353,13 @@ compute_residual_smoother <- function(fitted, standardized_residual) {
 ANCOVA_QQ_ENVELOPE_NSIM <- 1000L
 ANCOVA_QQ_ENVELOPE_MIN_NSIM <- 200L
 # The bootstrap costs about `nsim * n` row-operations; measured on a 4-column
-# design, 1e7 of them take roughly a second. Capping the product keeps the
-# envelope under ~2s for ANY row count instead of letting a 100k-row ANCOVA pay
+# design, 1e7 of them take roughly a second. Capping the product holds the
+# envelope near ~2s up to about 100k rows instead of letting a large ANCOVA pay
 # ~10s for a diagnostic chart (the issue calls this out as the case that needs
-# an adjusted simulation count).
+# an adjusted simulation count). Past 100k the MIN_NSIM floor takes over and the
+# cost grows with n again -- deliberately: below ~200 draws a 2.5% quantile is
+# an interpolation between the 5th and 6th order statistics and the band's tails
+# turn to noise, which is worse than being slow.
 ANCOVA_QQ_ENVELOPE_WORK_BUDGET <- 2e7
 ANCOVA_QQ_ENVELOPE_LEVEL <- 0.95
 ANCOVA_QQ_ENVELOPE_SEED <- 123L
@@ -426,6 +429,27 @@ compute_qq_envelope <- function(model, valid, idx,
   if (n < 3 || length(idx) < 1) return(empty)
   if (is.null(nsim)) nsim <- ancova_qq_envelope_nsim(n)
 
+  # The caller hands in the residual mask rather than the residuals being
+  # recomputed here, so the leverages and the plotted points could in principle
+  # come from different rows -- same LENGTH, wrong PAIRING, no error, every point
+  # sitting slightly wrong against the band. Cheap to rule out, so rule it out.
+  own_valid <- is.finite(stats::rstandard(model))
+  if (length(own_valid) != length(valid) || !identical(unname(own_valid), unname(valid))) {
+    return(empty)
+  }
+
+  # A fixed seed makes the band reproducible, but set.seed() is a SESSION-wide
+  # side effect: Rserve keeps one R session per window, so without this every
+  # later random operation in that session (another analytics' bootstrap, a
+  # sampling step) would start from a state determined by seed 123 just because
+  # this chart happened to render.
+  had_seed <- exists(".Random.seed", envir = globalenv(), inherits = FALSE)
+  if (had_seed) {
+    saved_seed <- get(".Random.seed", envir = globalenv(), inherits = FALSE)
+    on.exit(assign(".Random.seed", saved_seed, envir = globalenv()), add = TRUE)
+  } else {
+    on.exit(suppressWarnings(rm(".Random.seed", envir = globalenv())), add = TRUE)
+  }
   set.seed(seed)
   sims <- matrix(NA_real_, nrow = nsim, ncol = length(idx))
   for (b in seq_len(nsim)) {
@@ -437,11 +461,16 @@ compute_qq_envelope <- function(model, valid, idx,
     sims[b, ] <- sort(residual_sim / (sigma_sim * sqrt(1 - leverage)))[idx]
   }
   alpha <- 1 - level
-  tibble::tibble(
+  out <- tibble::tibble(
     lower = apply(sims, 2, stats::quantile, probs = alpha / 2, na.rm = TRUE, names = FALSE),
     upper = apply(sims, 2, stats::quantile, probs = 1 - alpha / 2, na.rm = TRUE, names = FALSE),
     expected = apply(sims, 2, stats::median, na.rm = TRUE)
   )
+  # How many draws the band was actually built from. It is NOT always the
+  # default (see ancova_qq_envelope_nsim), and a reader comparing two reports
+  # cannot otherwise tell that one band's tails are noisier than the other's.
+  attr(out, "nsim") <- nsim
+  out
 }
 
 #' Q-Q data, thinned by evenly spaced ORDER STATISTICS.
@@ -484,6 +513,7 @@ compute_qq_data <- function(standardized_residual, model = NULL) {
     points = points,
     reference_line = list(intercept = 0, slope = 1),
     envelope_level = if (nrow(envelope) == nrow(points)) ANCOVA_QQ_ENVELOPE_LEVEL else NA_real_,
+    envelope_nsim = if (nrow(envelope) == nrow(points)) attr(envelope, "nsim") else NA_integer_,
     n_total = n,
     n_displayed = length(idx),
     sampled = length(idx) < n
@@ -515,6 +545,7 @@ compute_ancova_residual_diagnostics <- function(final_model, analysis_data, safe
       points = qq$points,
       reference_line = qq$reference_line,
       envelope_level = qq$envelope_level,
+      envelope_nsim = qq$envelope_nsim,
       n_total = qq$n_total,
       n_displayed = qq$n_displayed,
       sampled = qq$sampled

--- a/R/ancova_v2_diagnostics.R
+++ b/R/ancova_v2_diagnostics.R
@@ -350,14 +350,116 @@ compute_residual_smoother <- function(fitted, standardized_residual) {
   tibble::tibble(fitted = sm$x, smoothed_residual = sm$y)
 }
 
+ANCOVA_QQ_ENVELOPE_NSIM <- 1000L
+ANCOVA_QQ_ENVELOPE_MIN_NSIM <- 200L
+# The bootstrap costs about `nsim * n` row-operations; measured on a 4-column
+# design, 1e7 of them take roughly a second. Capping the product keeps the
+# envelope under ~2s for ANY row count instead of letting a 100k-row ANCOVA pay
+# ~10s for a diagnostic chart (the issue calls this out as the case that needs
+# an adjusted simulation count).
+ANCOVA_QQ_ENVELOPE_WORK_BUDGET <- 2e7
+ANCOVA_QQ_ENVELOPE_LEVEL <- 0.95
+ANCOVA_QQ_ENVELOPE_SEED <- 123L
+
+#' Simulation count for a model with `n` rows: the full 1000 until the work
+#' budget bites, then fewer, never below `ANCOVA_QQ_ENVELOPE_MIN_NSIM` (the
+#' point at which a pointwise 2.5%/97.5% quantile stops being meaningful).
+#' @noRd
+ancova_qq_envelope_nsim <- function(n) {
+  if (!is.finite(n) || n <= 0) return(ANCOVA_QQ_ENVELOPE_NSIM)
+  as.integer(max(ANCOVA_QQ_ENVELOPE_MIN_NSIM,
+                 min(ANCOVA_QQ_ENVELOPE_NSIM, floor(ANCOVA_QQ_ENVELOPE_WORK_BUDGET / n))))
+}
+
+#' Pointwise 95% Q-Q envelope by PARAMETRIC BOOTSTRAP off the fitted model
+#' (tam#38520).
+#'
+#' A Q-Q plot with only a reference line does not say how far off the line a
+#' point may drift before it means anything. The envelope answers that: it is
+#' the middle 95% of where each order statistic lands when the model IS true.
+#'
+#' Simulating plain `rnorm(n)` would answer a different, weaker question --
+#' "what does a normal sample look like" -- and would ignore the design. This
+#' simulates the OUTCOME from the fitted model (`fitted + rnorm(0, sigma_hat)`),
+#' refits the SAME model matrix, and standardizes with each simulation's own
+#' sigma and the ORIGINAL leverages, so the band reflects the real factor,
+#' covariates and per-observation leverage.
+#'
+#' `stats::lm.fit()` on the already-decomposed model matrix is what makes 1000
+#' refits cheap (~0.14s at n = 1470, ~1.8s at n = 20000).
+#'
+#' Only the RETAINED order statistics are kept per iteration, so the simulation
+#' matrix is bounded by `nsim x ANCOVA_QQ_MAX_POINTS` no matter how many rows
+#' the data has -- a 100k-row model costs the same memory as a 2k-row one.
+#'
+#' @param model The fitted `lm` the reported statistics came from.
+#' @param valid Logical vector marking the finite standardized residuals, in
+#'   the model's own row order (NOT sorted).
+#' @param idx Indices into the SORTED residuals that the chart will plot.
+#' @return tibble(lower, upper, expected) with one row per `idx`, or an empty
+#'   tibble when the model cannot support the simulation.
+#' @noRd
+compute_qq_envelope <- function(model, valid, idx,
+                                level = ANCOVA_QQ_ENVELOPE_LEVEL,
+                                nsim = NULL,
+                                seed = ANCOVA_QQ_ENVELOPE_SEED) {
+  empty <- tibble::tibble(lower = numeric(0), upper = numeric(0), expected = numeric(0))
+  if (!inherits(model, "lm")) return(empty)
+  sigma_hat <- tryCatch(summary(model)$sigma, error = function(e) NA_real_)
+  df_residual <- stats::df.residual(model)
+  if (!is.finite(sigma_hat) || sigma_hat <= 0 || !is.finite(df_residual) || df_residual <= 0) {
+    return(empty)
+  }
+  X <- tryCatch(stats::model.matrix(model), error = function(e) NULL)
+  fitted_values <- stats::fitted(model)
+  leverage <- stats::hatvalues(model)
+  if (is.null(X) || nrow(X) != length(valid) ||
+      length(fitted_values) != length(valid) || length(leverage) != length(valid)) {
+    return(empty)
+  }
+  X <- X[valid, , drop = FALSE]
+  fitted_values <- fitted_values[valid]
+  # A leverage of exactly 1 leaves a zero-variance residual; clamp so the
+  # standardization below cannot divide by 0.
+  leverage <- pmin(leverage[valid], 1 - 1e-12)
+  n <- nrow(X)
+  if (n < 3 || length(idx) < 1) return(empty)
+  if (is.null(nsim)) nsim <- ancova_qq_envelope_nsim(n)
+
+  set.seed(seed)
+  sims <- matrix(NA_real_, nrow = nsim, ncol = length(idx))
+  for (b in seq_len(nsim)) {
+    y_sim <- fitted_values + stats::rnorm(n, mean = 0, sd = sigma_hat)
+    fit_sim <- stats::lm.fit(x = X, y = y_sim)
+    residual_sim <- fit_sim$residuals
+    sigma_sim <- sqrt(sum(residual_sim^2) / df_residual)
+    if (!is.finite(sigma_sim) || sigma_sim <= 0) return(empty)
+    sims[b, ] <- sort(residual_sim / (sigma_sim * sqrt(1 - leverage)))[idx]
+  }
+  alpha <- 1 - level
+  tibble::tibble(
+    lower = apply(sims, 2, stats::quantile, probs = alpha / 2, na.rm = TRUE, names = FALSE),
+    upper = apply(sims, 2, stats::quantile, probs = 1 - alpha / 2, na.rm = TRUE, names = FALSE),
+    expected = apply(sims, 2, stats::median, na.rm = TRUE)
+  )
+}
+
 #' Q-Q data, thinned by evenly spaced ORDER STATISTICS.
 #'
 #' Sorting first and then taking every k-th value keeps both tails, which is
 #' the part of a Q-Q plot that carries the information; a random subsample
 #' would preferentially drop them (section 51).
+#'
+#' tam#38520 changed the reference line from the conventional first/third-
+#' quartile line to the IDENTITY y = x. The Y axis here is the STANDARDIZED
+#' residual, which is compared against a mean-0, sd-about-1 normal, so y = x is
+#' the position "perfectly normal" actually predicts -- and it is the only line
+#' the envelope below is centered on. A quartile line fitted to the data would
+#' absorb part of the very departure the band exists to show.
 #' @noRd
-compute_qq_data <- function(standardized_residual) {
-  z <- sort(standardized_residual[is.finite(standardized_residual)])
+compute_qq_data <- function(standardized_residual, model = NULL) {
+  ok <- is.finite(standardized_residual)
+  z <- sort(standardized_residual[ok])
   n <- length(z)
   if (n < 3) {
     return(list(points = tibble::tibble(), reference_line = list(intercept = NA_real_, slope = NA_real_),
@@ -370,16 +472,18 @@ compute_qq_data <- function(standardized_residual) {
     idx <- unique(round(seq(1, n, length.out = ANCOVA_QQ_MAX_POINTS)))
   }
 
-  # Reference line through the first and third quartiles -- the conventional
-  # Q-Q line, computed from ALL residuals even when the points are thinned.
-  xq <- stats::qnorm(c(0.25, 0.75))
-  yq <- stats::quantile(z, c(0.25, 0.75), names = FALSE)
-  slope <- diff(yq) / diff(xq)
-  intercept <- yq[[1]] - slope * xq[[1]]
+  points <- tibble::tibble(theoretical = theoretical[idx], observed = z[idx])
+  envelope <- compute_qq_envelope(model, ok, idx)
+  if (nrow(envelope) == nrow(points)) {
+    points$envelope_lower <- envelope$lower
+    points$envelope_upper <- envelope$upper
+    points$expected <- envelope$expected
+  }
 
   list(
-    points = tibble::tibble(theoretical = theoretical[idx], observed = z[idx]),
-    reference_line = list(intercept = intercept, slope = slope),
+    points = points,
+    reference_line = list(intercept = 0, slope = 1),
+    envelope_level = if (nrow(envelope) == nrow(points)) ANCOVA_QQ_ENVELOPE_LEVEL else NA_real_,
     n_total = n,
     n_displayed = length(idx),
     sampled = length(idx) < n
@@ -392,7 +496,7 @@ compute_ancova_residual_diagnostics <- function(final_model, analysis_data, safe
   rf <- compute_residual_fitted_data(final_model, analysis_data, safe_factor,
                                      ANCOVA_MAX_POINTS_PER_CHART)
   smoother <- compute_residual_smoother(rf$full_fitted, rf$full_std_resid)
-  qq <- compute_qq_data(rf$full_std_resid)
+  qq <- compute_qq_data(rf$full_std_resid, final_model)
 
   list(
     available = TRUE,
@@ -410,6 +514,7 @@ compute_ancova_residual_diagnostics <- function(final_model, analysis_data, safe
     qq = list(
       points = qq$points,
       reference_line = qq$reference_line,
+      envelope_level = qq$envelope_level,
       n_total = qq$n_total,
       n_displayed = qq$n_displayed,
       sampled = qq$sampled

--- a/R/ancova_v2_diagnostics.R
+++ b/R/ancova_v2_diagnostics.R
@@ -352,6 +352,11 @@ compute_residual_smoother <- function(fitted, standardized_residual) {
 
 ANCOVA_QQ_ENVELOPE_NSIM <- 1000L
 ANCOVA_QQ_ENVELOPE_MIN_NSIM <- 200L
+# With fewer than three residual degrees of freedom, internally studentized
+# residuals are too degenerate for a useful pointwise envelope (for example,
+# with one residual degree of freedom they collapse to +/-1). Keep the Q-Q
+# points and identity line, but omit the envelope in that case.
+ANCOVA_QQ_ENVELOPE_MIN_DF_RESIDUAL <- 3L
 # The bootstrap costs about `nsim * n` row-operations; measured on a 4-column
 # design, 1e7 of them take roughly a second. Capping the product holds the
 # envelope near ~2s up to about 100k rows instead of letting a large ANCOVA pay
@@ -410,7 +415,8 @@ compute_qq_envelope <- function(model, valid, idx,
   if (!inherits(model, "lm")) return(empty)
   sigma_hat <- tryCatch(summary(model)$sigma, error = function(e) NA_real_)
   df_residual <- stats::df.residual(model)
-  if (!is.finite(sigma_hat) || sigma_hat <= 0 || !is.finite(df_residual) || df_residual <= 0) {
+  if (!is.finite(sigma_hat) || sigma_hat <= 0 || !is.finite(df_residual) ||
+      df_residual < ANCOVA_QQ_ENVELOPE_MIN_DF_RESIDUAL) {
     return(empty)
   }
   X <- tryCatch(stats::model.matrix(model), error = function(e) NULL)

--- a/R/ancova_v2_wrapper.R
+++ b/R/ancova_v2_wrapper.R
@@ -535,13 +535,25 @@ ancova_v2_qq_table <- function(x) {
   qq <- d$qq
   if (nrow(qq$points) == 0) return(tibble::tibble())
   ref <- qq$reference_line
-  tibble::tibble(
+  out <- tibble::tibble(
     `Theoretical Quantile` = qq$points$theoretical,
     `Standardized Residual` = qq$points$observed,
     # The reference line as a per-row column, so the chart can draw it as a
-    # second series without a second query.
+    # second series without a second query. Since tam#38520 this is the
+    # IDENTITY line (intercept 0, slope 1) -- see compute_qq_data().
     `Reference` = ref$intercept + ref$slope * qq$points$theoretical
   )
+  # 95% Q-Q envelope (tam#38520). Absent when the simulation could not run
+  # (no fitted model, degenerate sigma), and the chart simply draws no band --
+  # so a consumer must treat these as OPTIONAL columns.
+  if (!is.null(qq$points$envelope_lower)) {
+    out$`Envelope Lower` <- qq$points$envelope_lower
+    out$`Envelope Upper` <- qq$points$envelope_upper
+    # Returned for completeness (the simulated median at each order statistic);
+    # the report chart draws the identity line and the band, not this.
+    out$`Expected` <- qq$points$expected
+  }
+  out
 }
 
 #' Global slope-homogeneity test, one row (sections 5-7).

--- a/tests/testthat/test_ancova_v2_diagnostics.R
+++ b/tests/testthat/test_ancova_v2_diagnostics.R
@@ -393,6 +393,25 @@ test_that("Test 9b: a model the simulation cannot use degrades to no band, not a
   expect_equal(qq$reference_line$slope, 1)
 })
 
+test_that("Test 9b: too few residual degrees of freedom degrades to no band", {
+  # With one residual degree of freedom, studentized residuals collapse to
+  # +/-1, so the simulated envelope cannot represent the identity line.
+  d <- data.frame(
+    y = c(1.5, 0.4, -0.6, -2.2),
+    group = factor(c("A", "A", "B", "B")),
+    X1 = c(-0.02, 0.94, 0.82, 0.59)
+  )
+  fit <- stats::lm(y ~ group + X1, data = d)
+  expect_equal(stats::df.residual(fit), 1)
+
+  qq <- compute_qq_data(stats::rstandard(fit), model = fit)
+  expect_equal(nrow(qq$points), nrow(d))
+  expect_false("envelope_lower" %in% colnames(qq$points))
+  expect_true(is.na(qq$envelope_level))
+  expect_true(is.na(qq$envelope_nsim))
+  expect_equal(qq$reference_line, list(intercept = 0, slope = 1))
+})
+
 # ------------------------------------------------------------
 # Test 10 (section 75): statistics on all rows, charts on a sample
 # ------------------------------------------------------------

--- a/tests/testthat/test_ancova_v2_diagnostics.R
+++ b/tests/testthat/test_ancova_v2_diagnostics.R
@@ -267,6 +267,99 @@ test_that("Test 9: near-normal residuals hug the Q-Q reference line and heavy ta
 })
 
 # ------------------------------------------------------------
+# Test 9b (tam#38520): the 95% Q-Q envelope
+# ------------------------------------------------------------
+test_that("Test 9b: the Q-Q reference line is the identity y = x", {
+  res <- run_ancova_v2(make_diag_data(n_per_group = 120, seed = 21), "y", "group", "X1")
+  qq <- res$diagnostics$residuals$qq
+  # tam#38520: the Y axis is the STANDARDIZED residual, so "perfectly normal"
+  # sits on y = x. A quartile-fitted line would absorb part of the departure
+  # the envelope exists to show.
+  expect_equal(qq$reference_line$intercept, 0)
+  expect_equal(qq$reference_line$slope, 1)
+})
+
+test_that("Test 9b: the envelope brackets the points and is widest in the tails", {
+  res <- run_ancova_v2(make_diag_data(n_per_group = 150, seed = 22), "y", "group", "X1")
+  qq <- res$diagnostics$residuals$qq
+  pts <- qq$points
+
+  expect_equal(qq$envelope_level, 0.95)
+  expect_true(all(c("envelope_lower", "envelope_upper", "expected") %in% colnames(pts)))
+  expect_equal(nrow(pts), length(pts$envelope_lower))
+  expect_true(all(pts$envelope_lower < pts$envelope_upper))
+  # The simulated median sits inside its own band, by construction.
+  expect_true(all(pts$expected >= pts$envelope_lower & pts$expected <= pts$envelope_upper))
+
+  # Coverage is checked ACROSS datasets, not within one. Order statistics are
+  # strongly correlated, so a single normal sample lands anywhere from ~0.80 to
+  # 1.00 inside a POINTWISE 95% band (measured: 0.80-1.00 over ten seeds); a
+  # per-dataset threshold would be a flake generator. The average is the
+  # statement worth pinning.
+  inside_for <- function(seed) {
+    p <- run_ancova_v2(make_diag_data(n_per_group = 150, seed = seed),
+                       "y", "group", "X1")$diagnostics$residuals$qq$points
+    mean(p$observed >= p$envelope_lower & p$observed <= p$envelope_upper)
+  }
+  expect_gt(mean(vapply(21:26, inside_for, numeric(1))), 0.85)
+
+  # The band is wider at the extremes than in the middle: that shape is the
+  # whole point (an outlying tail point means less than a middle one).
+  width <- pts$envelope_upper - pts$envelope_lower
+  middle <- width[round(length(width) / 2)]
+  expect_gt(width[1], middle)
+  expect_gt(width[length(width)], middle)
+})
+
+test_that("Test 9b: heavy tails break OUT of the envelope while normal ones do not", {
+  normal_qq <- run_ancova_v2(make_diag_data(n_per_group = 150, seed = 23),
+                             "y", "group", "X1")$diagnostics$residuals$qq
+  heavy <- make_diag_data(n_per_group = 150, seed = 23)
+  set.seed(101)
+  heavy$y <- heavy$y + stats::rt(nrow(heavy), df = 2) * 12
+  heavy_qq <- run_ancova_v2(heavy, "y", "group", "X1")$diagnostics$residuals$qq
+
+  outside <- function(p) mean(p$observed < p$envelope_lower | p$observed > p$envelope_upper)
+  # The envelope has to DISCRIMINATE, or it is decoration.
+  expect_gt(outside(heavy_qq$points), outside(normal_qq$points))
+})
+
+test_that("Test 9b: the envelope is reproducible and model-based, not a plain rnorm band", {
+  d <- make_diag_data(n_per_group = 120, seed = 24)
+  a <- run_ancova_v2(d, "y", "group", "X1")$diagnostics$residuals$qq$points
+  b <- run_ancova_v2(d, "y", "group", "X1")$diagnostics$residuals$qq$points
+  # Same data in, same band out: the seed is fixed so a report does not move
+  # between two runs of the same analysis.
+  expect_equal(a$envelope_lower, b$envelope_lower)
+  expect_equal(a$envelope_upper, b$envelope_upper)
+
+  # A HIGH-leverage design must produce a different band from a balanced one on
+  # the same residual count -- that is what makes this a parametric bootstrap
+  # off the fitted model rather than a rnorm(n) band that ignores the design.
+  skewed <- d
+  skewed$X1[1:5] <- skewed$X1[1:5] + 500
+  c_pts <- run_ancova_v2(skewed, "y", "group", "X1")$diagnostics$residuals$qq$points
+  expect_false(isTRUE(all.equal(a$envelope_upper, c_pts$envelope_upper)))
+})
+
+test_that("Test 9b: the simulation count is bounded by row count, never below the floor", {
+  expect_equal(ancova_qq_envelope_nsim(1470), ANCOVA_QQ_ENVELOPE_NSIM)
+  expect_lt(ancova_qq_envelope_nsim(100000), ANCOVA_QQ_ENVELOPE_NSIM)
+  expect_gte(ancova_qq_envelope_nsim(10000000), ANCOVA_QQ_ENVELOPE_MIN_NSIM)
+  # The budget is what keeps a 100k-row ANCOVA from paying ~10s for a chart.
+  expect_lte(ancova_qq_envelope_nsim(100000) * 100000, ANCOVA_QQ_ENVELOPE_WORK_BUDGET)
+})
+
+test_that("Test 9b: a model the simulation cannot use degrades to no band, not an error", {
+  qq <- compute_qq_data(stats::rnorm(50), model = NULL)
+  expect_equal(nrow(qq$points), 50)
+  expect_false("envelope_lower" %in% colnames(qq$points))
+  expect_true(is.na(qq$envelope_level))
+  # The reference line is still the identity even with no envelope.
+  expect_equal(qq$reference_line$slope, 1)
+})
+
+# ------------------------------------------------------------
 # Test 10 (section 75): statistics on all rows, charts on a sample
 # ------------------------------------------------------------
 test_that("Test 10: a large N is fitted in full and only the scatter points are sampled", {

--- a/tests/testthat/test_ancova_v2_diagnostics.R
+++ b/tests/testthat/test_ancova_v2_diagnostics.R
@@ -350,6 +350,40 @@ test_that("Test 9b: the simulation count is bounded by row count, never below th
   expect_lte(ancova_qq_envelope_nsim(100000) * 100000, ANCOVA_QQ_ENVELOPE_WORK_BUDGET)
 })
 
+test_that("Test 9b: the envelope leaves the session RNG exactly as it found it", {
+  # Rserve keeps ONE R session per window. An unrestored set.seed(123) would make
+  # every later random operation in that session -- another analytics' bootstrap,
+  # a sampling step -- start from a state determined by this chart having rendered.
+  d <- make_diag_data(n_per_group = 40, seed = 25)
+  fit <- stats::lm(y ~ group + X1, data = d)
+  set.seed(999)
+  before <- .Random.seed
+  compute_qq_envelope(fit, is.finite(stats::rstandard(fit)), seq_len(nrow(d)))
+  expect_identical(before, .Random.seed)
+})
+
+test_that("Test 9b: a residual mask that is not this model's degrades to no band", {
+  # The caller supplies the mask, so the leverages and the plotted points could be
+  # the same LENGTH but the wrong PAIRING -- every point sitting slightly wrong
+  # against the band, with nothing to notice. Guarded, not assumed.
+  d <- make_diag_data(n_per_group = 40, seed = 26)
+  fit <- stats::lm(y ~ group + X1, data = d)
+  ok <- is.finite(stats::rstandard(fit))
+  wrong <- ok
+  wrong[1] <- FALSE
+  expect_equal(nrow(compute_qq_envelope(fit, wrong, seq_len(sum(wrong)))), 0)
+  expect_gt(nrow(compute_qq_envelope(fit, ok, seq_len(sum(ok)))), 0)
+})
+
+test_that("Test 9b: the draw count the band was built from is reported", {
+  res <- run_ancova_v2(make_diag_data(n_per_group = 40, seed = 27), "y", "group", "X1")
+  qq <- res$diagnostics$residuals$qq
+  # It is NOT always the default, so a reader comparing two reports could not
+  # otherwise tell that one band's tails came from fewer draws.
+  expect_equal(qq$envelope_nsim, ANCOVA_QQ_ENVELOPE_NSIM)
+  expect_equal(compute_qq_data(stats::rnorm(50), model = NULL)$envelope_nsim, NA_integer_)
+})
+
 test_that("Test 9b: a model the simulation cannot use degrades to no band, not an error", {
   qq <- compute_qq_data(stats::rnorm(50), model = NULL)
   expect_equal(nrow(qq$points), 50)

--- a/tests/testthat/test_ancova_v2_wrapper.R
+++ b/tests/testthat/test_ancova_v2_wrapper.R
@@ -397,13 +397,34 @@ test_that("type='qq' carries the reference line as a per-row column", {
   df <- make_wrapper_data()
   tbl <- tidy_rowwise(fit_v2(df), model, type = "qq")
 
+  # tam#38520 added the envelope columns after Reference.
   expect_equal(colnames(tbl),
-               c("Theoretical Quantile", "Standardized Residual", "Reference"))
+               c("Theoretical Quantile", "Standardized Residual", "Reference",
+                 "Envelope Lower", "Envelope Upper", "Expected"))
   expect_equal(nrow(tbl), nrow(df))
   # A straight line in the theoretical quantile: equal spacing in x gives
   # equal spacing in Reference.
   slopes <- diff(tbl$Reference) / diff(tbl$`Theoretical Quantile`)
   expect_lt(diff(range(slopes)), 1e-8)
+  # Since tam#38520 that line is the IDENTITY, so the chart's band is centered
+  # on the position a perfectly normal residual would occupy.
+  expect_equal(tbl$Reference, tbl$`Theoretical Quantile`)
+})
+
+test_that("type='qq' carries the 95% envelope as two per-row columns (tam#38520)", {
+  tbl <- tidy_rowwise(fit_v2(make_wrapper_data()), model, type = "qq")
+
+  expect_true(all(tbl$`Envelope Lower` < tbl$`Envelope Upper`))
+  # The band brackets the identity line it is centered on.
+  expect_true(all(tbl$`Envelope Lower` <= tbl$Reference))
+  expect_true(all(tbl$`Envelope Upper` >= tbl$Reference))
+  # Widest in the tails: an outlying point at the extreme means less than one
+  # in the middle, and the band has to show that.
+  width <- tbl$`Envelope Upper` - tbl$`Envelope Lower`
+  expect_gt(width[1], width[round(length(width) / 2)])
+  expect_gt(width[length(width)], width[round(length(width) / 2)])
+  # Every column is finite -- an NA would render as a hole in the band.
+  expect_true(all(is.finite(c(tbl$`Envelope Lower`, tbl$`Envelope Upper`, tbl$Expected))))
 })
 
 test_that("the diagnostic surfaces degrade to empty rather than erroring when a fit is unavailable", {


### PR DESCRIPTION
# Description

Adds a **95% Q-Q envelope** to the ANCOVA Q-Q plot, and changes that chart's reference line to the identity `y = x`. Paired with tam PR for [tam#38520](https://github.com/exploratory-io/tam/issues/38520).

A Q-Q plot with only a reference line does not tell the reader how far off the line a point has to drift before it means anything. The envelope answers that: the middle 95% of where each order statistic lands when the model **is** true.

### `compute_qq_envelope()` — parametric bootstrap, not `rnorm(n)`

The issue is explicit that a plain `rnorm(n)` band answers a weaker question and ignores the design. So this simulates the **outcome** from the fitted model (`fitted + rnorm(0, sigma_hat)`), refits the **same** model matrix with `lm.fit()`, and standardizes with each simulation's own sigma and the **original** leverages. The band therefore reflects the real factor, covariates and per-observation leverage.

An independent review confirmed this numerically rather than by reading the code: on a 450-row fit the middle band width is **0.136**, which matches a model-conditioned replication (0.138) and *not* an iid `rnorm` envelope (0.231) — the intercept constraint and the `I - H` projection shrink the middle of the band, and the shipped numbers land on the model-based value.

### The reference line is now `y = x`

The Y axis is the **standardized** residual, compared against a mean-0, sd-about-1 normal, so `y = x` is the position "perfectly normal" actually predicts — and it is the line the envelope is centred on. The old first/third-quartile line is fitted to the data, so it absorbs part of the very departure the band exists to show.

### Cost

Bounded on both axes:

- Only the **retained order statistics** are kept per iteration, so the simulation matrix is `nsim x ANCOVA_QQ_MAX_POINTS` whatever the row count — a 100k-row model costs the same memory as a 2k-row one.
- `nsim` backs off past a work budget: the full 1000 up to ~20k rows, never below 200. Measured: 0.12s at 450 rows, 0.14s at 1,470, 1.76s at 20,000.

### Contract

`tidy(type="qq")` gains `Envelope Lower` / `Envelope Upper` / `Expected`. They are **optional** — a model the simulation cannot use (no fit, degenerate sigma) degrades to no band rather than an error — so a consumer must tolerate their absence. `envelope_level` and `envelope_nsim` are reported alongside, because `nsim` is not always the default and a reader comparing two reports could not otherwise tell that one band's tails came from fewer draws.

Three details worth calling out, all from the independent review:

- **`set.seed()` is restored.** Rserve keeps one R session per window, so an unrestored seed would make every later random operation in that session start from a state determined by this chart having rendered.
- **The residual mask is verified against the model's own.** The caller supplies it, so the leverages and the plotted points could be the same *length* but the wrong *pairing* — every point sitting slightly wrong against the band, with nothing to notice. Mismatch now degrades to no band.
- **Coverage is asserted across datasets, not within one.** Order statistics are strongly correlated, so a single normal sample lands anywhere from 0.80 to 1.00 inside a pointwise 95% band (measured over ten seeds). A per-dataset threshold would be a flake generator. The test carrying the weight is the discrimination one: heavy tails break out of the envelope, normal ones do not.

# Checklist

- [x] Add test cases for this fix/enhancement — `test_ancova_v2_diagnostics.R` "Test 9b" (8 tests: identity line, band shape, discrimination, reproducibility, design-sensitivity, nsim budget, RNG restore, mask guard, degradation) and `test_ancova_v2_wrapper.R` (column contract + band properties)
- [ ] Pass `devtools::check()` — not run
- [x] Pass `devtools::test()` — for the three ANCOVA suites (`test_ancova_v2.R`, `test_ancova_v2_diagnostics.R`, `test_ancova_v2_wrapper.R`), all passing. Full-package run not done.
- [ ] Test installing from github — not run
- [x] Tested with Exploratory — the tam side renders the band from this branch's output in `chart-rendering-playground`, and tam's live-R harness (865 chart-answer tests) still passes against the *released* package, exercising the no-envelope degradation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Review follow-up

For models with fewer than 3 residual degrees of freedom, the studentized residual Q-Q envelope is too degenerate to be meaningful and may not contain the identity line. The envelope is therefore omitted in that case while the Q-Q points and identity reference remain available.