### PR TITLE
Fix internal factor column name leaking into ANCOVA pair labels (16.1.23)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.22
+Version: 16.1.23
 Date: 2026-09-07
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/ancova_v2.R
+++ b/R/ancova_v2.R
@@ -531,7 +531,7 @@ ancova_tidy_emm <- function(emm, safe_factor, confidence_level, source_model) {
 #' factor levels, instead of assuming " - " never occurs inside a level's
 #' own text (a level like "Q1 - Q2" would otherwise be mis-split).
 #' @noRd
-ancova_split_pair_label <- function(label, levels) {
+ancova_split_pair_label <- function(label, levels, factor_col = NULL) {
   positions <- gregexpr(" - ", label, fixed = TRUE)[[1]]
   if (positions[1] == -1) {
     return(c(NA_character_, NA_character_))
@@ -548,6 +548,19 @@ ancova_split_pair_label <- function(label, levels) {
       unwrapped <- substr(part, 2, nchar(part) - 1)
       if (unwrapped %in% levels) {
         return(unwrapped)
+      }
+    }
+    # emmeans PREFIXES the variable name onto the level when the levels are not
+    # syntactically distinguishable on their own -- numeric-looking levels are the
+    # common case, so a factor with levels 1..5 contrasts as
+    # `.ancova_factor1 - .ancova_factor2`. Without this, no branch matches, the
+    # positional fallback below returns the raw text, and the report's Multiple
+    # Comparisons table shows the INTERNAL column name to the user (tam#38510's
+    # Japanese report dump: every グループ1/グループ2 cell read `.ancova_factorN`).
+    if (!is.null(factor_col) && nzchar(factor_col) && startsWith(part, factor_col)) {
+      stripped <- substr(part, nchar(factor_col) + 1, nchar(part))
+      if (stripped %in% levels) {
+        return(stripped)
       }
     }
     NA_character_
@@ -572,13 +585,14 @@ ancova_split_pair_label <- function(label, levels) {
 #' group1/group2/<estimate col>/... using level-validated label splitting.
 #' @noRd
 ancova_tidy_pairs <- function(pw, levels, confidence_level, estimate_col_out,
-                               extra_cols = list(), source_model) {
+                               extra_cols = list(), source_model, factor_col = NULL) {
   summ <- as.data.frame(summary(pw, level = confidence_level, infer = c(TRUE, TRUE)))
   # Defensive: as.data.frame() can hand back the contrast label as a factor
   # depending on R/emmeans version defaults; vapply() over a factor would
   # silently iterate its integer codes instead of the label text.
   contrast_labels <- as.character(summ$contrast)
-  pairs_split <- t(vapply(contrast_labels, ancova_split_pair_label, character(2), levels = levels))
+  pairs_split <- t(vapply(contrast_labels, ancova_split_pair_label, character(2),
+                          levels = levels, factor_col = factor_col))
   out <- tibble::tibble(
     group1 = pairs_split[, 1],
     group2 = pairs_split[, 2],
@@ -629,10 +643,12 @@ compute_ancova_adjusted_means <- function(model, safe_factor, safe_xc,
 #' Pairwise comparisons from the exact emmGrid object used for the means
 #' above (never a fresh emmeans() call).
 #' @noRd
-compute_ancova_pairwise <- function(emm, factor_levels, confidence_level, source_model) {
+compute_ancova_pairwise <- function(emm, factor_levels, confidence_level, source_model,
+                                    factor_col = NULL) {
   pw <- emmeans::contrast(emm, method = "pairwise", adjust = "tukey")
   ancova_tidy_pairs(pw, factor_levels, confidence_level,
-                     estimate_col_out = "adjusted_difference", source_model = source_model)
+                     estimate_col_out = "adjusted_difference", source_model = source_model,
+                     factor_col = factor_col)
 }
 
 # ------------------------------------------------------------
@@ -670,6 +686,7 @@ compute_ancova_slopes <- function(model_interaction, safe_factor, safe_xc,
     pw <- emmeans::contrast(trend_emm, method = "pairwise", adjust = "tukey")
     slope_comparisons <- ancova_tidy_pairs(
       pw, factor_levels, confidence_level, estimate_col_out = "slope_difference",
+      factor_col = safe_factor,
       extra_cols = list(covariate = covariate_names[j]), source_model = "interaction"
     ) %>% dplyr::select(covariate, group1, group2, slope_difference, standard_error, df,
                         t_value, p_value, confidence_lower, confidence_upper, adjustment,
@@ -858,7 +875,8 @@ run_ancova_v2 <- function(data, outcome, factor, covariates, alpha = 0.05,
       adjusted_means <- list(means = am$means, reference_covariates = am$reference_covariates)
       reported_emm <- am$emm
       pairwise_comparisons <- compute_ancova_pairwise(
-        am$emm, prep$factor_levels, confidence_level, source_model = "additive")
+        am$emm, prep$factor_levels, confidence_level, source_model = "additive",
+        factor_col = prep$safe_factor)
     } else {
       cm <- compute_ancova_adjusted_means(
         final_model, prep$safe_factor, centered$safe_xc, centered$covariate_means,
@@ -866,7 +884,8 @@ run_ancova_v2 <- function(data, outcome, factor, covariates, alpha = 0.05,
       conditional_means <- list(means = cm$means, reference_covariates = cm$reference_covariates)
       reported_emm <- cm$emm
       conditional_pairwise <- compute_ancova_pairwise(
-        cm$emm, prep$factor_levels, confidence_level, source_model = "interaction")
+        cm$emm, prep$factor_levels, confidence_level, source_model = "interaction",
+        factor_col = prep$safe_factor)
       interaction_details <- compute_ancova_slopes(
         final_model, prep$safe_factor, centered$safe_xc, prep$covariate_names,
         prep$factor_levels, confidence_level)

--- a/R/ancova_v2_wrapper.R
+++ b/R/ancova_v2_wrapper.R
@@ -346,8 +346,12 @@ ancova_v2_pairs_table <- function(x, pairs_adjust) {
     ret <- tibble::as_tibble(pw) %>%
       dplyr::mutate(conf.low = ci$lower.CL, conf.high = ci$upper.CL)
     levels_vec <- unlist(res$analysis_sample$factor_levels)
+    # Pass the internal factor column so a level emmeans PREFIXED with the
+    # variable name can be mapped back. Without it a numeric-looking level set
+    # (1..5) contrasts as `.ancova_factor1 - .ancova_factor2` and the internal
+    # column name reaches the user's Multiple Comparisons table (tam#38510).
     pairs_split <- purrr::map_dfr(ret$contrast, function(label) {
-      parts <- ancova_split_pair_label(label, levels_vec)
+      parts <- ancova_split_pair_label(label, levels_vec, x$internals$safe_factor)
       tibble::tibble(`Group 1` = parts[[1]], `Group 2` = parts[[2]])
     })
     ret <- dplyr::bind_cols(pairs_split, ret %>% dplyr::select(-contrast))

--- a/tests/testthat/test_ancova_v2_wrapper.R
+++ b/tests/testthat/test_ancova_v2_wrapper.R
@@ -440,3 +440,55 @@ test_that("the diagnostic surfaces degrade to empty rather than erroring when a 
   expect_gt(nrow(tidy_rowwise(ret, model, type = "residual_fitted")), 0)
   expect_gt(nrow(tidy_rowwise(ret, model, type = "qq")), 0)
 })
+
+# ------------------------------------------------------------
+# tam#38510 follow-up: numeric-looking factor levels
+# ------------------------------------------------------------
+test_that("numeric-looking group levels do not leak the internal factor column", {
+  # emmeans PREFIXES the variable name onto a level when the levels are not
+  # syntactically distinguishable on their own, so a factor with levels 1..5
+  # contrasts as `.ancova_factor1 - .ancova_factor2` rather than `1 - 2`. The
+  # label splitter could not map that back to a level, fell through to its
+  # positional fallback, and the report's Multiple Comparisons table showed the
+  # INTERNAL column name in every グループ1/グループ2 cell -- found in a Japanese
+  # report dump from the running app, not by any test.
+  set.seed(1)
+  n <- 300
+  df <- data.frame(y = rnorm(n) + rep(1:5, each = 60),
+                   g = factor(rep(1:5, each = 60)),
+                   x = runif(n))
+  tbl <- tidy_rowwise(exp_ancova(df, y, g, covariates = "x"), model,
+                      type = "pairs", pairs_adjust = "bonferroni")
+
+  groups <- unique(c(as.character(tbl$`Group 1`), as.character(tbl$`Group 2`)))
+  expect_setequal(groups, as.character(1:5))
+  expect_false(any(grepl("ancova_factor", groups, fixed = TRUE)))
+})
+
+test_that("the label splitter handles bare, parenthesised and prefixed levels", {
+  levels_vec <- c("1", "2", "10")
+  expect_equal(ancova_split_pair_label("1 - 2", levels_vec), c("1", "2"))
+  expect_equal(ancova_split_pair_label(".ancova_factor1 - .ancova_factor2", levels_vec,
+                                       ".ancova_factor"), c("1", "2"))
+  # The prefix must be stripped WHOLE: "10" must not be read as the level "1"
+  # with a stray character left over.
+  expect_equal(ancova_split_pair_label(".ancova_factor10 - .ancova_factor1", levels_vec,
+                                       ".ancova_factor"), c("10", "1"))
+  # A level that genuinely contains the separator still wins over the prefix path.
+  expect_equal(ancova_split_pair_label("(A - B) - C", c("A - B", "C")), c("A - B", "C"))
+  # No factor column supplied -> unchanged behaviour.
+  expect_equal(ancova_split_pair_label(".ancova_factor1 - .ancova_factor2", levels_vec),
+               c(".ancova_factor1", ".ancova_factor2"))
+})
+
+test_that("text group levels are unaffected by the prefix handling", {
+  set.seed(2)
+  n <- 300
+  df <- data.frame(y = rnorm(n) + rep(1:3, each = 100),
+                   g = factor(rep(c("A法", "B法", "C法"), each = 100)),
+                   x = runif(n))
+  tbl <- tidy_rowwise(exp_ancova(df, y, g, covariates = "x"), model,
+                      type = "pairs", pairs_adjust = "bonferroni")
+  expect_setequal(unique(c(as.character(tbl$`Group 1`), as.character(tbl$`Group 2`))),
+                  c("A法", "B法", "C法"))
+})


### PR DESCRIPTION
## Problem

Found in a Japanese ANCOVA report dump captured from the running app (tam#38510 render pass): the 多重比較 (Multiple Comparisons) table showed `.ancova_factor1` / `.ancova_factor2` in every グループ1 / グループ2 cell instead of the actual factor levels.

`emmeans` prefixes the variable name onto a contrast label when the factor's levels are not syntactically distinguishable on their own — a factor with levels `1..5` contrasts as `.ancova_factor1 - .ancova_factor2`, not `1 - 2`. `ancova_split_pair_label()` could not map those parts back to a level, so it fell through to its positional fallback and emitted the internal column name verbatim.

Text levels (`A法`, `B法`) were never affected, which is why no test caught it.

## Fix

- `ancova_split_pair_label()` gains an optional `factor_col`. When a label part starts with that prefix and the remainder is an actual level, the prefix is stripped. The whole-level check keeps `10` from being read as `1`.
- Threaded `factor_col` through `ancova_tidy_pairs()`, `compute_ancova_pairwise()` and `compute_ancova_slopes()`.
- **`ancova_v2_pairs_table()` in `R/ancova_v2_wrapper.R` calls the splitter itself** — that is the path the report actually uses, and patching only `ancova_v2.R` left the leak in place. It now passes `x$internals$safe_factor`.

## Verification

```
numeric levels -> Group 1: 1 | 1 | 1   Group 2: 2 | 3 | 4
text levels    -> Group 1: A法 | A法 | B法
```

Three new tests in `test_ancova_v2_wrapper.R`: an end-to-end numeric-level run, a unit test of the splitter across bare / parenthesised / prefixed / separator-containing levels, and a text-level non-regression. `test_ancova_v2_wrapper.R`, `test_ancova_v2.R`, `test_ancova_v2_diagnostics.R` all pass (0 failures, 0 errors).

Version bumped to 16.1.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)