### PR TITLE
Bump version to 16.1.24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.23
-Date: 2026-09-07
+Version: 16.1.24
+Date: 2026-09-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory


### PR DESCRIPTION
## Why

[#1667](https://github.com/exploratory-io/exploratory_func/pull/1667) ("ANCOVA: drop the R-side jitter from the covariate relationship chart", tam#38513) merged onto master **without bumping `DESCRIPTION`**, so master still reads `Version: 16.1.23`.

16.1.23 was already tagged, built, and published to download2 (from `1cf5e23`, [#1668](https://github.com/exploratory-io/exploratory_func/pull/1668)). Master is now that plus #1667's four changed files, under the same version string — one version number, two different packages. Nothing downstream can tell them apart: the version string and the md5 of the published artifact both still look correct, which is exactly the shape of the 16.1.6 incident (tam#38196).

tam#38513's chart change reads the raw `Covariate Value` column instead of the one R used to jitter, so it needs a version of its own for `requiredRPackagesReduced.json` to pin.

## Verification

`test_ancova_v2_wrapper.R`, `test_ancova_v2.R` and `test_ancova_v2_diagnostics.R` on master's content: 0 failures, 0 errors.

Version only — no code change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)