### PR TITLE
fix(chaid): sort Final Intervals ascending by bucket lower bound

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.24
+Version: 16.1.25
 Date: 2026-09-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/chaid.R
+++ b/R/chaid.R
@@ -1895,11 +1895,22 @@ chaid_numeric_intervals <- function(model) {
     child_labels <- edges$label[edges$parent_id == node_id]
     # tam #37177: each child edge's label is a " + "-joined run of bins; show the
     # range it actually covers. Binning method and bin count are separate columns.
-    # tam #37691: report-display only -- "> N" -> "N <" (chaid_display_symbol_after_number).
     child_labels <- vapply(child_labels, function(label) {
-      chaid_display_symbol_after_number(chaid_normalize_group_label(
-        label, chaid_group_level_order(model, variable), collapse = TRUE))
+      chaid_normalize_group_label(label, chaid_group_level_order(model, variable), collapse = TRUE)
     }, character(1), USE.NAMES = FALSE)
+    # tam #38550: `edges` inherits the CHART's own left-to-right child order
+    # (chaid_order_children_for_display() -- TRUE-rate-first for a logical
+    # target, ascending bound only as a tie-break), not numeric order. The
+    # report column must always read smallest-to-largest, so re-sort by each
+    # bucket's own lower bound before applying the display flip below.
+    lower_values <- vapply(child_labels, function(label) {
+      interval <- chaid_parse_interval(label)
+      if (is.null(interval)) NA_real_ else interval$lower_value
+    }, numeric(1))
+    child_labels <- child_labels[order(lower_values)]
+    # tam #37691: report-display only -- "> N" -> "N <" (chaid_display_symbol_after_number).
+    child_labels <- vapply(child_labels, chaid_display_symbol_after_number,
+                            character(1), USE.NAMES = FALSE)
     data.frame(
       Node = node_id,
       # tam#38107: `variable` stays CLEAN (fit-time name) for the binmap/

--- a/tests/testthat/test_build_chaid.R
+++ b/tests/testthat/test_build_chaid.R
@@ -323,6 +323,41 @@ test_that("Final Intervals shows 'N <' for display while cond_value keeps '> N' 
                "cond_value must never carry the report-display 'N <' shape")
 })
 
+test_that("Final Intervals lists a numeric variable's buckets in ascending order, not TRUE-rate order (tam #38550)", {
+  # A logical target's siblings are drawn TRUE-rate-first for the CHART's own
+  # left-to-right order (chaid_order_children_for_display()) -- here the
+  # HIGHER-salary bucket is deliberately made more TRUE-heavy, so the buggy
+  # (un-sorted) "Final Intervals" column would list it FIRST, out of numeric
+  # order. The report column must always read smallest-to-largest regardless
+  # of which child is more TRUE-heavy.
+  set.seed(21); n <- 900
+  df <- data.frame(
+    salary = round(runif(n, 1000, 20000)),
+    dept = sample(c("sales", "rnd", "hr"), n, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+  df$churn <- df$salary > 11000 | runif(n) < 0.05
+  model_df <- suppressWarnings(exp_chaid(df, churn, salary, dept,
+                                         min_split = 40, min_bucket = 20,
+                                         max_depth = 2))
+  ni <- model_df %>% tidy_rowwise(model, type = "numeric_intervals")
+  salary_rows <- ni[ni$Variable == "salary", , drop = FALSE]
+  expect_true(nrow(salary_rows) > 0)
+  for (final in salary_rows[["Final Intervals"]]) {
+    tokens <- trimws(strsplit(final, " / ", fixed = TRUE)[[1]])
+    expect_true(length(tokens) >= 2, "the repro needs at least 2 buckets to prove ordering")
+    lowers <- vapply(tokens, function(tok) {
+      # chaid_display_symbol_after_number() has already flipped an
+      # unbounded-above bucket to "N <" -- undo that just for the sort-key
+      # parse, since chaid_parse_interval() expects the raw "> N" shape.
+      raw <- if (grepl("<$", tok)) paste0("> ", sub("\\s*<$", "", tok)) else tok
+      interval <- chaid_parse_interval(raw)
+      if (is.null(interval)) NA_real_ else interval$lower_value
+    }, numeric(1))
+    expect_false(is.unsorted(lowers), info = paste("Final Intervals not ascending:", final))
+  }
+})
+
 test_that("category_error_distribution is empty for a non-ordered target", {
   df <- make_ordered_df()
   df$grade <- as.character(df$grade) # drop the ordered attribute


### PR DESCRIPTION
## Summary

`chaid_numeric_intervals()` now lists a split node's numeric final buckets in ascending order by bucket lower bound, independently of the chart's visual child order. This is the R-side companion fix for [exploratory-io/tam#38550](https://github.com/exploratory-io/tam/issues/38550).

## Fix

- Normalize the child labels first.
- Sort the normalized interval labels by `chaid_parse_interval()$lower_value`.
- Apply the existing report-only `"> N"` to `"N <"` display conversion after sorting.
- Keep the machine-readable `cond_value` format unchanged.

## Test plan

- Added a regression test in `tests/testthat/test_build_chaid.R` covering a logical target whose TRUE-rate order differs from numeric bucket order.
- `test_build_chaid.R`: passed; 35 pre-existing environment/dependency warnings remain.
- `test_chaid_report_format.R`: passed.
- `git diff --check`: passed.

## Release

- Bumped `DESCRIPTION` from 16.1.24 to 16.1.25.