### PR TITLE
feat: Analysis Conditions tables for Correlation and Cronbach's Alpha (tam#38607)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.25
+Version: 16.1.26
 Date: 2026-09-08
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -735,8 +735,8 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
         # tam#37638: a FIXED sentence, not the old composed "N items used". This cell is rendered
         # in the 説明 column of 分析条件とデータの確認 and the client translates report cells by
         # EXACT string match, so a runtime-composed string can never be localized.
-        "Number of variables used in the analysis",
-        "Variables used in the analysis",
+        "Number of variables used in the analysis.",
+        "Names of the variables used in the analysis.",
         "Rows with no missing values",
         "Rows with 1+ missing value",
         reliability_correlation_reason(correlation_method, item_types),

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -696,16 +696,35 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
              round(confidence_interval$upper[[1]], 3))
     } else NA_character_
 
+    # tam#37638. The report renders this ONE table as TWO sections -- 分析条件とデータの確認
+    # (the data/method rows) and 信頼性の指標 (the coefficient rows) -- by filtering on Metric,
+    # so the rows are grouped in the order each section wants them.
+    #   * "Complete Responses" / "Responses with Missing" became "Row Count" / "Rows Removed":
+    #     keys the client's translation map ALREADY carries as 行数 / 削除された行数 from the
+    #     Factor Analysis and PCA tables, which is exactly the wanted wording.
+    #   * "Variable Names", "Correlation" and "Reliability Metric" are new. Correlation's reason
+    #     used to live in the separate correlation_method table, which the report drops.
     summary_table <- tibble::tibble(
-      Metric = c(coefficient_name, "Standardized Alpha", "95% CI", "Number of Variables",
-                 "Complete Responses", "Responses with Missing", "Total Missing Cells",
-                 "Average Inter-item Correlation", "Flagged Item"),
+      Metric = c(coefficient_name, "Standardized Alpha", "95% CI",
+                 "Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+                 "Correlation", "Reliability Metric",
+                 "Total Missing Cells", "Average Inter-item Correlation", "Flagged Item"),
       Value = c(as.character(round(display_alpha, 3)),
                 as.character(round(standardized_alpha, 3)),
                 ci_text,
                 as.character(ncol(cleaned_df)),
+                paste(colnames(cleaned_df), collapse = ", "),
                 as.character(complete_n),
-                as.character(rows_with_missing_n),
+                # "N (P%)", matching the Factor Analysis / PCA 削除された行数 rows this report is
+                # being standardized against (tam#37638). total_n is the pre-filter row count.
+                if (is.null(total_n) || length(total_n) != 1L || is.na(total_n) || total_n <= 0) {
+                  as.character(rows_with_missing_n)
+                } else {
+                  paste0(rows_with_missing_n, " (",
+                         format(round(rows_with_missing_n / total_n * 100, 1), nsmall = 1), "%)")
+                },
+                reliability_correlation_label(selected_method),
+                coefficient_name,
                 as.character(total_missing_n),
                 as.character(round(average_r, 3)),
                 flagged_item),
@@ -713,9 +732,15 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
         reliability_classify_alpha(display_alpha),
         "Standardized consistency",
         if (nrow(confidence_interval) > 0) "Feldt/Duhachek interval" else NA_character_,
-        paste0(ncol(cleaned_df), " items used"),
+        # tam#37638: a FIXED sentence, not the old composed "N items used". This cell is rendered
+        # in the 説明 column of 分析条件とデータの確認 and the client translates report cells by
+        # EXACT string match, so a runtime-composed string can never be localized.
+        "Number of variables used in the analysis",
+        "Variables used in the analysis",
         "Rows with no missing values",
         "Rows with 1+ missing value",
+        reliability_correlation_reason(correlation_method, item_types),
+        reliability_metric_reason(selected_method),
         "Missing cells across all items",
         dplyr::case_when(
           average_r >= 0.50 ~ "High relatedness",
@@ -774,6 +799,50 @@ exp_cronbach_alpha <- function(df, ..., correlation_method = "auto", check_keys 
 }
 
 # ------------------------------------------------------------
+# Correlation / coefficient labels and their selection reasons (tam#37638).
+# Extracted so the 分析条件とデータの確認 table and the legacy correlation_method table cannot
+# drift apart. Every returned sentence is a FIXED English string, never composed at runtime: the
+# client translates report table cells by exact string match, so a runtime-composed sentence would
+# render untranslated in Japanese.
+# ------------------------------------------------------------
+
+reliability_correlation_label <- function(selected_method) {
+  switch(selected_method,
+    pearson = "Pearson Correlation",
+    polychoric = "Polychoric Correlation",
+    mixed = "Mixed Correlation",
+    selected_method)
+}
+
+reliability_correlation_reason <- function(requested_method, item_types) {
+  requested <- if (is.null(requested_method)) "auto" else requested_method
+  if (requested != "auto") {
+    return(switch(requested,
+      pearson = "Pearson was specified in the settings.",
+      polychoric = "Polychoric was specified in the settings.",
+      mixed = "Mixed Correlation was specified in the settings.",
+      "Specified in the settings."))
+  }
+  unique_types <- unique(unname(item_types))
+  if (all(unique_types == "continuous")) {
+    "All variables are Numeric."
+  } else if (all(unique_types %in% c("ordinal", "dichotomous"))) {
+    "All variables are Factor or Logical."
+  } else {
+    "Numeric and Factor/Logical variables are mixed."
+  }
+}
+
+# Why THIS reliability coefficient: it follows directly from the correlation that was selected.
+reliability_metric_reason <- function(selected_method) {
+  switch(selected_method,
+    pearson = "Cronbach's Alpha was selected because the correlation is Pearson.",
+    polychoric = "Ordinal Alpha was selected because the correlation is Polychoric.",
+    mixed = "Mixed-Correlation Alpha was selected because the correlation is Mixed.",
+    "Selected based on the correlation used.")
+}
+
+# ------------------------------------------------------------
 # glance / tidy
 # ------------------------------------------------------------
 
@@ -828,28 +897,10 @@ tidy.cronbach_alpha_exploratory <- function(x, type = "summary", pretty.name = F
   } else if (type == "correlation_method") {
     # The "which correlation was used and why" table. English labels only -- the
     # Analytics report localizes them through the usual translation path.
-    method_label <- switch(x$selected_method,
-      pearson = "Pearson Correlation",
-      polychoric = "Polychoric Correlation",
-      mixed = "Mixed Correlation",
-      x$selected_method)
-    requested <- if (is.null(x$requested_method)) "auto" else x$requested_method
-    reason <- if (requested != "auto") {
-      switch(requested,
-        pearson = "Pearson was specified in the settings.",
-        polychoric = "Polychoric was specified in the settings.",
-        mixed = "Mixed Correlation was specified in the settings.",
-        "Specified in the settings.")
-    } else {
-      unique_types <- unique(unname(x$item_types))
-      if (all(unique_types == "continuous")) {
-        "All variables are Numeric."
-      } else if (all(unique_types %in% c("ordinal", "dichotomous"))) {
-        "All variables are Factor or Logical."
-      } else {
-        "Numeric and Factor/Logical variables are mixed."
-      }
-    }
+    # tam#37638: the label / reason logic is shared with the summary table's Correlation row, so
+    # the two can never disagree about which correlation was used or why.
+    method_label <- reliability_correlation_label(x$selected_method)
+    reason <- reliability_correlation_reason(x$requested_method, x$item_types)
     res <- tibble::tibble(
       `Item` = c("Correlation Type", "Primary Metric", "Selection Reason"),
       `Value` = c(method_label, x$coefficient_name, reason))

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -266,7 +266,13 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
     else {
       # Return cor_exploratory model, which is a set of correlation data frame and the original data.
       # We use the original data for scatter matrix on Analytics View.
-      ret <- list(cor = ret, data = df)
+      # analysis_conditions feeds the report's Analysis Conditions and Data table (tam#37638).
+      # Computed here because `mat` (the SELECTED columns, before any pair filtering) is only in
+      # scope now. do_cor.kv_ deliberately does NOT do this -- its `mat` is a matrix from
+      # simple_cast(), not a data frame, so the per-column predicates below do not apply. A kv_
+      # model falls through to tidy()'s empty-tibble branch instead.
+      ret <- list(cor = ret, data = df,
+                  analysis_conditions = cor_analysis_conditions(mat, method, use))
       class(ret) <- c("cor_exploratory", class(ret))
       ret
     }
@@ -280,6 +286,103 @@ do_cor.cols <- function(df, ..., use = "pairwise.complete.obs", method = "pearso
   else {
     do_on_each_group(df, do_cor_each, name = "model", with_unnest = FALSE)
   }
+}
+
+
+# Correlation report: the Analysis Conditions and Data table (tam#37638).
+#
+# Built at fit time, while the selected columns are still in hand, and stored on the
+# cor_exploratory model -- tidy() only reads it back. Every sentence is a FIXED English string
+# (never composed at runtime) because the client translates report table cells by exact string
+# match; a composed sentence would render untranslated in Japanese. The strings deliberately
+# match the ones reliability.R already emits, so both reports share one set of translations.
+cor_correlation_label <- function(resolved_method) {
+  switch(resolved_method,
+    pearson = "Pearson Correlation",
+    polychoric = "Polychoric Correlation",
+    mixed = "Mixed Correlation",
+    spearman = "Spearman Correlation",
+    kendall = "Kendall Correlation",
+    resolved_method)
+}
+
+cor_correlation_reason <- function(mat, requested_method) {
+  if (!identical(requested_method, "auto")) {
+    return(switch(requested_method,
+      pearson = "Pearson was specified in the settings.",
+      polychoric = "Polychoric was specified in the settings.",
+      mixed = "Mixed Correlation was specified in the settings.",
+      spearman = "Spearman was specified in the settings.",
+      kendall = "Kendall was specified in the settings.",
+      "Specified in the settings."))
+  }
+  is_ordinal <- vapply(mat, function(x) is.factor(x) || is.logical(x), logical(1))
+  is_continuous <- vapply(mat, is.numeric, logical(1))
+  if (all(is_continuous)) {
+    "All variables are Numeric."
+  } else if (all(is_ordinal)) {
+    "All variables are Factor or Logical."
+  } else {
+    "Numeric and Factor/Logical variables are mixed."
+  }
+}
+
+cor_analysis_conditions <- function(mat, requested_method, use) {
+  variable_names <- colnames(mat)
+  # A variable that is entirely missing, or that never varies, cannot produce a correlation with
+  # anything -- the same predicate PCA uses to decide what it drops before analysis.
+  is_unusable <- vapply(mat, function(x) {
+    values <- x[!is.na(x)]
+    length(values) == 0 || length(unique(values)) < 2
+  }, logical(1))
+  excluded_names <- variable_names[is_unusable]
+  total_rows <- nrow(mat)
+  # With the default pairwise.complete.obs a row still contributes to every pair it has both
+  # values for, so only an ALL-missing row is truly unused. Under complete.obs any missing value
+  # drops the whole row. Report whichever the analysis actually did.
+  rows_used <- if (identical(use, "complete.obs")) {
+    sum(stats::complete.cases(mat))
+  } else {
+    sum(rowSums(!is.na(mat)) > 0)
+  }
+  rows_removed <- max(0L, as.integer(total_rows - rows_used))
+  removed_pct <- if (total_rows > 0) rows_removed / total_rows * 100 else 0
+  resolved_method <- resolve_correlation_method(mat, requested_method)
+  tibble::tibble(
+    Metric = c("Number of Variables", "Variable Names", "Excluded Variables",
+               "Row Count", "Rows Removed", "Correlation"),
+    Value = c(
+      as.character(length(variable_names)),
+      if (length(variable_names) == 0) "N/A" else paste(variable_names, collapse = ", "),
+      if (length(excluded_names) == 0) "None" else paste(excluded_names, collapse = ", "),
+      as.character(rows_used),
+      paste0(rows_removed, " (", format(round(removed_pct, 1), nsmall = 1), "%)"),
+      cor_correlation_label(resolved_method)
+    ),
+    Description = c(
+      "Number of variables used in the analysis.",
+      "Names of the variables used in the analysis.",
+      "Variables dropped before analysis because they were all missing or had only one unique value.",
+      "Number of rows used in the analysis.",
+      "Number and rate of rows removed because of missing values.",
+      "Which correlation the coefficients were computed with."
+    ),
+    # Hidden columns: the report reads them to decide whether to explain the automatic choice.
+    # Explicit "TRUE"/"FALSE" STRINGS, not R logicals -- a logical can reach the client as "1"/"0"
+    # depending on the pivot pipeline, and the client's isTrue() only accepts "TRUE"/"true"/true.
+    correlation_type = resolved_method,
+    correlation_is_auto = if (identical(requested_method, "auto")) "TRUE" else "FALSE",
+    reason = cor_correlation_reason(mat, requested_method)
+  )
+}
+
+# Same column shape as cor_analysis_conditions(), with no rows. Returned for a model saved before
+# analysis_conditions existed, so the report's table renders empty instead of erroring and the
+# client's extractor falls back to its own defaults.
+cor_empty_analysis_conditions <- function() {
+  tibble::tibble(Metric = character(0), Value = character(0), Description = character(0),
+                 correlation_type = character(0), correlation_is_auto = character(0),
+                 reason = character(0))
 }
 
 
@@ -419,12 +522,25 @@ do_cor_internal <- function(mat, use, method, diag, output_cols, na.rm) {
 }
 
 #' @export
-tidy.cor_exploratory <- function(x, type = "cor", ...) { #TODO: add test
+tidy.cor_exploratory <- function(x, type = "cor", ...) {
   if (type == "cor") {
     x$cor
   }
-  else {
+  else if (type == "analysis_conditions") {
+    # tam#37638. The Correlation report's Analysis Conditions and Data table.
+    if (is.null(x$analysis_conditions)) cor_empty_analysis_conditions() else x$analysis_conditions
+  }
+  else if (type == "data" || type == "data.frame") {
+    # The original data, used for the scatter matrix on Analytics View.
     x$data
+  }
+  else {
+    # Deliberately an error, not a fallback. This used to be a catch-all `else` returning x$data,
+    # so asking for a type this function does not implement silently handed the caller the raw
+    # source data -- which then rendered as a plausible-looking but completely wrong report table
+    # (tam#37638 shipped its analysis_conditions template ahead of the R branch here). A wrong
+    # answer that looks right is worse than a loud failure.
+    stop(paste0("Unsupported tidy type for a correlation model: ", type))
   }
 }
 

--- a/R/stats_wrapper.R
+++ b/R/stats_wrapper.R
@@ -337,17 +337,21 @@ cor_analysis_conditions <- function(mat, requested_method, use) {
   }, logical(1))
   excluded_names <- variable_names[is_unusable]
   total_rows <- nrow(mat)
-  # With the default pairwise.complete.obs a row still contributes to every pair it has both
-  # values for, so only an ALL-missing row is truly unused. Under complete.obs any missing value
-  # drops the whole row. Report whichever the analysis actually did.
-  rows_used <- if (identical(use, "complete.obs")) {
+  resolved_method <- resolve_correlation_method(mat, requested_method)
+  # Pairwise correlations use a row only when at least two selected variables are observed; a row
+  # with one value cannot contribute to any off-diagonal pair. Polychoric and mixed correlations
+  # map every use mode other than complete.obs to pairwise.complete.obs in do_cor_internal().
+  uses_pairwise <- identical(use, "pairwise.complete.obs") ||
+    (resolved_method %in% c("polychoric", "mixed") && !identical(use, "complete.obs"))
+  rows_used <- if (uses_pairwise) {
+    sum(rowSums(!is.na(mat)) >= 2L)
+  } else if (use %in% c("complete.obs", "na.or.complete")) {
     sum(stats::complete.cases(mat))
   } else {
-    sum(rowSums(!is.na(mat)) > 0)
+    total_rows
   }
   rows_removed <- max(0L, as.integer(total_rows - rows_used))
   removed_pct <- if (total_rows > 0) rows_removed / total_rows * 100 else 0
-  resolved_method <- resolve_correlation_method(mat, requested_method)
   tibble::tibble(
     Metric = c("Number of Variables", "Variable Names", "Excluded Variables",
                "Row Count", "Rows Removed", "Correlation"),

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -369,3 +369,64 @@ test_that("exp_cronbach_alpha works with group_by (per group model)", {
   res <- model_df %>% glance_rowwise(model, pretty.name = TRUE)
   expect_equal(nrow(res), 2)
 })
+
+# tam#38607 / tam#37638 -- the "Analysis Conditions and Data" table.
+# The tam template filters tidy(type="summary") down to six Metric rows. Until this shipped, only
+# "Number of Variables" existed, so the report's conditions section rendered a single-row table.
+test_that("exp_cronbach_alpha summary carries the six Analysis Conditions rows", {
+  df <- make_reliability_df()
+  model_df <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson")
+  summary <- model_df %>% tidy_rowwise(model, type = "summary")
+
+  wanted <- c("Number of Variables", "Variable Names", "Row Count", "Rows Removed",
+              "Correlation", "Reliability Metric")
+  expect_true(all(wanted %in% summary$Metric))
+  # The row set the report's OTHER section (the reliability coefficients) filters on must survive.
+  expect_true(all(c("Cronbach's Alpha", "Standardized Alpha", "95% CI",
+                    "Average Inter-item Correlation") %in% summary$Metric))
+  # Renamed away from the old wording so the client's existing 行数 / 削除された行数 keys apply.
+  expect_false(any(c("Complete Responses", "Responses with Missing") %in% summary$Metric))
+
+  value_of <- function(metric) summary$Value[[match(metric, summary$Metric)]]
+  expect_equal(value_of("Variable Names"), paste(colnames(df), collapse = ", "))
+  expect_equal(value_of("Correlation"), "Pearson Correlation")
+  expect_equal(value_of("Reliability Metric"), "Cronbach's Alpha")
+})
+
+test_that("exp_cronbach_alpha reports Rows Removed as a count and a rate", {
+  df <- make_reliability_df()
+  df[[1]][1:2] <- NA
+  model_df <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson")
+  summary <- model_df %>% tidy_rowwise(model, type = "summary")
+  value_of <- function(metric) summary$Value[[match(metric, summary$Metric)]]
+
+  total <- nrow(df)
+  expect_equal(value_of("Row Count"), as.character(total - 2))
+  # "N (P%)", matching the Factor Analysis / PCA rows this table is standardized against.
+  expect_equal(value_of("Rows Removed"),
+               paste0("2 (", format(round(2 / total * 100, 1), nsmall = 1), "%)"))
+})
+
+test_that("the Correlation row and the correlation_method table cannot disagree", {
+  df <- make_reliability_df()
+  model_df <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "auto")
+  summary <- model_df %>% tidy_rowwise(model, type = "summary")
+  method <- model_df %>% tidy_rowwise(model, type = "correlation_method")
+
+  value_of <- function(metric) summary$Value[[match(metric, summary$Metric)]]
+  reason_of <- function(metric) summary$Interpretation[[match(metric, summary$Metric)]]
+  expect_equal(value_of("Correlation"), method$Value[[match("Correlation Type", method$Item)]])
+  expect_equal(value_of("Reliability Metric"), method$Value[[match("Primary Metric", method$Item)]])
+  expect_equal(reason_of("Correlation"), method$Value[[match("Selection Reason", method$Item)]])
+})
+
+test_that("the Number of Variables description is a fixed sentence, never composed", {
+  # Report table cells are translated by EXACT string match, so a runtime-composed description
+  # ("4 items used") could never be localized.
+  df <- make_reliability_df()
+  summary <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson") %>%
+    tidy_rowwise(model, type = "summary")
+  desc <- summary$Interpretation[[match("Number of Variables", summary$Metric)]]
+  expect_equal(desc, "Number of variables used in the analysis")
+  expect_false(grepl("^[0-9]", desc))
+})

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -432,3 +432,63 @@ test_that("the Number of Variables description is a fixed sentence, never compos
   expect_equal(desc, "Number of variables used in the analysis.")
   expect_false(grepl("^[0-9]", desc))
 })
+
+# Review follow-ups on tam#38607: the rows above were only spot-checked on the Pearson path.
+test_that("the Reliability Metric row names the coefficient each correlation implies", {
+  df <- make_reliability_df()
+  ordinal_df <- df %>% dplyr::mutate(dplyr::across(dplyr::everything(),
+                                                   ~ factor(.x, ordered = TRUE)))
+  row_of <- function(model_df, metric) {
+    s <- model_df %>% tidy_rowwise(model, type = "summary")
+    i <- match(metric, s$Metric)
+    list(value = s$Value[[i]], reason = s$Interpretation[[i]])
+  }
+
+  polychoric <- exp_cronbach_alpha(ordinal_df, dplyr::everything(),
+                                   correlation_method = "polychoric")
+  expect_equal(row_of(polychoric, "Correlation")$value, "Polychoric Correlation")
+  expect_equal(row_of(polychoric, "Reliability Metric")$value, "Ordinal Alpha")
+
+  mixed <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "mixed")
+  expect_equal(row_of(mixed, "Correlation")$value, "Mixed Correlation")
+  expect_equal(row_of(mixed, "Reliability Metric")$value, "Mixed-Correlation Alpha")
+})
+
+test_that("every Reliability Metric reason is one of three fixed sentences", {
+  # These are report cells, translated by EXACT string match, so their wording is a contract with
+  # the client -- not prose to reword freely. They currently reach only the Description column,
+  # which every Analysis Conditions template hides, so no ANALYTICS.UI key exists for them yet;
+  # locking them here means a future edit has to notice that before it ships.
+  expect_equal(reliability_metric_reason("pearson"),
+               "Cronbach's Alpha was selected because the correlation is Pearson.")
+  expect_equal(reliability_metric_reason("polychoric"),
+               "Ordinal Alpha was selected because the correlation is Polychoric.")
+  expect_equal(reliability_metric_reason("mixed"),
+               "Mixed-Correlation Alpha was selected because the correlation is Mixed.")
+  # An unrecognized method must still yield a fixed sentence, never a composed one.
+  expect_equal(reliability_metric_reason("something_new"),
+               "Selected based on the correlation used.")
+
+  df <- make_reliability_df()
+  summary <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson") %>%
+    tidy_rowwise(model, type = "summary")
+  expect_equal(summary$Interpretation[[match("Reliability Metric", summary$Metric)]],
+               reliability_metric_reason("pearson"))
+})
+
+test_that("Variable Names lists what survived, and no row yet says what was dropped", {
+  # exp_cronbach_alpha drops a constant column before fitting: Number of Variables and Variable
+  # Names both shrink, but unlike PCA and Correlation there is no Excluded Variables row naming
+  # it. Pinned as the CURRENT behavior, not as the desired one -- tam's own template does not
+  # filter for such a row yet either, so adding it is a follow-up, not part of this fix.
+  df <- make_reliability_df()
+  df$`常に同じ値` <- 3L
+  summary <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson") %>%
+    tidy_rowwise(model, type = "summary")
+  value_of <- function(metric) summary$Value[[match(metric, summary$Metric)]]
+
+  expect_equal(value_of("Number of Variables"), "4")
+  expect_equal(value_of("Variable Names"), paste(colnames(df)[1:4], collapse = ", "))
+  expect_false(grepl("常に同じ値", value_of("Variable Names"), fixed = TRUE))
+  expect_false("Excluded Variables" %in% summary$Metric)
+})

--- a/tests/testthat/test_reliability.R
+++ b/tests/testthat/test_reliability.R
@@ -427,6 +427,8 @@ test_that("the Number of Variables description is a fixed sentence, never compos
   summary <- exp_cronbach_alpha(df, dplyr::everything(), correlation_method = "pearson") %>%
     tidy_rowwise(model, type = "summary")
   desc <- summary$Interpretation[[match("Number of Variables", summary$Metric)]]
-  expect_equal(desc, "Number of variables used in the analysis")
+  # Byte-identical to the sentence do_cor's own conditions table uses, so the two tables share
+  # ONE translation key instead of drifting into two near-duplicates.
+  expect_equal(desc, "Number of variables used in the analysis.")
   expect_false(grepl("^[0-9]", desc))
 })

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -827,3 +827,76 @@ test_that("do_cor does not reseed when no rows are sampled", {
   invisible(long %>% do_cor(skv = c("subj", "key", "val"), max_nrow = NULL))
   expect_identical(.Random.seed, before)
 })
+
+# tam#37638 -- the Correlation report's "Analysis Conditions and Data" table.
+# Before this existed, tidy.cor_exploratory's catch-all `else` returned the raw source data for
+# any unrecognized type, so the report rendered the whole input data frame as its summary table.
+test_that("do_cor analysis_conditions returns the report's 6-row conditions table", {
+  set.seed(1)
+  df <- data.frame(a = rnorm(20), b = rnorm(20), c = rnorm(20))
+  model_df <- df %>% do_cor(`a`, `b`, `c`, method = "pearson", return_type = "model")
+  res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
+
+  expect_equal(res$Metric, c("Number of Variables", "Variable Names", "Excluded Variables",
+                             "Row Count", "Rows Removed", "Correlation"))
+  expect_equal(res$Value[[1]], "3")
+  expect_equal(res$Value[[2]], "a, b, c")
+  expect_equal(res$Value[[3]], "None")
+  expect_equal(res$Value[[4]], "20")
+  expect_equal(res$Value[[5]], "0 (0.0%)")
+  expect_equal(res$Value[[6]], "Pearson Correlation")
+  # Hidden columns the report binds its explanation text from. Strings, never R logicals.
+  expect_equal(unique(res$correlation_type), "pearson")
+  expect_equal(unique(res$correlation_is_auto), "FALSE")
+  expect_equal(unique(res$reason), "Pearson was specified in the settings.")
+})
+
+test_that("do_cor analysis_conditions reports the auto-resolved correlation and excluded variables", {
+  set.seed(2)
+  n <- 30
+  mk <- function() factor(sample(1:5, n, TRUE), levels = 1:5, ordered = TRUE)
+  df <- data.frame(q1 = mk(), q2 = mk(), flat = factor(rep(3, n), levels = 1:5, ordered = TRUE))
+  model_df <- suppressWarnings(df %>% do_cor(`q1`, `q2`, `flat`, method = "auto", return_type = "model"))
+  res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
+
+  # `flat` never varies, so it cannot correlate with anything.
+  expect_equal(res$Value[[3]], "flat")
+  expect_equal(res$Value[[6]], "Polychoric Correlation")
+  expect_equal(unique(res$correlation_is_auto), "TRUE")
+  expect_equal(unique(res$reason), "All variables are Factor or Logical.")
+})
+
+test_that("do_cor analysis_conditions counts rows the way the analysis actually did", {
+  df <- data.frame(a = c(1, 2, 3, NA), b = c(4, 5, NA, NA), c = c(1, 3, 2, NA))
+  # pairwise.complete.obs (the default): only an ALL-missing row is unused.
+  pairwise <- df %>% do_cor(`a`, `b`, `c`, method = "pearson", return_type = "model") %>%
+    tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(pairwise$Value[[4]], "3")
+  expect_equal(pairwise$Value[[5]], "1 (25.0%)")
+  # complete.obs: any missing value drops the whole row.
+  complete <- df %>% do_cor(`a`, `b`, `c`, method = "pearson", use = "complete.obs", return_type = "model") %>%
+    tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(complete$Value[[4]], "2")
+  expect_equal(complete$Value[[5]], "2 (50.0%)")
+})
+
+test_that("do_cor analysis_conditions returns an empty same-shape table for a model saved before it existed", {
+  df <- data.frame(a = c(1, 2, 3, 4), b = c(2, 4, 5, 9))
+  model_df <- df %>% do_cor(`a`, `b`, method = "pearson", return_type = "model")
+  # Simulate a model persisted before analysis_conditions was captured at fit time.
+  model_df$model[[1]]$analysis_conditions <- NULL
+  res <- model_df %>% tidy_rowwise(model, type = "analysis_conditions")
+
+  expect_equal(nrow(res), 0)
+  expect_true(all(c("Metric", "Value", "Description",
+                    "correlation_type", "correlation_is_auto", "reason") %in% colnames(res)))
+})
+
+test_that("tidy.cor_exploratory errors on an unsupported type instead of returning the source data", {
+  df <- data.frame(a = c(1, 2, 3, 4), b = c(2, 4, 5, 9))
+  model_df <- df %>% do_cor(`a`, `b`, method = "pearson", return_type = "model")
+  # The scatter matrix's own type must keep working.
+  expect_equal(nrow(model_df %>% tidy_rowwise(model, type = "data.frame")), 4)
+  expect_error(model_df %>% tidy_rowwise(model, type = "no_such_type"),
+               "Unsupported tidy type for a correlation model")
+})

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -868,7 +868,8 @@ test_that("do_cor analysis_conditions reports the auto-resolved correlation and 
 
 test_that("do_cor analysis_conditions counts rows the way the analysis actually did", {
   df <- data.frame(a = c(1, 2, 3, NA), b = c(4, 5, NA, NA), c = c(1, 3, 2, NA))
-  # pairwise.complete.obs (the default): only an ALL-missing row is unused.
+  # pairwise.complete.obs (the default): only an ALL-missing row is unused here
+  # (rows 1-2 are complete, row 3 has two values, row 4 is all NA).
   pairwise <- df %>% do_cor(`a`, `b`, `c`, method = "pearson", return_type = "model") %>%
     tidy_rowwise(model, type = "analysis_conditions")
   expect_equal(pairwise$Value[[4]], "3")
@@ -878,6 +879,23 @@ test_that("do_cor analysis_conditions counts rows the way the analysis actually 
     tidy_rowwise(model, type = "analysis_conditions")
   expect_equal(complete$Value[[4]], "2")
   expect_equal(complete$Value[[5]], "2 (50.0%)")
+
+  # A row with a single observed value contributes to no pairwise coefficient.
+  one_obs <- data.frame(
+    a = c(1, 4, NA, 7),
+    b = c(2, NA, 5, 8),
+    c = c(3, NA, 6, 9)
+  )
+  pairwise_one <- one_obs %>% do_cor(`a`, `b`, `c`, method = "pearson", return_type = "model") %>%
+    tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(pairwise_one$Value[[4]], "3")
+  expect_equal(pairwise_one$Value[[5]], "1 (25.0%)")
+  # na.or.complete is listwise, same as complete.obs.
+  na_or_complete <- one_obs %>% do_cor(`a`, `b`, `c`, method = "pearson", use = "na.or.complete",
+                                      return_type = "model") %>%
+    tidy_rowwise(model, type = "analysis_conditions")
+  expect_equal(na_or_complete$Value[[4]], "2")
+  expect_equal(na_or_complete$Value[[5]], "2 (50.0%)")
 })
 
 test_that("do_cor analysis_conditions returns an empty same-shape table for a model saved before it existed", {

--- a/tests/testthat/test_stats_wrapper.R
+++ b/tests/testthat/test_stats_wrapper.R
@@ -898,6 +898,27 @@ test_that("do_cor analysis_conditions counts rows the way the analysis actually 
   expect_equal(na_or_complete$Value[[5]], "2 (50.0%)")
 })
 
+test_that("do_cor analysis_conditions follows the use polychoric actually runs, not the one asked for", {
+  # do_cor_internal() hands hetcor "complete.obs" only when that was asked for, and
+  # "pairwise.complete.obs" for every other mode. So a polychoric fit requested with
+  # use = "everything" still runs pairwise, and the row count has to say so. Without that
+  # remap the count would fall through to "every row was used".
+  mk <- function(v) factor(v, levels = 1:3, ordered = TRUE)
+  df <- data.frame(
+    a = mk(c(1, 2, NA, 3, 1, 2)),
+    b = mk(c(2, NA, 3, 1, 2, 3)),
+    c = mk(c(3, NA, 1, 2, 3, 1))
+  )
+  # Row 2 has a single observed value, so it forms no pair.
+  res <- suppressWarnings(
+    df %>% do_cor(`a`, `b`, `c`, method = "polychoric", use = "everything", return_type = "model")
+  ) %>% tidy_rowwise(model, type = "analysis_conditions")
+
+  expect_equal(res$Value[[6]], "Polychoric Correlation")
+  expect_equal(res$Value[[4]], "5")
+  expect_equal(res$Value[[5]], paste0("1 (", format(round(1 / 6 * 100, 1), nsmall = 1), "%)"))
+})
+
 test_that("do_cor analysis_conditions returns an empty same-shape table for a model saved before it existed", {
   df <- data.frame(a = c(1, 2, 3, 4), b = c(2, 4, 5, 9))
   model_df <- df %>% do_cor(`a`, `b`, method = "pearson", return_type = "model")


### PR DESCRIPTION
Paired R change for tam#38607 item 1.

## The bug

The Correlation report's "Analysis Conditions and Data" table showed the raw source data -- every input row and column, including columns the user never selected -- instead of the analysis conditions.

## Root cause

`tidy.cor_exploratory` dispatched on `type` with a catch-all `else`:

```r
tidy.cor_exploratory <- function(x, type = "cor", ...) {
  if (type == "cor") { x$cor }
  else { x$data }        # unknown type -> raw source data
}
```

tam's `do_cor.json` asks for `type="analysis_conditions"` (shipped with tam#37638). This function never implemented it, so the request fell through the catch-all and got the source data back, which then rendered as a plausible-looking but completely wrong report table. No error, no warning.

Reproduced against the shipped exploratory 16.1.25: asking for `analysis_conditions` on a 3-variable model returned 50 rows of `ID | A | B | C`.

The R implementation was written back then on branch `fix/issue-37638` (commit ece04785acf) and never merged. `git merge-base --is-ancestor ece04785acf origin/master` is false. This PR ports the do_cor part onto current master.

## Changes

- `do_cor.cols()` captures the conditions at fit time, while `mat` (the SELECTED columns) is still in scope, and stores them on the `cor_exploratory` model. Six rows: Number of Variables, Variable Names, Excluded Variables, Row Count, Rows Removed, Correlation. Hidden `correlation_type` / `correlation_is_auto` / `reason` columns feed the report's explanation text.
- Row counting honors the actual `use` setting: under `pairwise.complete.obs` only an all-missing row is unused, under `complete.obs` any missing value drops the row.
- Excluded variables use the same predicate PCA uses: all-missing, or fewer than 2 unique values.
- Every string is a FIXED English sentence, never composed at runtime, because the client translates report table cells by exact string match.
- `do_cor.kv_` deliberately does not do this. Its `mat` is a matrix from `simple_cast()`, not a data frame, so the per-column predicates do not apply; it falls through to the empty-tibble branch.
- `tidy.cor_exploratory` gains the `analysis_conditions` branch (empty same-shape tibble for a model saved before this existed), keeps `"data"` / `"data.frame"` for the Analytics View scatter matrix, and now `stop()`s on anything else.

## Why close the catch-all

A wrong answer that looks right is worse than a loud failure. The catch-all is exactly what turned a missing feature into a silently incorrect report. `tidy.pam_exploratory` already gets this right: its `switch` default is `.kmedoids_empty(type)`, an empty table.

I checked the rest of the package for the same class of defect. tam requests 116 distinct tidy types across 56 analytics types; `do_cor`'s `analysis_conditions` is the only one the shipped package does not implement. Other `tidy.*` methods do have catch-all `else` branches, but each returns a purpose-built default (coefficients, model summary, chi-square density data), not the source data.

## Verification

- 5 new testthat cases in `test_stats_wrapper.R`: the 6-row shape and its hidden columns, auto-resolution plus excluded-variable detection, row counting under both `use` settings, the empty-tibble path for a pre-existing model, and `stop()` on an unsupported type with `data.frame` still working.
- Full `test_stats_wrapper.R` passes under `pkgload::load_all()` against R 4.6 ARM (warnings only, all pre-existing).
- Live check with multibyte column names and a constant column: 6 rows, `Excluded Variables` correctly names the constant column, `Correlation` reads `Polychoric Correlation` under Auto.

## Release note

tam's fix ships a client-side guard so the table renders empty rather than wrong until this is released, but the table stays empty until a version bump carrying this change is built and uploaded.

---

## Update: this PR now also fixes Cronbach's Alpha

Same leftover, second victim. tam's `exp_cronbach_alpha` template filters `tidy(type="summary")` down to six Metric rows for its Analysis Conditions table, and only `Number of Variables` existed, so the section rendered a one-row table. Confirmed live against 16.1.25 for pearson, polychoric and mixed alike, and confirmed by the reporter's screenshot.

`R/reliability.R`:

- `tidy(type="summary")` gains `Variable Names`, `Correlation` and `Reliability Metric`, each carrying its selection reason in `Interpretation`.
- `Complete Responses` / `Responses with Missing` become `Row Count` / `Rows Removed`, the wording Factor Analysis and PCA already use, so the client's existing translation keys apply. `Rows Removed` is now `"N (P%)"` like theirs.
- The composed `"N items used"` description becomes a fixed sentence, byte-identical to the one `do_cor` uses so the two tables share one translation key. Report cells translate by exact string match, so a composed string can never be localized.
- The correlation label and reason move into shared helpers that the legacy `correlation_method` tidy type now calls too, so the two tables cannot disagree about which correlation was used or why.

`glance()` is untouched.

### Why not just reopen #1599

Only its `reliability.R` hunk is still needed. Its `prcomp.R` hunk would revert three later commits (`03daa929195`, `a857bedfa49`, `d083db84707`), because PCA's `analysis_conditions` landed independently via #37019 and has moved since. Its `factanal.R` hunk is comment-only. The `reliability.R` hunk applies cleanly to current master and is ported here.

### Verification

- 4 new testthat cases in `test_reliability.R`: the six-row set plus the coefficient rows surviving alongside it, the old Metric names being gone, `Rows Removed` as count and rate, the summary Correlation row agreeing with the `correlation_method` table on all three fields, and the description being a fixed sentence rather than a composed one.
- `test_reliability.R`: 93 passing, 0 failed, 0 errors under `pkgload::load_all()` on R 4.6 ARM.
- Live check of what the tam preprocessor actually keeps: 6 rows, correct values, with `correlation_method` still working.