### PR TITLE
LCA: accept numeric indicators, converted like K-Modes (tam#38689)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: exploratory
 Type: Package
 Title: R package for Exploratory
-Version: 16.1.27
-Date: 2026-09-11
+Version: 16.1.28
+Date: 2026-09-12
 Authors@R: c(person("Hideaki", "Hayashi", email = "hideaki@exploratory.io", role = c("aut", "cre")), person("Hide", "Kojima", email = "hide@exploratory.io", role = c("aut")), person("Kan", "Nishida", email = "kan@exploratory.io", role = c("aut")), person("Kei", "Saito", email = "kei@exploratory.io", role = c("aut")), person("Yosuke", "Yasuda", email = "double.y.919.quick@gmail.com", role = c("aut")))
 URL: https://github.com/exploratory-io/exploratory_func
 Description: Functions for Exploratory

--- a/R/lca.R
+++ b/R/lca.R
@@ -20,6 +20,9 @@
 #'   class for the report.
 #' @param max_nrow Maximum number of rows to fit on. Larger inputs are randomly
 #'   sampled down to this many rows. \code{NULL} uses every row.
+#' @param numeric_handling How a numeric indicator becomes categories: one of
+#'   "auto", "as_category", "equal_width". Same rule as K-Modes (tam#38689).
+#' @param numeric_bins Number of equal-width bins for a numeric indicator.
 #' @export
 exp_lca <- function(df, ...,
                     min_nclass = 2,
@@ -30,7 +33,9 @@ exp_lca <- function(df, ...,
                     seed = 1,
                     relationship_column = NULL,
                     feature_top_n = 10,
-                    max_nrow = NULL) {
+                    max_nrow = NULL,
+                    numeric_handling = "auto",
+                    numeric_bins = 10) {
   if (!requireNamespace("poLCA", quietly = TRUE)) {
     stop("Latent Class Analysis requires the poLCA package.")
   }
@@ -57,6 +62,13 @@ exp_lca <- function(df, ...,
     if (relationship_col %in% grouped_cols) {
       stop("Repeat-By column cannot be used as a relationship variable.")
     }
+    # tam#38689: numeric indicators are now converted to categories, but the relationship
+    # variable is a descriptive categorical comparison and is never converted. Refuse a
+    # non-categorical one instead of silently as.character()-ing each distinct number.
+    relationship_values <- df[[relationship_col]]
+    if (!(is.character(relationship_values) || is.factor(relationship_values) || is.logical(relationship_values))) {
+      stop("The relationship variable must be a character, factor, ordered, or logical column.")
+    }
   }
 
   min_nclass <- as.integer(min_nclass)
@@ -77,11 +89,20 @@ exp_lca <- function(df, ...,
     stop("Trial Times, Max Iteration Times, and Number of Characteristics must be 1 or larger.")
   }
 
+  numeric_handling <- match.arg(as.character(numeric_handling),
+                                c("auto", "as_category", "equal_width"))
+  numeric_bins <- suppressWarnings(as.integer(numeric_bins))
+  if (length(numeric_bins) != 1 || is.na(numeric_bins) || numeric_bins < 2) {
+    stop("Number of Bins must be 2 or larger.")
+  }
+
+  # tam#38689: numeric is supported (converted to categories by lca_prepare_indicators).
+  # is.numeric() is FALSE for Date / POSIXct / difftime, so those stay unsupported.
   unsupported <- selected_cols[!vapply(df[selected_cols], function(x) {
-    is.character(x) || is.factor(x) || is.logical(x)
+    is.character(x) || is.factor(x) || is.logical(x) || is.numeric(x)
   }, logical(1))]
   if (length(unsupported)) {
-    stop(paste0("Latent Class Analysis supports character, factor, ordered, and logical variables only. Unsupported: ",
+    stop(paste0("Latent Class Analysis supports character, factor, ordered, logical, and numeric variables only. Unsupported: ",
                 paste(unsupported, collapse = ", "), "."))
   }
 
@@ -101,7 +122,12 @@ exp_lca <- function(df, ...,
       group_df <- group_df %>% sample_rows(max_nrow)
     }
     original <- group_df %>% dplyr::mutate(.lca_row_id = dplyr::row_number())
-    indicators <- lca_encode_indicators(original, selected_cols)
+    # tam#38689: numeric indicators become ordered factors for the MODEL only. `original`
+    # keeps the raw values, because it is what the Output Data table is built from.
+    indicator_df <- lca_prepare_indicators(original, selected_cols,
+                                           numeric_handling = numeric_handling,
+                                           numeric_bins = numeric_bins)
+    indicators <- lca_encode_indicators(indicator_df, selected_cols)
     complete_rows <- stats::complete.cases(indicators)
     used <- indicators[complete_rows, , drop = FALSE]
     used_row_ids <- original$.lca_row_id[complete_rows]
@@ -167,7 +193,7 @@ exp_lca <- function(df, ...,
     selected <- normalized$fit
 
     class_selection <- lca_class_selection_table(candidates)
-    profiles <- lca_profile_table(selected, original[complete_rows, selected_cols, drop = FALSE], selected_cols)
+    profiles <- lca_profile_table(selected, indicator_df[complete_rows, selected_cols, drop = FALSE], selected_cols)
     characteristics <- profiles %>%
       dplyr::group_by(class) %>%
       dplyr::arrange(dplyr::desc(abs_difference), variable, category, .by_group = TRUE) %>%
@@ -175,7 +201,7 @@ exp_lca <- function(df, ...,
       dplyr::filter(rank <= feature_top_n) %>%
       dplyr::ungroup()
     row_assignments <- lca_assignment_table(original, used_row_ids, selected)
-    class_distribution <- lca_class_composition_table(selected, original[complete_rows, selected_cols, drop = FALSE],
+    class_distribution <- lca_class_composition_table(selected, indicator_df[complete_rows, selected_cols, drop = FALSE],
                                                       selected_cols)
     variable_discrimination <- calculate_lca_variable_discrimination(profiles)
     relationship <- lca_relationship_table(original, used_row_ids, selected$predclass, relationship_col)
@@ -240,6 +266,37 @@ lca_indicator_levels <- function(x) {
     return(c(kept, sort(setdiff(present, kept), method = "radix")))
   }
   sort(present, method = "radix")
+}
+
+#' Convert numeric LCA indicators to ordered factors (tam#38689).
+#'
+#' The keep-values-or-bin decision is K-Modes' own kmodes_prepare_column(), so the two
+#' analytics cannot drift into different rules. What LCA adds is ORDER: the result is a
+#' factor, and lca_indicator_levels() already honours a factor's declared levels, so the
+#' encoding and every report table agree on it with no further change.
+#'   - equal-width bins keep cut()'s ascending order ("(2,3]" before "(10,11]");
+#'   - values kept as categories sort numerically (1, 2, 10 -- not "1", "10", "2").
+#' Non-finite values are NA'd by kmodes_prepare_column(), so those rows are excluded.
+#' Non-numeric columns are returned untouched.
+#' @param df The data frame.
+#' @param cols The indicator column names.
+#' @param numeric_handling One of "auto", "as_category", "equal_width".
+#' @param numeric_bins Number of equal-width bins.
+#' @return `df` with each numeric indicator replaced by a factor.
+lca_prepare_indicators <- function(df, cols, numeric_handling = "auto", numeric_bins = 10) {
+  for (col in cols) {
+    x <- df[[col]]
+    if (!is.numeric(x)) {
+      next
+    }
+    converted <- kmodes_prepare_column(x, numeric_handling = numeric_handling, numeric_bins = numeric_bins)
+    levels <- converted$display_levels
+    if (is.null(levels)) {
+      levels <- as.character(sort(unique(x[is.finite(x)])))
+    }
+    df[[col]] <- factor(converted$values, levels = levels)
+  }
+  df
 }
 
 lca_encode_indicators <- function(df, cols) {

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -149,9 +149,11 @@ test_that("exp_lca excludes non-converged fits from the recommended model and al
 })
 
 test_that("exp_lca rejects non-categorical, insufficient, and invalid class selections", {
-  df <- data.frame(a = c("x", "y", "x", "y"), b = c("m", "m", "n", "n"), number = 1:4)
+  df <- data.frame(a = c("x", "y", "x", "y"), b = c("m", "m", "n", "n"), number = 1:4,
+                   day = as.Date("2026-01-01") + 0:3)
   expect_error(exp_lca(df, a), "at least 2 categorical variables")
-  expect_error(exp_lca(df, a, number), "supports character, factor, ordered, and logical")
+  # tam#38689: numeric indicators are accepted now; a Date still has no category meaning.
+  expect_error(exp_lca(df, a, day), "supports character, factor, ordered, logical, and numeric")
   expect_error(exp_lca(df, a, b, min_nclass = 4, max_nclass = 2), "Class counts")
   expect_error(exp_lca(df, a, b, relationship_column = a), "must be different")
 })
@@ -545,6 +547,100 @@ test_that("exp_lca reports factor categories in their declared order", {
   observed_order <- as.character(unique(tenure_rows$category[order(tenure_rows$class,
                                                                   as.integer(tenure_rows$category))]))
   expect_equal(observed_order[seq_along(lv)], lv)
+})
+
+# ---------------------------------------------------------------------------
+# tam#38689 -- numeric indicators, converted to categories the way K-Modes does
+# ---------------------------------------------------------------------------
+
+lca_numeric_fixture <- function(n = 300, seed = 38689) {
+  set.seed(seed)
+  cls <- sample(1:2, n, replace = TRUE)
+  df <- data.frame(
+    # distinct 3 -> kept as categories. Chosen so numeric order (1, 2, 10) and text order
+    # ("1", "10", "2") disagree -- a fixture where they coincide cannot tell them apart.
+    score = ifelse(cls == 1, sample(c(1, 2, 10), n, TRUE, c(.6, .3, .1)),
+                   sample(c(1, 2, 10), n, TRUE, c(.1, .3, .6))),
+    # distinct 15 -> kept under numeric_bins >= 15, binned below that.
+    days = ifelse(cls == 1, sample(1:15, n, TRUE, rep(c(.12, .01), c(8, 7))),
+                  sample(1:15, n, TRUE, rep(c(.01, .12), c(7, 8)))),
+    # continuous -> equal-width bins under auto. The canonical stress-test name.
+    amount = ifelse(cls == 1, stats::runif(n, 0, 50), stats::runif(n, 40, 100)),
+    b = ifelse(cls == 1, sample(c("m", "n"), n, TRUE, c(.8, .2)), sample(c("m", "n"), n, TRUE, c(.2, .8))),
+    stringsAsFactors = FALSE
+  )
+  names(df)[names(df) == "amount"] <- "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
+  df
+}
+
+lca_class1_categories <- function(model, variable) {
+  profiles <- tidy(model, type = "profiles")
+  as.character(profiles$category[profiles$variable == variable & profiles$class == "Class 1"])
+}
+
+lca_bin_lower_bounds <- function(labels) {
+  as.numeric(sub("^[[(]([^,]+),.*$", "\\1", labels))
+}
+
+test_that("exp_lca accepts numeric indicators as ordered categories and keeps raw values in the output (tam#38689)", {
+  df <- lca_numeric_fixture()
+  stress <- "航空 会社 !\"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表"
+  model <- exp_lca(df, score, `航空 会社 !"#$%&'()*+, -./:;<=>?@[]^_'{|}~ 表`, b,
+                   min_nclass = 2, max_nclass = 2, nrep = 3, maxiter = 300, seed = 1)$model[[1]]
+
+  # Few distinct values: the values ARE the categories, in numeric order.
+  expect_equal(lca_class1_categories(model, "score"), c("1", "2", "10"))
+
+  # Continuous: 10 equal-width bins (the default), in ascending bin order, not text order.
+  bins <- lca_class1_categories(model, stress)
+  expect_equal(length(bins), 10)
+  expect_true(all(diff(lca_bin_lower_bounds(bins)) > 0))
+
+  # The same order reaches the class composition table (one shared level rule).
+  composition <- tidy(model, type = "class_distribution")
+  comp_bins <- unique(as.character(composition$category[composition$variable == stress]))
+  expect_equal(comp_bins, bins)
+
+  # Conversion feeds the model only: Output Data keeps the original numbers.
+  data <- tidy(model, type = "data")
+  expect_true(is.numeric(data[[stress]]))
+  expect_equal(sort(data[[stress]]), sort(df[[stress]]))
+  expect_equal(sort(data$score), sort(df$score))
+})
+
+test_that("exp_lca numeric_handling and numeric_bins follow the K-Modes rule (tam#38689)", {
+  df <- lca_numeric_fixture()
+  fit <- function(...) {
+    exp_lca(df, days, b, min_nclass = 2, max_nclass = 2, nrep = 1, maxiter = 100, seed = 1, ...)$model[[1]]
+  }
+  # auto: 15 distinct > 10 bins -> binned into 10.
+  expect_equal(length(lca_class1_categories(fit(), "days")), 10)
+  # auto: 15 distinct <= 20 bins -> the threshold is the CONFIGURED bin count, so values stay.
+  expect_equal(lca_class1_categories(fit(numeric_bins = 20), "days"), as.character(1:15))
+  # as_category forces the values, in numeric order (text order would put "10" after "1").
+  expect_equal(lca_class1_categories(fit(numeric_handling = "as_category"), "days"), as.character(1:15))
+  # equal_width with an explicit bin count.
+  four <- lca_class1_categories(fit(numeric_handling = "equal_width", numeric_bins = 4), "days")
+  expect_equal(length(four), 4)
+  expect_true(all(diff(lca_bin_lower_bounds(four)) > 0))
+})
+
+test_that("exp_lca treats non-finite numeric indicator values as missing (tam#38689)", {
+  df <- lca_numeric_fixture()
+  df$score[c(3, 7)] <- c(Inf, -Inf)
+  model <- exp_lca(df, score, b, min_nclass = 2, max_nclass = 2, nrep = 1, maxiter = 100, seed = 1)$model[[1]]
+  expect_equal(model$excluded_nrow, 2)
+  expect_equal(lca_class1_categories(model, "score"), c("1", "2", "10"))
+  data <- tidy(model, type = "data")
+  expect_equal(sum(data$`Is Excluded`), 2)
+})
+
+test_that("exp_lca validates numeric settings and keeps the relationship variable categorical (tam#38689)", {
+  df <- lca_numeric_fixture(n = 60)
+  expect_error(exp_lca(df, score, b, numeric_bins = 1), "Number of Bins must be 2 or larger.")
+  expect_error(exp_lca(df, score, b, numeric_handling = "bogus"), "should be one of")
+  expect_error(exp_lca(df, b, days, relationship_column = score),
+               "relationship variable must be a character, factor, ordered, or logical column")
 })
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `exp_lca` gains `numeric_handling` (`auto` / `as_category` / `equal_width`) and `numeric_bins` (default 10), matching `exp_kmodes`.
- A numeric indicator goes through K-Modes' own `kmodes_prepare_column()` (one keep-values-or-bin rule for both analytics) and becomes an ordered factor **for the model only**:
  - values kept as categories sort numerically (1, 2, 10 — not "1", "10", "2");
  - equal-width bins keep `cut()` order;
  - `Inf`/`-Inf` are treated as missing (row excluded, retained in Output Data).
- The existing `lca_indicator_levels()` already honours factor levels, so encoding, Response Profile and Class Composition all get the same order without touching those functions.
- Output Data keeps the raw numeric values.
- Date / POSIXct stay unsupported (message updated). A non-categorical `relationship_column` is now refused instead of silently `as.character()`'d.
- Formals are appended after `max_nrow`; tam emits them only when a numeric variable is selected (the #38420 `...`/tidyselect older-package trap).

tam issue: https://github.com/exploratory-io/tam/issues/38689

## Test plan
- [x] `tests/testthat/test_lca.R` — 42 tests, 0 failures (4 new: order + raw output with the stress-test column name, auto/as_category/equal_width rules, non-finite values, validation + numeric relationship refused; updated the unsupported-type case to Date)
- [ ] Version bump + binaries after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)